### PR TITLE
fix: correct plugin schema for Claude Code compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,51 @@
+{
+  "name": "ProjectMnemosyne",
+  "owner": {
+    "name": "HomericIntelligence",
+    "url": "https://github.com/HomericIntelligence"
+  },
+  "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "grpo-external-vllm",
+      "description": "GRPO training with external vLLM server. Use when: (1) Running vLLM on separate GPUs, (2) Encountering vllm_skip_weight_sync errors, (3) OpenAI API parsing issues.",
+      "version": "1.0.0",
+      "source": "./plugins/training/grpo-external-vllm",
+      "category": "training",
+      "tags": ["grpo", "vllm", "reinforcement-learning", "llm-training"]
+    },
+    {
+      "name": "mojo-simd-errors",
+      "description": "Debug SIMD vectorization errors in Mojo. Use when: (1) SIMD comparison operators fail, (2) Conditional selection with masks, (3) Vectorized tensor operations.",
+      "version": "1.0.0",
+      "source": "./plugins/debugging/mojo-simd-errors",
+      "category": "debugging",
+      "tags": ["mojo", "simd", "vectorization", "tensor"]
+    },
+    {
+      "name": "github-actions-mojo",
+      "description": "GitHub Actions CI setup for Mojo projects. Use when: (1) Setting up Mojo CI/CD, (2) Configuring pixi with GitHub Actions, (3) Running mojo test in CI.",
+      "version": "1.0.0",
+      "source": "./plugins/ci-cd/github-actions-mojo",
+      "category": "ci-cd",
+      "tags": ["github-actions", "mojo", "ci-cd", "pixi"]
+    },
+    {
+      "name": "layerwise-gradient-check",
+      "description": "Layerwise gradient checking for neural network testing. Use when: (1) Validating backward pass implementations, (2) Debugging gradient computation, (3) TDD for neural network layers.",
+      "version": "1.0.0",
+      "source": "./plugins/testing/layerwise-gradient-check",
+      "category": "testing",
+      "tags": ["testing", "gradients", "neural-network", "tdd"]
+    },
+    {
+      "name": "skill-marketplace-design",
+      "description": "Design patterns for Claude Code skill marketplaces. Use when: (1) Setting up team knowledge capture, (2) Implementing /advise and /retrospective, (3) Designing plugin validation.",
+      "version": "1.0.0",
+      "source": "./plugins/architecture/skill-marketplace-design",
+      "category": "architecture",
+      "tags": ["marketplace", "skills", "claude-code", "knowledge-management"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@ ProjectMnemosyne is a skills marketplace for the HomericIntelligence agentic eco
 Named after Mnemosyne, the Greek goddess of memory, this repository serves as the
 collective memory where team learnings are preserved and made searchable.
 
+## Installation
+
+Register the marketplace and install plugins using Claude Code CLI:
+
+```bash
+# Add the marketplace
+claude plugin marketplace add HomericIntelligence/ProjectMnemosyne
+
+# Install all plugins
+claude plugin install grpo-external-vllm@ProjectMnemosyne
+claude plugin install mojo-simd-errors@ProjectMnemosyne
+claude plugin install github-actions-mojo@ProjectMnemosyne
+claude plugin install layerwise-gradient-check@ProjectMnemosyne
+claude plugin install skill-marketplace-design@ProjectMnemosyne
+```
+
+Or install from a local clone:
+
+```bash
+git clone https://github.com/HomericIntelligence/ProjectMnemosyne
+claude plugin marketplace add /path/to/ProjectMnemosyne
+claude plugin install <plugin-name>@ProjectMnemosyne
+```
+
+Verify installation:
+
+```bash
+claude plugin marketplace list
+```
+
 ## Quick Start
 
 ### Search for Knowledge

--- a/plugins/architecture/skill-marketplace-design/.claude-plugin/plugin.json
+++ b/plugins/architecture/skill-marketplace-design/.claude-plugin/plugin.json
@@ -5,9 +5,5 @@
   "author": {
     "name": "ML Odyssey Team"
   },
-  "date": "2025-12-28",
-  "category": "architecture",
-  "tags": ["marketplace", "skills", "claude-code", "knowledge-management", "hooks"],
-  "skills": "./skills",
-  "source_project": "ProjectMnemosyne"
+  "skills": "./skills"
 }

--- a/plugins/ci-cd/github-actions-mojo/.claude-plugin/plugin.json
+++ b/plugins/ci-cd/github-actions-mojo/.claude-plugin/plugin.json
@@ -5,9 +5,5 @@
   "author": {
     "name": "ML Odyssey Team"
   },
-  "date": "2025-12-28",
-  "category": "ci-cd",
-  "tags": ["github-actions", "mojo", "ci-cd", "pixi", "testing"],
-  "skills": "./skills",
-  "source_project": "ProjectOdyssey"
+  "skills": "./skills"
 }

--- a/plugins/debugging/mojo-simd-errors/.claude-plugin/plugin.json
+++ b/plugins/debugging/mojo-simd-errors/.claude-plugin/plugin.json
@@ -5,9 +5,5 @@
   "author": {
     "name": "ML Odyssey Team"
   },
-  "date": "2025-12-28",
-  "category": "debugging",
-  "tags": ["mojo", "simd", "vectorization", "tensor", "performance"],
-  "skills": "./skills",
-  "source_project": "ProjectOdyssey"
+  "skills": "./skills"
 }

--- a/plugins/testing/layerwise-gradient-check/.claude-plugin/plugin.json
+++ b/plugins/testing/layerwise-gradient-check/.claude-plugin/plugin.json
@@ -5,9 +5,5 @@
   "author": {
     "name": "ML Odyssey Team"
   },
-  "date": "2025-12-28",
-  "category": "testing",
-  "tags": ["testing", "gradients", "neural-network", "tdd", "numerical-verification"],
-  "skills": "./skills",
-  "source_project": "ProjectOdyssey"
+  "skills": "./skills"
 }

--- a/plugins/training/grpo-external-vllm/.claude-plugin/plugin.json
+++ b/plugins/training/grpo-external-vllm/.claude-plugin/plugin.json
@@ -5,9 +5,5 @@
   "author": {
     "name": "ML Odyssey Team"
   },
-  "date": "2025-12-28",
-  "category": "training",
-  "tags": ["grpo", "vllm", "reinforcement-learning", "llm-training", "distributed"],
-  "skills": "./skills",
-  "source_project": "ProjectOdyssey"
+  "skills": "./skills"
 }


### PR DESCRIPTION
## Summary

Fixes plugin.json schema to be compatible with Claude Code's plugin system.

## Changes

- Add `.claude-plugin/marketplace.json` with correct schema (owner as object)
- Remove unsupported fields from plugin.json files:
  - `date`, `category`, `tags`, `source_project`
- Add **Installation** section to README with exact CLI commands

## Installation Commands

```bash
# Add the marketplace
claude plugin marketplace add HomericIntelligence/ProjectMnemosyne

# Install plugins
claude plugin install grpo-external-vllm@ProjectMnemosyne
claude plugin install mojo-simd-errors@ProjectMnemosyne
# ... etc
```

## Verified

All plugins successfully install after these fixes:

```
✔ Successfully installed plugin: grpo-external-vllm@ProjectMnemosyne
✔ Successfully installed plugin: mojo-simd-errors@ProjectMnemosyne
✔ Successfully installed plugin: github-actions-mojo@ProjectMnemosyne
✔ Successfully installed plugin: layerwise-gradient-check@ProjectMnemosyne
✔ Successfully installed plugin: skill-marketplace-design@ProjectMnemosyne
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)