### PR TITLE
feat: add claude-plugin-format skill

### DIFF
--- a/plugins/tooling/claude-plugin-format/.claude-plugin/plugin.json
+++ b/plugins/tooling/claude-plugin-format/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "claude-plugin-format",
+  "version": "1.0.0",
+  "description": "Official Claude Code plugin format requirements. Use when: (1) Creating a new plugin, (2) Debugging plugin validation errors, (3) Skills or commands not appearing after install.",
+  "author": {
+    "name": "ML Odyssey Team"
+  },
+  "skills": "./skills"
+}

--- a/plugins/tooling/claude-plugin-format/references/notes.md
+++ b/plugins/tooling/claude-plugin-format/references/notes.md
@@ -1,0 +1,115 @@
+# Claude Plugin Format - Session Notes
+
+## Session Context
+
+**Date**: 2025-12-29
+**Objective**: Fix ProjectMnemosyne marketplace plugins that weren't loading
+**Initial Error**: `Plugin has an invalid manifest file... Unrecognized key(s) in object: 'tags'`
+
+## Problem Discovery Timeline
+
+### Issue 1: Skills not appearing
+User installed `skills-registry-commands` plugin but `/advise` and `/retrospective` didn't appear.
+
+**Investigation**:
+- Checked plugin structure
+- Found skills in `skills/` directory (correct)
+- Found commands in `commands/` directory (correct)
+- Found duplicate skills in project `.claude/skills/` (incorrect)
+
+### Issue 2: Marketplace file location
+- Root `marketplace.json` was current but wrong location
+- `.claude-plugin/marketplace.json` was outdated with deleted plugins
+
+**Resolution**: Moved to `.claude-plugin/marketplace.json` per official docs
+
+### Issue 3: plugin.json validation error
+Error: `Unrecognized key(s) in object: 'tags'`
+
+**Investigation via official repo**:
+```bash
+# Analyzed anthropics/claude-plugins-official
+# Found commit-commands plugin.json:
+{
+  "name": "commit-commands",
+  "description": "...",
+  "author": { "name": "Anthropic", "email": "..." }
+}
+# NO tags field!
+```
+
+**Resolution**: Removed `tags` from all plugin.json files
+
+### Issue 4: SKILL.md validation error
+Skills had non-standard frontmatter fields causing validation failures.
+
+**Investigation via official repo**:
+```yaml
+# Official example-skill frontmatter:
+---
+name: example-skill
+description: This skill should be used when...
+version: 1.0.0
+---
+# Only these fields allowed!
+```
+
+**Resolution**: Stripped all SKILL.md files to only `name` and `description`
+
+## Files Modified
+
+### Deleted
+- `/marketplace.json` (wrong location)
+- `/.claude/skills/advise/` (duplicate)
+- `/.claude/skills/retrospective/` (duplicate)
+
+### Updated
+- `.claude-plugin/marketplace.json` - moved from root, updated with current 4 plugins
+- `scripts/generate_marketplace.py` - output to `.claude-plugin/`
+- `scripts/validate_plugins.py` - removed non-standard required fields
+- `plugins/ci-cd/github-actions-mojo/.claude-plugin/plugin.json` - removed tags
+- `plugins/tooling/skills-registry-commands/.claude-plugin/plugin.json` - removed tags
+- `plugins/training/grpo-external-vllm/.claude-plugin/plugin.json` - removed tags
+- `plugins/training/spec-driven-experimentation/.claude-plugin/plugin.json` - removed tags
+- `plugins/tooling/skills-registry-commands/skills/advise/SKILL.md` - removed category, invokedBy
+- `plugins/tooling/skills-registry-commands/skills/retrospective/SKILL.md` - removed category, invokedBy
+- `plugins/tooling/skills-registry-commands/skills/documentation-patterns/SKILL.md` - removed category, source, date
+- `plugins/tooling/skills-registry-commands/skills/validation-workflow/SKILL.md` - removed category, source, date
+
+### Added
+- `plugins/tooling/skills-registry-commands/commands/advise.md` - slash command
+- `plugins/tooling/skills-registry-commands/commands/retrospective.md` - slash command
+
+## Commits Created
+
+1. `fee587b` - fix: update marketplace to official Claude Code plugin format
+2. `587be28` - fix: add trailing newline and update bundled script output path
+3. `6712128` - fix: remove non-standard required fields from validation
+4. `db4f54d` - fix: remove tags from plugin.json (not in official schema)
+5. `e55f911` - feat: add advise and retrospective as slash commands
+6. `c2e4c9c` - fix: remove non-standard frontmatter fields from SKILL.md files
+7. `af63c35` - fix: add target repository to /retrospective command
+
+## Key Documentation References
+
+- https://github.com/anthropics/claude-plugins-official
+- https://code.claude.com/docs/en/plugins
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/discover-plugins
+
+## Testing Results
+
+After all fixes:
+- Plugin validation script passes: 4/4 plugins valid
+- Marketplace location correct: `.claude-plugin/marketplace.json`
+- No schema errors on installation
+- Commands appear as `/skills-registry-commands:advise` and `/skills-registry-commands:retrospective`
+
+## Lessons for Future Plugins
+
+1. **Always check official repo first** before adding custom fields
+2. **Schema is strict** - any unrecognized field breaks validation
+3. **Location matters** - marketplace must be in `.claude-plugin/`
+4. **Commands vs skills** - understand the distinction
+5. **Tags only in marketplace** - not in individual plugin.json files
+6. **Frontmatter minimalism** - only official fields in SKILL.md

--- a/plugins/tooling/claude-plugin-format/skills/claude-plugin-format/SKILL.md
+++ b/plugins/tooling/claude-plugin-format/skills/claude-plugin-format/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: claude-plugin-format
+description: Official Claude Code plugin format requirements. Use when creating new plugins, debugging "plugin has invalid manifest" errors, or when skills/commands don't appear after installation.
+---
+
+# Claude Code Plugin Format
+
+Official format requirements for Claude Code plugins based on debugging a marketplace that wouldn't load.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2025-12-29 |
+| Objective | Fix ProjectMnemosyne marketplace to use official Claude Code plugin format |
+| Outcome | All plugins validated and working after schema compliance fixes |
+| Source | https://github.com/anthropics/claude-plugins-official |
+
+## When to Use
+
+- Creating a new Claude Code plugin from scratch
+- Getting "Unrecognized key(s) in object" validation errors
+- Skills not appearing after plugin installation
+- Commands not showing up in slash command list
+- Setting up a plugin marketplace
+- Converting custom plugins to official format
+
+## Verified Workflow
+
+### 1. Marketplace Location (CRITICAL)
+
+**Official requirement**: `.claude-plugin/marketplace.json` at repository root
+
+```bash
+# Correct location
+.claude-plugin/marketplace.json
+
+# Wrong locations (will not work)
+marketplace.json                    # Root level - NOT VALID
+.claude/marketplace.json            # Wrong directory
+plugins/marketplace.json            # Wrong directory
+```
+
+**Marketplace format**:
+```json
+{
+  "name": "ProjectMnemosyne",
+  "owner": {
+    "name": "HomericIntelligence",
+    "url": "https://github.com/HomericIntelligence"
+  },
+  "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "plugin-name",
+      "description": "...",
+      "version": "1.0.0",
+      "source": "./plugins/category/plugin-name",
+      "category": "tooling",
+      "tags": ["tag1", "tag2"]
+    }
+  ]
+}
+```
+
+### 2. Plugin Directory Structure
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json          # ONLY plugin.json goes here
+├── commands/                 # User-invocable slash commands
+│   └── command-name.md
+├── skills/                   # Background knowledge
+│   └── skill-name/
+│       └── SKILL.md
+├── agents/                   # Optional: custom agents
+├── hooks/                    # Optional: lifecycle hooks
+│   └── hooks.json
+└── references/               # Optional: supporting docs
+    └── notes.md
+```
+
+**CRITICAL**: Only `plugin.json` goes in `.claude-plugin/`. All other directories (`commands/`, `skills/`, etc.) go at plugin root.
+
+### 3. plugin.json Schema (STRICT)
+
+**Allowed fields ONLY**:
+```json
+{
+  "name": "plugin-name",
+  "version": "1.0.0",
+  "description": "What it does. Use when: (1) trigger 1, (2) trigger 2.",
+  "author": {
+    "name": "Author Name"
+  },
+  "skills": "./skills"
+}
+```
+
+**Fields that cause validation errors**:
+- `tags` - NOT allowed in plugin.json (only in marketplace.json)
+- `category` - NOT allowed (derived from directory structure)
+- `date` - NOT allowed
+- Any other custom fields
+
+### 4. SKILL.md Frontmatter Schema (STRICT)
+
+**Allowed fields ONLY**:
+```yaml
+---
+name: skill-name
+description: What it does. Use when <specific triggers>. Use after <specific scenarios>.
+---
+```
+
+Optional fields:
+- `version: 1.0.0`
+- `license: MIT`
+
+**Fields that cause validation errors**:
+- `category` - NOT in official schema
+- `invokedBy` - NOT in official schema
+- `source` - NOT in official schema
+- `date` - NOT in official schema
+- Any other custom fields
+
+### 5. Command vs Skill Distinction
+
+**Commands** (`commands/` directory):
+- User-invocable slash commands
+- Show up as `/plugin-name:command-name`
+- Frontmatter: `description`, `allowed-tools` (optional)
+
+**Skills** (`skills/` directory):
+- Background knowledge Claude uses automatically
+- NOT user-invocable
+- Activated based on `description` triggers
+- Frontmatter: `name`, `description`
+
+### 6. Validation Script Requirements
+
+Update `validate_plugins.py` to match official schema:
+
+```python
+# Required fields per official docs
+REQUIRED_PLUGIN_FIELDS = {"name", "version", "description"}
+
+# NOT required (contrary to custom implementations)
+# category - derived from directory structure
+# date - optional metadata
+# tags - only in marketplace.json, not plugin.json
+```
+
+## Failed Attempts
+
+| Attempt | Why it Failed | Lesson Learned |
+|---------|---------------|----------------|
+| Adding `tags` to plugin.json | "Unrecognized key(s) in object: 'tags'" error | Tags only go in marketplace.json index, not individual plugin.json files |
+| Root-level `marketplace.json` | Claude Code doesn't read it | Must be `.claude-plugin/marketplace.json` per official docs |
+| Extra frontmatter in SKILL.md (`category`, `invokedBy`, `source`, `date`) | Plugin validator rejected unknown fields | Only `name` and `description` allowed in SKILL.md frontmatter |
+| Putting skills in project `.claude/skills/` AND plugin `skills/` | Duplication and confusion | Use plugin `skills/` directory only |
+| Expecting `tags` field in validation | CI failed because official schema doesn't require it | Only validate `name`, `version`, `description` |
+| Using `/advise` as a skill instead of command | Skill didn't show up for users to invoke | Skills are auto-activated, commands are user-invocable |
+
+## Results & Parameters
+
+### Valid plugin.json (copy-paste ready)
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "Short description. Use when: (1) specific trigger.",
+  "author": {
+    "name": "Your Name"
+  },
+  "skills": "./skills"
+}
+```
+
+### Valid SKILL.md frontmatter (copy-paste ready)
+```yaml
+---
+name: my-skill
+description: What it does. Use when starting X, debugging Y, or implementing Z.
+---
+```
+
+### Valid command frontmatter (copy-paste ready)
+```yaml
+---
+description: What this command does
+allowed-tools: Bash(git:*), Read, Write
+---
+```
+
+### Marketplace generation script
+```python
+# Output to correct location
+output_file = ".claude-plugin/marketplace.json"
+
+# Don't require non-standard fields
+REQUIRED_PLUGIN_FIELDS = {"name", "version", "description"}
+```
+
+### Directory structure checklist
+- [ ] `.claude-plugin/marketplace.json` exists (NOT root marketplace.json)
+- [ ] plugin.json has no `tags` field
+- [ ] SKILL.md frontmatter has only `name` and `description`
+- [ ] Commands in `commands/` directory (if user-invocable)
+- [ ] Skills in `skills/` directory (if background knowledge)
+- [ ] No duplicate skills in `.claude/skills/`
+
+## Key Insights
+
+1. **Schema is strict**: Claude Code plugin validator rejects ANY unrecognized fields
+2. **Marketplace location matters**: Must be `.claude-plugin/marketplace.json`
+3. **Tags go in marketplace, not plugins**: Searchability is in the index, not individual plugins
+4. **Commands ≠ Skills**: Commands are slash commands, skills are auto-activated knowledge
+5. **Validation must match official schema**: Custom fields will break installation
+
+## References
+
+- Official plugins repo: https://github.com/anthropics/claude-plugins-official
+- Example plugin: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin
+- Plugin docs: https://code.claude.com/docs/en/plugins
+- Skills docs: https://code.claude.com/docs/en/skills
+- Marketplace docs: https://code.claude.com/docs/en/discover-plugins


### PR DESCRIPTION
Documents official Claude Code plugin format requirements learned from debugging ProjectMnemosyne marketplace.

Key learnings:
- Marketplace must be in .claude-plugin/marketplace.json
- plugin.json cannot have 'tags' field
- SKILL.md frontmatter only allows name, description
- Commands vs Skills distinction
- Validation script must match official schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)