### PR TITLE
fix: improve retrospective workflow with build directory and error handling

### DIFF
--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -10,6 +10,7 @@ Capture session learnings and create a new skill plugin in the ProjectMnemosyne 
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
 **Base branch**: `main`
+**Clone location**: `<ProjectRoot>/build/ProjectMnemosyne/`
 
 ## Instructions
 
@@ -26,11 +27,21 @@ When the user invokes this command:
    - Category (training, evaluation, optimization, debugging, architecture, tooling, ci-cd, testing)
    - Skill name (kebab-case)
 
-3. **Clone/checkout the marketplace repository**:
+3. **Setup repository** (IMPORTANT: Don't remove/reclone if exists):
    ```bash
-   gh repo clone HomericIntelligence/ProjectMnemosyne /tmp/ProjectMnemosyne
-   cd /tmp/ProjectMnemosyne
-   git checkout -b skill/<category>/<name>
+   # Create build directory if it doesn't exist
+   mkdir -p build
+
+   # Clone only if directory doesn't exist
+   if [ ! -d "build/ProjectMnemosyne" ]; then
+     gh repo clone HomericIntelligence/ProjectMnemosyne build/ProjectMnemosyne
+   fi
+
+   cd build/ProjectMnemosyne
+
+   # Fetch latest changes and create branch from origin/main
+   git fetch origin
+   git checkout -b skill/<category>/<name> origin/main
    ```
 
 4. **Generate plugin files** in `plugins/<category>/<name>/`:
@@ -38,28 +49,92 @@ When the user invokes this command:
    - `skills/<name>/SKILL.md` with findings
    - `references/notes.md` with raw details
 
-5. **Create PR**:
+5. **Commit and push**:
    ```bash
    git add plugins/<category>/<name>/
-   git commit -m "feat: add <name> skill"
-   git push -u origin skill/<category>/<name>
+   git commit -m "feat: add <name> skill
 
-   # Write PR body to a temp file
-   cat > /tmp/pr-body.md << 'EOF'
+Documents <brief description>.
+
+Key learnings:
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+   git push -u origin skill/<category>/<name>
+   ```
+
+6. **Create PR** (only if push succeeded):
+   ```bash
+   # Write PR body to build directory (not /tmp)
+   cat > ../pr-body-<name>.md << 'EOF'
    ## Summary
-   - <1-3 bullet points about what was learned>
+
+   Documents <brief description of what was learned>.
+
+   - <Key point 1>
+   - <Key point 2>
+   - <Key point 3>
 
    ## Key Findings
-   - What worked
-   - What failed (most valuable)
+
+   **What Worked**:
+   - <Successful approach 1>
+   - <Successful approach 2>
+
+   **What Failed**:
+   - <Failed attempt 1> → <Why it failed>
+   - <Failed attempt 2> → <Why it failed>
+
+   ## Test Plan
+
+   - [ ] Validate plugin with `python scripts/validate_plugins.py plugins/`
+   - [ ] Install plugin and verify skill appears
+   - [ ] Check skill activation with relevant triggers
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    EOF
 
    gh pr create --repo HomericIntelligence/ProjectMnemosyne --base main \
      --title "feat: add <name> skill" \
-     --body-file /tmp/pr-body.md
+     --body-file ../pr-body-<name>.md
    ```
+
+## Common Issues & Solutions
+
+### Issue: "No commits between main and skill/..."
+
+**Cause**: The branch was already merged or rebased incorrectly.
+
+**Solution**: Don't rebase. Create branch directly from `origin/main`:
+```bash
+git checkout -b skill/<category>/<name> origin/main
+```
+
+### Issue: Repository already exists
+
+**Cause**: Tried to remove and reclone unnecessarily.
+
+**Solution**: Never `rm -rf` the build directory. Just fetch and create new branch:
+```bash
+cd build/ProjectMnemosyne
+git fetch origin
+git checkout -b skill/<category>/<name> origin/main
+```
+
+### Issue: Uncommitted changes warning
+
+**Cause**: Previous retrospective left uncommitted files.
+
+**Solution**: Clean or stash before creating new branch:
+```bash
+git stash
+git checkout -b skill/<category>/<name> origin/main
+```
 
 ## Required SKILL.md Sections
 


### PR DESCRIPTION
## Summary

Updates the `/retrospective` command workflow based on learnings from testing it during the claude-plugin-format skill creation.

- Uses `build/ProjectMnemosyne/` for persistent cloning instead of `/tmp`
- Avoids unnecessary repository removal/recloning
- Documents common issues and solutions
- Uses `--body-file` for PR creation

## Key Improvements

**Better Repository Management**:
- Clones to `<ProjectRoot>/build/ProjectMnemosyne/` for persistence across sessions
- Checks if directory exists before cloning (no unnecessary reclones)
- Uses `git fetch origin` + branch from `origin/main` instead of risky rebases

**Common Issues Documented**:
- "No commits between main and skill/..." → caused by rebasing, solution: branch directly from origin/main
- Repository already exists → don't `rm -rf`, just fetch and create new branch
- Uncommitted changes → stash before creating new branch

**PR Creation Fix**:
- Uses `--body-file ../pr-body-<name>.md` in build directory
- Avoids command-line length limits with inline body

## Test Plan

- [x] Tested workflow during claude-plugin-format skill creation (PR #7)
- [ ] Validate that future `/retrospective` invocations use build directory correctly
- [ ] Verify no "repository already exists" errors on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
