### PR TITLE
feat(skill): add retrospective-hook-integration skill

### DIFF
--- a/plugins/tooling/retrospective-hook-integration/.claude-plugin/plugin.json
+++ b/plugins/tooling/retrospective-hook-integration/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "retrospective-hook-integration",
+  "version": "1.0.0",
+  "description": "Setup SessionEnd hooks for automatic retrospective prompts in Claude Code. TRIGGER: (1) When integrating ProjectMnemosyne marketplace with another repository, (2) When setting up /advise and /retrospective skills, (3) When configuring automatic session-end knowledge capture. Verified on Claude Code with ProjectOdyssey integration.",
+  "author": {
+    "name": "HomericIntelligence"
+  },
+  "date": "2025-12-29",
+  "category": "tooling",
+  "tags": ["claude-code", "hooks", "marketplace", "retrospective", "session-end", "knowledge-capture"],
+  "skills": "./skills",
+  "source_project": "ProjectOdyssey"
+}

--- a/plugins/tooling/retrospective-hook-integration/references/notes.md
+++ b/plugins/tooling/retrospective-hook-integration/references/notes.md
@@ -1,0 +1,131 @@
+# Session Notes: Retrospective Hook Integration
+
+## Context
+
+Session focused on analyzing the Hugging Face blog post about Claude Code skills training and setting up `/advise` and `/retrospective` commands in ProjectOdyssey by integrating with the ProjectMnemosyne marketplace.
+
+## Initial Discovery
+
+- Blog URL: https://huggingface.co/blog/sionic-ai/claude-code-skills-training
+- Target repository: HomericIntelligence/ProjectMnemosyne (private)
+- Integration target: ProjectOdyssey
+
+## Key Findings from Blog
+
+### Core Commands
+
+1. **`/advise`**: Search marketplace for relevant past experiments
+   - Returns: what worked, what failed, recommended parameters
+   - Triggered before starting new work
+
+2. **`/retrospective`**: Auto-save session learnings as a new skill
+   - Analyzes entire conversation
+   - Extracts successes, failures, parameters
+   - Creates PR automatically
+
+### Skill Structure
+
+```
+plugins/<category>/<name>/
+├── .claude-plugin/plugin.json
+├── skills/<name>/SKILL.md
+├── references/notes.md
+└── scripts/ (optional)
+```
+
+### Critical Success Factor
+
+The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
+
+## Implementation Steps Taken
+
+### 1. Explored ProjectMnemosyne Repository
+
+- Repository already had 5 skills (grpo-external-vllm, mojo-simd-errors, github-actions-mojo, layerwise-gradient-check, skill-marketplace-design)
+- `/advise` and `/retrospective` skills already implemented in `.claude/skills/`
+- CI/CD automation for marketplace.json generation
+- SessionEnd hook infrastructure already present
+
+### 2. Updated ProjectMnemosyne README
+
+**Changes**:
+- Fixed CLI syntax (`claude plugin` vs `/plugin`)
+- Added Option A (GitHub) and Option B (Local Directory)
+- Added prerequisites section
+- Changed to SSH URL for clone
+- Clarified commands work inside Claude Code sessions
+
+### 3. Configured ProjectOdyssey
+
+**Changes**:
+- Added SessionEnd hook to `.claude/settings.json`
+- Copied `retrospective-trigger.py` to `.claude/hooks/`
+- Used worktree workflow to avoid conflicts
+
+### 4. Created PRs
+
+- ProjectOdyssey PR #2963: SessionEnd hook integration
+- ProjectMnemosyne PR #3: README improvements
+
+## Raw Session Transcript Highlights
+
+### User Question Clarifications
+
+1. **Repository existence**: Clarified repo was private at ~/ProjectMnemosyne-marketplace
+2. **Command naming**: Confirmed `/retrospective` (not `/introspective`)
+3. **Setup method**: Chose marketplace registration over copying skills
+4. **README enhancements**: Installation focus, no troubleshooting section
+
+### Technical Decisions
+
+1. **Marketplace registration**: Both GitHub URL and local directory paths supported
+2. **Hook configuration**: 120s timeout, 10-message minimum transcript
+3. **Worktree workflow**: Avoid conflicts with other Claude instances
+4. **Both syntaxes**: Terminal (`claude plugin`) and session (`/plugin`)
+
+## Configuration Details
+
+### .claude/settings.json
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [...],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### retrospective-trigger.py
+
+- Reads JSON input from stdin
+- Triggers only on `"exit"` or `"clear"` reasons
+- Checks transcript has >10 messages
+- Outputs systemMessage prompt
+
+## Lessons Learned
+
+1. **Private repos need clear documentation**: Always note access requirements
+2. **Dual syntax matters**: Terminal vs in-session commands are different
+3. **Worktrees prevent conflicts**: Critical for multi-instance Claude Code usage
+4. **Failed Attempts are gold**: Most valuable section in any skill
+5. **Blog provided excellent structure**: 7-section format works well
+6. **Marketplace registration is clean**: Better than copying files manually
+7. **Hook system is powerful**: Auto-prompts on session end without friction
+
+## Related Resources
+
+- Blog: https://huggingface.co/blog/sionic-ai/claude-code-skills-training
+- Claude Code docs: https://code.claude.com/docs/en/discover-plugins
+- Skills docs: https://code.claude.com/docs/en/skills
+- Anthropic skills repo: https://github.com/anthropics/skills

--- a/plugins/tooling/retrospective-hook-integration/skills/retrospective-hook-integration/SKILL.md
+++ b/plugins/tooling/retrospective-hook-integration/skills/retrospective-hook-integration/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: retrospective-hook-integration
+description: "Setup SessionEnd hooks for automatic retrospective prompts in Claude Code. Use when integrating ProjectMnemosyne marketplace."
+category: tooling
+source: ProjectOdyssey
+date: 2025-12-29
+---
+
+# Retrospective Hook Integration
+
+Setup SessionEnd hooks to automatically prompt for `/retrospective` when ending Claude Code sessions.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2025-12-29 |
+| **Objective** | Integrate ProjectMnemosyne marketplace with ProjectOdyssey for automatic knowledge capture |
+| **Outcome** | Successfully configured SessionEnd hooks and marketplace registration with worktree workflow |
+| **Source** | ProjectOdyssey integration |
+
+## When to Use
+
+- Integrating ProjectMnemosyne skills marketplace with another repository
+- Setting up `/advise` and `/retrospective` commands in a new project
+- Configuring automatic session-end knowledge capture prompts
+- Implementing worktree-based workflow to avoid conflicts with other Claude instances
+
+## Verified Workflow
+
+### 1. Register the Marketplace
+
+**Option A: From GitHub URL (Recommended)**
+
+Inside Claude Code session:
+
+```text
+/plugin marketplace add https://github.com/HomericIntelligence/ProjectMnemosyne
+```
+
+Or from terminal:
+
+```bash
+claude plugin marketplace add https://github.com/HomericIntelligence/ProjectMnemosyne
+```
+
+**Option B: From Local Directory**
+
+```bash
+git clone git@github.com:HomericIntelligence/ProjectMnemosyne.git
+```
+
+Then:
+
+```text
+/plugin marketplace add /path/to/ProjectMnemosyne
+```
+
+### 2. Configure SessionEnd Hook
+
+Create worktree to avoid conflicts:
+
+```bash
+cd /path/to/project
+git worktree add worktrees/retrospective-hook main -b retrospective-hook
+cd worktrees/retrospective-hook
+```
+
+Update `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-exec.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. Copy Hook Script
+
+```bash
+cp /path/to/ProjectMnemosyne/.claude/hooks/retrospective-trigger.py .claude/hooks/
+```
+
+### 4. Commit and Create PR
+
+```bash
+git add .claude/settings.json .claude/hooks/retrospective-trigger.py
+git commit -m "feat(hooks): add SessionEnd hook for retrospective prompts"
+git push -u origin retrospective-hook
+gh pr create --title "feat(hooks): add SessionEnd hook" --body "..."
+gh pr merge --auto --rebase
+```
+
+### 5. Install Skills
+
+After marketplace registration:
+
+```text
+/plugin install grpo-external-vllm@ProjectMnemosyne
+/plugin install mojo-simd-errors@ProjectMnemosyne
+/plugin install github-actions-mojo@ProjectMnemosyne
+/plugin install layerwise-gradient-check@ProjectMnemosyne
+/plugin install skill-marketplace-design@ProjectMnemosyne
+```
+
+## Failed Attempts
+
+| Attempt | Why it Failed | Lesson Learned |
+|---------|---------------|----------------|
+| Used `claude plugin` in README as in-session command | Wrong syntax - `claude plugin` is terminal CLI, `/plugin` is in-session | Document both syntaxes: terminal (`claude plugin`) vs session (`/plugin`) |
+| Tried to access GitHub URL without noting private repo | Repository is private, requires HomericIntelligence org access | Always note access requirements in prerequisites |
+| Made changes in main working directory | Conflicts with other Claude instances working on same repo | Always use worktrees for isolated changes |
+| Confused `/retrospective` with `/introspective` | Blog used `/retrospective`, user initially mentioned `/introspective` | Verify exact command names from source documentation |
+| Initial GitHub URL returned 404 | Private repository, not public access | Use SSH URLs for private repos, clarify access requirements |
+
+## Results & Parameters
+
+### Hook Configuration
+
+```json
+{
+  "SessionEnd": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+          "timeout": 120
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Hook Script Parameters
+
+- **Minimum transcript length**: 10 messages
+- **Trigger reasons**: `"exit"` or `"clear"` only
+- **Timeout**: 120 seconds
+- **Output**: JSON with `systemMessage` field
+
+### Marketplace Registration
+
+```bash
+# GitHub URL (private repo)
+/plugin marketplace add https://github.com/HomericIntelligence/ProjectMnemosyne
+
+# Local directory
+/plugin marketplace add /home/user/ProjectMnemosyne-marketplace
+```
+
+### Worktree Pattern
+
+```bash
+# Create worktree
+git worktree add worktrees/<branch-name> main -b <branch-name>
+
+# Work in worktree
+cd worktrees/<branch-name>
+
+# Cleanup after merge
+git worktree remove worktrees/<branch-name>
+```
+
+## References
+
+- ProjectMnemosyne: https://github.com/HomericIntelligence/ProjectMnemosyne
+- Blog post: https://huggingface.co/blog/sionic-ai/claude-code-skills-training
+- Claude Code plugin docs: https://code.claude.com/docs/en/discover-plugins
+- Claude Code skills docs: https://code.claude.com/docs/en/skills


### PR DESCRIPTION
## Summary

Add new skill documenting SessionEnd hook setup for automatic retrospective prompts when integrating ProjectMnemosyne marketplace with other repositories.

## Skill Details

- **Category**: tooling
- **Name**: retrospective-hook-integration
- **Source**: ProjectOdyssey integration session

## What's Covered

- Marketplace registration (GitHub URL and local directory options)
- SessionEnd hook configuration in `.claude/settings.json`
- Hook script (`retrospective-trigger.py`) setup
- Worktree workflow to avoid conflicts with other Claude instances
- Installation of skills from marketplace

## Failed Attempts Section

Includes 5 documented failures:
1. Wrong CLI syntax confusion (`claude plugin` vs `/plugin`)
2. Private repo access not documented
3. Working in main directory causing conflicts
4. Command name confusion (`/retrospective` vs `/introspective`)
5. GitHub URL 404 errors

## Files

- `.claude-plugin/plugin.json` - Plugin metadata with trigger conditions
- `skills/retrospective-hook-integration/SKILL.md` - Complete workflow documentation
- `references/notes.md` - Raw session details and learnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)