### PR TITLE
docs(skills): add fix-docker-platform skill

### DIFF
--- a/plugins/ci-cd/fix-docker-platform/.claude-plugin/plugin.json
+++ b/plugins/ci-cd/fix-docker-platform/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "fix-docker-platform",
+  "version": "1.0.0",
+  "description": "Fix Docker build failures caused by platform mismatches. Use when: (1) Docker builds fail with 'unsupported platform' errors, (2) pixi install fails in Docker with linux-aarch64 errors, (3) Multi-arch builds fail when pixi.toml only supports one platform.",
+  "author": {
+    "name": "ML Odyssey Team"
+  },
+  "category": "ci-cd",
+  "date": "2025-12-28",
+  "tags": ["docker", "ghcr", "arm64", "pixi", "platform", "ci"],
+  "skills": "./skills"
+}

--- a/plugins/ci-cd/fix-docker-platform/references/notes.md
+++ b/plugins/ci-cd/fix-docker-platform/references/notes.md
@@ -1,0 +1,91 @@
+# Fix Docker Platform - Session Notes
+
+## Context
+
+Date: 2025-12-28
+Project: ProjectOdyssey
+Session Goal: Fix CI failures blocking PRs
+
+## Problem Discovery
+
+Docker builds were failing on every PR with ARM64 platform error:
+
+```
+#31 0.456 Error: unsupported-platform
+#31 0.458
+#31 0.465   × The workspace does not support 'linux-aarch64'.
+#31 0.465   │ Add it with 'pixi workspace platform add linux-aarch64'.
+#31 0.465   help: supported platforms are linux-64
+#31 0.466
+#31 ERROR: process "/bin/sh -c pixi install --frozen" did not complete successfully: exit code: 1
+```
+
+## Root Cause Analysis
+
+1. Docker workflow configured for multi-arch: `platforms: linux/amd64,linux/arm64`
+2. Dockerfile.ci line 60: `RUN pixi install --frozen`
+3. pixi.toml only has: `platforms = ["linux-64"]`
+4. When Docker builds ARM64 image, pixi fails because linux-aarch64 not in lock file
+
+## Solution Applied
+
+Changed platforms in two workflow files:
+
+### docker.yml (line 86)
+
+```yaml
+# Before
+platforms: linux/amd64,linux/arm64
+
+# After
+platforms: linux/amd64
+```
+
+### release.yml (line 454)
+
+```yaml
+# Before
+platforms: linux/amd64,linux/arm64
+
+# After
+platforms: linux/amd64
+```
+
+## PR Details
+
+- PR #2978: fix(ci): remove ARM64 Docker builds
+- Branch: remove-arm64-builds
+- Auto-merge enabled
+- Status: Merged
+
+## Additional Notes
+
+- First CI run had flaky test failure in `test_slicing.mojo` (execution crashed)
+- Re-ran with `gh run rerun <id> --failed` and it passed
+- The `build-and-push` job was NOT a required check, but still blocked perception of CI health
+- Related issue #995 tracks proper ARM64 support for the future
+
+## Commands Used
+
+```bash
+# Find ARM64 references
+grep -rn "arm64\|aarch64" .github/workflows/
+
+# Create fix branch
+git checkout -b remove-arm64-builds origin/main
+
+# Edit files
+# Changed platforms: linux/amd64,linux/arm64 → platforms: linux/amd64
+
+# Commit and push
+git add .github/workflows/docker.yml .github/workflows/release.yml
+git commit -m "fix(ci): remove ARM64 Docker builds"
+git push -u origin remove-arm64-builds
+
+# Create PR with auto-merge
+gh pr create --title "fix(ci): remove ARM64 Docker builds" --body "..."
+gh pr merge 2978 --auto --rebase
+
+# Re-run failed tests
+gh run rerun 20560292060 --failed
+```

--- a/plugins/ci-cd/fix-docker-platform/skills/fix-docker-platform/SKILL.md
+++ b/plugins/ci-cd/fix-docker-platform/skills/fix-docker-platform/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: fix-docker-platform
+description: Fix Docker build failures caused by platform mismatches between workflow config and pixi.toml
+category: ci-cd
+created: 2025-12-28
+tags: [docker, ghcr, arm64, pixi, platform, ci]
+---
+
+# Fix Docker Platform Mismatch
+
+| Field | Value |
+|-------|-------|
+| Date | 2025-12-28 |
+| Objective | Fix Docker build failures caused by ARM64 platform not supported by pixi.toml |
+| Outcome | Successfully removed ARM64 builds, all Docker CI jobs now pass |
+
+## When to Use
+
+Use this skill when:
+
+- Docker builds fail with "unsupported platform" errors
+- `pixi install --frozen` fails in Docker with platform mismatch
+- Error message contains: "The workspace does not support 'linux-aarch64'"
+- Multi-arch builds (`linux/amd64,linux/arm64`) fail but single-arch works
+- Building Docker images that use pixi for dependency management
+
+## Verified Workflow
+
+### 1. Identify Platform Support in pixi.toml
+
+```bash
+grep -A5 "platforms" pixi.toml
+```
+
+Expected output for x86-only support:
+
+```toml
+platforms = ["linux-64"]
+```
+
+If only `linux-64` is listed, ARM64 (`linux-aarch64`) builds will fail.
+
+### 2. Find ARM64 References in Workflows
+
+```bash
+grep -rn "arm64\|aarch64\|linux/arm" .github/workflows/
+```
+
+Common locations:
+
+- `.github/workflows/docker.yml`
+- `.github/workflows/release.yml`
+
+### 3. Remove Unsupported Platforms
+
+Edit the `platforms` field in `docker/build-push-action`:
+
+```yaml
+# Before (fails if pixi doesn't support ARM64)
+- name: Build and push
+  uses: docker/build-push-action@v6
+  with:
+    platforms: linux/amd64,linux/arm64
+
+# After (works with linux-64 only pixi.toml)
+- name: Build and push
+  uses: docker/build-push-action@v6
+  with:
+    platforms: linux/amd64
+```
+
+### 4. Verify and Create PR
+
+```bash
+# Commit changes
+git add .github/workflows/docker.yml .github/workflows/release.yml
+git commit -m "fix(ci): remove ARM64 Docker builds"
+git push -u origin <branch>
+
+# Create PR with auto-merge
+gh pr create --title "fix(ci): remove ARM64 Docker builds" \
+  --body "Remove linux/arm64 platform - pixi.toml only supports linux-64"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Happened | Why It Failed | Lesson Learned |
+|---------|---------------|---------------|----------------|
+| Build ARM64 without pixi support | Docker workflow tried `linux/arm64` | Dockerfile runs `pixi install --frozen` which validates platform | Check pixi.toml platforms before enabling multi-arch builds |
+| Ignore Docker failures | Left ARM64 in workflow, Docker failed on every PR | `build-and-push` wasn't a required check but blocked auto-merge | Non-required failing checks still cause friction |
+| Fix via pixi platform add | Considered adding ARM64 to pixi.toml | Would require regenerating lock file and testing | Removal is simpler when ARM64 not actually needed |
+
+## Results & Parameters
+
+### Files Modified
+
+| File | Line | Change |
+|------|------|--------|
+| `.github/workflows/docker.yml` | 86 | `linux/amd64,linux/arm64` → `linux/amd64` |
+| `.github/workflows/release.yml` | 454 | `linux/amd64,linux/arm64` → `linux/amd64` |
+
+### Error Message Pattern
+
+```text
+× The workspace does not support 'linux-aarch64'.
+│ Add it with 'pixi workspace platform add linux-aarch64'.
+help: supported platforms are linux-64
+```
+
+### Commands Reference
+
+```bash
+# Find platform config
+grep -rn "platforms:" .github/workflows/
+
+# Check pixi support
+grep "platforms" pixi.toml
+
+# Re-run failed CI jobs
+gh run rerun <run-id> --failed
+
+# Check CI status
+gh pr checks <pr-number>
+```
+
+## Related
+
+- PR #2978 in ProjectOdyssey - Implementation of this fix
+- Issue #995 - Feature request to add ARM64 support properly


### PR DESCRIPTION
## Summary

Adds a new skill capturing learnings from fixing Docker build failures in ProjectOdyssey.

## Problem Addressed

Docker builds were failing on every PR with:
```
× The workspace does not support 'linux-aarch64'.
```

This happened because workflows configured `platforms: linux/amd64,linux/arm64` but pixi.toml only supported `linux-64`.

## Skill Contents

- **When to Use**: Docker builds fail with platform mismatch errors
- **Verified Workflow**: Steps to identify and remove unsupported platforms
- **Failed Attempts**: Documents why building ARM64 without pixi support fails
- **Results**: Copy-paste ready workflow changes

## Files Added

- `plugins/ci-cd/fix-docker-platform/.claude-plugin/plugin.json`
- `plugins/ci-cd/fix-docker-platform/skills/fix-docker-platform/SKILL.md`
- `plugins/ci-cd/fix-docker-platform/references/notes.md`

## Related

- ProjectOdyssey PR #2978 - Implementation of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)