### PR TITLE
fix(retrospective): use UUID build dirs and switch to UserPromptSubmit hook

### DIFF
--- a/.claude/hooks/retrospective-trigger.py
+++ b/.claude/hooks/retrospective-trigger.py
@@ -1,62 +1,57 @@
 #!/usr/bin/env python3
 """
-Hook script triggered on SessionEnd to prompt for retrospective.
+Hook triggered on UserPromptSubmit when user types session-ending keywords.
+Adds context reminding about /retrospective - does not block.
 
 Receives JSON input with:
+- prompt: The user's prompt text
 - session_id: Session identifier
-- transcript_path: Path to session transcript (.jsonl)
-- reason: "exit" | "clear" | "logout" | "prompt_input_exit" | "other"
 - cwd: Current working directory
 
 Outputs JSON to stdout for Claude to process.
+
+Installation:
+1. Copy this file to your project's .claude/hooks/ directory
+2. Add the hook config to .claude/settings.json (see settings.json.example)
 """
 
 import json
 import sys
-from pathlib import Path
+import re
 
 
 def main():
     """Main entry point for the hook."""
     try:
-        # Read hook input from stdin
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError:
-        # Invalid input, exit silently
         sys.exit(0)
 
-    reason = input_data.get("reason", "other")
-    transcript_path = input_data.get("transcript_path", "")
+    prompt = input_data.get("prompt", "").lower()
 
-    # Only trigger on explicit session end (not other reasons)
-    if reason not in ("exit", "clear"):
-        sys.exit(0)
+    # Check for session-ending keywords
+    ending_patterns = [
+        r"\b(exit|quit|bye|goodbye)\b",
+        r"^/clear\b",
+        r"\b(done|finished|wrapping up)\b",
+        r"\b(end.*session|session.*end)\b",
+    ]
 
-    # Check if transcript has meaningful content (> 10 messages)
-    try:
-        transcript = Path(transcript_path)
-        if transcript.exists():
-            line_count = sum(1 for _ in transcript.open())
-            if line_count < 10:
-                # Session too short for retrospective
-                sys.exit(0)
-        else:
-            # No transcript file
+    for pattern in ending_patterns:
+        if re.search(pattern, prompt):
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": (
+                        "[Retrospective Reminder] Before ending this session, "
+                        "consider running /retrospective to capture any learnings."
+                    ),
+                }
+            }
+            print(json.dumps(output))
             sys.exit(0)
-    except Exception:
-        # Error reading transcript, exit silently
-        sys.exit(0)
 
-    # Output message prompting retrospective
-    output = {
-        "systemMessage": (
-            "Session ending. Consider running /retrospective to capture learnings "
-            "from this session. Would you like to save your learnings to the "
-            "skills marketplace before ending?"
-        )
-    }
-
-    print(json.dumps(output))
+    # No match, exit silently
     sys.exit(0)
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,13 @@
 {
   "hooks": {
-    "SessionEnd": [
+    "UserPromptSubmit": [
       {
+        "matcher": "(?i)(exit|quit|clear|done|finished|bye|goodbye|session)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
-            "timeout": 120
+            "timeout": 5
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Save learnings after a session (auto-creates PR).
 6. Commit and push
 7. Create PR with summary
 
-**Auto-trigger**: SessionEnd hook prompts retrospective on `/exit` and `/clear`.
+**Auto-trigger**: UserPromptSubmit hook reminds about retrospective when you type session-ending keywords.
 
 ## Plugin Standards
 
@@ -116,9 +116,14 @@ plugins/<category>/<name>/
 
 The project uses Claude Code hooks for automatic retrospective prompts.
 
-**SessionEnd Hook**: Triggers on `/exit` and `/clear` to prompt knowledge capture.
+**Important**: SessionEnd hooks CANNOT display messages to users (Claude Code limitation).
+This project uses UserPromptSubmit hooks instead.
 
-See `.claude/settings.json` for configuration.
+**UserPromptSubmit Hook**: Triggers when user types session-ending keywords (exit, quit,
+clear, done, finished, etc.) to remind about `/retrospective`.
+
+See `.claude/settings.json` for configuration and
+`plugins/tooling/skills-registry-commands/hooks/settings.json.example` for reference.
 
 ## Contributing a Skill
 

--- a/plugins/tooling/skills-registry-commands/hooks/settings.json.example
+++ b/plugins/tooling/skills-registry-commands/hooks/settings.json.example
@@ -1,12 +1,13 @@
 {
   "hooks": {
-    "SessionEnd": [
+    "UserPromptSubmit": [
       {
+        "matcher": "(?i)(exit|quit|clear|done|finished|bye|goodbye|session)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
-            "timeout": 120
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Add UUID-based build directories to prevent conflicts between parallel Claude agents
- Replace broken SessionEnd hook with working UserPromptSubmit hook
- Document Claude Code hook limitation in CLAUDE.md

## Key Changes

**UUID Build Directories**:
- Changed from static `build/ProjectMnemosyne/` to `build/<UUID>/ProjectMnemosyne/`
- Each retrospective session gets isolated clone via `uuidgen`
- Updated Common Issues with UUID-relevant troubleshooting

**Hook Fix**:
- SessionEnd hooks CANNOT display messages to users (Claude Code limitation)
- Switched to UserPromptSubmit which triggers on keywords: exit, quit, done, finished, clear, etc.
- Uses `additionalContext` output format which actually works

## Test plan

- [ ] Run `/retrospective` and verify UUID-based build directory is created
- [ ] Type "I'm done" and verify retrospective reminder appears
- [ ] Type "exit" and verify retrospective reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)