### PR TITLE
feat(skill): add batch-pr-ci-fixer skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "batch-pr-ci-fixer",
+  "version": "1.0.0",
+  "description": "Batch create PRs from orphaned branches and systematically fix CI failures",
+  "category": "ci-cd",
+  "created": "2025-12-31",
+  "repository": "mvillmow/ProjectOdyssey",
+  "tags": ["pr-management", "ci-fix", "github", "mojo", "pre-commit"],
+  "triggers": [
+    "multiple branches need PRs",
+    "batch CI failures",
+    "orphaned branches with completed work"
+  ],
+  "tools_used": [
+    "gh pr create",
+    "gh pr checks",
+    "gh run view --log-failed",
+    "pixi run mojo format",
+    "pixi run ruff check --fix"
+  ]
+}

--- a/references/batch-pr-ci-fixer-notes.md
+++ b/references/batch-pr-ci-fixer-notes.md
@@ -1,0 +1,119 @@
+# Raw Notes: Batch PR CI Fixer Session
+
+## Session Context
+- Date: 2025-12-31
+- Repository: mvillmow/ProjectOdyssey
+- Duration: ~30 minutes
+
+## Branches Analyzed
+
+```
+origin/3008--testing--fp4-mxfp4-test-cover
+origin/3009--testing--float16-precision-is
+origin/3010--testing--placeholder-test-fix
+origin/3011--cleanup--unused-variable-decl
+origin/3012--external--bfloat16-workaround (duplicate of #3017)
+origin/3013--feature--extensor-operations-
+origin/3014--feature--autograd-enhancement
+origin/3015--feature--simd-mixed-precision
+```
+
+## CI Failure Log Excerpts
+
+### PR #3022 - Float16 Precision
+```
+pre-commit  Run pre-commit hooks  Mojo Format..............................................................Failed
+- hook id: mojo-format
+- files were modified by this hook
+
+reformatted shared/core/matrix.mojo
+reformatted shared/core/conv.mojo
+```
+
+### PR #3023 - Placeholder Tests
+```
+Check for deprecated List[Type](args) syntax.............................Failed
+tests/shared/conftest.mojo:80:            assert_shape(t, List[Int](3, 3))
+tests/shared/conftest.mojo:102:            assert_shape(t, List[Int](5, 10))
+
+Ruff Check Python........................................................Failed
+F841 Local variable `path` is assigned to but never used
+  --> tests/scripts/test_worktree_manager.py:75:9
+```
+
+### PR #3027 - Autograd Enhancement
+```
+Mojo Format..............................................................Failed
+reformatted tests/shared/core/test_composed_op.mojo
+reformatted shared/core/traits.mojo
+reformatted tests/shared/autograd/test_no_grad_context.mojo
+
+Validate Test Coverage...................................................Failed
+❌ Found 1 uncovered test file(s):
+   • tests/shared/core/test_composed_op.mojo
+```
+
+## Git Commands Used
+
+```bash
+# List branches
+git fetch --all
+git branch -r --format='%(refname:short)'
+
+# Compare branch to main
+git log origin/main..origin/<branch> --oneline
+git diff origin/main..origin/<branch> --stat
+
+# Create PR
+gh pr create --head "<branch>" --title "<title>" --body "<body>"
+
+# Enable auto-merge
+gh pr merge <pr> --auto --rebase
+
+# Check CI status
+gh pr checks <pr>
+
+# Get failure logs
+gh run view <run-id> --log-failed
+
+# Fix formatting
+pixi run mojo format <files>
+pixi run ruff check --fix <files>
+
+# Close duplicate
+gh pr close <pr> --comment "Closing as duplicate of #<other>"
+```
+
+## Files Modified During Fixes
+
+### PR #3022
+- shared/core/conv.mojo (mojo format)
+- shared/core/matrix.mojo (mojo format)
+
+### PR #3023
+- tests/shared/conftest.mojo (List syntax)
+- tests/shared/integration/test_packaging.mojo (mojo format)
+- tests/scripts/test_dependency_resolver.py (unused imports)
+- tests/scripts/test_worktree_manager.py (unused variable)
+
+### PR #3026
+- shared/core/shape.mojo (mojo format)
+
+### PR #3027
+- shared/core/traits.mojo (mojo format)
+- tests/shared/core/test_composed_op.mojo (mojo format)
+- tests/shared/autograd/test_no_grad_context.mojo (mojo format)
+- .github/workflows/comprehensive-tests.yml (add test to coverage)
+
+## Workflow Pattern
+
+1. `gh pr list` → identify missing PRs
+2. `git log origin/main..<branch>` → verify work is done
+3. `gh pr create` → create PR with proper linking
+4. `gh pr merge --auto --rebase` → enable auto-merge
+5. `gh pr checks` → monitor CI
+6. `gh run view --log-failed` → diagnose failures
+7. `git checkout <branch>` → switch to fix
+8. `pixi run mojo format` / `ruff check --fix` → apply fixes
+9. `git commit && git push` → push fixes
+10. Repeat steps 5-9 until CI passes

--- a/skills/batch-pr-ci-fixer/SKILL.md
+++ b/skills/batch-pr-ci-fixer/SKILL.md
@@ -1,0 +1,159 @@
+# Batch PR Creation and CI Fixer
+
+| Field | Value |
+|-------|-------|
+| Date | 2025-12-31 |
+| Objective | Create PRs for orphaned branches and fix CI failures across multiple PRs |
+| Outcome | Successfully created 8 PRs and fixed CI failures in 4 of them |
+| Repository | mvillmow/ProjectOdyssey |
+
+## When to Use
+
+- Multiple branches exist without corresponding PRs
+- Several PRs are failing CI with similar issues
+- Need to batch process branches after a development sprint
+- Orphaned feature branches need cleanup
+
+## Verified Workflow
+
+### Phase 1: Identify Orphaned Branches
+
+```bash
+# List all remote branches
+git fetch --all
+git branch -r --format='%(refname:short)' | grep -v 'origin/HEAD'
+
+# Check existing PRs to avoid duplicates
+gh pr list --state all --json number,title,headRefName,state
+
+# Compare commits between branch and main
+git log origin/main..origin/<branch> --oneline
+```
+
+### Phase 2: Batch Create PRs
+
+```bash
+# For each branch with completed work:
+gh pr create --head "<branch-name>" \
+  --title "<type>(scope): description" \
+  --body "$(cat <<'EOF'
+## Summary
+- Key change 1
+- Key change 2
+
+## Test Plan
+- [x] Tests pass
+- [x] Pre-commit passes
+
+Closes #<issue-number>
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# Enable auto-merge immediately
+gh pr merge <pr-number> --auto --rebase
+```
+
+### Phase 3: Diagnose CI Failures
+
+```bash
+# Check CI status
+gh pr checks <pr-number>
+
+# Get failed run logs
+gh run view <run-id> --log-failed | head -100
+
+# Common failure patterns to look for:
+# - "mojo-format" → needs `pixi run mojo format`
+# - "List[Type](args)" → deprecated syntax
+# - "validate-test-coverage" → new test not in CI workflow
+# - "ruff-check-python" → unused imports/variables
+```
+
+### Phase 4: Fix Each PR
+
+```bash
+# Checkout the branch
+git checkout <branch-name>
+git pull origin <branch-name>
+
+# Fix mojo formatting
+pixi run mojo format <file1.mojo> <file2.mojo>
+
+# Fix Python linting
+pixi run ruff check --fix <file.py>
+
+# Commit and push
+git add <files>
+git commit -m "fix: resolve pre-commit issues"
+git push
+```
+
+## Failed Attempts
+
+### 1. Pushing Without Running Pre-commit Locally
+**What happened**: All 8 PRs were created but 4 failed CI due to formatting issues.
+**Why it failed**: `mojo format` wasn't run on new/modified files before pushing.
+**Lesson**: Always run `just pre-commit-all` before pushing.
+
+### 2. Missing Test Coverage Validation
+**What happened**: PR #3027 failed because `test_composed_op.mojo` wasn't in CI workflow.
+**Why it failed**: New test files must be explicitly added to `.github/workflows/comprehensive-tests.yml`.
+**Fix**: Add new test files to the appropriate test group pattern.
+
+### 3. Deprecated List Syntax in Docstrings
+**What happened**: `List[Int](3, 3)` in docstring examples triggered CI failure.
+**Why it failed**: Pre-commit hook checks all `.mojo` files including code in docstrings.
+**Fix**: Use list literals `[3, 3]` even in documentation examples.
+
+## Results & Parameters
+
+### PRs Created
+
+| PR | Branch | Issue | Status |
+|----|--------|-------|--------|
+| #3021 | 3008--testing--fp4-mxfp4-test-cover | #3008 | Passed |
+| #3022 | 3009--testing--float16-precision-is | #3009 | Fixed |
+| #3023 | 3010--testing--placeholder-test-fix | #3010 | Fixed |
+| #3024 | 3011--cleanup--unused-variable-decl | #3011 | Passed |
+| #3026 | 3013--feature--extensor-operations- | #3013 | Fixed |
+| #3027 | 3014--feature--autograd-enhancement | #3014 | Fixed |
+| #3028 | 3015--feature--simd-mixed-precision | #3015 | Passed |
+
+### Common CI Fixes Applied
+
+| Issue | Files Affected | Fix |
+|-------|----------------|-----|
+| Mojo format | conv.mojo, matrix.mojo, shape.mojo, traits.mojo | `pixi run mojo format <file>` |
+| Deprecated List syntax | conftest.mojo | `List[Int](3, 3)` → `[3, 3]` |
+| Unused Python imports | test_dependency_resolver.py | `pixi run ruff check --fix` |
+| Missing test coverage | comprehensive-tests.yml | Add test file to pattern |
+
+### Key Commands Reference
+
+```bash
+# Batch check all PR statuses
+for pr in 3021 3022 3023 3024 3026 3027 3028; do
+  echo "PR #$pr:"
+  gh pr checks $pr 2>&1 | grep -E "fail|pass" | head -5
+done
+
+# Get failed logs for a specific PR
+gh pr checks <pr> | grep fail | awk '{print $4}' | xargs -I{} gh run view {} --log-failed
+
+# Fix and push in one command
+git checkout <branch> && \
+  pixi run mojo format $(git diff --name-only HEAD~1 | grep '\.mojo$') && \
+  git add -A && \
+  git commit -m "style: apply mojo format" && \
+  git push
+```
+
+## Checklist for Future Use
+
+- [ ] Run `just pre-commit-all` before creating PRs
+- [ ] Check if new test files need CI workflow updates
+- [ ] Use list literals `[1, 2, 3]` not `List[Int](1, 2, 3)`
+- [ ] Enable auto-merge immediately after PR creation
+- [ ] Close duplicate PRs with proper comments


### PR DESCRIPTION
## Summary

Adds a new skill capturing the workflow for batch PR creation and CI fixing.

## Skill Overview

| Field | Value |
|-------|-------|
| Name | batch-pr-ci-fixer |
| Category | ci-cd |
| Repository | mvillmow/ProjectOdyssey |

## What This Skill Covers

- **Phase 1**: Identifying orphaned branches that need PRs
- **Phase 2**: Batch creating PRs with proper issue linking
- **Phase 3**: Diagnosing CI failures using `gh run view --log-failed`
- **Phase 4**: Fixing common issues (mojo format, deprecated syntax, test coverage)

## Key Learnings Captured

1. Always run `just pre-commit-all` before pushing
2. New test files must be explicitly added to CI workflow
3. Use list literals `[1, 2, 3]` even in docstring examples
4. Enable auto-merge immediately after PR creation

## Files Added

- `.claude-plugin/plugin.json` - Plugin metadata
- `skills/batch-pr-ci-fixer/SKILL.md` - Main skill documentation
- `references/batch-pr-ci-fixer-notes.md` - Raw session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)