### PR TITLE
feat(skills-registry-commands): use gh clone with shared PID-based directory

### DIFF
--- a/plugins/tooling/skills-registry-commands/commands/advise.md
+++ b/plugins/tooling/skills-registry-commands/commands/advise.md
@@ -9,7 +9,9 @@ Search the skills registry for relevant prior learnings before starting work.
 ## Target Repository
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
-**Clone location**: `<ProjectRoot>/build/advise/`
+**Clone location**: `<ProjectRoot>/build/<PID>/`
+
+Commands in the same session share the clone via process ID.
 
 ## Instructions
 
@@ -17,7 +19,7 @@ When the user invokes this command:
 
 1. **Setup repository** (if not already cloned):
    ```bash
-   BUILD_DIR="build/advise"
+   BUILD_DIR="build/$$"
 
    # Clone repository if not present
    if [ ! -d "$BUILD_DIR" ]; then

--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -10,9 +10,9 @@ Capture session learnings and create a new skill plugin in the ProjectMnemosyne 
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
 **Base branch**: `main`
-**Clone location**: `<ProjectRoot>/build/<UUID>/`
+**Clone location**: `<ProjectRoot>/build/<PID>/`
 
-Each retrospective generates a unique UUID to prevent conflicts with parallel Claude agents.
+Commands in the same session share the clone via process ID.
 
 ## Instructions
 
@@ -31,17 +31,18 @@ When the user invokes this command:
 
 3. **Setup repository**:
    ```bash
-   # Generate unique build directory to prevent conflicts with parallel agents
-   SESSION_UUID=$(uuidgen)
-   BUILD_DIR="build/${SESSION_UUID}"
+   BUILD_DIR="build/$$"
 
-   # Clone repository directly into build directory
-   gh repo clone HomericIntelligence/ProjectMnemosyne "$BUILD_DIR"
+   # Clone repository if not present, otherwise update
+   if [ ! -d "$BUILD_DIR" ]; then
+     gh repo clone HomericIntelligence/ProjectMnemosyne "$BUILD_DIR"
+   else
+     git -C "$BUILD_DIR" fetch origin
+   fi
 
    cd "$BUILD_DIR"
 
-   # Fetch latest changes and create branch from origin/main
-   git fetch origin
+   # Create branch from origin/main
    git checkout -b skill/<category>/<name> origin/main
    ```
 
@@ -114,19 +115,6 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
 **Solution**: Don't rebase. Create branch directly from `origin/main`:
 ```bash
 git checkout -b skill/<category>/<name> origin/main
-```
-
-### Issue: uuidgen not found
-
-**Cause**: `uuidgen` not installed on system.
-
-**Solution**: Install uuid-runtime or use alternative:
-```bash
-# On Debian/Ubuntu
-sudo apt install uuid-runtime
-
-# Alternative using Python
-SESSION_UUID=$(python3 -c "import uuid; print(uuid.uuid4())")
 ```
 
 ### Issue: Build directory cleanup


### PR DESCRIPTION
## Summary

Updates `/advise` and `/retrospective` commands to use GitHub CLI for cloning and share a common build directory based on process ID.

- Add `gh repo clone HomericIntelligence/ProjectMnemosyne` step to both commands
- Use `build/$$` (process ID) as shared clone location within a session
- Simplify clone command to use build dir directly (no nested subdirectory)
- Remove obsolete uuidgen troubleshooting section

## Key Changes

**`/advise`**: Now clones the ProjectMnemosyne repo before searching for skills, ensuring access to all skill files.

**`/retrospective`**: Simplified clone setup - reuses existing clone if present, uses PID for session isolation.

**Shared directory**: Commands in the same Claude session share the clone via `build/$$`, reducing redundant clones.

## Test Plan

- [ ] Run `/advise` and verify it clones the repo
- [ ] Run `/retrospective` and verify it uses the same clone directory
- [ ] Verify branch creation still works in `/retrospective`

🤖 Generated with [Claude Code](https://claude.com/claude-code)