### PR TITLE
feat(debugging): add orphan-branch-recovery skill

### DIFF
--- a/plugins/debugging/orphan-branch-recovery/.claude-plugin/plugin.json
+++ b/plugins/debugging/orphan-branch-recovery/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "orphan-branch-recovery",
+  "version": "1.0.0",
+  "description": "Use when a branch has no common ancestor with main, cannot be merged, or was pushed from the wrong repository. Triggers: 'no merge base', 'branch diverged completely', 'cannot merge unrelated histories', 'pushed from wrong repo'. Provides workflow for diagnosing orphan branches and recovering valuable content.",
+  "category": "debugging",
+  "date": "2026-01-01",
+  "tags": [
+    "git",
+    "branch",
+    "orphan",
+    "diverged",
+    "merge-base",
+    "recovery",
+    "wrong-repo"
+  ]
+}

--- a/plugins/debugging/orphan-branch-recovery/references/notes.md
+++ b/plugins/debugging/orphan-branch-recovery/references/notes.md
@@ -1,0 +1,98 @@
+# Session Notes: Orphan Branch Recovery
+
+## Date: 2026-01-01
+
+## Context
+
+Branch `skill/debugging/fixme-todo-cleanup-v2` in ProjectMnemosyne-marketplace was reported as "completely diverged from main". Investigation revealed it was pushed from a different repository entirely (ProjectOdyssey).
+
+## Investigation Steps
+
+### 1. Initial Fetch and Analysis
+
+```bash
+git fetch origin skill/debugging/fixme-todo-cleanup-v2
+
+# Check commits ahead of main - showed ProjectOdyssey commits
+git log --oneline origin/main..origin/skill/debugging/fixme-todo-cleanup-v2 | head -20
+# Output included: training, core, tests, mojo commits - wrong repo!
+
+# Check commits behind main - showed all ProjectMnemosyne commits
+git log --oneline origin/skill/debugging/fixme-todo-cleanup-v2..origin/main | head -20
+# Output: All marketplace skill commits
+```
+
+### 2. Confirm No Common Ancestor
+
+```bash
+git merge-base origin/main origin/skill/debugging/fixme-todo-cleanup-v2
+# Exit code 1, no output - confirmed no merge base
+```
+
+### 3. Identify Wrong Repository
+
+```bash
+# Check oldest commits
+git log --oneline origin/skill/debugging/fixme-todo-cleanup-v2 | tail -10
+# Output:
+# c2c68b6e Initial commit
+# fca85e8d feat: initial commit of the repository
+# These are ProjectOdyssey's initial commits!
+
+# Check files on branch
+git ls-tree --name-only origin/skill/debugging/fixme-todo-cleanup-v2 | head -20
+# Output included: .mojo-version, CONTRIBUTING.md, agent hierarchy
+# These are ProjectOdyssey files, not marketplace files
+```
+
+### 4. Extract Valuable Content
+
+The tip commit `9f65c6f3` did contain valid skill content:
+
+```bash
+git show origin/skill/debugging/fixme-todo-cleanup-v2 --name-only
+# plugins/debugging/fixme-todo-cleanup/.claude-plugin/plugin.json
+# plugins/debugging/fixme-todo-cleanup/skills/fixme-todo-cleanup/SKILL.md
+# plugins/debugging/fixme-todo-cleanup/references/notes.md
+```
+
+### 5. Discovery: Skill Already Merged
+
+Before recreating, checked if skill existed on main:
+
+```bash
+git log --oneline origin/main -- plugins/debugging/fixme-todo-cleanup/
+# ada780a7 feat(skills): add fixme-todo-cleanup skill from retrospective
+```
+
+The skill was already merged! The `-v2` branch was a stale duplicate.
+
+### 6. Resolution
+
+```bash
+# Delete the broken branch
+git push origin --delete skill/debugging/fixme-todo-cleanup-v2
+
+# No recreation needed - content already on main
+```
+
+## Root Cause
+
+Someone ran `/retrospective` from within ProjectOdyssey's working directory but pushed to ProjectMnemosyne-marketplace's remote. This created a branch with ProjectOdyssey's entire history instead of branching from ProjectMnemosyne-marketplace's main.
+
+## Prevention
+
+1. Always verify you're in the correct repository before pushing
+2. Check `git remote -v` matches expected repository
+3. Use separate directories for different projects
+4. The `/retrospective` command now clones the target repo to a build directory to avoid this issue
+
+## Key Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `git merge-base A B` | Find common ancestor (empty = orphan) |
+| `git log A..B` | Commits in B not in A |
+| `git ls-tree --name-only ref` | List files at ref |
+| `git show ref:path` | Extract file content |
+| `git push origin --delete branch` | Delete remote branch |

--- a/plugins/debugging/orphan-branch-recovery/skills/orphan-branch-recovery/SKILL.md
+++ b/plugins/debugging/orphan-branch-recovery/skills/orphan-branch-recovery/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: orphan-branch-recovery
+description: Diagnose and fix branches with no common ancestor that cannot be merged
+---
+
+# Orphan Branch Recovery
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Fix a branch that completely diverged from main with no common history |
+| Outcome | Identified branch was pushed from wrong repo, extracted content, deleted and recreated |
+
+## When to Use
+
+- `git merge-base` returns nothing between branch and main
+- Error: "fatal: refusing to merge unrelated histories"
+- Branch appears to have completely different commit history
+- Suspicion that branch was pushed from wrong repository
+- PR shows massive unexpected file changes
+
+## Verified Workflow
+
+### Step 1: Diagnose the Problem
+
+```bash
+# Check if branches share common history
+git fetch origin <branch-name>
+git merge-base origin/main origin/<branch-name>
+
+# If no output, branches have no common ancestor
+```
+
+### Step 2: Understand the Divergence
+
+```bash
+# Commits on branch not in main
+git log --oneline origin/main..origin/<branch-name> | head -20
+
+# Commits on main not in branch
+git log --oneline origin/<branch-name>..origin/main | head -20
+
+# Check oldest commits on branch (reveals origin)
+git log --oneline origin/<branch-name> | tail -10
+```
+
+### Step 3: Inspect Branch Contents
+
+```bash
+# List top-level files (reveals if wrong repo)
+git ls-tree --name-only origin/<branch-name> | head -20
+
+# Show what the tip commit added
+git show origin/<branch-name> --name-only --oneline
+```
+
+### Step 4: Extract Valuable Content
+
+```bash
+# Extract specific files from the branch
+git show origin/<branch-name>:<path/to/file> > /tmp/extracted-file
+
+# Example: Extract plugin files
+git show origin/<branch>:plugins/category/name/.claude-plugin/plugin.json > /tmp/plugin.json
+git show origin/<branch>:plugins/category/name/skills/name/SKILL.md > /tmp/SKILL.md
+```
+
+### Step 5: Delete and Recreate
+
+```bash
+# Delete the broken remote branch
+git push origin --delete <branch-name>
+
+# Create new branch from main
+git checkout main
+git pull origin main
+git checkout -b <branch-name>
+
+# Add extracted files and commit
+mkdir -p <plugin-path>
+cp /tmp/extracted-files <plugin-path>/
+git add .
+git commit -m "feat: add skill (recreated from broken branch)"
+git push -u origin <branch-name>
+```
+
+## Failed Attempts
+
+| Attempt | What Failed | Why |
+|---------|-------------|-----|
+| Merging directly | "refusing to merge unrelated histories" | No common ancestor exists |
+| Rebasing onto main | Creates duplicate commits, history becomes confusing | Rebase replays commits but doesn't fix the root cause |
+| Using `--allow-unrelated-histories` | Works but creates messy history with duplicate content | Only use as last resort |
+
+## Results & Parameters
+
+### Diagnostic Commands
+
+```bash
+# Quick check for orphan branch
+git merge-base origin/main origin/<branch> || echo "ORPHAN: No common ancestor"
+
+# Show file diff (will be massive if wrong repo)
+git diff --stat origin/main...origin/<branch> | tail -5
+```
+
+### Signs of Wrong-Repo Push
+
+1. `git log --oneline <branch> | tail -5` shows unfamiliar "Initial commit"
+2. `git ls-tree --name-only <branch>` shows unexpected files (e.g., `.mojo-version` in a Python project)
+3. Massive number of commits ahead/behind main
+4. Commit messages reference different project
+
+### Recovery Checklist
+
+- [ ] Verify branch has no merge-base with main
+- [ ] Identify valuable content on branch tip
+- [ ] Extract files before deletion
+- [ ] Delete remote branch
+- [ ] Create new branch from main
+- [ ] Add extracted content
+- [ ] Push and create PR


### PR DESCRIPTION
## Summary

Documents workflow for diagnosing and fixing branches with no common ancestor, typically caused by pushing from the wrong repository.

- Diagnostic commands to detect orphan branches (`git merge-base`)
- How to identify wrong-repo pushes (`git ls-tree`, commit history)
- Content extraction before deletion
- Clean recreation from correct base

## Key Findings

**What Worked**:
- Using `git merge-base` to detect branches with no common ancestor
- Extracting files with `git show ref:path > file`
- Deleting remote branch and recreating from main

**What Failed**:
- Merging directly → "refusing to merge unrelated histories"
- Rebasing → creates confusing duplicate history

## Test Plan

- [ ] Validate plugin with `python scripts/validate_plugins.py plugins/`
- [ ] Check skill activation with relevant triggers
- [ ] Verify workflow steps are copy-paste ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)