### PR TITLE
skill(evaluation): add e2e-judge-rubric-design

### DIFF
--- a/plugins/evaluation/e2e-judge-rubric-design/.claude-plugin/plugin.json
+++ b/plugins/evaluation/e2e-judge-rubric-design/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e-judge-rubric-design",
+  "description": "Design LLM-as-Judge evaluation rubrics for E2E agent testing. Use when: (1) Building agent evaluation systems with LLM judges, (2) Designing weighted scoring criteria for code quality, (3) Handling invalid evaluations (rate limits, errors) distinctly from failures, (4) Standardizing judge prompts across test runs.",
+  "version": "1.0.0",
+  "category": "evaluation",
+  "date": "2026-01-01",
+  "tags": [
+    "llm-judge",
+    "evaluation",
+    "rubric",
+    "e2e-testing",
+    "agent-testing",
+    "scoring",
+    "rate-limits"
+  ]
+}

--- a/plugins/evaluation/e2e-judge-rubric-design/references/notes.md
+++ b/plugins/evaluation/e2e-judge-rubric-design/references/notes.md
@@ -1,0 +1,132 @@
+# E2E Judge Rubric Design - Session Notes
+
+## Context
+
+This skill was extracted from a debugging session in ProjectScylla where E2E test results were showing false positives due to incorrect error handling in the LLM judge fallback logic.
+
+## Original Problem
+
+When running E2E experiments:
+```bash
+pixi run python scripts/run_e2e_experiment.py \
+  --repo https://github.com/octocat/Hello-World \
+  --commit 7fd1a60 \
+  --prompt tests/fixtures/tests/test-001/prompt.md \
+  --tiers T0 T1 \
+  --runs 2
+```
+
+Rate-limited runs were being marked as PASS with score 0.7 because the Claude CLI output had:
+```json
+{
+  "type": "result",
+  "subtype": "success",
+  "is_error": true,
+  "result": "You've hit your limit"
+}
+```
+
+The fallback judge checked `subtype == "success"` before `is_error`, so it returned a passing result.
+
+## Key Code Changes
+
+### llm_judge.py - Fallback Logic Fix
+
+```python
+# BEFORE (buggy)
+def _fallback_judge(agent_output):
+    data = json.loads(agent_output)
+    if data.get("subtype") == "success":  # Checked first!
+        return JudgeResult(score=0.7, passed=True, ...)
+    elif data.get("is_error"):
+        return JudgeResult(score=0.0, passed=False, ...)
+
+# AFTER (fixed)
+def _fallback_judge(agent_output):
+    data = json.loads(agent_output)
+    # Check is_error FIRST
+    if data.get("is_error"):
+        return JudgeResult(score=0.0, passed=False, is_valid=False, ...)
+    if data.get("subtype") == "success":
+        return JudgeResult(score=0.7, passed=True, is_valid=True, ...)
+```
+
+### JudgeResult - Added is_valid Field
+
+```python
+@dataclass
+class JudgeResult:
+    score: float
+    passed: bool
+    grade: str
+    reasoning: str
+    is_valid: bool = True  # NEW: False if evaluation couldn't complete
+    criteria_scores: dict[str, float] | None = None
+    raw_response: str | None = None
+```
+
+### _call_claude_judge - System Prompt File
+
+```python
+JUDGE_SYSTEM_PROMPT_FILE = Path(__file__).parent.parent.parent.parent / "config" / "judge" / "system_prompt.md"
+
+cmd = [
+    "claude",
+    "--model", model,
+    "--print",
+    "--output-format", "text",
+    "--dangerously-skip-permissions",
+    "--max-turns", "1",
+    "--system-prompt-file", str(JUDGE_SYSTEM_PROMPT_FILE),  # NEW
+    evaluation_context,
+]
+
+result = subprocess.run(
+    cmd,
+    capture_output=True,
+    text=True,
+    timeout=1200,  # 20 minutes (was 120s)
+    env={**os.environ},
+)
+```
+
+## Rubric Evolution
+
+### Original (4 criteria)
+1. Correctness
+2. Completeness
+3. Quality (generic)
+4. Following Instructions
+
+### Final (10 criteria, weighted)
+
+**Functional (50%)**:
+1. Correctness - Does code work?
+2. Completeness - All requirements met?
+3. Edge Case Handling - Boundaries handled?
+4. Following Instructions - Specific instructions followed?
+
+**Code Quality (30%)**:
+5. Code Structure - CC < 15, LOC < 50, nesting < 4
+6. Documentation - Docstrings present?
+7. Linting Compliance - PEP8/style followed?
+8. Testability - Mockable, clear I/O?
+
+**Security & Safety (20%)**:
+9. Security - No secrets, no injection?
+10. Error Handling - Graceful failures?
+
+## Research Sources
+
+- G-Eval: https://www.confident-ai.com/blog/g-eval-the-definitive-guide
+- ICER 2025 Paper: https://dl.acm.org/doi/10.1145/3702652.3744220
+- LLM-as-Judge Biases: https://labelyourdata.com/articles/llm-as-a-judge
+
+## Files Modified
+
+- `src/scylla/e2e/llm_judge.py` - Bug fixes and improvements
+- `config/judge/system_prompt.md` - New standardized rubric
+
+## PR Reference
+
+ProjectScylla PR #104: https://github.com/HomericIntelligence/ProjectScylla/pull/104

--- a/plugins/evaluation/e2e-judge-rubric-design/skills/e2e-judge-rubric-design/SKILL.md
+++ b/plugins/evaluation/e2e-judge-rubric-design/skills/e2e-judge-rubric-design/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: e2e-judge-rubric-design
+description: "Design LLM-as-Judge evaluation rubrics for E2E agent testing"
+category: evaluation
+source: ProjectScylla
+date: 2026-01-01
+---
+
+# E2E Judge Rubric Design
+
+Design comprehensive evaluation rubrics for LLM-as-Judge systems in agent testing frameworks.
+
+## Overview
+
+| Date | Objective | Outcome |
+|------|-----------|---------|
+| 2026-01-01 | Fix false positives in E2E judge and expand evaluation criteria | 10-criteria weighted rubric, validity tracking, PR #104 merged |
+
+## When to Use
+
+- (1) Building agent evaluation systems that use LLM-as-Judge
+- (2) Designing weighted scoring criteria for code generation tasks
+- (3) Need to distinguish "invalid evaluation" from "evaluated and failed"
+- (4) Standardizing judge prompts across multiple test runs
+- (5) Handling rate limits and API errors in evaluation pipelines
+
+## Verified Workflow
+
+### 1. Design Weighted Criteria Categories
+
+Organize criteria into weighted categories for balanced evaluation:
+
+```yaml
+criteria_weights:
+  functional: 0.50      # Core functionality
+  code_quality: 0.30    # Structure, docs, style
+  security: 0.20        # Safety and error handling
+```
+
+### 2. Define Specific Criteria Per Category
+
+**Functional (50%)**:
+- `correctness` - Does the code work as intended?
+- `completeness` - Were all requirements satisfied?
+- `edge_case_handling` - Are boundary conditions handled?
+- `following_instructions` - Did agent follow specific instructions?
+
+**Code Quality (30%)**:
+- `code_structure` - Well-organized? (CC < 15, LOC < 50, nesting < 4)
+- `documentation` - Docstrings, comments present and accurate?
+- `linting_compliance` - Follows language style guidelines?
+- `testability` - Clear inputs/outputs, mockable dependencies?
+
+**Security & Safety (20%)**:
+- `security` - No secrets, injection vulnerabilities, unsafe patterns?
+- `error_handling` - Graceful failures, meaningful messages?
+
+### 3. Set Explicit Pass Thresholds
+
+```yaml
+pass_threshold:
+  score: 0.7           # Weighted average must be >= 0.7
+  correctness: 0.8     # AND correctness must be >= 0.8
+
+score_bands:
+  excellent: [0.9, 1.0]    # Production ready
+  good: [0.8, 0.89]        # Minor improvements
+  acceptable: [0.7, 0.79]  # Some issues but functional
+  marginal: [0.6, 0.69]    # Significant issues
+  failing: [0.0, 0.59]     # Does not meet requirements
+```
+
+### 4. Add Validity Tracking
+
+Distinguish "couldn't evaluate" from "evaluated and failed":
+
+```python
+@dataclass
+class JudgeResult:
+    score: float
+    passed: bool
+    grade: str
+    reasoning: str
+    is_valid: bool = True  # False if evaluation couldn't complete
+    criteria_scores: dict[str, float] | None = None
+```
+
+### 5. Handle API Errors First
+
+**Critical**: Check `is_error` BEFORE `subtype` in fallback logic:
+
+```python
+def _fallback_judge(agent_output: str) -> JudgeResult:
+    data = json.loads(agent_output)
+
+    # Check is_error FIRST - rate limits have BOTH
+    # "subtype": "success" AND "is_error": true
+    if data.get("is_error"):
+        return JudgeResult(
+            score=0.0, passed=False, grade="N/A",
+            reasoning=f"Invalid: {data.get('result')}",
+            is_valid=False  # Mark as invalid, not failed
+        )
+
+    # Only check success if no error
+    if data.get("subtype") == "success":
+        return JudgeResult(score=0.7, passed=True, ...)
+```
+
+### 6. Use Checked-In System Prompt
+
+Store judge prompt in version control for consistency:
+
+```python
+JUDGE_SYSTEM_PROMPT_FILE = Path("config/judge/system_prompt.md")
+
+cmd = [
+    "claude",
+    "--model", "claude-opus-4-5-20251101",
+    "--system-prompt-file", str(JUDGE_SYSTEM_PROMPT_FILE),
+    "--max-turns", "1",
+    evaluation_context,
+]
+```
+
+## Results & Parameters
+
+### Complete Judge Configuration
+
+```yaml
+# Judge model settings
+judge:
+  model: claude-opus-4-5-20251101  # REQUIRED: Opus for accuracy
+  timeout: 1200                     # 20 minutes for complex evals
+  system_prompt_file: config/judge/system_prompt.md
+
+# Evaluation rubric
+rubric:
+  categories:
+    functional:
+      weight: 0.50
+      criteria:
+        - correctness
+        - completeness
+        - edge_case_handling
+        - following_instructions
+    code_quality:
+      weight: 0.30
+      criteria:
+        - code_structure
+        - documentation
+        - linting_compliance
+        - testability
+    security:
+      weight: 0.20
+      criteria:
+        - security
+        - error_handling
+
+# Pass/fail thresholds
+thresholds:
+  pass_score: 0.7
+  min_correctness: 0.8
+
+# Code quality benchmarks
+quality_limits:
+  cyclomatic_complexity: 15
+  function_loc: 50
+  nesting_depth: 4
+```
+
+### System Prompt Template
+
+```markdown
+# LLM Judge System Prompt
+
+You are an expert evaluator for AI agent task completion.
+
+## Evaluation Criteria
+
+### Functional Criteria (Weight: 50%)
+1. **Correctness**: Does the code work as intended?
+2. **Completeness**: Were all requirements satisfied?
+3. **Edge Case Handling**: Are boundary conditions handled?
+4. **Following Instructions**: Did agent follow specific instructions?
+
+### Code Quality Criteria (Weight: 30%)
+5. **Code Structure**: Well-organized? (CC < 15, LOC < 50)
+6. **Documentation**: Docstrings present and accurate?
+7. **Linting Compliance**: Follows style guidelines?
+8. **Testability**: Clear inputs/outputs, mockable?
+
+### Security & Safety Criteria (Weight: 20%)
+9. **Security**: No secrets, injection vulnerabilities?
+10. **Error Handling**: Graceful failures?
+
+## Response Format
+{
+  "score": 0.78,
+  "passed": true,
+  "reasoning": "...",
+  "criteria_scores": { ... }
+}
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| Check `subtype` before `is_error` | Rate-limited runs have BOTH `"subtype": "success"` AND `"is_error": true` - marked as passing | Always check error conditions FIRST |
+| 120s timeout for judge | Opus model needs more time for thorough evaluation | Use 20 minutes (1200s) for Opus |
+| Pass prompt as CLI argument | Shell argument length limits; hard to maintain | Use `--system-prompt-file` with checked-in file |
+| 4 generic criteria | Missing security, testability, edge cases - incomplete evaluation | Expand to 10 criteria across weighted categories |
+| Single pass threshold (score only) | Low correctness could still pass with high style scores | Require BOTH score >= 0.7 AND correctness >= 0.8 |
+| No validity tracking | Couldn't distinguish "rate limited" from "failed evaluation" | Add `is_valid` field to JudgeResult |
+
+## Error Handling
+
+| Problem | Solution |
+|---------|----------|
+| Rate limit hit during judging | Return `is_valid=False` with reason, don't mark as pass/fail |
+| Judge timeout | Increase to 20 minutes; Opus needs time for thorough analysis |
+| Malformed JSON response | Parse with fallback; extract pass/fail from text if needed |
+| Missing criteria scores | Use partial scores; mark evaluation as degraded |
+
+## References
+
+- [G-Eval Framework](https://www.confident-ai.com/blog/g-eval-the-definitive-guide) - LLM-as-Judge with CoT
+- [ICER 2025: Rubric Is All You Need](https://dl.acm.org/doi/10.1145/3702652.3744220) - Question-specific rubrics
+- [LLM-as-Judge Guide](https://labelyourdata.com/articles/llm-as-a-judge) - Bias handling
+- ProjectScylla PR #104 - Implementation of this pattern


### PR DESCRIPTION
## Summary

Captures learnings from fixing LLM judge false positives in ProjectScylla E2E testing framework.

## Key Findings

### What Worked
- Check `is_error` BEFORE `subtype` in fallback logic
- Add `is_valid` field to distinguish invalid evaluations from failures
- 10 criteria across weighted categories (Functional 50%, Code Quality 30%, Security 20%)
- Use `--system-prompt-file` for maintainable judge prompts
- Explicit pass threshold: `score >= 0.7 AND correctness >= 0.8`

### What Failed
| Attempt | Why Failed |
|---------|------------|
| Check `subtype` before `is_error` | Rate limits have BOTH `"subtype": "success"` AND `"is_error": true` |
| 120s timeout for judge | Opus needs more time; increased to 20 minutes |
| Pass prompt as CLI argument | Shell limits; hard to maintain |
| 4 generic criteria | Missing security, testability, edge cases |

## Files Added

```
plugins/evaluation/e2e-judge-rubric-design/
├── .claude-plugin/plugin.json
├── skills/e2e-judge-rubric-design/SKILL.md
└── references/notes.md
```

## Reference

- ProjectScylla PR #104: https://github.com/HomericIntelligence/ProjectScylla/pull/104

🤖 Generated with [Claude Code](https://claude.com/claude-code)