### PR TITLE
skill(tooling): add plugin-generalization skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,22 @@
       "tags": []
     },
     {
+      "name": "codebase-consolidation",
+      "description": "Systematic approach to finding and consolidating duplicate code, aligning implementations to consistent patterns, and documenting intentional type variations. Use when: analyzing codebase for duplicates, unifying implementations across modules, creating backward-compatible refactors.",
+      "version": "1.0.0",
+      "source": "./plugins/architecture/codebase-consolidation",
+      "category": "architecture",
+      "tags": [
+        "refactor",
+        "deduplication",
+        "consolidation",
+        "backward-compatibility",
+        "type-alias",
+        "cross-reference",
+        "tech-debt"
+      ]
+    },
+    {
       "name": "doc-generate-adr",
       "description": "Generate Architecture Decision Records (ADRs) to document significant architectural decisions. Use when: (1) Making significant architectural decisions, (2) Choosing between technical alternatives, (3) Documenting design trade-offs.",
       "version": "1.0.0",
@@ -1095,6 +1111,21 @@
       "source": "./plugins/tooling/phase-package",
       "category": "tooling",
       "tags": []
+    },
+    {
+      "name": "plugin-generalization",
+      "description": "Generalize skills/plugins for cross-repository compatibility. Use when: (1) plugins reference specific repos in frontmatter, (2) hardcoded paths need abstraction, (3) migrating a skills marketplace to support multiple projects.",
+      "version": "1.0.0",
+      "source": "./plugins/tooling/plugin-generalization",
+      "category": "tooling",
+      "tags": [
+        "plugin",
+        "generalization",
+        "cross-repo",
+        "marketplace",
+        "migration",
+        "abstraction"
+      ]
     },
     {
       "name": "retrospective-hook-integration",

--- a/plugins/tooling/plugin-generalization/.claude-plugin/plugin.json
+++ b/plugins/tooling/plugin-generalization/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "plugin-generalization",
+  "version": "1.0.0",
+  "description": "Generalize skills/plugins for cross-repository compatibility. Use when: (1) plugins reference specific repos in frontmatter, (2) hardcoded paths need abstraction, (3) migrating a skills marketplace to support multiple projects.",
+  "author": {
+    "name": "HomericIntelligence"
+  },
+  "skills": "./skills",
+  "tags": ["plugin", "generalization", "cross-repo", "marketplace", "migration", "abstraction"],
+  "requires": {
+    "tools": [],
+    "languages": []
+  },
+  "verified_on": [
+    {"project": "ProjectMnemosyne", "context": "Generalized 33 plugins across 8 categories"}
+  ]
+}

--- a/plugins/tooling/plugin-generalization/references/notes.md
+++ b/plugins/tooling/plugin-generalization/references/notes.md
@@ -1,0 +1,110 @@
+# Session Notes: plugin-generalization
+
+Detailed notes from the plugin generalization session.
+
+## Verified Examples
+
+### Example 1: ProjectMnemosyne Marketplace
+
+**Date**: 2026-01-03
+**Context**: Generalize all 33 repository-specific plugins to work across multiple repositories
+
+**Scope**:
+- 33 plugins with `source:` field removed
+- 42 files changed total
+- 109 plugins validated after migration
+
+**Categories Affected**:
+| Category | Plugins Updated |
+|----------|-----------------|
+| ci-cd | 9 |
+| tooling | 9 |
+| testing | 5 |
+| evaluation | 5 |
+| architecture | 4 |
+| training | 2 |
+
+**Specific Commands Used**:
+
+```bash
+# Find all plugins with source field
+grep -r "^source:" plugins/ --include="SKILL.md"
+
+# Batch remove source fields (example for testing category)
+for file in plugins/testing/*/skills/*/SKILL.md; do
+  sed -i '/^source: ProjectOdyssey$/d' "$file"
+done
+
+# Validate all plugins
+python scripts/validate_plugins.py
+
+# Regenerate marketplace
+python scripts/generate_marketplace.py
+```
+
+**Key Files Modified**:
+- `CLAUDE.md` - Added "Cross-Repository Compatibility" section
+- `templates/experiment-skill/skills/SKILL_NAME/SKILL.md` - Updated template
+- `templates/experiment-skill/.claude-plugin/plugin.json` - Added requires/verified_on
+- `templates/experiment-skill/references/notes.md` - "Verified Examples" structure
+
+**Commit**: `bcbf719e refactor: generalize plugins for cross-repository compatibility`
+
+## Raw Findings
+
+### Source Field Patterns Found
+
+1. **Project sources** (to remove):
+   - `source: ProjectOdyssey`
+   - `source: ProjectScylla`
+
+2. **URL sources** (to keep as references):
+   - `source: https://huggingface.co/blog/sionic-ai/...`
+
+3. **Inline code examples** (to keep):
+   - `source:` in YAML code blocks showing config structure
+
+### Template Structure Changes
+
+**Before**:
+```yaml
+---
+name: skill-name
+source: ProjectOdyssey
+date: YYYY-MM-DD
+---
+```
+
+**After**:
+```yaml
+---
+name: skill-name
+date: YYYY-MM-DD
+---
+# ... content ...
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Original implementation | [notes.md](../references/notes.md) |
+```
+
+### Plugin.json Optional Fields
+
+```json
+{
+  "requires": {
+    "tools": [{"name": "mojo", "version": ">=0.25.0"}],
+    "languages": ["mojo", "python"]
+  },
+  "verified_on": [
+    {"project": "ProjectOdyssey", "context": "CI setup"}
+  ]
+}
+```
+
+## External References
+
+- Sionic AI skills pattern: https://huggingface.co/blog/sionic-ai/claude-code-skills-training
+- Claude Code plugin docs: https://docs.claude.com/claude-code/plugins

--- a/plugins/tooling/plugin-generalization/skills/plugin-generalization/SKILL.md
+++ b/plugins/tooling/plugin-generalization/skills/plugin-generalization/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: plugin-generalization
+description: "Generalize skills/plugins for cross-repository compatibility"
+category: tooling
+date: 2026-01-03
+---
+
+# Plugin Generalization
+
+Migrate plugins/skills from repository-specific to cross-repository compatible format.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-01-03 |
+| Objective | Make plugins work across multiple repositories without hardcoded references |
+| Outcome | Success - 33 plugins migrated, 109 validated |
+
+## When to Use
+
+- Plugins have `source: ProjectName` in YAML frontmatter
+- Hardcoded paths like `tests/shared/core/` need abstraction
+- PR numbers embedded in workflows (e.g., "PR #3050")
+- Migrating a skills marketplace to support multiple projects
+- New team wants to use existing skills in different codebase
+
+## Verified Workflow
+
+### 1. Identify Repository-Specific Content
+
+```bash
+# Find all plugins with source: field in frontmatter
+grep -r "^source:" plugins/ --include="SKILL.md"
+
+# Count affected plugins
+grep -r "^source:" plugins/ --include="SKILL.md" | wc -l
+```
+
+### 2. Update Templates First
+
+Update `templates/experiment-skill/` with new structure:
+
+**SKILL.md template changes:**
+- Remove `source:` from frontmatter
+- Add "Verified On" section at bottom
+- Use placeholders: `<project-root>`, `<test-path>`, `<package-manager>`
+
+**plugin.json template changes:**
+- Remove `source_project` field
+- Add optional `requires` object for tool dependencies
+- Add optional `verified_on` array for provenance
+
+### 3. Batch Remove Source Fields
+
+```bash
+# Remove source: lines from frontmatter
+for file in plugins/<category>/*/skills/*/SKILL.md; do
+  sed -i '/^source: ProjectName$/d' "$file"
+done
+```
+
+### 4. Add "Verified On" Sections
+
+Add to end of each SKILL.md:
+
+```markdown
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectName | PR #XXX context | [notes.md](../../references/notes.md) |
+```
+
+### 5. Move Specifics to References
+
+Create `references/notes.md` with project-specific details:
+- Exact commands used
+- Specific file paths
+- PR/commit links
+- Environment details
+
+### 6. Update CLAUDE.md
+
+Add "Cross-Repository Compatibility" section with guidelines.
+
+### 7. Validate and Regenerate
+
+```bash
+# Validate all plugins
+python scripts/validate_plugins.py
+
+# Regenerate marketplace index
+python scripts/generate_marketplace.py
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Writing notes.md before reading | File write error - must read first | Always read files before writing to them |
+| Assuming all `source:` were frontmatter | Some were inline code examples | Use `^source:` regex to match only frontmatter |
+| Manual file-by-file updates | Too slow for 33 plugins | Use sed/batch scripts for bulk changes |
+| Removing source URLs | URLs are references, not project sources | Only remove `source: ProjectName`, keep reference URLs |
+
+## Results & Parameters
+
+### Files Changed Per Plugin
+
+| File | Change Type | Lines |
+|------|-------------|-------|
+| SKILL.md | Modify | ~10-20 (remove source, add Verified On) |
+| references/notes.md | Create | ~30-50 (project-specific details) |
+| plugin.json | Modify | ~5 (add requires, verified_on) |
+
+### Generalization Checklist
+
+- [ ] Remove `source:` from YAML frontmatter
+- [ ] Replace hardcoded paths with placeholders
+- [ ] Add "Verified On" section
+- [ ] Create/update references/notes.md with specifics
+- [ ] Update plugin.json with optional fields
+- [ ] Run validation script
+- [ ] Regenerate marketplace.json
+
+### Placeholder Reference
+
+| Placeholder | Example | Purpose |
+|-------------|---------|---------|
+| `<project-root>` | `/home/user/project` | Repository root |
+| `<test-path>` | `tests/` | Test directory |
+| `<package-manager>` | `pixi`, `npm`, `pip` | Package manager command |
+| `<pr-number>` | `3050` | Pull request number |
+| `<branch>` | `feature/xyz` | Git branch name |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | Generalized 33 plugins across 8 categories | [notes.md](../../references/notes.md) |
+
+## References
+
+- CLAUDE.md "Cross-Repository Compatibility" section
+- templates/experiment-skill/ for updated templates
+- scripts/validate_plugins.py for validation


### PR DESCRIPTION
## Summary

Captures session learnings from generalizing 33 plugins for cross-repository compatibility.

**Key findings:**
- Remove `source:` from YAML frontmatter (use `^source:` regex)
- Add "Verified On" section to preserve provenance
- Move project-specific details to `references/notes.md`
- Use placeholders: `<test-path>`, `<package-manager>`, `<project-root>`
- Batch process with sed for efficiency

**Failed attempts documented:**
- Writing files before reading them
- Assuming all `source:` fields were frontmatter (some are inline code)
- Manual file-by-file updates (too slow for 33 plugins)

## Files Added

- `plugins/tooling/plugin-generalization/.claude-plugin/plugin.json`
- `plugins/tooling/plugin-generalization/skills/plugin-generalization/SKILL.md`
- `plugins/tooling/plugin-generalization/references/notes.md`
- Updated `.claude-plugin/marketplace.json` (111 plugins)

## Test Plan

- [x] Plugin validation passes (111/111)
- [x] Marketplace regenerated
- [x] SKILL.md has all required sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)