### PR TITLE
feat(skills): add user-invocable field to declutter slash command menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ plugins/<category>/<name>/
 **SKILL.md**:
 
 - YAML frontmatter (name, description, category, date)
+  - `user-invocable`: Set to `false` for internal/sub-skills (declutters slash command menu)
+  - Set to `true` only for skills users should directly invoke
 - Overview table (date, objective, outcome)
 - When to Use (trigger conditions)
 - Verified Workflow (what worked)

--- a/plugins/ci-cd/ci-failure-workflow/skills/analyze/SKILL.md
+++ b/plugins/ci-cd/ci-failure-workflow/skills/analyze/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: analyze
 description: "Parse and analyze CI failure logs to identify root causes and error patterns"
+user-invocable: false
 ---
 
 # Analyze CI Failure Logs

--- a/plugins/ci-cd/ci-failure-workflow/skills/fix/SKILL.md
+++ b/plugins/ci-cd/ci-failure-workflow/skills/fix/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fix
 description: "Diagnose and fix CI/CD failures systematically"
+user-invocable: false
 ---
 
 # Fix CI Failures

--- a/plugins/tooling/gh-pr-review-workflow/skills/fix-feedback/SKILL.md
+++ b/plugins/tooling/gh-pr-review-workflow/skills/fix-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fix-feedback
 description: "Address PR review feedback by making changes and replying to comments"
+user-invocable: false
 ---
 
 # Fix PR Review Feedback

--- a/plugins/tooling/gh-pr-review-workflow/skills/get-comments/SKILL.md
+++ b/plugins/tooling/gh-pr-review-workflow/skills/get-comments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: get-comments
 description: "Retrieve all review comments from a pull request using GitHub API"
+user-invocable: false
 ---
 
 # Get PR Review Comments

--- a/plugins/tooling/gh-pr-review-workflow/skills/reply-comment/SKILL.md
+++ b/plugins/tooling/gh-pr-review-workflow/skills/reply-comment/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reply-comment
 description: "Reply to PR review comments using correct GitHub API endpoint"
+user-invocable: false
 ---
 
 # Reply to Review Comments

--- a/plugins/tooling/git-worktree-workflow/skills/cleanup/SKILL.md
+++ b/plugins/tooling/git-worktree-workflow/skills/cleanup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cleanup
 description: "Remove merged or stale git worktrees safely"
+user-invocable: false
 ---
 
 # Worktree Cleanup

--- a/plugins/tooling/git-worktree-workflow/skills/create/SKILL.md
+++ b/plugins/tooling/git-worktree-workflow/skills/create/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create
 description: "Create isolated git worktrees for parallel development"
+user-invocable: false
 ---
 
 # Worktree Create

--- a/plugins/tooling/git-worktree-workflow/skills/switch/SKILL.md
+++ b/plugins/tooling/git-worktree-workflow/skills/switch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: switch
 description: "Switch between git worktrees for parallel development"
+user-invocable: false
 ---
 
 # Worktree Switch

--- a/plugins/tooling/git-worktree-workflow/skills/sync/SKILL.md
+++ b/plugins/tooling/git-worktree-workflow/skills/sync/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sync
 description: "Sync git worktrees with remote and main branch changes"
+user-invocable: false
 ---
 
 # Worktree Sync

--- a/plugins/tooling/skills-registry-commands/skills/advise/SKILL.md
+++ b/plugins/tooling/skills-registry-commands/skills/advise/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: advise
 description: Search team knowledge before starting work. Use when starting experiments, debugging unfamiliar errors, or before implementing features with unknowns.
+user-invocable: false
 ---
 
 # /advise

--- a/plugins/tooling/skills-registry-commands/skills/documentation-patterns/SKILL.md
+++ b/plugins/tooling/skills-registry-commands/skills/documentation-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: documentation-patterns
 description: Best practices for writing effective skill documentation. Use when creating new skills, improving skill discoverability, or documenting failed attempts.
+user-invocable: false
 ---
 
 # Skill Documentation Patterns

--- a/plugins/tooling/skills-registry-commands/skills/retrospective/SKILL.md
+++ b/plugins/tooling/skills-registry-commands/skills/retrospective/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retrospective
 description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
+user-invocable: false
 ---
 
 # /retrospective

--- a/plugins/tooling/skills-registry-commands/skills/validation-workflow/SKILL.md
+++ b/plugins/tooling/skills-registry-commands/skills/validation-workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: validation-workflow
 description: GitHub Actions CI for validating skill plugins. Use when setting up CI/CD for a skills marketplace or enforcing plugin quality.
+user-invocable: false
 ---
 
 # Plugin Validation Workflow

--- a/scripts/add_user_invocable.py
+++ b/scripts/add_user_invocable.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Add user-invocable: false to skill frontmatter."""
+
+import re
+from pathlib import Path
+
+# Sub-skills that should be marked as user-invocable: false
+SUB_SKILLS = [
+    # gh-pr-review-workflow
+    "plugins/tooling/gh-pr-review-workflow/skills/fix-feedback/SKILL.md",
+    "plugins/tooling/gh-pr-review-workflow/skills/get-comments/SKILL.md",
+    "plugins/tooling/gh-pr-review-workflow/skills/reply-comment/SKILL.md",
+    # git-worktree-workflow
+    "plugins/tooling/git-worktree-workflow/skills/cleanup/SKILL.md",
+    "plugins/tooling/git-worktree-workflow/skills/create/SKILL.md",
+    "plugins/tooling/git-worktree-workflow/skills/switch/SKILL.md",
+    "plugins/tooling/git-worktree-workflow/skills/sync/SKILL.md",
+    # skills-registry-commands
+    "plugins/tooling/skills-registry-commands/skills/advise/SKILL.md",
+    "plugins/tooling/skills-registry-commands/skills/documentation-patterns/SKILL.md",
+    "plugins/tooling/skills-registry-commands/skills/retrospective/SKILL.md",
+    "plugins/tooling/skills-registry-commands/skills/validation-workflow/SKILL.md",
+    # ci-failure-workflow
+    "plugins/ci-cd/ci-failure-workflow/skills/analyze/SKILL.md",
+    "plugins/ci-cd/ci-failure-workflow/skills/fix/SKILL.md",
+]
+
+def add_user_invocable(file_path: Path) -> bool:
+    """Add user-invocable: false to frontmatter if not present."""
+    content = file_path.read_text()
+
+    # Check if already has user-invocable
+    if "user-invocable:" in content:
+        print(f"  ✓ {file_path.name} already has user-invocable field")
+        return False
+
+    # Match YAML frontmatter
+    pattern = r'^(---\n)(.*?)(---\n)'
+    match = re.match(pattern, content, re.DOTALL)
+
+    if not match:
+        print(f"  ✗ {file_path.name} has no frontmatter")
+        return False
+
+    frontmatter = match.group(2)
+    # Add user-invocable: false after the last field
+    new_frontmatter = frontmatter.rstrip() + "\nuser-invocable: false\n"
+    new_content = f"---\n{new_frontmatter}---\n" + content[match.end():]
+
+    file_path.write_text(new_content)
+    print(f"  ✓ Added user-invocable: false to {file_path.name}")
+    return True
+
+def main():
+    root = Path(__file__).parent.parent
+    updated = 0
+
+    for skill_path in SUB_SKILLS:
+        full_path = root / skill_path
+        if not full_path.exists():
+            print(f"  ✗ Not found: {skill_path}")
+            continue
+
+        if add_user_invocable(full_path):
+            updated += 1
+
+    print(f"\n✓ Updated {updated} skills with user-invocable: false")
+
+if __name__ == "__main__":
+    main()

--- a/templates/experiment-skill/skills/SKILL_NAME/SKILL.md
+++ b/templates/experiment-skill/skills/SKILL_NAME/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: SKILL_NAME
 description: "TRIGGER CONDITIONS: When to use this skill"
+user-invocable: false  # Set to true only for user-facing commands, false for internal/sub-skills
 category: CATEGORY
 date: YYYY-MM-DD
 ---


### PR DESCRIPTION
## Summary

Add `user-invocable: false` to all internal sub-skills following Claude Code v2.1.0 specification. This declutters the slash command menu by hiding skills that agents call internally, not skills users directly invoke.

## Changes

**Updated 13 sub-skills** with `user-invocable: false`:
- ✅ ci-failure-workflow: `analyze`, `fix`
- ✅ gh-pr-review-workflow: `fix-feedback`, `get-comments`, `reply-comment`  
- ✅ git-worktree-workflow: `cleanup`, `create`, `switch`, `sync`
- ✅ skills-registry-commands: `advise`, `documentation-patterns`, `retrospective`, `validation-workflow`

**Documentation updates**:
- ✅ Updated template with `user-invocable` field and inline comment
- ✅ Updated CLAUDE.md with usage guidance

## Test Plan

- [ ] Install marketplace locally
- [ ] Verify sub-skills are hidden from slash command menu
- [ ] Verify main commands (`/advise`, `/retrospective`) still appear
- [ ] CI validation passes

## References

- Claude Code v2.1.0 CHANGELOG: Skills `user-invocable` field support
- Related: Part of 5-PR Claude Code v2.1.0 feature adoption series

🤖 Generated with [Claude Code](https://claude.com/claude-code)