### PR TITLE
feat(hooks): add once field to prevent duplicate SessionEnd hook execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,17 @@ This project uses UserPromptSubmit hooks instead.
 **UserPromptSubmit Hook**: Triggers when user types session-ending keywords (exit, quit,
 clear, done, finished, etc.) to remind about `/retrospective`.
 
+**NEW in v2.1.0**: Hooks support `once: true` field to execute only once per session:
+```json
+{
+  "hooks": [{
+    "type": "command",
+    "command": "script.sh",
+    "once": true
+  }]
+}
+```
+
 See `.claude/settings.json` for configuration and
 `plugins/tooling/skills-registry-commands/hooks/settings.json.example` for reference.
 

--- a/plugins/tooling/retrospective-hook-integration/skills/retrospective-hook-integration/SKILL.md
+++ b/plugins/tooling/retrospective-hook-integration/skills/retrospective-hook-integration/SKILL.md
@@ -87,7 +87,8 @@ Update `.claude/settings.json`:
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
-            "timeout": 120
+            "timeout": 120,
+            "once": true
           }
         ]
       }
@@ -136,7 +137,7 @@ After marketplace registration:
 
 ## Results & Parameters
 
-### Hook Configuration
+### Hook Configuration (v2.1.0+)
 
 ```json
 {
@@ -146,7 +147,8 @@ After marketplace registration:
         {
           "type": "command",
           "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
-          "timeout": 120
+          "timeout": 120,
+          "once": true
         }
       ]
     }
@@ -154,11 +156,14 @@ After marketplace registration:
 }
 ```
 
+**NEW in v2.1.0**: `once: true` ensures hook runs only once per session, preventing duplicate retrospective prompts.
+
 ### Hook Script Parameters
 
 - **Minimum transcript length**: 10 messages
 - **Trigger reasons**: `"exit"` or `"clear"` only
 - **Timeout**: 120 seconds
+- **once**: `true` (v2.1.0+) - Run only once per session
 - **Output**: JSON with `systemMessage` field
 
 ### Marketplace Registration


### PR DESCRIPTION
## Summary

Document and implement the `once: true` field for hooks from Claude Code v2.1.0. This prevents SessionEnd hooks from executing multiple times per session, avoiding duplicate retrospective prompts.

## Changes

**Updated retrospective-hook-integration skill**:
- ✅ Added `once: true` to SessionEnd hook configuration examples
- ✅ Documented v2.1.0 once field behavior
- ✅ Updated hook script parameters section

**Updated CLAUDE.md**:
- ✅ Added hooks `once` field documentation in Hooks Configuration section
- ✅ Provided JSON example with once: true

## Hook Configuration Example

### Before (Runs multiple times)
```json
{
  "SessionEnd": [{
    "hooks": [{
      "type": "command",
      "command": "retrospective-trigger.py",
      "timeout": 120
    }]
  }]
}
```

### After (Runs once per session)
```json
{
  "SessionEnd": [{
    "hooks": [{
      "type": "command",
      "command": "retrospective-trigger.py",
      "timeout": 120,
      "once": true
    }]
  }]
}
```

## Test Plan

- [ ] Verify SessionEnd hook with once: true runs only once per session
- [ ] Verify retrospective prompt doesn't duplicate
- [ ] CI validation passes

## References

- Claude Code v2.1.0 CHANGELOG: Hooks once field
- Part of 5-PR Claude Code v2.1.0 feature adoption series (FINAL PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)