### PR TITLE
feat(ci-cd): add yaml-frontmatter-validation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -511,6 +511,21 @@
       ]
     },
     {
+      "name": "yaml-frontmatter-validation",
+      "description": "Fix CI failures caused by missing YAML frontmatter in SKILL.md files. Use when: (1) plugin validation fails with 'missing YAML frontmatter' errors, (2) multiple PRs failing with same root cause, (3) SKILL.md doesn't start with '---', (4) systematic fixes needed across main and feature branches.",
+      "version": "1.0.0",
+      "source": "./plugins/ci-cd/yaml-frontmatter-validation",
+      "category": "ci-cd",
+      "tags": [
+        "ci-cd",
+        "validation",
+        "yaml",
+        "frontmatter",
+        "github-actions",
+        "pr-fixes"
+      ]
+    },
+    {
       "name": "analyze-code-structure",
       "description": "Examine code organization and identify structural patterns. Use when reviewing module design.",
       "version": "1.0.0",
@@ -612,6 +627,24 @@
       ]
     },
     {
+      "name": "global-semaphore-parallelism",
+      "description": "Debugging and implementing global parallelism control using multiprocessing.Manager().Semaphore() to limit concurrent agents across all tiers",
+      "version": "1.0.0",
+      "source": "./plugins/debugging/global-semaphore-parallelism",
+      "category": "debugging",
+      "tags": [
+        "semaphore",
+        "parallelism",
+        "multiprocessing",
+        "concurrency-control",
+        "process-pool",
+        "global-limits",
+        "cross-process-sharing",
+        "e2e-testing",
+        "debugging"
+      ]
+    },
+    {
       "name": "orphan-branch-recovery",
       "description": "Use when a branch has no common ancestor with main, cannot be merged, or was pushed from the wrong repository. Triggers: 'no merge base', 'branch diverged completely', 'cannot merge unrelated histories', 'pushed from wrong repo'. Provides workflow for diagnosing orphan branches and recovering valuable content.",
       "version": "1.0.0",
@@ -639,6 +672,20 @@
         "migration",
         "python",
         "bug-fix"
+      ]
+    },
+    {
+      "name": "resume-crash-debugging",
+      "description": "Pattern for debugging resume crashes in long-running experiments with checkpoint systems. Use when: (1) experiments crash on resume with FileNotFoundError or similar, (2) file path mismatches between validation and loading, (3) need to diagnose progressive degradation (works 1st time, fails on Nth resume), (4) checkpoint state is out of sync with filesystem.",
+      "version": "1.0.0",
+      "source": "./plugins/debugging/resume-crash-debugging",
+      "category": "debugging",
+      "tags": [
+        "debugging",
+        "resume",
+        "checkpoint",
+        "e2e",
+        "file-path-mismatch"
       ]
     },
     {

--- a/plugins/ci-cd/yaml-frontmatter-validation/.claude-plugin/plugin.json
+++ b/plugins/ci-cd/yaml-frontmatter-validation/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "yaml-frontmatter-validation",
+  "version": "1.0.0",
+  "description": "Fix CI failures caused by missing YAML frontmatter in SKILL.md files. Use when: (1) plugin validation fails with 'missing YAML frontmatter' errors, (2) multiple PRs failing with same root cause, (3) SKILL.md doesn't start with '---', (4) systematic fixes needed across main and feature branches.",
+  "author": {
+    "name": "HomericIntelligence"
+  },
+  "category": "ci-cd",
+  "date": "2026-01-08",
+  "tags": ["ci-cd", "validation", "yaml", "frontmatter", "github-actions", "pr-fixes"],
+  "skills": "./skills"
+}

--- a/plugins/ci-cd/yaml-frontmatter-validation/references/notes.md
+++ b/plugins/ci-cd/yaml-frontmatter-validation/references/notes.md
@@ -1,0 +1,373 @@
+# YAML Frontmatter Validation - Session Notes
+
+Session date: 2026-01-08
+
+## Initial Problem
+
+User request: "Lets fix failing CI/CD runs on the open PR's"
+
+## Analysis Phase
+
+### Step 1: List Open PRs
+
+```bash
+gh pr list --state open --json number,title,headRefName,statusCheckRollup --limit 20
+```
+
+**Results:**
+- PR #74: `skill/tooling/claude-code-v2.1-adoption` - 1 failure (FAILURE)
+- PR #73: `feature/hooks-once-field` - 1 failure (FAILURE)
+- PR #72: `feature/skills-agent-field` - No CI status
+- PR #69: `skill/debugging/resume-crash-debugging` - 1 failure (FAILURE)
+- PR #68: `skill/debugging/global-semaphore-parallelism` - 1 failure (FAILURE)
+
+All failures from workflow: "Validate Plugins"
+
+### Step 2: Get Failure Details
+
+Extracted failing plugins from CI logs:
+
+**PR #74** (3 failures):
+- `claude-code-v2.1-adoption` - Invalid name format (has period)
+- `retry-transient-errors` - Missing YAML frontmatter
+- `judge-criteria-enhancement` - Missing YAML frontmatter
+
+**PR #73** (2 failures):
+- `retry-transient-errors` - Missing YAML frontmatter
+- `judge-criteria-enhancement` - Missing YAML frontmatter
+
+**PR #69** (2 failures):
+- `retry-transient-errors` - Missing YAML frontmatter
+- `judge-criteria-enhancement` - Missing YAML frontmatter
+
+**PR #68** (3 failures):
+- `retry-transient-errors` - Missing YAML frontmatter
+- `global-semaphore-parallelism` - Missing YAML frontmatter
+- `judge-criteria-enhancement` - Missing YAML frontmatter
+
+### Step 3: Identify Patterns
+
+**Common failures (on main branch):**
+- `retry-transient-errors` - Appears in all 4 failing PRs
+- `judge-criteria-enhancement` - Appears in all 4 failing PRs
+
+**PR-specific failures:**
+- `claude-code-v2.1-adoption` - Only on PR #74 (invalid name with period)
+- `global-semaphore-parallelism` - Only on PR #68 (missing frontmatter on feature branch)
+
+## Fix Implementation
+
+### Fix 1: Main Branch (commit 4b8b469)
+
+**Branch:** `main`
+
+**Files modified:**
+1. `plugins/debugging/retry-transient-errors/skills/retry-transient-errors/SKILL.md`
+2. `plugins/evaluation/judge-criteria-enhancement/skills/judge-criteria-enhancement/SKILL.md`
+
+**Changes:** Added YAML frontmatter to both files:
+
+```yaml
+---
+name: retry-transient-errors
+description: "Fix git clone failures caused by transient network errors. Use when experiencing connection reset, curl 56, or timeout errors in subprocess calls."
+user-invocable: false
+---
+```
+
+```yaml
+---
+name: judge-criteria-enhancement
+description: "Add new evaluation criteria to LLM judge systems. Use when penalizing over-engineering, fixing result validation, or adding proportionality scoring."
+user-invocable: false
+---
+```
+
+**Verification:**
+```bash
+python3 scripts/validate_plugins.py 2>&1 | grep -E "(PASS|FAIL):\s+(retry-transient-errors|judge-criteria-enhancement)"
+```
+Output:
+```
+PASS: judge-criteria-enhancement
+PASS: retry-transient-errors
+```
+
+**Commit:**
+```bash
+git add plugins/debugging/retry-transient-errors/skills/retry-transient-errors/SKILL.md plugins/evaluation/judge-criteria-enhancement/skills/judge-criteria-enhancement/SKILL.md
+git commit -m "fix: add missing YAML frontmatter to retry-transient-errors and judge-criteria-enhancement skills"
+git push
+```
+
+### Fix 2: PR #74 - Rename Plugin (commit 1fe4ca8)
+
+**Branch:** `skill/tooling/claude-code-v2.1-adoption`
+
+**Problem:** Plugin name `claude-code-v2.1-adoption` contains period (`.`), which violates validation regex `^[a-z0-9-]+$`
+
+**Actions:**
+
+1. Rebased on main to pick up frontmatter fixes:
+   ```bash
+   git checkout skill/tooling/claude-code-v2.1-adoption
+   git pull --rebase origin main
+   ```
+
+2. Updated plugin name in files:
+   - `plugins/tooling/claude-code-v2.1-adoption/.claude-plugin/plugin.json`: Changed `name` to `claude-code-v21-adoption`
+   - `plugins/tooling/claude-code-v2.1-adoption/skills/claude-code-v2.1-adoption/SKILL.md`: Changed frontmatter `name` to `claude-code-v21-adoption`
+
+3. Renamed directories:
+   ```bash
+   git mv plugins/tooling/claude-code-v2.1-adoption plugins/tooling/claude-code-v21-adoption
+   git mv plugins/tooling/claude-code-v21-adoption/skills/claude-code-v2.1-adoption plugins/tooling/claude-code-v21-adoption/skills/claude-code-v21-adoption
+   ```
+
+4. Regenerated marketplace:
+   ```bash
+   python3 scripts/generate_marketplace.py
+   # Output: Generated .claude-plugin/marketplace.json (Plugins indexed: 132)
+   ```
+
+5. Verified:
+   ```bash
+   python3 scripts/validate_plugins.py 2>&1 | grep -E "(PASS|FAIL):\s+claude-code-v2"
+   # Output: PASS: claude-code-v21-adoption
+   ```
+
+6. Committed and pushed:
+   ```bash
+   git add -A
+   git commit -m "fix: rename claude-code-v2.1-adoption to claude-code-v21-adoption (remove period)"
+   git push --force-with-lease
+   ```
+
+### Fix 3: PR #68 - Add Frontmatter (commit 8b80c67)
+
+**Branch:** `skill/debugging/global-semaphore-parallelism`
+
+**Problem:** New plugin on feature branch missing YAML frontmatter
+
+**Actions:**
+
+1. Checked out branch:
+   ```bash
+   git fetch origin skill/debugging/global-semaphore-parallelism
+   git checkout skill/debugging/global-semaphore-parallelism
+   ```
+
+2. Added frontmatter to `plugins/debugging/global-semaphore-parallelism/skills/global-semaphore-parallelism/SKILL.md`:
+   ```yaml
+   ---
+   name: global-semaphore-parallelism
+   description: "Implement global parallelism control using shared semaphores. Use when limiting concurrent workers across multiple process pools or fixing per-tier parallelism issues."
+   user-invocable: false
+   ---
+   ```
+
+3. Verified:
+   ```bash
+   python3 scripts/validate_plugins.py 2>&1 | grep -E "(PASS|FAIL):\s+global-semaphore-parallelism"
+   # Output: PASS: global-semaphore-parallelism
+   ```
+
+4. Committed, rebased, and pushed:
+   ```bash
+   git add plugins/debugging/global-semaphore-parallelism/skills/global-semaphore-parallelism/SKILL.md
+   git commit -m "fix: add missing YAML frontmatter to global-semaphore-parallelism skill"
+   git pull --rebase origin main
+   git push --force-with-lease
+   ```
+
+### Fix 4: Rebase PR #73
+
+**Branch:** `feature/hooks-once-field`
+
+**Actions:**
+```bash
+git fetch origin feature/hooks-once-field
+git checkout feature/hooks-once-field
+git pull --rebase origin main
+git push --force-with-lease
+```
+
+Result: Successfully rebased, inherited main branch frontmatter fixes.
+
+### Fix 5: Rebase PR #69
+
+**Branch:** `skill/debugging/resume-crash-debugging`
+
+**Actions:**
+```bash
+git fetch origin skill/debugging/resume-crash-debugging
+git checkout skill/debugging/resume-crash-debugging
+git pull --rebase origin main
+git push --force-with-lease
+```
+
+Result: Successfully rebased, inherited main branch frontmatter fixes.
+
+### Fix 6: Rebase PR #72 (with conflict resolution)
+
+**Branch:** `feature/skills-agent-field`
+
+**Problem:** Merge conflict in `templates/experiment-skill/skills/SKILL_NAME/SKILL.md`
+
+**Actions:**
+
+1. Attempted rebase:
+   ```bash
+   git fetch origin main
+   git fetch origin feature/skills-agent-field
+   git checkout feature/skills-agent-field
+   git pull --rebase origin main
+   ```
+
+2. Conflict occurred:
+   ```
+   CONFLICT (content): Merge conflict in templates/experiment-skill/skills/SKILL_NAME/SKILL.md
+   ```
+
+3. Inspected conflict:
+   ```yaml
+   ---
+   name: SKILL_NAME
+   description: "TRIGGER CONDITIONS: When to use this skill"
+   user-invocable: false  # Set to true only for user-facing commands, false for internal/sub-skills
+   <<<<<<< HEAD
+   =======
+   agent: specialist-agent  # Optional: specify which agent type should execute this skill
+   >>>>>>> 5879aee (feat(skills): add agent field to route skills to specialized agents)
+   category: CATEGORY
+   date: YYYY-MM-DD
+   ---
+   ```
+
+4. Resolved by keeping both fields (both are valid optional fields):
+   ```yaml
+   ---
+   name: SKILL_NAME
+   description: "TRIGGER CONDITIONS: When to use this skill"
+   user-invocable: false  # Set to true only for user-facing commands, false for internal/sub-skills
+   agent: specialist-agent  # Optional: specify which agent type should execute this skill
+   category: CATEGORY
+   date: YYYY-MM-DD
+   ---
+   ```
+
+5. Completed rebase:
+   ```bash
+   git add templates/experiment-skill/skills/SKILL_NAME/SKILL.md
+   git rebase --continue
+   git push --force-with-lease
+   ```
+
+## Final Verification
+
+```bash
+gh pr list --state open --json number,title,statusCheckRollup --limit 10
+```
+
+**Results:**
+
+| PR | Status | Conclusion |
+|----|--------|------------|
+| #74 | COMPLETED | SUCCESS ✅ |
+| #73 | COMPLETED | SUCCESS ✅ |
+| #72 | COMPLETED | SUCCESS ✅ |
+| #69 | COMPLETED | SUCCESS ✅ |
+| #68 | COMPLETED | SUCCESS ✅ |
+
+## Validation Script Insights
+
+From `scripts/validate_plugins.py`:
+
+**Name validation (line 102-103):**
+```python
+if not re.match(r"^[a-z0-9-]+$", name):
+    errors.append(f"Invalid name format '{name}' (use lowercase, numbers, hyphens)")
+```
+
+**Frontmatter validation (line 158-159):**
+```python
+if not content.startswith("---"):
+    errors.append("SKILL.md missing YAML frontmatter (must start with ---)")
+```
+
+**Required frontmatter fields:**
+- `name` (must match plugin.json)
+- `description` (20+ chars minimum)
+
+**Optional frontmatter fields:**
+- `user-invocable` (boolean)
+- `category` (one of 8 approved)
+- `date` (YYYY-MM-DD format)
+- `agent` (specialist name)
+
+## Commands Reference
+
+### Analysis Commands
+```bash
+# List PRs with CI status
+gh pr list --state open --json number,title,headRefName,statusCheckRollup --limit 20
+
+# Get CI run logs
+gh run view <run-id> --log 2>/dev/null | grep -A 50 "Run python scripts/validate_plugins.py"
+
+# Get specific failures
+gh run view <run-id> --log 2>/dev/null | grep -E "^validate.*FAIL:" | head -20
+gh run view <run-id> --log 2>/dev/null | grep -A 10 "FAIL: plugin-name"
+```
+
+### Validation Commands
+```bash
+# Full validation
+python3 scripts/validate_plugins.py
+
+# Check specific plugins
+python3 scripts/validate_plugins.py 2>&1 | grep -E "(PASS|FAIL):\s+(plugin1|plugin2)"
+
+# Show only failures
+python3 scripts/validate_plugins.py 2>&1 | grep "FAIL:"
+```
+
+### Git Commands
+```bash
+# Fix workflow
+git checkout main && git pull
+# Make edits
+git add <files>
+git commit -m "fix: <description>"
+git push
+
+# Rebase workflow
+git checkout <branch>
+git pull --rebase origin main
+# Resolve conflicts if needed
+git add <conflicted-file>
+git rebase --continue
+git push --force-with-lease
+
+# Rename plugin
+git mv plugins/category/old-name plugins/category/new-name
+git mv plugins/category/new-name/skills/old-name plugins/category/new-name/skills/new-name
+python3 scripts/generate_marketplace.py
+git add -A
+```
+
+## Lessons Learned
+
+1. **Pattern recognition is key** - Same error across multiple PRs immediately suggests main branch issue
+
+2. **Fix propagation order matters** - Main → Feature branches (via rebase) avoids duplicate work
+
+3. **Plugin naming is stricter than expected** - Periods are invalid despite being common in semantic versioning (v2.1.0)
+
+4. **Tool requirements** - Edit tool requires Read first, even after previous reads
+
+5. **Merge conflicts in templates** - When adding optional fields, conflicts are expected and should keep both changes
+
+6. **CI lag** - GitHub Actions can take 20-30s to start, use `sleep` + `gh pr view` for verification
+
+7. **Force-push safety** - `--force-with-lease` prevents overwriting remote changes, unlike `--force`

--- a/plugins/ci-cd/yaml-frontmatter-validation/skills/yaml-frontmatter-validation/SKILL.md
+++ b/plugins/ci-cd/yaml-frontmatter-validation/skills/yaml-frontmatter-validation/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: yaml-frontmatter-validation
+description: "Fix CI failures caused by missing YAML frontmatter in SKILL.md files. Use when plugin validation fails with 'missing YAML frontmatter' errors across multiple PRs."
+user-invocable: false
+category: ci-cd
+date: 2026-01-08
+---
+
+# YAML Frontmatter Validation Fixes
+
+Systematic approach to diagnosing and fixing CI validation failures across multiple PRs when the root cause is missing YAML frontmatter in SKILL.md files.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-01-08 |
+| Objective | Fix CI failures on 5 open PRs (4 with failures) caused by missing YAML frontmatter |
+| Outcome | ✅ Successfully fixed all 5 PRs - all CI now passing |
+| Strategy | Fix main branch first, then fix PR-specific issues, then rebase |
+
+## When to Use
+
+Use this skill when you encounter:
+
+1. **Multiple PRs failing with similar validation errors** - Same error appearing across different PRs suggests shared root cause
+2. **"SKILL.md missing YAML frontmatter" errors** - Validation script reports files don't start with `---`
+3. **Plugin name validation failures** - Invalid characters in plugin names (e.g., periods in `claude-code-v2.1-adoption`)
+4. **CI failures that shouldn't affect feature branches** - Errors in main branch plugins affecting all PRs
+5. **Need to fix both main and feature branches** - Systematic approach required for cascading fixes
+
+### Trigger Patterns
+
+```text
+FAIL: plugin-name
+  Errors:
+    - SKILL.md missing YAML frontmatter (must start with ---)
+```
+
+```text
+FAIL: plugin-name
+  Errors:
+    - Invalid name format 'plugin-v2.1-name' (use lowercase, numbers, hyphens)
+```
+
+## Verified Workflow
+
+### Phase 1: Analyze the Failures
+
+**What worked:**
+
+1. **List all open PRs with CI status:**
+   ```bash
+   gh pr list --state open --json number,title,headRefName,statusCheckRollup --limit 20
+   ```
+
+2. **Get failure details for each failing run:**
+   ```bash
+   gh run view <run-id> --log 2>/dev/null | grep -E "(PASS|FAIL):" | head -20
+   gh run view <run-id> --log 2>/dev/null | grep -A 10 "FAIL: plugin-name"
+   ```
+
+3. **Identify patterns:**
+   - Common failures across multiple PRs → likely main branch issue
+   - PR-specific failures → branch-specific issues
+   - Count unique failing plugins to understand scope
+
+**Example from this session:**
+- 5 open PRs, 4 with failures
+- 2 plugins failing on main: `retry-transient-errors`, `judge-criteria-enhancement`
+- 2 PR-specific issues: `claude-code-v2.1-adoption` (period in name), `global-semaphore-parallelism` (missing frontmatter)
+
+### Phase 2: Fix Main Branch First
+
+**Critical principle:** Fix shared root causes on main before touching feature branches.
+
+**What worked:**
+
+1. **Checkout main and pull latest:**
+   ```bash
+   git checkout main
+   git pull
+   ```
+
+2. **Add YAML frontmatter to each failing plugin:**
+   ```yaml
+   ---
+   name: plugin-name
+   description: "Brief description with trigger conditions. Use when..."
+   user-invocable: false
+   ---
+   ```
+
+3. **Verify fixes locally:**
+   ```bash
+   python3 scripts/validate_plugins.py 2>&1 | grep -E "(PASS|FAIL): (plugin1|plugin2)"
+   ```
+
+4. **Commit and push to main:**
+   ```bash
+   git add plugins/.../SKILL.md
+   git commit -m "fix: add missing YAML frontmatter to <plugin-names> skills"
+   git push
+   ```
+
+**Why this order matters:**
+- Fixes propagate to all branches during rebase
+- Reduces duplicate work across PRs
+- Ensures consistent fixes
+
+### Phase 3: Fix PR-Specific Issues
+
+**What worked:**
+
+For each PR with unique failures:
+
+1. **Checkout the feature branch:**
+   ```bash
+   git checkout <branch-name>
+   git pull --rebase origin main  # Pick up main branch fixes
+   ```
+
+2. **Fix PR-specific validation errors:**
+
+   **For missing frontmatter:**
+   - Add YAML frontmatter as in Phase 2
+
+   **For invalid plugin names (periods, underscores, uppercase):**
+   ```bash
+   # Update plugin.json name field
+   # Update SKILL.md frontmatter name field
+   # Rename directories
+   git mv plugins/category/old-name plugins/category/new-name
+   git mv plugins/category/new-name/skills/old-name plugins/category/new-name/skills/new-name
+
+   # Regenerate marketplace
+   python3 scripts/generate_marketplace.py
+   ```
+
+3. **Verify and commit:**
+   ```bash
+   python3 scripts/validate_plugins.py 2>&1 | grep "FAIL:"
+   git add -A
+   git commit -m "fix: <specific fix description>"
+   git push --force-with-lease
+   ```
+
+### Phase 4: Rebase Remaining PRs
+
+**What worked:**
+
+For PRs that only had main branch failures (now fixed):
+
+```bash
+git fetch origin <branch-name>
+git checkout <branch-name>
+git pull --rebase origin main
+git push --force-with-lease
+```
+
+**Handle merge conflicts:**
+- Template files often conflict (e.g., `templates/experiment-skill/skills/SKILL_NAME/SKILL.md`)
+- Keep both changes when adding new optional fields
+- Mark resolved: `git add <file> && git rebase --continue`
+
+### Phase 5: Verify All PRs
+
+**What worked:**
+
+```bash
+gh pr list --state open --json number,title,statusCheckRollup
+```
+
+Check for `"conclusion":"SUCCESS"` in all PRs.
+
+**Wait for CI if needed:**
+```bash
+sleep 30 && gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.workflowName == "Validate Plugins") | {status: .status, conclusion: .conclusion}'
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson Learned |
+|---------|-----------|----------------|
+| Fixing PR branches before main | Had to add same frontmatter fixes to every PR individually | Always fix main branch shared issues first, then rebase PRs to inherit fixes |
+| Using `git push` instead of `git push --force-with-lease` after rebase | Push rejected because history was rewritten | After rebase, must use `--force-with-lease` to safely force-push |
+| Not checking local validation before pushing | Pushed invalid changes, triggering another CI failure | Always run `python3 scripts/validate_plugins.py` locally before pushing |
+| Trying to read files before Edit without explicit Read | Edit tool error: "File has not been read yet" | Must use Read tool before Edit, even if file was previously read and modified |
+
+## Results & Parameters
+
+### Validation Rules (from `scripts/validate_plugins.py`)
+
+**Plugin name requirements:**
+- Regex: `^[a-z0-9-]+$`
+- Lowercase only
+- Numbers allowed
+- Hyphens allowed
+- NO periods, underscores, uppercase
+
+**YAML frontmatter requirements:**
+```yaml
+---
+name: plugin-name  # Must match directory name
+description: "Trigger conditions..."  # 20+ chars
+user-invocable: false  # or true
+# Optional fields:
+category: ci-cd  # One of 8 categories
+date: YYYY-MM-DD
+agent: specialist-name
+---
+```
+
+### Fix Strategy Decision Matrix
+
+| Scenario | Action |
+|----------|--------|
+| Same error on multiple PRs | Fix on main first |
+| Plugin name validation error | Rename plugin (directories + files) |
+| Missing frontmatter | Add frontmatter block at file start |
+| PR only needs main fixes | Rebase on main |
+| PR has unique failures | Fix on branch, then rebase |
+| Merge conflict in template | Keep both changes if adding optional fields |
+
+### Commands Used
+
+```bash
+# Analysis
+gh pr list --state open --json number,title,statusCheckRollup --limit 20
+gh run view <run-id> --log 2>/dev/null | grep -A 10 "FAIL:"
+
+# Local validation
+python3 scripts/validate_plugins.py 2>&1 | grep "FAIL:"
+
+# Git workflow
+git checkout main && git pull
+git checkout -b fix/<issue>
+git add <files>
+git commit -m "fix: <description>"
+git push --force-with-lease  # After rebase
+
+# Rebase
+git pull --rebase origin main
+git rebase --continue  # After resolving conflicts
+
+# Rename plugin
+git mv plugins/category/old plugins/category/new
+python3 scripts/generate_marketplace.py
+```
+
+### Session Results
+
+**Before:**
+- 5 open PRs
+- 4 PRs with failing CI
+- 6 unique failing plugins (2 on main, 4 PR-specific)
+
+**After:**
+- 5 open PRs
+- 0 PRs with failing CI ✅
+- All validations passing
+
+**Commits:**
+1. Main: `4b8b469` - Added frontmatter to 2 plugins
+2. PR #74: `1fe4ca8` - Renamed `claude-code-v2.1-adoption` → `claude-code-v21-adoption`
+3. PR #68: `8b80c67` - Added frontmatter to `global-semaphore-parallelism`
+4. PR #73, #69, #72: Rebased on main
+
+## Key Takeaways
+
+1. **Fix main first, then branches** - Shared issues on main propagate to all PRs. Fix once, rebase everywhere.
+
+2. **Use CI logs to identify patterns** - Same error across PRs = main branch issue. Unique errors = branch-specific.
+
+3. **Plugin naming is strict** - Only `[a-z0-9-]` allowed. No periods (`.`), underscores (`_`), or uppercase.
+
+4. **YAML frontmatter is mandatory** - Must start with `---` and include `name` and `description` fields.
+
+5. **Validate locally before pushing** - Run `scripts/validate_plugins.py` to catch errors before CI.
+
+6. **Force-push safely after rebase** - Use `--force-with-lease` not `--force` to avoid overwriting others' work.
+
+7. **Template conflicts are common** - When rebasing PRs that add optional fields, keep both changes in merge conflicts.
+
+8. **CI can lag behind** - Use `gh pr view <number> --json statusCheckRollup` or wait 30s to verify success.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | PR #74, #73, #72, #69, #68 | Fixed 4 failing PRs by adding frontmatter and renaming plugins. See [notes.md](../references/notes.md) for CI logs and commands. |
+
+## References
+
+- `scripts/validate_plugins.py` - Plugin validation script
+- CLAUDE.md - Plugin standards documentation
+- Related skill: `claude-plugin-format` - Plugin structure requirements
+- Related skill: `retrospective-hook-integration` - CI/CD workflow patterns


### PR DESCRIPTION
## Summary

Captures systematic approach to fixing CI failures across multiple PRs when the root cause is missing YAML frontmatter in SKILL.md files.

This skill documents the session where we fixed 4 failing PRs (out of 5 open) by identifying and resolving both shared (main branch) and PR-specific validation errors.

## Changes

**New skill**: `plugins/ci-cd/yaml-frontmatter-validation/`

- ✅ SKILL.md with complete workflow for diagnosing and fixing multi-PR CI failures
- ✅ Documented fix strategy: main branch first → PR-specific fixes → rebase
- ✅ Failed attempts: fixing branches before main, force-push without --force-with-lease
- ✅ Command reference for CI analysis, validation, and git workflows
- ✅ Decision matrix for different failure scenarios
- ✅ Session notes with detailed CI logs and fix implementation

## Key Learnings

1. **Fix main first** - Shared issues on main propagate to all PRs. Fix once, rebase everywhere.
2. **Plugin naming rules** - Only `[a-z0-9-]` allowed (no periods, underscores, uppercase)
3. **YAML frontmatter mandatory** - Must start with `---` and include `name` + `description`
4. **Safe force-push** - Use `--force-with-lease` not `--force` after rebase

## Session Results

Fixed 4 failing PRs:
- PR #74: Renamed `claude-code-v2.1-adoption` → `claude-code-v21-adoption` (removed period)
- PR #68: Added frontmatter to `global-semaphore-parallelism`
- PR #73, #69: Rebased on main to inherit frontmatter fixes
- Main branch: Added frontmatter to `retry-transient-errors` and `judge-criteria-enhancement`

All PRs now passing CI ✅

## Test Plan

- [x] Plugin passes validation: `python3 scripts/validate_plugins.py`
- [x] marketplace.json regenerated successfully
- [x] SKILL.md follows required structure (Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters)
- [x] Captures decision matrix and command reference for future CI debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)