### PR TITLE
feat(skills): Add fix-ci-test-failures from ProjectScylla

### DIFF
--- a/skills/testing/fix-ci-test-failures/SKILL.md
+++ b/skills/testing/fix-ci-test-failures/SKILL.md
@@ -1,0 +1,211 @@
+# Skill: Fix CI Test Failures
+
+| Property | Value |
+|----------|-------|
+| **Date** | 2026-01-17 |
+| **Objective** | Fix 6 unit tests passing locally but failing in CI due to environment differences |
+| **Outcome** | ✅ All 6 tests fixed - absolute symlinks → relative, mock bypassed methods |
+| **Context** | PR #191 had CI failures; all tests passed locally but 6 failed in GitHub Actions |
+
+## When to Use This Skill
+
+Use this skill when:
+- Tests pass locally but fail in CI/GitHub Actions
+- Error messages mention "file not found" for symlinked files
+- Mock objects aren't being used despite being configured
+- Docker images or executables are missing in CI environment
+- Absolute paths appear in test fixtures or configuration
+
+**Key Indicators**:
+- Same test suite: 1037 tests pass locally, 1031 pass in CI (6 failures)
+- Error: `Unable to find image 'scylla-runner:latest'` (but test uses mocks)
+- Error: `assert False` where `False = isinstance(None, ModelConfig)` (file not found)
+
+## Verified Workflow
+
+### 1. Identify Root Causes
+
+**Compare local vs CI failures:**
+```bash
+# Check CI logs
+gh pr checks <pr-number>
+gh run view <run-id> --log-failed | grep "FAILED"
+
+# Check if main branch has same failures (pre-existing issues)
+gh run list --branch main --limit 3
+```
+
+**Common patterns**:
+- Symlinks with absolute paths (`/home/user/...`)
+- Mocks on wrong method (mocking `executor.run()` when code calls `_run_with_volumes()`)
+- Missing Docker images in CI environment
+
+### 2. Fix Symlink Issues
+
+**Problem**: Absolute symlinks break in CI
+```bash
+# Before (broken in CI)
+/home/mvillmow/ProjectScylla/config/models/_test-model.yaml
+
+# After (works everywhere)
+../../../../config/models/_test-model.yaml
+```
+
+**Fix**:
+```bash
+cd tests/fixtures/config/models
+rm test-model.yaml test-model-2.yaml
+ln -s ../../../../config/models/_test-model.yaml test-model.yaml
+ln -s ../../../../config/models/_test-model-2.yaml test-model-2.yaml
+
+# Verify symlink works
+cat test-model.yaml  # Should show file content
+```
+
+### 3. Fix Mock Bypass Issues
+
+**Problem**: Test mocks `executor.run()` but code calls `_run_with_volumes()` directly
+
+**Diagnosis**:
+```python
+# Code inspection reveals bypass
+def run_judge(self, config):
+    # This bypasses self.executor!
+    result = self._run_with_volumes(...)
+```
+
+**Fix**:
+```python
+# Before (doesn't work)
+mock_executor = MagicMock()
+mock_executor.run.return_value = ContainerResult(...)
+manager = JudgeContainerManager(executor=mock_executor)
+
+# After (works)
+@patch.object(JudgeContainerManager, "_run_with_volumes")
+def test_run_success(self, mock_run_with_volumes: MagicMock, tmp_path: Path):
+    mock_run_with_volumes.return_value = ContainerResult(...)
+    manager = JudgeContainerManager()
+    result = manager.run_judge(config)
+```
+
+### 4. Verify Fixes
+
+```bash
+# Test all previously failing tests
+pixi run pytest \
+  tests/unit/executor/test_judge_container.py::TestJudgeContainerManagerRunJudge::test_run_success \
+  tests/unit/executor/test_judge_container.py::TestJudgeContainerManagerRunJudge::test_run_timeout \
+  tests/unit/test_config_loader.py::TestConfigLoaderModel::test_load_model \
+  tests/unit/test_config_loader.py::TestConfigLoaderModel::test_load_all_models \
+  tests/unit/test_config_loader.py::TestConfigLoaderMerged::test_load_merged_with_model \
+  tests/unit/test_config_loader.py::TestConfigLoaderMerged::test_load_merged_with_test_override \
+  -v
+
+# Expected: 6 passed in <1s
+```
+
+### 5. Create Separate PR
+
+```bash
+git checkout -b fix/ci-test-failures
+git add <fixed-files>
+git commit -m "fix(tests): fix 6 CI test failures"
+git push -u origin fix/ci-test-failures
+gh pr create --title "fix(tests): fix 6 CI test failures" --body "..."
+```
+
+## Failed Attempts
+
+### ❌ Attempt 1: Ignore the failures (assumed pre-existing)
+**What we tried**: Check if main branch has same failures, assume they're pre-existing issues
+
+**Why it failed**: While main DID have the same failures, this doesn't mean we shouldn't fix them. The PR should improve the codebase, not perpetuate existing issues.
+
+**Lesson**: Pre-existing CI failures should be fixed in a separate PR, not ignored.
+
+### ❌ Attempt 2: Mock the executor instead of the actual method
+**What we tried**: Mock `executor.run()` to avoid Docker calls
+
+**Why it failed**: The code doesn't use `self.executor.run()` - it calls `self._run_with_volumes()` directly via subprocess.
+
+**Lesson**: Read the actual implementation to see what methods are called, don't assume based on the constructor parameter.
+
+### ❌ Attempt 3: Skip tests when Docker image missing
+**What we considered**: Add `@pytest.mark.skipif` to skip tests when `scylla-runner:latest` doesn't exist
+
+**Why we didn't**: These are unit tests that should work with mocks. Skipping them would reduce test coverage. Proper mocking is the correct solution.
+
+**Lesson**: Unit tests should never depend on external resources like Docker images.
+
+## Results & Parameters
+
+### Symlink Fixes
+**Files changed**:
+- `tests/fixtures/config/models/test-model.yaml`
+- `tests/fixtures/config/models/test-model-2.yaml`
+
+**Before**:
+```bash
+$ readlink tests/fixtures/config/models/test-model.yaml
+/home/mvillmow/ProjectScylla/config/models/_test-model.yaml
+```
+
+**After**:
+```bash
+$ readlink tests/fixtures/config/models/test-model.yaml
+../../../../config/models/_test-model.yaml
+```
+
+### Mock Fixes
+**File changed**: `tests/unit/executor/test_judge_container.py`
+
+**Before**:
+```python
+def test_run_success(self, tmp_path: Path) -> None:
+    mock_executor = MagicMock()
+    mock_executor.run.return_value = ContainerResult(...)
+    manager = JudgeContainerManager(executor=mock_executor)
+    result = manager.run_judge(config)
+```
+
+**After**:
+```python
+@patch.object(JudgeContainerManager, "_run_with_volumes")
+def test_run_success(self, mock_run_with_volumes: MagicMock, tmp_path: Path) -> None:
+    mock_run_with_volumes.return_value = ContainerResult(...)
+    manager = JudgeContainerManager()
+    result = manager.run_judge(config)
+```
+
+### Test Results
+```
+====== 6 passed in 0.27s ======
+```
+
+All tests now pass in both local and CI environments.
+
+## Key Takeaways
+
+1. **Symlinks must be relative** - Absolute paths break when workspace location changes
+2. **Mock the actual method called** - Don't assume what gets called; read the code
+3. **Separate PRs for separate concerns** - Don't mix feature work with CI fixes
+4. **Pre-existing failures should be fixed** - Don't perpetuate technical debt
+5. **Unit tests shouldn't depend on external resources** - Use mocks, not real Docker/images
+
+## Port to ProjectMnemosyne
+
+After merging this skill to ProjectScylla, copy to team knowledge base:
+
+```bash
+# Copy skill to ProjectMnemosyne
+cp -r .claude-plugin/skills/fix-ci-test-failures \
+  ../build/ProjectMnemosyne/skills/testing/
+
+# Create PR in ProjectMnemosyne
+cd ../build/ProjectMnemosyne
+git checkout -b skill/testing/fix-ci-test-failures
+git add skills/testing/fix-ci-test-failures
+git commit -m "feat(skills): Add fix-ci-test-failures from ProjectScylla"
+gh pr create --title "feat(skills): Add fix-ci-test-failures skill"
+```

--- a/skills/testing/fix-ci-test-failures/plugin.json
+++ b/skills/testing/fix-ci-test-failures/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "fix-ci-test-failures",
+  "version": "1.0.0",
+  "description": "Skill for fixing unit tests that pass locally but fail in CI due to symlinks and mocking issues",
+  "category": "testing",
+  "author": "Claude Sonnet 4.5",
+  "created": "2026-01-17",
+  "tags": [
+    "ci-cd",
+    "testing",
+    "symlinks",
+    "mocking",
+    "github-actions",
+    "pytest"
+  ],
+  "trigger_conditions": [
+    "Tests pass locally but fail in CI",
+    "Symlink 'file not found' errors in CI",
+    "Mock objects not being used despite configuration",
+    "Docker image missing in CI but test uses mocks"
+  ],
+  "outcomes": {
+    "success_rate": "100%",
+    "tests_fixed": 6,
+    "root_causes": [
+      "Absolute symlinks with local paths",
+      "Mocking wrong method (executor.run vs _run_with_volumes)"
+    ]
+  },
+  "related_skills": [
+    "pytest-mocking",
+    "ci-debugging",
+    "symlink-management"
+  ],
+  "applies_to": [
+    "Python",
+    "pytest",
+    "GitHub Actions",
+    "Docker testing"
+  ]
+}

--- a/skills/testing/fix-ci-test-failures/references/notes.md
+++ b/skills/testing/fix-ci-test-failures/references/notes.md
@@ -1,0 +1,154 @@
+# Session Notes: Fixing CI Test Failures
+
+## Session Context
+
+**Date**: 2026-01-17
+**PR**: #191 - refactor(e2e): move resource suffixes from task prompt to CLAUDE.md
+**Initial Problem**: PR had 6 test failures in CI, but all tests passed locally (1037/1037)
+
+## Timeline
+
+### 1. Initial Investigation
+- Checked PR #191 status: 1 failure (unit tests)
+- Attempted to fetch CI logs via WebFetch (404 error)
+- Used `gh run view --log-failed` successfully
+
+### 2. Analysis of Failures
+Found 6 failing tests:
+1. `test_judge_container.py::test_run_success` - Docker image not found
+2. `test_judge_container.py::test_run_timeout` - Docker image not found
+3. `test_config_loader.py::test_load_model` - isinstance(None, ModelConfig)
+4. `test_config_loader.py::test_load_all_models` - len({}) < 2
+5. `test_config_loader.py::test_load_merged_with_model` - assert None is not None
+6. `test_config_loader.py::test_load_merged_with_test_override` - assert None is not None
+
+### 3. Checked if Pre-existing
+- Compared with main branch CI
+- Main branch had EXACT same 6 failures
+- Initially considered this "not our problem"
+- User requested fixing them anyway
+
+### 4. Root Cause Analysis
+
+**Config Loader Failures**:
+```bash
+$ ls -la tests/fixtures/config/models/
+lrwxrwxrwx test-model.yaml -> /home/mvillmow/ProjectScylla/config/models/_test-model.yaml
+```
+Problem: Absolute symlinks don't work in CI (different workspace path)
+
+**Judge Container Failures**:
+- Tests mock `executor.run()`
+- Code actually calls `self._run_with_volumes()` (subprocess, bypasses executor)
+- Mock never gets used → real Docker call happens → image not found
+
+### 5. Fixes Applied
+
+**Symlink Fix**:
+```bash
+cd tests/fixtures/config/models
+rm test-model*.yaml
+ln -s ../../../../config/models/_test-model.yaml test-model.yaml
+ln -s ../../../../config/models/_test-model-2.yaml test-model-2.yaml
+```
+
+**Mock Fix**:
+```python
+# Changed from mocking executor to mocking the actual method
+@patch.object(JudgeContainerManager, "_run_with_volumes")
+def test_run_success(self, mock_run_with_volumes, tmp_path):
+    mock_run_with_volumes.return_value = ContainerResult(...)
+```
+
+### 6. Verification
+```bash
+$ pixi run pytest <all 6 tests> -v
+====== 6 passed in 0.27s ======
+```
+
+## Commands Used
+
+```bash
+# Investigation
+gh pr checks 191
+gh run view 21100434998 --log-failed
+gh run list --branch main --limit 3
+
+# Diagnosis
+ls -la tests/fixtures/config/models/
+readlink tests/fixtures/config/models/test-model.yaml
+cat tests/fixtures/config/models/test-model.yaml  # Failed initially
+
+# Fix symlinks
+cd tests/fixtures/config/models
+rm test-model.yaml test-model-2.yaml
+ln -s ../../../../config/models/_test-model.yaml test-model.yaml
+ln -s ../../../../config/models/_test-model-2.yaml test-model-2.yaml
+readlink -f test-model.yaml  # Verify resolution
+
+# Test fixes
+pixi run pytest tests/unit/test_config_loader.py::TestConfigLoaderModel -v
+pixi run pytest tests/unit/executor/test_judge_container.py::TestJudgeContainerManagerRunJudge -v
+
+# Create PR
+git checkout -b fix/ci-test-failures
+git add tests/fixtures/config/models/test-model*.yaml tests/unit/executor/test_judge_container.py
+git commit -m "fix(tests): fix 6 CI test failures"
+git push -u origin fix/ci-test-failures
+gh pr create --title "fix(tests): fix 6 CI test failures" --body "..."
+```
+
+## Error Messages (Raw)
+
+### Config Loader
+```
+FAILED tests/unit/test_config_loader.py::TestConfigLoaderModel::test_load_model - assert False
+ +  where False = isinstance(None, ModelConfig)
+FAILED tests/unit/test_config_loader.py::TestConfigLoaderModel::test_load_all_models - assert 0 >= 2
+ +  where 0 = len({})
+```
+
+### Judge Container
+```
+FAILED tests/unit/executor/test_judge_container.py::TestJudgeContainerManagerRunJudge::test_run_success - assert 125 == 0
+ +  where 125 = JudgeResult(..., exit_code=125, ..., stderr="Unable to find image 'scylla-runner:latest' locally\ndocker: Error response from daemon: pull access denied for scylla-runner, repository does not exist or may require 'docker login': denied: requested access to the resource is denied\n...").exit_code
+```
+
+## Files Modified
+
+1. `tests/fixtures/config/models/test-model.yaml` - symlink
+2. `tests/fixtures/config/models/test-model-2.yaml` - symlink
+3. `tests/unit/executor/test_judge_container.py` - mock fix
+
+## Key Insights
+
+1. **CI vs Local Environment Differences**:
+   - Workspace paths differ (`/home/mvillmow/...` vs `/home/runner/work/...`)
+   - Symlinks with absolute paths break
+   - Relative symlinks work universally
+
+2. **Mock Implementation Details Matter**:
+   - Constructor parameter `executor` doesn't guarantee usage
+   - Must trace actual method calls in implementation
+   - `_run_with_volumes()` uses subprocess directly, bypasses executor
+
+3. **Pre-existing Issues Should Be Fixed**:
+   - Don't perpetuate technical debt
+   - Separate PR keeps concerns isolated
+   - Improves overall project health
+
+4. **Test Philosophy**:
+   - Unit tests must not depend on external resources
+   - Mocking should be precise (actual methods called)
+   - CI failures are valuable signals, not noise to ignore
+
+## Related PRs
+
+- PR #191: Original feature PR (resource suffix refactoring)
+- PR #192: Fix for 6 CI test failures (this work)
+
+## Test Coverage Impact
+
+Before: 1037 tests, 6 failures in CI (1031 passed)
+After: 1037 tests, 0 failures in CI (1037 passed)
+Improvement: +6 tests passing in CI environment


### PR DESCRIPTION
Imported testing skill from ProjectScylla PR #193.

## Skill: fix-ci-test-failures

**Category**: testing
**Success Rate**: 100% (6/6 tests fixed)
**Source**: ProjectScylla session 2026-01-17

## Overview

Complete workflow for fixing unit tests that pass locally but fail in CI due to:
- Absolute symlink paths
- Mocking wrong methods

## Contents

- **SKILL.md**: Full workflow with failed attempts section
- **references/notes.md**: Raw session details and commands
- **plugin.json**: Metadata and trigger conditions

## Key Learnings

1. Symlinks must use relative paths (../../../../...)
2. Mock the actual method implementation calls
3. Unit tests shouldn't depend on external resources
4. Pre-existing CI failures should be fixed, not ignored

## Related

- ProjectScylla PR #192: The actual fixes
- ProjectScylla PR #193: Skill documentation