### PR TITLE
feat(validation): add documentation category to validator

### DIFF
--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -38,6 +38,7 @@ VALID_CATEGORIES = {
     "tooling",
     "ci-cd",
     "testing",
+    "documentation",
 }
 
 # Required plugin.json fields (per official Claude Code plugin docs)


### PR DESCRIPTION
## Summary

Add `documentation` category to the validator's `VALID_CATEGORIES` set.

## Changes

- Added `"documentation"` to `VALID_CATEGORIES` in `scripts/validate_plugins.py`

## Rationale

This category is needed for skills related to:
- Academic paper writing and review
- Publication workflows
- LaTeX and arXiv submissions
- Documentation quality assurance

Without this category, documentation-related plugins fail validation.

## Related

This supports skills migrated from ProjectScylla that use the documentation category.