### PR TITLE
feat(debugging): add ci-test-matrix-management skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -820,6 +820,21 @@
       ]
     },
     {
+      "name": "ci-test-matrix-management",
+      "description": "Safely modify CI test matrix without breaking coverage validation. Use when: (1) Disabling flaky tests from CI workflow, (2) Removing or commenting out test groups from comprehensive-tests.yml, (3) Pre-commit validate-test-coverage hook fails after CI matrix changes.",
+      "version": "1.0.0",
+      "source": "./plugins/debugging/ci-test-matrix-management",
+      "category": "debugging",
+      "tags": [
+        "ci-cd",
+        "test-matrix",
+        "coverage",
+        "pre-commit",
+        "flaky-tests",
+        "github-actions"
+      ]
+    },
+    {
       "name": "global-semaphore-parallelism",
       "description": "Debugging and implementing global parallelism control using multiprocessing.Manager().Semaphore() to limit concurrent agents across all tiers",
       "version": "1.0.0",

--- a/plugins/debugging/ci-test-matrix-management/.claude-plugin/plugin.json
+++ b/plugins/debugging/ci-test-matrix-management/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ci-test-matrix-management",
+  "version": "1.0.0",
+  "description": "Safely modify CI test matrix without breaking coverage validation. Use when: (1) Disabling flaky tests from CI workflow, (2) Removing or commenting out test groups from comprehensive-tests.yml, (3) Pre-commit validate-test-coverage hook fails after CI matrix changes.",
+  "author": {
+    "name": "ML Odyssey Team"
+  },
+  "category": "debugging",
+  "date": "2026-02-08",
+  "tags": ["ci-cd", "test-matrix", "coverage", "pre-commit", "flaky-tests", "github-actions"],
+  "skills": "./skills"
+}

--- a/plugins/debugging/ci-test-matrix-management/references/notes.md
+++ b/plugins/debugging/ci-test-matrix-management/references/notes.md
@@ -1,0 +1,144 @@
+# Raw Session Notes: ci-test-matrix-management
+
+## Context
+
+Working on PR #3119 to fix two issues:
+1. Replace gitleaks-action with free CLI (license requirement)
+2. Disable flaky Core Loss tests that fail intermittently
+
+## Problem Discovery
+
+After disabling tests in `.github/workflows/comprehensive-tests.yml`, the pre-commit hook failed:
+
+```
+Error: Found 2 test files not included in any test group:
+  - tests/shared/core/test_loss.mojo
+  - tests/shared/core/test_metrics.mojo
+
+Test coverage validation failed. Please ensure all test files are included in comprehensive-tests.yml
+```
+
+## Initial Confusion
+
+The error was confusing because:
+1. The tests WERE in the CI matrix (just commented out)
+2. The error message suggested adding them to `comprehensive-tests.yml`
+3. It wasn't obvious that a separate validation script existed
+
+## Root Cause Discovery
+
+Found the validation script: `scripts/validate_test_coverage.py`
+
+Key insight: This script has an `EXCLUSIONS` set that must be updated when tests are disabled in CI:
+
+```python
+EXCLUSIONS = {
+    # Temporarily disabled tests should be added here
+    # Example: "tests/shared/core/test_loss.mojo",
+}
+```
+
+The pre-commit hook calls this script via `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: validate-test-coverage
+      name: validate-test-coverage
+      entry: python scripts/validate_test_coverage.py
+      language: system
+      pass_filenames: false
+```
+
+## Solution Timeline
+
+### Commit 1: d1024768
+- Replaced gitleaks-action with free CLI
+- Initial attempt to disable flaky tests
+
+### Commit 2: ea8f3cbd
+- Added gitleaks allowlist for test files
+- Attempted to disable Core Loss tests but missed coverage validation
+
+### Commit 3: 27e4ed89
+- **Fixed the coverage validation issue**
+- Added disabled tests to `EXCLUSIONS` in `validate_test_coverage.py`
+- Pre-commit hooks now pass
+
+## Exact Error Output
+
+```
+$ python scripts/validate_test_coverage.py
+Error: Found 2 test files not included in any test group:
+  - tests/shared/core/test_loss.mojo
+  - tests/shared/core/test_metrics.mojo
+
+Test coverage validation failed. Please ensure all test files are included in comprehensive-tests.yml
+or add them to EXCLUSIONS if they should not be tested.
+```
+
+## The Hidden Dependency
+
+The key learning is that there are TWO places where tests are tracked:
+
+1. **CI Matrix** (`.github/workflows/comprehensive-tests.yml`)
+   - Defines which tests actually run in CI
+   - Visible and obvious
+
+2. **Coverage Validation Script** (`scripts/validate_test_coverage.py`)
+   - Validates that all tests are either in CI or explicitly excluded
+   - Hidden in pre-commit hooks
+   - Not obvious from CI workflow alone
+
+When you modify one, you MUST update the other.
+
+## Files Modified in Final Solution
+
+### .github/workflows/comprehensive-tests.yml
+
+```yaml
+# Line 180-185 (commented out)
+# Temporarily disabled - flaky Core Loss tests (see issue #3120)
+# - name: "Core Loss"
+#   path: "tests/shared/core"
+#   pattern: "test_loss.mojo"
+# - name: "Core Metrics"
+#   path: "tests/shared/core"
+#   pattern: "test_metrics.mojo"
+```
+
+### scripts/validate_test_coverage.py
+
+```python
+# Added to EXCLUSIONS set
+EXCLUSIONS = {
+    # Flaky tests disabled in CI (see issue #3120)
+    "tests/shared/core/test_loss.mojo",
+    "tests/shared/core/test_metrics.mojo",
+}
+```
+
+### .gitleaks.toml
+
+```toml
+[[rules.allowlist]]
+description = "Test fixtures and test data in Core tests"
+paths = [
+    '''tests/shared/core/test_loss\.mojo''',
+    '''tests/shared/core/test_metrics\.mojo''',
+]
+```
+
+## Related Issues
+
+- Issue #3120: Track re-enabling the flaky Core Loss tests
+- Need to investigate why these tests fail intermittently
+- Consider using pytest-retry or similar for flaky test handling
+
+## Lessons Learned
+
+1. **Always check pre-commit hooks locally** before pushing
+2. **Read error messages carefully** - the script told us about EXCLUSIONS but we missed it initially
+3. **Document WHY tests are disabled** - future developers need context
+4. **Create tracking issues** - disabled tests should have a path back to being enabled
+5. **The coverage validation is a good thing** - it prevents tests from being silently lost

--- a/plugins/debugging/ci-test-matrix-management/skills/ci-test-matrix-management/SKILL.md
+++ b/plugins/debugging/ci-test-matrix-management/skills/ci-test-matrix-management/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ci-test-matrix-management
+description: Safely modify CI test matrix without breaking coverage validation
+category: debugging
+date: 2026-02-08
+tags: [ci-cd, test-matrix, coverage, pre-commit, flaky-tests, github-actions]
+user-invocable: false
+---
+
+# ci-test-matrix-management
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-08 |
+| Context | PR #3119 - Fix gitleaks license requirement + disable flaky Core Loss tests |
+| Objective | Safely disable flaky tests from CI workflow matrix without breaking pre-commit coverage validation |
+| Outcome | ✅ Success - Tests disabled, coverage validation updated, CI passing |
+
+## When to Use
+
+Use this skill when:
+
+1. **Disabling flaky tests from CI workflow** - Tests fail intermittently and need to be temporarily removed from the test matrix
+2. **Removing test groups from comprehensive-tests.yml** - Commenting out or deleting test group entries in the CI matrix
+3. **Pre-commit validate-test-coverage hook fails** - After CI matrix changes, the coverage validation hook fails because it detects "uncovered" test files
+
+**Key Indicator**: Error message like:
+```
+Error: Found 2 test files not included in any test group:
+  - tests/shared/core/test_loss.mojo
+  - tests/shared/core/test_metrics.mojo
+```
+
+## Verified Workflow
+
+### Step 1: Disable Tests in CI Matrix
+
+Locate `.github/workflows/comprehensive-tests.yml` and comment out or remove the problematic test group:
+
+```yaml
+# Temporarily disabled - flaky Core Loss tests (see issue #3120)
+# - name: "Core Loss"
+#   path: "tests/shared/core"
+#   pattern: "test_loss.mojo"
+```
+
+**Important**: Add a comment explaining WHY the tests are disabled and link to a tracking issue.
+
+### Step 2: Update Coverage Validation Exclusion List
+
+This is the **CRITICAL STEP** that is easy to miss.
+
+Locate `scripts/validate_test_coverage.py` and add the disabled test files to the `EXCLUSIONS` set:
+
+```python
+EXCLUSIONS = {
+    # Flaky tests disabled in CI (see issue #3120)
+    "tests/shared/core/test_loss.mojo",
+    "tests/shared/core/test_metrics.mojo",
+    # ... other exclusions
+}
+```
+
+**Why this matters**: The pre-commit hook `validate-test-coverage` checks that ALL test files under `tests/` are included in the CI matrix. If you disable tests in the workflow but don't update the exclusion list, the hook will fail.
+
+### Step 3: Update Gitleaks Allowlist (If Needed)
+
+If the disabled tests contain patterns that trigger gitleaks (like test data with fake credentials), add them to `.gitleaks.toml`:
+
+```toml
+[[rules.allowlist]]
+description = "Test fixtures with mock credentials"
+paths = [
+    '''tests/shared/core/test_loss\.mojo''',
+    '''tests/shared/core/test_metrics\.mojo''',
+]
+```
+
+### Step 4: File Tracking Issue
+
+Create a GitHub issue to track re-enabling the disabled tests:
+
+```bash
+gh issue create \
+  --title "Re-enable flaky Core Loss tests" \
+  --body "Tests disabled in PR #3119 due to intermittent failures. Investigate root cause and re-enable." \
+  --label "testing,flaky-test"
+```
+
+Reference this issue in both the CI workflow comment and the exclusion list.
+
+## Failed Attempts
+
+| Approach | Why It Failed | Lesson Learned |
+|----------|---------------|----------------|
+| Only disable tests in CI matrix | Pre-commit hook failed with "uncovered test files" error | Must also update `scripts/validate_test_coverage.py` exclusion list |
+
+## Results & Parameters
+
+### Files Modified
+
+1. `.github/workflows/comprehensive-tests.yml` - Comment out flaky test groups
+2. `scripts/validate_test_coverage.py` - Add disabled tests to `EXCLUSIONS` set
+3. `.gitleaks.toml` (optional) - Add paths to allowlist if needed
+
+### Commands
+
+```bash
+# Verify coverage validation passes locally
+python scripts/validate_test_coverage.py
+
+# Run pre-commit hooks to verify
+pixi run pre-commit run validate-test-coverage --all-files
+
+# Check CI status after pushing
+gh pr checks
+```
+
+### Verification Checklist
+
+- [ ] Tests commented out in `.github/workflows/comprehensive-tests.yml` with reason
+- [ ] Test files added to `EXCLUSIONS` in `scripts/validate_test_coverage.py`
+- [ ] Gitleaks allowlist updated if needed (`.gitleaks.toml`)
+- [ ] Tracking issue created and referenced in comments
+- [ ] Pre-commit hooks pass locally
+- [ ] CI checks pass on PR
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3119 - Fix gitleaks + disable flaky tests | [notes.md](../../references/notes.md) |
+
+## Related
+
+- PR #3119: Fix gitleaks license requirement + disable flaky Core Loss tests
+- Issue #3120: Re-enable flaky Core Loss tests (tracking issue)
+- Skill: `run-precommit` - Run pre-commit hooks locally
+- Skill: `fix-ci-failures` - Diagnose and fix CI failures
+
+## Notes
+
+**The Hidden Dependency**: The `validate_test_coverage.py` script is called by a pre-commit hook, but it's not obvious from the CI workflow alone. This causes confusion when tests are disabled in CI but the coverage validation still expects them.
+
+**Best Practice**: Always create a tracking issue when disabling tests. This ensures the work doesn't get lost and provides context for future developers.
+
+**Future Improvement**: Consider adding a check in the CI workflow that validates the exclusion list is in sync with the test matrix. This would catch the mismatch earlier.


### PR DESCRIPTION
## Summary

Captures the learning from PR #3119 (ProjectOdyssey): when disabling tests from the CI workflow matrix, you must also update the `validate_test_coverage.py` exclusion list — otherwise the pre-commit hook fails.

This skill documents the complete workflow for safely modifying the CI test matrix without breaking coverage validation.

## Plugin Details

**Category**: debugging  
**Tags**: ci-cd, test-matrix, coverage, pre-commit, flaky-tests, github-actions

## When to Use

Use this skill when:
1. Disabling flaky tests from CI workflow
2. Removing or commenting out test groups from comprehensive-tests.yml
3. Pre-commit validate-test-coverage hook fails after CI matrix changes

## Key Learning

The **CRITICAL STEP** that's easy to miss: After disabling tests in the CI workflow, you must add them to the `EXCLUSIONS` set in `scripts/validate_test_coverage.py`. This script is called by a pre-commit hook and validates that all test files are either in the CI matrix or explicitly excluded.

## Files Added

- `plugins/debugging/ci-test-matrix-management/.claude-plugin/plugin.json` - Plugin metadata
- `plugins/debugging/ci-test-matrix-management/skills/ci-test-matrix-management/SKILL.md` - Main workflow documentation
- `plugins/debugging/ci-test-matrix-management/references/notes.md` - Raw session notes

## Files Modified

- `.claude-plugin/marketplace.json` - Added registry entry

## Verified On

- ProjectOdyssey PR #3119 - Fix gitleaks license requirement + disable flaky Core Loss tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)