### PR TITLE
feat(skills): Add retrospective-integration from ProjectScylla

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -237,30 +237,6 @@
       "tags": []
     },
     {
-      "name": "plan-create-component",
-      "description": "DEPRECATED: The notes/plan/ directory has been removed. Planning is now done directly through GitHub issues. See gh-read-issue-context and gh-post-issue-update skills instead.",
-      "version": "1.0.0",
-      "source": "./plugins/architecture/plan-create-component",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "plan-regenerate-issues",
-      "description": "DEPRECATED: The notes/plan/ directory has been removed. Planning is now done directly through GitHub issues. See gh-read-issue-context and gh-post-issue-update skills instead.",
-      "version": "1.0.0",
-      "source": "./plugins/architecture/plan-regenerate-issues",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "plan-validate-structure",
-      "description": "DEPRECATED: The notes/plan/ directory has been removed. Planning is now done directly through GitHub issues. See gh-read-issue-context and gh-post-issue-update skills instead.",
-      "version": "1.0.0",
-      "source": "./plugins/architecture/plan-validate-structure",
-      "category": "architecture",
-      "tags": []
-    },
-    {
       "name": "quality-complexity-check",
       "description": "Analyze code complexity metrics including cyclomatic complexity and nesting depth. Use when: (1) Code review process, (2) Identifying refactoring candidates, (3) Maintaining code quality standards.",
       "version": "1.0.0",
@@ -2177,6 +2153,20 @@
       "source": "./plugins/training/train-model",
       "category": "training",
       "tags": []
+    },
+    {
+      "name": "retrospective-integration",
+      "description": "Integrate /retrospective skill into automation pipelines to automatically capture session learnings",
+      "version": "1.0.0",
+      "source": "./skills/retrospective-integration",
+      "category": "automation",
+      "tags": [
+        "automation",
+        "claude-cli",
+        "session-management",
+        "pipeline-integration",
+        "graceful-degradation"
+      ]
     }
   ]
 }

--- a/skills/retrospective-integration/SKILL.md
+++ b/skills/retrospective-integration/SKILL.md
@@ -1,0 +1,127 @@
+# Skill: Retrospective Integration into Automation Pipeline
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-02-13 |
+| **Category** | Automation |
+| **Objective** | Integrate `/retrospective` skill into `implement_issues.py` to automatically capture learnings |
+| **Outcome** | ✅ Success - Full implementation with comprehensive test coverage |
+| **PR** | https://github.com/HomericIntelligence/ProjectScylla/pull/609 |
+
+## When to Use This Skill
+
+- **Capture session context automatically** - Resume Claude Code sessions for post-implementation tasks
+- **Extract session IDs from Claude CLI** - Parse JSON output to get session identifiers  
+- **Add optional pipeline phases** - Integrate new phases into existing automation workflows
+- **Implement graceful degradation** - Add non-blocking features that enhance but don't break pipelines
+- **Design opt-in features** - Add capabilities disabled by default to avoid disrupting workflows
+
+## Verified Workflow
+
+### 1. Capture Session ID from Claude CLI JSON Output
+
+```python
+result = run(["claude", "--message", prompt, "--output-format", "json"], ...)
+try:
+    data = json.loads(result.stdout)
+    return data.get("session_id")
+except (json.JSONDecodeError, AttributeError):
+    logger.warning("Could not parse session_id")
+    return None
+```
+
+**Key**: Use `.get()` for graceful None return, log warnings but never fail pipeline
+
+### 2. Resume Session to Preserve Context
+
+```python
+run([
+    "claude", "--resume", session_id, "--message",
+    "Use the /skills-registry-commands:retrospective skill..."
+], cwd=worktree_path, timeout=600)
+```
+
+**Key**: `--resume` preserves full session history, never re-raise exceptions
+
+### 3. Add New Phase to Pydantic State Model
+
+```python
+class ImplementationPhase(str, Enum):
+    RETROSPECTIVE = "retrospective"  # Add to enum
+
+class ImplementationState(BaseModel):
+    session_id: str | None = None  # Add optional field with None default
+```
+
+**Key**: New fields must have defaults for backward compatibility with persisted state
+
+### 4. Integrate into Pipeline with Conditional Logic
+
+```python
+if self.options.enable_retrospective and state.session_id:
+    state.phase = ImplementationPhase.RETROSPECTIVE
+    self._save_state(state)
+    self._run_retrospective(state.session_id, worktree_path, issue_number)
+```
+
+**Key**: Check both feature flag AND required data, always mark COMPLETED even if retrospective fails
+
+## Failed Attempts
+
+### ❌ Testing Claude CLI JSON Output in Nested Session
+
+**Tried**: Running `claude --print "Hello" --output-format json` in test
+
+**Failed**: `"Error: Claude Code cannot be launched inside another Claude Code session"`
+
+**Why**: By design to prevent resource conflicts and crashes
+
+**Solution**: Mock subprocess calls in unit tests, validate JSON parsing logic separately
+
+## Results & Parameters
+
+| Component | Value | Rationale |
+|-----------|-------|-----------|
+| Session resume timeout | 600s | Retrospective involves cloning + PR creation |
+| Implementation timeout | 1800s | Complex implementations need generous timeout |
+| Phase ordering | After CREATING_PR, before COMPLETED | Work saved but state not finalized |
+| Default flag state | False | Opt-in to avoid disrupting workflows |
+| Error handling | Log warning, never raise | Non-blocking enhancement |
+
+### Test Coverage
+
+```bash
+178 passed in 7.39s  # All automation tests pass
+All checks passed     # Pre-commit hooks pass
+```
+
+### Usage
+
+```bash
+# With retrospective enabled
+python scripts/implement_issues.py --epic 123 --retrospective
+```
+
+## Reusable Patterns
+
+**Extract JSON CLI Output**:
+```python
+try:
+    data = json.loads(result.stdout)
+    value = data.get("key")
+except (json.JSONDecodeError, AttributeError):
+    return None
+```
+
+**Non-Blocking Optional Phase**:
+```python
+try:
+    execute_optional_feature()
+except Exception as e:
+    logger.warning(f"Feature failed: {e}")
+    # Don't re-raise
+```
+
+## Tags
+
+`automation` `claude-cli` `session-management` `pipeline-integration` `graceful-degradation`

--- a/skills/retrospective-integration/plugin.json
+++ b/skills/retrospective-integration/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "retrospective-integration",
+  "version": "1.0.0",
+  "category": "automation",
+  "description": "Integrate /retrospective skill into automation pipelines to automatically capture session learnings",
+  "author": "ProjectScylla Team",
+  "date": "2026-02-13",
+  "tags": ["automation", "claude-cli", "session-management", "pipeline-integration", "graceful-degradation"],
+  "related_skills": ["advise-before-planning", "automation-testing"],
+  "verified": true,
+  "outcome": "success"
+}


### PR DESCRIPTION
## Summary

Captures learnings from integrating the `/retrospective` skill into ProjectScylla's `implement_issues.py` automation pipeline.

## Key Patterns Documented

1. **Extracting session IDs from Claude CLI JSON output**
   - Use `--output-format json` to get structured output
   - Parse session_id with graceful error handling

2. **Resuming Claude sessions to preserve context**
   - Use `claude --resume <session_id>` for post-implementation tasks
   - Maintains full session history for high-quality retrospectives

3. **Adding optional phases to Pydantic state models**
   - Extend enums with new phase values
   - Add optional fields with None defaults for backward compatibility

4. **Implementing graceful degradation**
   - Non-blocking optional features that never break pipelines
   - Log warnings, never re-raise exceptions

5. **Opt-in feature design**
   - Default disabled to avoid disrupting existing workflows
   - Clear CLI flags with helpful documentation

## Failed Attempts

Documented the attempt to test Claude CLI JSON output in nested sessions, which fails by design to prevent resource conflicts.

## Related Work

- ProjectScylla PR: https://github.com/HomericIntelligence/ProjectScylla/pull/609
- Similar to advise-before-planning integration pattern

## Files

- `skills/retrospective-integration/SKILL.md` - Full skill documentation
- `skills/retrospective-integration/plugin.json` - Plugin metadata
- `.claude-plugin/marketplace.json` - Marketplace registry update

🤖 Generated with [Claude Code](https://claude.com/claude-code)