### PR TITLE
feat(skills): Add pydantic-none-coercion-pattern from ProjectScylla

### DIFF
--- a/plugins/debugging/pydantic-none-coercion-pattern/.claude-plugin/plugin.json
+++ b/plugins/debugging/pydantic-none-coercion-pattern/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pydantic-none-coercion-pattern",
+  "description": "Fix Pydantic ValidationError caused by None flowing into non-Optional dict fields. Use when you see 'Input should be a valid dictionary [type=dict_type, input_value=None]' or when dict.get() with a default fails to guard against explicit null values in JSON data.",
+  "category": "debugging",
+  "date": "2026-02-19",
+  "tags": ["pydantic", "validation", "none", "dict", "json", "null", "coercion", "field_validator", "e2e", "checkpoint"],
+  "version": "1.0.0"
+}

--- a/plugins/debugging/pydantic-none-coercion-pattern/references/notes.md
+++ b/plugins/debugging/pydantic-none-coercion-pattern/references/notes.md
@@ -1,0 +1,153 @@
+# Raw Notes: pydantic-none-coercion-pattern
+
+## Session Context
+
+- **Date**: 2026-02-19
+- **Project**: ProjectScylla
+- **PR**: https://github.com/HomericIntelligence/ProjectScylla/pull/760
+- **Branch**: `fix-criteria-scores-none-propagation`
+- **Trigger**: 2026-02-14 dry run of 47 E2E tests — 13 tests produced incorrect results ($0 cost, 8-22s, zero tokens)
+
+## Root Cause Discovery
+
+The bug was tracked to `criteria_scores=None` entering `E2ERunResult` which types the field as non-Optional:
+
+```python
+# E2ERunResult (scylla/e2e/models.py:310)
+criteria_scores: dict[str, dict[str, Any]] = Field(default_factory=dict)  # NOT Optional
+
+# JudgeResult (scylla/e2e/llm_judge.py:48)
+criteria_scores: dict[str, dict[str, Any]] | None = None  # Optional
+
+# JudgeResultSummary (scylla/e2e/models.py:247)
+criteria_scores: dict[str, dict[str, Any]] | None = None  # Optional
+```
+
+The Pydantic error was:
+```
+pydantic_core._pydantic_core.ValidationError: 1 validation error for RunResult
+criteria_scores
+  Input should be a valid dictionary [type=dict_type, input_value=None, input_url=...]
+```
+
+## Complete Vulnerability Map (All 9 Sites)
+
+### Site 1: subtest_executor.py:360 (checkpoint resume)
+```python
+# BEFORE:
+criteria_scores=report_data.get("criteria_scores", {}),
+# AFTER:
+criteria_scores=report_data.get("criteria_scores") or {},
+```
+
+### Site 2: subtest_executor.py:858 (live run after judging)
+```python
+# BEFORE:
+criteria_scores=judgment.get("criteria_scores", {}),
+# AFTER:
+criteria_scores=judgment.get("criteria_scores") or {},
+```
+
+### Site 3: regenerate.py:210 (scan/load path)
+```python
+# BEFORE:
+criteria_scores=data.get("criteria_scores", {}),
+# AFTER:
+criteria_scores=data.get("criteria_scores") or {},
+```
+
+### Site 4: regenerate.py:400 (rejudge path, direct assignment)
+```python
+# BEFORE:
+run.criteria_scores = judge_result.criteria_scores
+# AFTER:
+run.criteria_scores = judge_result.criteria_scores or {}
+```
+
+### Site 5: rerun.py:740 (rerun experiment path)
+```python
+# BEFORE:
+"criteria_scores": judge_result.get("criteria_scores", {}),
+# AFTER:
+"criteria_scores": judge_result.get("criteria_scores") or {},
+```
+
+### Site 6: rerun_judges.py:606 (MISSING write in update function)
+```python
+# BEFORE (missing line):
+run_data["judge_score"] = consensus_score
+run_data["judge_passed"] = passed
+run_data["judge_grade"] = grade
+run_data["judge_reasoning"] = representative_reasoning
+# criteria_scores NOT written — stale value persists!
+
+# AFTER (added line):
+run_data["judge_score"] = consensus_score
+run_data["judge_passed"] = passed
+run_data["judge_grade"] = grade
+run_data["judge_reasoning"] = representative_reasoning
+run_data["criteria_scores"] = representative_criteria or {}  # NEW
+```
+
+### Site 7: judge_runner.py:246 (consensus from closest judge)
+```python
+# BEFORE:
+primary_criteria_scores = closest_judge.criteria_scores
+# AFTER:
+primary_criteria_scores = closest_judge.criteria_scores or {}
+```
+
+### Site 8: judge_runner.py:249 (single-judge fallback)
+```python
+# BEFORE:
+primary_criteria_scores = judges[0].criteria_scores if judges else None
+# AFTER:
+primary_criteria_scores = (judges[0].criteria_scores if judges else None) or {}
+```
+
+### Site 9: models.py (defense-in-depth Pydantic validator)
+```python
+# ADDED to E2ERunResult class:
+@field_validator("criteria_scores", mode="before")
+@classmethod
+def coerce_none_criteria_scores(cls, v: Any) -> dict:
+    """Coerce None to empty dict — judges may return None for criteria_scores."""
+    return v if v is not None else {}
+```
+
+## Tests Added (7 new tests)
+
+### test_models.py (3 tests in TestE2ERunResult)
+- `test_criteria_scores_coerces_none_to_empty_dict` — validator coerces None → {}
+- `test_criteria_scores_accepts_empty_dict` — {} passthrough
+- `test_criteria_scores_accepts_populated_dict` — populated dict preserved
+
+### test_subtest_executor.py (2 tests in TestCheckpointResumeWithNullCriteriaScores)
+- `test_criteria_scores_null_in_report_data` — null value in stored JSON
+- `test_criteria_scores_missing_key_in_report_data` — key absent from stored JSON
+
+### test_rerun_judges.py (2 standalone tests)
+- `test_regenerate_consensus_writes_criteria_scores_to_run_result_json` — write is present
+- `test_regenerate_consensus_writes_empty_criteria_scores_when_null` — null becomes {}
+
+## Test Results
+- All 71 tests in targeted files passed
+- `pre-commit run --all-files` — all hooks passed (ruff, mypy, black, etc.)
+
+## Why `rerun_judges.py` Was the Hardest to Find
+
+The missing write in `rerun_judges.py` was the only site that was NOT a `.get()` pattern issue.
+It was a **logic gap**: the function updated `judge_score`, `judge_passed`, `judge_grade`,
+`judge_reasoning` in `run_result.json` but simply never updated `criteria_scores`. This meant:
+- Old `criteria_scores` persisted in `run_result.json` even after re-judging
+- If the original run had `null` criteria_scores, re-judging wouldn't fix it
+- The bug was invisible until you checked `run_result.json` after a re-judge run
+
+## Analysis Tool That Found All Sites
+
+Three parallel sub-agents were launched to audit the codebase:
+1. `feature-dev:code-explorer` — read all relevant source files and mapped type definitions
+2. `feature-dev:code-explorer` (second instance) — deep sweep of all criteria_scores references
+3. `feature-dev:code-explorer` (third instance) — audited judge error handling paths
+
+The combination of all three reports produced the complete 9-site vulnerability map.

--- a/plugins/debugging/pydantic-none-coercion-pattern/skills/pydantic-none-coercion-pattern/SKILL.md
+++ b/plugins/debugging/pydantic-none-coercion-pattern/skills/pydantic-none-coercion-pattern/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: pydantic-none-coercion-pattern
+description: Fix Pydantic ValidationError when None flows into non-Optional dict fields via dict.get() with a default value
+category: debugging
+date: 2026-02-19
+tags: [pydantic, validation, none, dict, json, null, coercion, field_validator, checkpoint]
+user-invocable: false
+---
+
+# Pydantic None Coercion Pattern
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-02-19 |
+| **Objective** | Fix `ValidationError` from `criteria_scores=None` propagating into a non-Optional Pydantic field |
+| **Outcome** | ✅ Fixed 8 vulnerable sites + added defense-in-depth Pydantic validator |
+| **Project** | ProjectScylla |
+| **PR** | [#760](https://github.com/HomericIntelligence/ProjectScylla/pull/760) |
+
+## When to Use
+
+Use this skill when you encounter:
+
+- `pydantic_core._pydantic_core.ValidationError: Input should be a valid dictionary [type=dict_type, input_value=None]`
+- A Pydantic field typed as `dict[K, V]` (non-Optional) is receiving `None` at construction time
+- Symptoms: silent failures with `$0 cost + 8-22s duration + zero tokens` in E2E runs
+- Data is loaded from JSON files (checkpoint/resume) where the field may be stored as `null`
+- A `dict.get("field", {})` guard is in place but still passes `None`
+
+## The Core Trap: `dict.get()` Does NOT Guard Against Explicit `null`
+
+```python
+# BROKEN: Only returns {} when the key is ABSENT
+data = {"criteria_scores": None}  # key exists, value is null
+data.get("criteria_scores", {})   # Returns None, NOT {}
+
+# CORRECT: Returns {} both when key absent AND when value is None
+data.get("criteria_scores") or {}  # Returns {}
+```
+
+This is the most common mistake when loading data from JSON files where a field may be stored as `null`.
+
+## Problem
+
+A type mismatch exists when data flows between two layers with different Optional-ness:
+
+```python
+# Source type (Optional - can be None):
+class JudgeResult:
+    criteria_scores: dict[str, dict[str, Any]] | None = None
+
+# Destination type (non-Optional - must be dict):
+class E2ERunResult(BaseModel):
+    criteria_scores: dict[str, dict[str, Any]] = Field(default_factory=dict)
+```
+
+When `JudgeResult.criteria_scores = None` flows into `E2ERunResult` construction, Pydantic raises:
+```
+ValidationError: 1 validation error for E2ERunResult
+criteria_scores
+  Input should be a valid dictionary [type=dict_type, input_value=None, ...]
+```
+
+The error manifests as silent test failures — the entire run is marked as failed with $0 cost.
+
+## Verified Workflow
+
+### 1. Find All Vulnerable `.get()` Calls
+
+```bash
+# Find all dict.get() calls with a default that target the field
+grep -rn '.get("criteria_scores", {})' <project-root>/
+# Every match is vulnerable to explicit null values in JSON
+```
+
+### 2. Fix the `.get()` Pattern
+
+```python
+# BEFORE (vulnerable):
+criteria_scores = data.get("criteria_scores", {})
+
+# AFTER (safe):
+criteria_scores = data.get("criteria_scores") or {}
+```
+
+### 3. Fix Direct Assignments From Optional Sources
+
+```python
+# BEFORE (can assign None to non-Optional field):
+run.criteria_scores = judge_result.criteria_scores
+
+# AFTER (guard at assignment):
+run.criteria_scores = judge_result.criteria_scores or {}
+```
+
+### 4. Fix Upstream Producers (Prevent None From Entering the Dict)
+
+When a consensus dict or similar intermediate structure is built and consumed downstream:
+
+```python
+# BEFORE (produces None in the dict):
+primary_criteria_scores = closest_judge.criteria_scores  # can be None
+consensus_dict = {"criteria_scores": primary_criteria_scores}
+
+# AFTER (normalize at the source):
+primary_criteria_scores = closest_judge.criteria_scores or {}
+consensus_dict = {"criteria_scores": primary_criteria_scores}
+```
+
+### 5. Add a Pydantic Validator for Defense-in-Depth
+
+Even after fixing all call sites, add a validator to the Pydantic model as a backstop:
+
+```python
+from pydantic import BaseModel, Field, field_validator
+from typing import Any
+
+class E2ERunResult(BaseModel):
+    criteria_scores: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+    @field_validator("criteria_scores", mode="before")
+    @classmethod
+    def coerce_none_criteria_scores(cls, v: Any) -> dict:
+        """Coerce None to empty dict — upstream sources may return None."""
+        return v if v is not None else {}
+```
+
+This catches any future callers that pass `None` without requiring all call sites to be perfect.
+
+### 6. Fix Missing Writes in Update Functions
+
+When a function updates stored JSON (e.g., `run_result.json`) but omits the field, stale data persists:
+
+```python
+# BEFORE (missing criteria_scores write):
+run_data["judge_score"] = consensus_score
+run_data["judge_passed"] = passed
+run_data["judge_reasoning"] = representative_reasoning
+# criteria_scores NOT updated — stale value persists!
+
+# AFTER (include criteria_scores in every update):
+run_data["judge_score"] = consensus_score
+run_data["judge_passed"] = passed
+run_data["judge_reasoning"] = representative_reasoning
+run_data["criteria_scores"] = representative_criteria or {}
+```
+
+### 7. Run Tests
+
+```bash
+<package-manager> run python -m pytest tests/unit/ -v -k "criteria_scores"
+pre-commit run --all-files
+```
+
+## Failed Attempts
+
+| Approach | Why It Failed |
+|----------|---------------|
+| `dict.get("criteria_scores", {})` | Only returns `{}` when the key is **missing**; returns `None` when key exists with `null` value |
+| Typing `criteria_scores` as `Optional[dict]` in destination model | Allows `None` but then downstream code using `.items()` or `.keys()` crashes with `AttributeError: 'NoneType'` |
+| Only fixing the highest-visibility call site | The bug has 8+ manifestations across multiple files; must do a complete audit with `grep` |
+| Relying on Pydantic's `default_factory=dict` | Default only applies when the field is **not provided** at construction time; explicit `None` overrides the default and causes ValidationError |
+
+## Audit Checklist
+
+When fixing this pattern, audit ALL locations where the affected field is:
+
+1. Read from JSON/dict via `.get()` with a default
+2. Assigned from an Optional-typed source to a non-Optional destination
+3. Updated in stored JSON files (look for "update functions" that write some fields but not others)
+4. Produced by consensus/aggregation functions and placed into intermediate dicts
+
+```bash
+# Find all occurrences of the field across the codebase:
+grep -rn "criteria_scores" <project-root>/scylla/
+grep -rn "criteria_scores" <project-root>/tests/
+
+# Check each one: is the field Optional at the source? Non-Optional at the destination?
+```
+
+## Results & Parameters
+
+### Vulnerability Map (ProjectScylla example)
+
+| # | File | Pattern | Fix |
+|---|------|---------|-----|
+| 1 | `subtest_executor.py:360` | `.get("criteria_scores", {})` on checkpoint data | `or {}` |
+| 2 | `subtest_executor.py:858` | `.get("criteria_scores", {})` on consensus dict | `or {}` |
+| 3 | `regenerate.py:210` | `.get("criteria_scores", {})` on stored data | `or {}` |
+| 4 | `regenerate.py:400` | `run.criteria_scores = judge_result.criteria_scores` | `or {}` |
+| 5 | `rerun.py:740` | `.get("criteria_scores", {})` on judge result | `or {}` |
+| 6 | `rerun_judges.py:606` | Missing write in update function | Add write with `or {}` |
+| 7 | `judge_runner.py:246` | `primary_criteria_scores = closest_judge.criteria_scores` | `or {}` |
+| 8 | `judge_runner.py:249` | `judges[0].criteria_scores if judges else None` | `or {}` |
+| 9 | `models.py` | `E2ERunResult.criteria_scores` field | Add `field_validator` |
+
+### Test Pattern
+
+```python
+def test_criteria_scores_coerces_none_to_empty_dict() -> None:
+    """Test that criteria_scores=None is coerced to {} by the Pydantic validator."""
+    result = MyModel(
+        # ... other required fields ...
+        criteria_scores=None,  # type: ignore[arg-type]
+    )
+    assert result.criteria_scores == {}
+
+
+def test_criteria_scores_null_in_checkpoint_data() -> None:
+    """Test that null in stored JSON does not raise ValidationError on resume."""
+    data = {"criteria_scores": None, ...}  # Simulates run_result.json with null
+
+    result = MyModel(
+        # ... other fields ...
+        criteria_scores=data.get("criteria_scores") or {},  # Safe pattern
+    )
+    assert result.criteria_scores == {}
+```
+
+## Key Learnings
+
+1. **`dict.get(key, default)` trap**: The default is only used when the **key is absent**. If the key exists with value `None`, the default is ignored and `None` is returned. Always use `dict.get(key) or default` when the stored value can be `null`.
+
+2. **Audit all 3 vulnerability types**: `.get()` calls, direct assignments from Optional sources, and missing writes in update functions.
+
+3. **Defense-in-depth**: Fix all call sites AND add a Pydantic `field_validator`. The validator catches future regressions without requiring every caller to be perfect.
+
+4. **Type mismatch root cause**: When an Optional source (`dict | None`) flows into a non-Optional destination (`dict`), every handoff point is a potential bug. Either make all types consistent, or add guards at every handoff.
+
+5. **Symptom identification**: `$0 cost + 8-22s duration + zero tokens` in E2E evaluation results = Pydantic ValidationError in the framework, not a model failure.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #760 - 8 sites fixed after 2026-02-14 dry run revealed 13 failing tests | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

- Documents the `dict.get(key, default)` trap: the default is **not** returned when the key exists with value `None`
- Provides the correct fix: `dict.get(key) or default`
- Shows how to add a Pydantic `field_validator` for defense-in-depth
- Documents 3 vulnerability types to audit: `.get()` calls, direct assignments from Optional sources, missing writes in update functions

## Source

**ProjectScylla PR #760** — Fixed 8 vulnerable sites after 2026-02-14 dry run revealed 13 E2E tests producing silent failures ($0 cost, 8-22s duration, zero tokens).

## Skill Details

- **Category**: debugging
- **Tags**: pydantic, validation, none, dict, json, null, coercion, field_validator, checkpoint
- **Symptom to trigger on**: `Input should be a valid dictionary [type=dict_type, input_value=None]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)