### PR TITLE
feat(skills): Add pydantic-type-consolidation-metrics-judgment

### DIFF
--- a/skills/pydantic-type-consolidation-metrics-judgment/SKILL.md
+++ b/skills/pydantic-type-consolidation-metrics-judgment/SKILL.md
@@ -52,11 +52,13 @@ grep -n "class MetricsInfo\|class JudgmentInfo" scylla/reporting/result.py
 ### 2. Design Base Fields
 
 For **MetricsInfoBase** — core token/cost concepts:
+
 - `tokens_input: int = Field(...)` — always required
 - `tokens_output: int = Field(...)` — always required
 - `cost_usd: float = Field(default=0.0)` — optional (may not be known yet)
 
 For **JudgmentInfoBase** — core judgment concepts:
+
 - `passed: bool = Field(...)` — always required
 - `impl_rate: float = Field(default=0.0)` — optional (may not be computed)
 


### PR DESCRIPTION
## Summary

- Adds `pydantic-type-consolidation-metrics-judgment` skill documenting the second application of the Pydantic type consolidation pattern
- Covers `MetricsInfoBase` and `JudgmentInfoBase` consolidation from ProjectScylla issue #729 / PR #788
- Complements the existing `pydantic-type-consolidation` skill (#658) with new learnings specific to metrics/judgment types

## Key Learnings Captured

- Pattern scales cleanly to additional type families with no new patterns needed
- Preemptive base extraction (no duplicates needed) is valid and useful
- Default field strategy: required when always semantically meaningful; `default=0.0` when may not be known at construction
- Ruff formatter auto-fix on commit is expected behavior, not a failure
- 35 new tests added (33 in new file + 2 in existing file), all 2247 suite tests passing

## Source

- ProjectScylla issue: #729
- ProjectScylla PR: #788
- Prior pattern: `pydantic-type-consolidation` (from #658)

🤖 Generated with [Claude Code](https://claude.com/claude-code)