### PR TITLE
feat(skills): Add validate-tier-id-filename-consistency

### DIFF
--- a/skills/validate-tier-id-filename-consistency/SKILL.md
+++ b/skills/validate-tier-id-filename-consistency/SKILL.md
@@ -1,0 +1,210 @@
+# Validate Tier ID / Filename Consistency
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-02-22 |
+| **Category** | testing |
+| **Objective** | Fix silent key/value disagreement when `load_all_tiers()` stores configs under filename keys without verifying the `tier` field inside each config matches |
+| **Outcome** | ✅ `ConfigurationError` raised immediately on mismatch; 2398 tests pass; 74.16% coverage |
+| **Issue** | #807 (follow-up from #733) |
+| **PR** | #945 |
+
+## When to Use
+
+Use this skill when:
+
+- A `load_all_*()` function globs files and stores results by filename stem, but the loaded object has an ID field that could disagree with that stem.
+- A caller trusts either the dict key or the object's own ID field and the two could silently diverge.
+- You see patterns like: `result[filename_stem] = self.load_X(filename_stem)` where `load_X` may use the file body's ID field instead of the filename stem.
+- A related individual loader (`load_tier`, `load_model`) normalizes the identifier and you need to ensure the aggregation layer applies the same normalization before comparing.
+
+## Problem Pattern
+
+**Root Cause**: `load_all_tiers()` used the filename stem as the dict key, but `load_tier()` injected `tier` into the YAML data only when the key was absent. If `tier: t1` was declared in `t0.yaml`, `load_tier("t0")` returned a config with `config.tier == "t1"` while the caller stored it under key `"t0"`. Silent disagreement.
+
+```python
+# BEFORE — silent mismatch possible
+for tier_file in sorted(tiers_dir.glob("t*.yaml")):
+    tier_name = tier_file.stem        # "t0"
+    result[tier_name] = self.load_tier(tier_name)
+    # If t0.yaml has `tier: t1`, result["t0"].tier == "t1" — caller gets bad data
+```
+
+## Verified Workflow
+
+### 1. Identify the aggregation pattern
+
+Look for `load_all_*()` methods that:
+- Glob files and extract a key from the filename stem.
+- Call an individual `load_*()` method that may use body-level ID fields.
+- Store results as `result[stem] = loaded_object`.
+
+```bash
+grep -n "glob\|stem\|result\[" scylla/config/loader.py
+```
+
+### 2. Determine normalization used by the individual loader
+
+Read the individual `load_*()` to find how it normalizes the identifier:
+
+```python
+# In load_tier():
+tier = tier.lower().strip()
+if not tier.startswith("t"):
+    tier = f"t{tier}"
+```
+
+### 3. Apply the same normalization in the aggregation check
+
+Add a post-load guard **after** calling the individual loader, **before** storing:
+
+```python
+for tier_file in sorted(tiers_dir.glob("t*.yaml")):
+    tier_name = tier_file.stem              # e.g., "t0"
+    tier_config = self.load_tier(tier_name)
+
+    # Apply same normalization as load_tier() to compute expected
+    expected = tier_name.lower().strip()
+    if not expected.startswith("t"):
+        expected = f"t{expected}"
+
+    if tier_config.tier != expected:
+        raise ConfigurationError(
+            f"Tier ID mismatch in {tier_file}: "
+            f"filename implies '{expected}' but config declares tier='{tier_config.tier}'"
+        )
+
+    result[tier_name] = tier_config
+```
+
+**Key decisions**:
+- Reuse the individual loader's normalization exactly — do not invent a new one.
+- Error message must name both the filename path and the conflicting field value.
+- Guard goes between `load_tier()` call and `result[...] =` assignment.
+- No new helpers, classes, or abstractions needed.
+
+### 4. Write tests with `tmp_path` (not shared fixtures)
+
+Use pytest's `tmp_path` fixture for the mismatch test to avoid polluting the shared fixtures directory and breaking existing count assertions:
+
+```python
+def test_load_all_tiers_mismatched_id_raises(self, tmp_path: Path) -> None:
+    """load_all_tiers() raises ConfigurationError when filename and config.tier disagree."""
+    tiers_dir = tmp_path / "config" / "tiers"
+    tiers_dir.mkdir(parents=True)
+
+    # File named t0.yaml but declares tier: t1
+    (tiers_dir / "t0.yaml").write_text(
+        "tier: t1\nname: Mismatch Test\ndescription: Intentionally mismatched\n"
+        "uses_tools: false\nuses_delegation: false\nuses_hierarchy: false\n"
+    )
+
+    loader = ConfigLoader(base_path=tmp_path)
+    with pytest.raises(ConfigurationError, match="t0") as exc_info:
+        loader.load_all_tiers()
+
+    assert "t1" in str(exc_info.value)
+
+
+def test_load_all_tiers_consistent_ids(self) -> None:
+    """All dict keys returned by load_all_tiers() equal their config.tier value."""
+    loader = ConfigLoader(base_path=FIXTURES_PATH)
+    tiers = loader.load_all_tiers()
+
+    for key, config in tiers.items():
+        assert key == config.tier, f"Key {key!r} does not match config.tier {config.tier!r}"
+```
+
+### 5. Run and verify
+
+```bash
+# Tier-specific tests (note: coverage will show <73% in isolation — that's expected)
+pixi run python -m pytest tests/unit/test_config_loader.py::TestConfigLoaderTier -v
+
+# Full suite (coverage must meet threshold)
+pixi run python -m pytest tests/ -v
+
+# Pre-commit hooks
+pre-commit run --all-files
+```
+
+**Expected results**:
+- `test_load_all_tiers_mismatched_id_raises` — PASS
+- `test_load_all_tiers_consistent_ids` — PASS
+- All existing tests — PASS (no regressions)
+- Coverage threshold met
+
+## Failed Attempts
+
+### Attempted: Creating a shared fixture file for the mismatch case
+
+**What**: Considered placing `tmismatch.yaml` (with `tier: t99`) in `tests/fixtures/config/tiers/` to be picked up by the glob.
+
+**Why it failed**: The existing `test_load_all_tiers` asserts `len(tiers) == 2`. Adding a file that triggers a `ConfigurationError` mid-iteration would break that test, and placing a valid but intentionally-mismatched fixture would change the count to 3.
+
+**Resolution**: Use `tmp_path` in the mismatch test instead. Isolated loader with its own temp directory — no impact on shared fixtures.
+
+### Pre-commit E501 line-too-long
+
+**What**: First docstring attempt was 101 characters, exceeding the 100-char limit.
+
+**Fix**: Shortened `"when filename stem and config.tier disagree"` to `"when filename and config.tier disagree"`.
+
+**Pattern**: Always check docstring line length when the method name is already long (e.g., `test_load_all_tiers_mismatched_id_raises`).
+
+## Results & Parameters
+
+### Production change
+
+**File**: `scylla/config/loader.py` — `load_all_tiers()` (lines 244–259)
+
+```python
+# Added after self.load_tier(tier_name) call:
+expected = tier_name.lower().strip()
+if not expected.startswith("t"):
+    expected = f"t{expected}"
+
+if tier_config.tier != expected:
+    raise ConfigurationError(
+        f"Tier ID mismatch in {tier_file}: "
+        f"filename implies '{expected}' but config declares tier='{tier_config.tier}'"
+    )
+```
+
+### Test changes
+
+**File**: `tests/unit/test_config_loader.py` — `TestConfigLoaderTier` class
+
+- Added `test_load_all_tiers_mismatched_id_raises` (uses `tmp_path`)
+- Added `test_load_all_tiers_consistent_ids` (uses shared fixtures)
+
+### Verification results
+
+```
+2398 passed, 8 warnings in 56.38s
+Coverage: 74.16% (threshold: 73%)
+Pre-commit: All checks passed
+```
+
+### PR
+
+- **Branch**: `807-auto-impl`
+- **PR**: #945
+- **Commit**: `fix(config): Validate tier IDs in load_all_tiers() match filenames`
+- **Auto-merge**: Enabled (--rebase)
+
+## Key Learnings
+
+1. **Validation belongs at the aggregation layer** — the individual `load_tier()` can only validate its own input; the aggregation layer `load_all_tiers()` must validate cross-cutting invariants (key == value.id).
+2. **Reuse the same normalization** — copy the normalization from the individual loader verbatim to avoid false positives from capitalization or prefix differences.
+3. **Use `tmp_path` for mismatch fixtures** — never add intentionally-broken fixtures to shared fixture directories if existing tests assert exact counts.
+4. **Check docstring line length** — long test method names plus descriptive docstrings easily breach 100-char limits; shorten prose rather than the method name.
+
+## Related Skills
+
+- `fix-resource-prompt-consistency` — catching inconsistent field mapping at the aggregation layer (analogous pattern)
+- `fix-yaml-config-propagation` — 4-stage pipeline tracing (YAML → parser → dataclass → executor)
+- `validate-model-configs-fix-mode` — similar filename/field consistency validation for model configs
+- `centralized-path-constants` — validation collocated with path logic

--- a/skills/validate-tier-id-filename-consistency/plugin.json
+++ b/skills/validate-tier-id-filename-consistency/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "validate-tier-id-filename-consistency",
+  "version": "1.0.0",
+  "category": "testing",
+  "tags": ["config", "validation", "tier", "consistency", "error-handling"],
+  "created": "2026-02-22",
+  "updated": "2026-02-22",
+  "description": "Validate that config field values match their source filename at the aggregation layer to prevent silent key/value disagreement",
+  "trigger_patterns": [
+    "load_all.*filename.*mismatch",
+    "config.*tier.*disagree",
+    "dict key.*config field.*inconsistent",
+    "aggregation.*filename.*consistency"
+  ]
+}

--- a/skills/validate-tier-id-filename-consistency/references/notes.md
+++ b/skills/validate-tier-id-filename-consistency/references/notes.md
@@ -1,0 +1,86 @@
+# Raw Notes — validate-tier-id-filename-consistency
+
+## Session Context
+
+- **Date**: 2026-02-22
+- **Issue**: ProjectScylla #807 (follow-up from #733)
+- **Branch**: `807-auto-impl`
+- **PR**: #945
+
+## Problem Statement
+
+`load_all_tiers()` globs `t*.yaml` files, extracts the filename stem (e.g. `"t0"`), calls
+`load_tier(stem)`, and stores the result under that stem as the dict key. However, `load_tier()`
+uses the body-level `tier:` field when present, only falling back to the filename stem when
+`tier` is absent from the YAML. This means a file named `t0.yaml` with `tier: t1` in its body
+produces `result["t0"].tier == "t1"` — the key and the object's own ID field disagree.
+
+Any caller that trusts the dict key to be authoritative (e.g., for logging, routing, or display)
+gets silently wrong data.
+
+## Execution Log
+
+### Step 1: Read issue and plan
+
+Read `.claude-prompt-807.md` and ran `gh issue view 807 --comments`. The issue already had a
+detailed implementation plan including:
+- Exact lines to change in `loader.py`
+- Which normalization to apply (`lower().strip()`, prefix with `"t"`)
+- Warning not to add fixture files to shared dir (use `tmp_path`)
+
+### Step 2: Read source files
+
+Read `scylla/config/loader.py` (full file) and `tests/unit/test_config_loader.py` (full file).
+
+Key observations:
+- `load_tier()` normalizes at lines 211–213; stores body `tier` field at lines 218–220
+- `load_all_tiers()` was 10 lines, no consistency check
+- Existing `test_load_all_tiers` asserts `len(tiers) == 2` — confirmed `tmp_path` strategy correct
+
+### Step 3: Implement production fix
+
+Edit to `load_all_tiers()`: 14-line change replacing 1 line. Added `expected` computation +
+guard block.
+
+### Step 4: Add tests
+
+Two methods added to `TestConfigLoaderTier`:
+1. `test_load_all_tiers_mismatched_id_raises` — uses `tmp_path`, creates `t0.yaml` with `tier: t1`
+2. `test_load_all_tiers_consistent_ids` — uses `FIXTURES_PATH`, asserts key == config.tier
+
+### Step 5: Run tests
+
+- Tier-only: 7/7 pass (coverage low in isolation — expected)
+- Full suite: 2398/2398 pass, 74.16% coverage (above 73% threshold)
+
+### Step 6: Commit
+
+Pre-commit hook failed first attempt: E501 on docstring line 197 (101 chars).
+Fixed by shortening `"when filename stem and config.tier disagree"` to
+`"when filename and config.tier disagree"`.
+Second commit succeeded: all hooks green.
+
+### Step 7: Push and PR
+
+```
+git push -u origin 807-auto-impl
+gh pr create --title "fix(config): Validate tier IDs in load_all_tiers() match filenames"
+gh pr merge --auto --rebase
+```
+
+PR #945 created, auto-merge enabled.
+
+## File Changes
+
+| File | Type | Lines changed |
+|------|------|--------------|
+| `scylla/config/loader.py` | Modified | +14, -1 (lines 244–261) |
+| `tests/unit/test_config_loader.py` | Modified | +25, -0 (after line 194) |
+
+## Team Knowledge Used
+
+The issue plan referenced these ProjectMnemosyne skills as prior learnings:
+- `fix-resource-prompt-consistency`
+- `fix-yaml-config-propagation`
+- `resume-crash-debugging`
+- `centralized-path-constants`


### PR DESCRIPTION
## Summary

- Adds new skill `validate-tier-id-filename-consistency` in category `testing`
- Captures the pattern for fixing silent key/value disagreement when `load_all_*()` functions store configs by filename stem without verifying the object's own ID field matches
- Sourced from ProjectScylla #807 (follow-up to #733)

## Skill Contents

- `SKILL.md` — Problem pattern, verified workflow, failed attempts (shared fixture pitfall, E501 docstring), key learnings
- `plugin.json` — Metadata and trigger patterns
- `references/notes.md` — Raw session execution log

## When Useful

When a `load_all_*()` method globs files and stores results by filename stem, but the loaded object may contain its own ID field sourced from the file body that could disagree with the stem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)