### PR TITLE
feat(skills): Add phantom-dir-reference-fix retrospective skill

### DIFF
--- a/skills/phantom-dir-reference-fix/SKILL.md
+++ b/skills/phantom-dir-reference-fix/SKILL.md
@@ -1,0 +1,127 @@
+# Skill: phantom-dir-reference-fix
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-22 |
+| Objective | Remove phantom `tests/integration/` directory references from README.md and CONTRIBUTING.md |
+| Outcome | Success — all phantom references removed, PR #954 created and auto-merge enabled |
+| Category | docs |
+
+## When to Use
+
+Use this skill when:
+- A quality audit identifies documentation referencing directories that do not exist in the repository
+- `grep -r "tests/integration" docs/ README.md CONTRIBUTING.md` returns hits in user-facing docs
+- Contributors are misled by stale test-category descriptions or nonexistent pytest invocation paths
+- You need to correct test counts or category descriptions after test restructuring
+
+## Verified Workflow
+
+### 1. Identify all phantom references
+
+```bash
+grep -rn "tests/integration" docs/ README.md CONTRIBUTING.md
+```
+
+Check which hits are in user-facing documentation (README.md, CONTRIBUTING.md, docs/) vs. archived snapshots (docs/arxiv/ dryrun workspaces) — archived snapshots are out of scope.
+
+### 2. Fix README.md — test category bullets
+
+Remove the phantom category bullet and fold its count into the parent category:
+
+**Before:**
+```markdown
+- **Unit Tests** (67+ files): Analysis, adapters, config, executors, judges, metrics, reporting
+- **Integration Tests** (2 files): End-to-end workflow testing
+```
+
+**After:**
+```markdown
+- **Unit Tests** (70+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
+```
+
+Key: update the unit test count to absorb the integration-style tests (they live in `tests/unit/analysis/` as `test_integration.py`, `test_cop_integration.py`, `test_duration_integration.py`).
+
+### 3. Fix README.md — running tests code block
+
+Remove the nonexistent invocation:
+
+**Before:**
+```bash
+# Integration tests
+pixi run pytest tests/integration/ -v
+
+# Coverage analysis
+```
+
+**After:**
+```bash
+# Coverage analysis
+```
+
+### 4. Fix CONTRIBUTING.md — write tests comment
+
+**Before:**
+```bash
+# Create tests in tests/unit/ or tests/integration/
+```
+
+**After:**
+```bash
+# Create tests in tests/unit/
+```
+
+### 5. Fix CONTRIBUTING.md — running tests section
+
+Replace the phantom invocation with the actual location of integration-style tests:
+
+**Before:**
+```bash
+pixi run pytest tests/unit/ -v          # Unit tests only
+pixi run pytest tests/integration/ -v   # Integration tests
+```
+
+**After:**
+```bash
+pixi run pytest tests/unit/ -v          # Unit tests only
+pixi run pytest tests/unit/analysis/ -v # Includes integration-style tests
+```
+
+### 6. Verify clean
+
+```bash
+grep -r "tests/integration" docs/ README.md CONTRIBUTING.md
+# Should return no results
+```
+
+### 7. Commit and PR
+
+```bash
+git add README.md CONTRIBUTING.md
+git commit -m "fix(docs): Remove phantom tests/integration/ references"
+git push -u origin 848-auto-impl
+gh pr create --title "fix(docs): Remove phantom tests/integration/ references" --body "Closes #848"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+None — the task was a straight documentation edit with no code changes required, so no approaches failed. The only subtlety was confirming that `docs/arxiv/` dryrun snapshot references were out of scope before declaring the grep clean.
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Files changed | `README.md`, `CONTRIBUTING.md` |
+| Lines removed | 7 |
+| Lines added | 3 |
+| Pre-commit hooks | All passed (markdown lint, trailing whitespace, end-of-file) |
+| PR | https://github.com/HomericIntelligence/ProjectScylla/pull/954 |
+| Issue | #848 |
+| Branch | `848-auto-impl` |
+
+## Key Insight
+
+Integration-style tests in ProjectScylla live inside `tests/unit/analysis/` under names like `test_integration.py`, `test_cop_integration.py`, and `test_duration_integration.py`. There is **no** dedicated `tests/integration/` directory. When documenting test categories, fold these into the unit test count with a clarifying note rather than listing them as a separate category.

--- a/skills/phantom-dir-reference-fix/plugin.json
+++ b/skills/phantom-dir-reference-fix/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "phantom-dir-reference-fix",
+  "version": "1.0.0",
+  "description": "Remove phantom directory references from documentation when a referenced path does not exist in the repository.",
+  "category": "docs",
+  "tags": ["documentation", "cleanup", "testing", "readme", "contributing"],
+  "trigger": "grep -r 'nonexistent-dir' docs/ README.md CONTRIBUTING.md returns hits",
+  "outcome": "All phantom directory references removed; documentation accurately reflects actual repository structure"
+}

--- a/skills/phantom-dir-reference-fix/references/notes.md
+++ b/skills/phantom-dir-reference-fix/references/notes.md
@@ -1,0 +1,43 @@
+# Raw Notes — phantom-dir-reference-fix
+
+## Session: 2026-02-22
+
+### Issue
+GitHub issue #848: README.md and CONTRIBUTING.md referenced `tests/integration/` which does not exist.
+
+### Specific phantom references found
+
+**README.md line 347:**
+```
+- **Integration Tests** (2 files): End-to-end workflow testing
+```
+
+**README.md line 366:**
+```
+pixi run pytest tests/integration/ -v
+```
+
+**CONTRIBUTING.md line 118:**
+```
+# Create tests in tests/unit/ or tests/integration/
+```
+
+**CONTRIBUTING.md line 239:**
+```
+pixi run pytest tests/integration/ -v   # Integration tests
+```
+
+### Actual test structure
+Integration-style tests are in `tests/unit/analysis/`:
+- `test_integration.py`
+- `test_cop_integration.py`
+- `test_duration_integration.py`
+
+### Scope clarification
+`docs/arxiv/dryrun/raw/T6/01/run_01/workspace/.claude/skills/phase-test-tdd/SKILL.md` and companion shell scripts also contain `tests/integration` references, but these are archived dryrun workspace snapshots and were explicitly out of scope per the issue.
+
+### Verification command (from issue success criteria)
+```bash
+grep -r "tests/integration" docs/ README.md CONTRIBUTING.md
+```
+Returns no results after fix (ignoring docs/arxiv/ snapshots).


### PR DESCRIPTION
## Summary

- Adds retrospective skill for removing phantom `tests/integration/` directory references from user-facing documentation
- Documents the exact edits needed in README.md and CONTRIBUTING.md
- Captures the key insight that ProjectScylla's integration-style tests live in `tests/unit/analysis/`

## Source

Session: 2026-02-22, Issue #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)