### PR TITLE
feat(skills): Add doc-stale-future-improvements-audit skill

### DIFF
--- a/plugins/documentation/doc-stale-future-improvements-audit/.claude-plugin/plugin.json
+++ b/plugins/documentation/doc-stale-future-improvements-audit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "doc-stale-future-improvements-audit",
+  "version": "1.0.0",
+  "description": "Systematically audit design docs for Future Improvements sections that describe features already implemented in source code. Use when an issue asks to audit docs for staleness, when CI flags stale docs, or after a period of active development.",
+  "category": "documentation",
+  "date": "2026-02-22",
+  "tags": ["documentation", "audit", "stale-docs", "future-improvements", "design-docs"]
+}

--- a/plugins/documentation/doc-stale-future-improvements-audit/skills/doc-stale-future-improvements-audit/SKILL.md
+++ b/plugins/documentation/doc-stale-future-improvements-audit/skills/doc-stale-future-improvements-audit/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: doc-stale-future-improvements-audit
+description: Systematically audit design docs for Future Improvements sections that describe features already implemented in source code. Use when an issue asks to audit docs for staleness, when CI flags stale docs, or after a period of active development.
+category: documentation
+date: 2026-02-22
+user-invocable: true
+---
+
 # Doc Stale Future Improvements Audit
 
 ## Overview
@@ -6,9 +14,8 @@
 |-----------|-------|
 | **Date** | 2026-02-22 |
 | **Objective** | Systematically audit all design docs for "Future Improvements" sections listing features already implemented in source code |
-| **Outcome** | Fixed stale entries across 2 doc files; confirmed 2 others have genuinely-future items; PR #989 merged |
-| **Category** | Documentation |
-| **Related Issues** | #880 (follow-up from #759) |
+| **Outcome** | Fixed stale entries across 2 doc files; confirmed 2 others have genuinely-future items; PR merged |
+| **Related Issues** | Follow-up from single-file audit to cover remaining docs |
 
 ## When to Use This Skill
 
@@ -17,7 +24,7 @@ Use this skill when:
 - A "Future Improvements" or "Future Work" section in documentation describes something that's already implemented
 - Systematic doc auditing is needed after a period of active development
 - Issue specifically asks to audit docs for staleness against actual source code
-- Follow-up after a single-file audit (like #759 for `container-architecture.md`) to cover remaining docs
+- Follow-up after a single-file audit to cover remaining docs
 
 **Triggers:**
 
@@ -35,8 +42,8 @@ grep -rn "Future Improvements\|Future Work\|Coming Soon\|Planned\|Not Implemente
   --include="*.md" | grep -v "docs/arxiv/"
 ```
 
-- Ignore `docs/arxiv/` (raw run output, not authoritative docs)
-- Ignore `docs/dev/code-quality-audit-*.md` (issue-tracking docs, not design docs)
+- Ignore raw run output directories (not authoritative docs)
+- Ignore issue-tracking docs (not design docs)
 
 ### Phase 2: Cross-reference Against Source Code
 
@@ -44,19 +51,13 @@ For each candidate entry, verify against actual implementation:
 
 **Adapters listed as Planned:**
 ```bash
-ls scylla/adapters/          # Check which .py files exist
-head -3 scylla/adapters/<name>.py  # Confirm it's real implementation, not stub
+ls <project-root>/adapters/          # Check which .py files exist
+head -3 <project-root>/adapters/<name>.py  # Confirm it's real implementation, not stub
 ```
 
-**Metrics listed as future:**
+**Functions listed as future:**
 ```bash
-grep -n "def calculate_\|def compute_\|def <function>" scylla/metrics/process.py
-grep -n "def <function>" scylla/analysis/stats.py
-```
-
-**Multi-experiment support:**
-```bash
-grep -n "load_all_experiments\|load_experiment" scylla/analysis/loader.py
+grep -n "def calculate_\|def compute_\|def <function>" <project-root>/<module>.py
 ```
 
 ### Phase 3: Categorize Findings
@@ -71,9 +72,9 @@ grep -n "load_all_experiments\|load_experiment" scylla/analysis/loader.py
 
 **Adapter status tables**: Update `Planned` → `Implemented`, add missing rows.
 
-**ASCII diagrams**: Add missing adapters to diagram if they exist.
+**ASCII diagrams**: Add missing components to diagram if they exist.
 
-**Directory listings**: Correct filenames (e.g., `codex.py` vs `openai_codex.py`).
+**Directory listings**: Correct filenames that have changed.
 
 **Research doc sections**: Move implemented-but-not-integrated items from "Future Work" to "Currently Implemented" with an accurate status note.
 
@@ -81,53 +82,39 @@ grep -n "load_all_experiments\|load_experiment" scylla/analysis/loader.py
 
 ```bash
 git add docs/design/architecture.md docs/research.md
-git commit -m "docs(design): audit and fix stale Future Improvements entries (#880)"
+git commit -m "docs(design): audit and fix stale Future Improvements entries (#<issue>)"
 git push -u origin <branch>
 gh pr create --title "docs(design): audit and fix stale Future Improvements entries" \
-  --body "Closes #880"
+  --body "Closes #<issue>"
 gh pr merge --auto --rebase
 ```
 
 ## Failed Attempts
 
-### Skill tool blocked in don't-ask mode
-
-The `/commit-commands:commit-push-pr` skill was attempted but denied in the current permission
-mode. Fell back to manual git commands — this worked fine and is the correct approach when
-skills are blocked.
-
-### Over-broad grep patterns
-
-Initial grep with `TODO\|FIXME` in docs/ produced hundreds of false positives from:
-- `docs/arxiv/` raw run capture (test template placeholders)
-- `docs/dev/code-quality-audit-*.md` (issue references, not stale design entries)
-
-**Fix**: Narrow scope with `grep -v "docs/arxiv/"` and focus on design docs only.
+| Attempt | What Happened | Why It Failed |
+|---------|--------------|---------------|
+| Skill tool invocation in don't-ask mode | `/commit-commands:commit-push-pr` denied | Permission mode blocked skill tool — use direct git commands instead |
+| Over-broad grep patterns (`TODO\|FIXME`) | Hundreds of false positives | Raw run archives and issue-tracking docs pollute results — narrow scope with `grep -v` |
 
 ## Key Observations
 
-1. **ASCII diagrams and directory listings go stale faster than tables** — when an adapter file
+1. **ASCII diagrams and directory listings go stale faster than tables** — when a component file
    is added, the status table might get updated but the diagram and `ls`-style directory block
    often don't. Always check both.
 
 2. **"Implemented but not integrated" is a valid intermediate state** — don't conflate
-   "function exists" with "fully integrated into pipeline". Stats functions may exist in
-   `stats.py` but not yet be surfaced in comparison tables. Document this accurately.
+   "function exists" with "fully integrated into pipeline". Stats functions may exist but
+   not yet be surfaced in outputs. Document this accurately.
 
-3. **Multi-experiment loaders can be added without updating docs** — `load_all_experiments()`
-   was implemented but the Future Work section still said "add multi-experiment support."
-   Cross-referencing loader.py revealed it was already done.
-
-4. **Raw run archives are not design docs** — `docs/arxiv/` contains captured workspace state
-   from evaluation runs. TODOs in those files are intentional template placeholders, not
-   documentation debt.
+3. **Raw run archives are not design docs** — captured workspace state from evaluation runs
+   contains intentional template placeholders, not documentation debt.
 
 ## Results
 
 | File | Stale Entries Found | Fixed |
 |------|--------------------|----|
-| `docs/design/architecture.md` | 4 adapters listed as Planned, GooseAdapter missing, wrong filename, diagram missing Goose | Yes |
-| `docs/research.md` | Power Analysis functions not listed as implemented; Multi-experiment loading not listed as done | Yes |
+| `docs/design/architecture.md` | 4 adapters listed as Planned, missing adapter, wrong filename, diagram missing entry | Yes |
+| `docs/research.md` | Functions not listed as implemented; multi-experiment loading not listed as done | Yes |
 | `docs/design/container-architecture.md` | None (ARM64, layer caching genuinely not implemented) | N/A |
 | `docs/design/analysis_pipeline.md` | Narrative generation genuinely future work | N/A |
 
@@ -140,9 +127,15 @@ grep -n "Planned\|Implemented\|Status" docs/design/architecture.md
 # Find all Future Improvements sections in real design docs
 grep -rn "## Future\|### Future\|Future Work\|Future Improvements" docs/design/ docs/dev/
 
-# Cross-reference adapters doc table vs actual files
-ls scylla/adapters/*.py | xargs -I{} basename {} .py
+# Cross-reference adapter doc table vs actual files
+ls <project-root>/adapters/*.py | xargs -I{} basename {} .py
 
-# Cross-reference research.md "implemented" claims vs stats.py
-grep -n "def " scylla/analysis/stats.py | grep -i "power\|mann\|kruskal"
+# Cross-reference "implemented" claims vs source
+grep -n "def " <project-root>/analysis/stats.py | grep -i "<function-name>"
 ```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #880 (follow-up from #759), PR #989 merged | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Adds a new skill capturing the workflow for systematically auditing design doc "Future Improvements" sections against actual source code, developed during ProjectScylla #880.

## Skill: `doc-stale-future-improvements-audit`

**Category**: Documentation

**When to use**: When an issue asks to audit docs for stale "Planned" / "Future Work" entries that describe features already implemented in source.

**Key insights captured**:
- ASCII diagrams and directory listings go stale faster than status tables — always check both
- "Implemented but not integrated" is a valid intermediate state distinct from "fully done"
- Raw run archives (`docs/arxiv/`) are not design docs — ignore their TODOs
- Reusable grep commands for cross-referencing adapter tables vs actual .py files

**Source**: ProjectScylla #880 (follow-up from #759)