### PR TITLE
feat(skills): Add fix-ci-broken-main-plugins skill

### DIFF
--- a/plugins/debugging/fix-ci-broken-main-plugins/.claude-plugin/plugin.json
+++ b/plugins/debugging/fix-ci-broken-main-plugins/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-ci-broken-main-plugins",
+  "version": "1.0.0",
+  "description": "Fix broken CI on main caused by plugins missing plugin.json or SKILL.md YAML frontmatter, then rebase all blocked PRs and re-enable auto-merge. Use when: (1) all PR CI runs fail with validate errors, (2) plugins exist in the directory but lack .claude-plugin/plugin.json, (3) SKILL.md files are missing the --- YAML frontmatter block, (4) PRs are stuck pending CI that can never pass due to main being broken.",
+  "skills": "./skills",
+  "tags": ["ci", "plugins", "plugin.json", "frontmatter", "validation", "rebase", "auto-merge", "pr-rescue"]
+}

--- a/plugins/debugging/fix-ci-broken-main-plugins/references/notes.md
+++ b/plugins/debugging/fix-ci-broken-main-plugins/references/notes.md
@@ -1,0 +1,124 @@
+# Raw Notes: fix-ci-broken-main-plugins
+
+## Session Context
+
+**Date**: 2026-02-22
+**Repository**: ProjectMnemosyne (skills marketplace)
+**Trigger**: 14 open PRs, all CI failing due to 3 broken plugins on main
+
+## Root Cause Analysis
+
+The `validate_plugins.py` script validates **all** plugins on main during every CI run.
+If any plugin fails validation, the entire CI job fails — including for PRs that don't
+touch plugins at all. Three plugins were breaking CI:
+
+### Plugin 1: `plugins/ci-cd/ci-deprecation-enforcement/`
+
+- **Problem**: Missing `.claude-plugin/plugin.json`
+- **Problem**: `SKILL.md` started with `# Skill:` (no YAML frontmatter)
+- **Problem**: `## Failed Attempts` section existed but had no `|` pipe table (only prose)
+- **Fix**: Created `plugin.json`, prepended `---` frontmatter block, added table to Failed Attempts
+
+### Plugin 2: `plugins/testing/config-filename-model-id-audit/`
+
+- **Problem**: Missing `.claude-plugin/plugin.json`
+- **Fix**: Created `plugin.json` (SKILL.md was already valid with frontmatter)
+
+### Plugin 3: `plugins/testing/deprecation-warning-migration/`
+
+- **Problem**: Missing `.claude-plugin/plugin.json`
+- **Problem**: `SKILL.md` started with `# Skill:` (no YAML frontmatter)
+- **Problem**: `## Failed Attempts` section had no `|` pipe table
+- **Fix**: Created `plugin.json`, prepended frontmatter, added table to Failed Attempts
+
+## Validation Script Requirements
+
+From reading `scripts/validate_plugins.py`:
+
+| Check | Severity | Field |
+|-------|----------|-------|
+| `.claude-plugin/plugin.json` exists | Error | Required |
+| `name`, `version`, `description` fields present | Error | Required |
+| `description` >= 20 chars | Error | Required |
+| `name` matches `^[a-z0-9-]+$` | Error | Required |
+| SKILL.md starts with `---` | Error | Required |
+| `## Failed Attempts` section present | Error | Required |
+| Failed Attempts contains `|` table | Warning | Recommended |
+| `category` is one of 8 valid values | Error | If present |
+| `date` matches `YYYY-MM-DD` | Error | If present |
+
+## "Skipped Previously Applied Commits" — What It Means
+
+During rebase, git reported:
+```
+note: skipped previously applied commit abc1234
+hint: use --reapply-cherry-picks to include skipped commits
+```
+
+This means the commit's patch was already applied to the base branch (main). Git identifies
+this by matching the patch diff content, not the commit SHA. When ALL commits on a branch
+are skipped, the branch becomes identical to main → GitHub detects the PR has no diff → PR is auto-closed.
+
+**4 PRs affected**: #132, #133, #134, #142
+
+These PRs added skills to the flat `skills/` directory (not `plugins/`). Their content was
+previously merged to main via a different path (likely another PR or direct commit).
+Confirmed by checking `ls /home/mvillmow/ProjectMnemosyne/skills/`:
+- `enforce-model-config-consistency-hook/` ✓ exists
+- `config-default-model-drift/` ✓ exists
+- `pydantic-frozen-consistency/` ✓ exists
+- `skill-path-resolution-fix/` ✓ exists
+
+## PR #145 — Stale Duplicate
+
+The skill `fix-mypy-valid-type-errors` was already on main at
+`skills/fix-mypy-valid-type-errors/`. PR #145 was a stale branch with merge
+conflicts. Closed with:
+```bash
+gh pr close 145 --comment "Closing as duplicate - this skill was already merged to main."
+```
+
+## Exact File Changes Made
+
+### Created files:
+- `plugins/ci-cd/ci-deprecation-enforcement/.claude-plugin/plugin.json`
+- `plugins/testing/config-filename-model-id-audit/.claude-plugin/plugin.json`
+- `plugins/testing/deprecation-warning-migration/.claude-plugin/plugin.json`
+
+### Modified files:
+- `plugins/ci-cd/ci-deprecation-enforcement/skills/ci-deprecation-enforcement/SKILL.md`
+  - Added 6-line YAML frontmatter block at top
+  - Added `| Attempt | Why Failed | Lesson |` table to Failed Attempts section
+- `plugins/testing/deprecation-warning-migration/skills/deprecation-warning-migration/SKILL.md`
+  - Added 7-line YAML frontmatter block at top
+  - Added `| Attempt | Why Failed | Lesson |` table to Failed Attempts section
+
+## Git Commands Used
+
+```bash
+# Close duplicate PR
+gh pr close 145 --comment "..."
+
+# Validate locally
+python3 scripts/validate_plugins.py plugins/
+
+# Commit to main
+git add plugins/...
+git commit -m "fix(plugins): Add missing plugin.json and YAML frontmatter for 3 broken plugins"
+git push origin main
+
+# Rebase each branch
+git fetch origin "$branch"
+git checkout "$branch"
+git rebase origin/main
+git push --force-with-lease origin "$branch"
+
+# Enable auto-merge
+gh pr merge "$pr" --auto --rebase
+```
+
+## Final State
+
+- 1 PR closed as duplicate (#145)
+- 4 PRs auto-closed after rebase (content already on main): #132, #133, #134, #142
+- 9 PRs open with auto-merge enabled: #131, #137, #138, #139, #152, #155, #158, #160, #165

--- a/plugins/debugging/fix-ci-broken-main-plugins/skills/fix-ci-broken-main-plugins/SKILL.md
+++ b/plugins/debugging/fix-ci-broken-main-plugins/skills/fix-ci-broken-main-plugins/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: "fix-ci-broken-main-plugins"
+description: "Fix broken CI on main caused by plugins missing plugin.json or SKILL.md YAML frontmatter, then rebase all blocked PRs"
+category: debugging
+date: 2026-02-22
+user-invocable: false
+---
+# Skill: fix-ci-broken-main-plugins
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-22 |
+| Objective | Fix broken CI on main (3 plugins missing plugin.json/frontmatter), rebase 13 PRs, enable auto-merge |
+| Outcome | Success — all validations pass, 9 open PRs rebased and auto-merge enabled, 4 PRs auto-closed (content already on main) |
+
+## When to Use
+
+Use this skill when:
+
+- All PR CI runs fail with plugin validation errors (even PRs that don't touch plugins)
+- A plugin directory exists but has no `.claude-plugin/plugin.json`
+- `SKILL.md` exists but does not start with `---` (missing YAML frontmatter block)
+- CI error is `SKILL.md missing YAML frontmatter (must start with ---)` or `Missing .claude-plugin/plugin.json`
+- Many PRs are blocked by a root-cause CI failure on main
+
+**Don't use when:**
+
+- CI fails on an individual PR branch (not a main-branch root cause)
+- The plugin.json exists but has incorrect field values (different fix needed)
+
+## Verified Workflow
+
+### 1. Identify broken plugins
+
+Run the validator locally to find all failures:
+
+```bash
+python3 scripts/validate_plugins.py plugins/
+```
+
+Look for `FAIL:` entries. Common errors:
+- `Missing .claude-plugin/plugin.json`
+- `SKILL.md missing YAML frontmatter (must start with ---)`
+- `Missing Failed Attempts section (REQUIRED)`
+
+### 2. Create missing plugin.json files
+
+Required fields: `name`, `version`, `description` (minimum 20 chars).
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "1.0.0",
+  "description": "<40+ char description with trigger conditions>",
+  "skills": "./skills",
+  "tags": ["tag1", "tag2"]
+}
+```
+
+Create the `.claude-plugin/` directory first:
+
+```bash
+mkdir -p plugins/<category>/<name>/.claude-plugin/
+```
+
+### 3. Add YAML frontmatter to SKILL.md
+
+Insert at the very top of the file (line 1 must be `---`):
+
+```markdown
+---
+name: "<skill-name>"
+description: "<description>"
+category: <category>
+date: <YYYY-MM-DD>
+user-invocable: false
+---
+# Skill: <skill-name>
+```
+
+### 4. Add Failed Attempts table if missing
+
+The validator warns (not errors) if `## Failed Attempts` has no `|` table.
+Add a minimal table immediately after the section header:
+
+```markdown
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| <attempt> | <reason> | <lesson> |
+```
+
+### 5. Validate locally before pushing
+
+```bash
+python3 scripts/validate_plugins.py plugins/
+```
+
+Must show `ALL VALIDATIONS PASSED` before committing to main.
+
+### 6. Commit and push fixes to main
+
+```bash
+git add plugins/<category>/<name>/.claude-plugin/plugin.json \
+        plugins/<category>/<name>/skills/<name>/SKILL.md
+git commit -m "fix(plugins): Add missing plugin.json and YAML frontmatter for broken plugins"
+git push origin main
+```
+
+### 7. Rebase all open PR branches
+
+After main is fixed, rebase each open PR branch sequentially:
+
+```bash
+gh pr list --state open --json number,headRefName --jq '.[].headRefName' | while read branch; do
+  git fetch origin "$branch"
+  git checkout "$branch"
+  git rebase origin/main
+  git push --force-with-lease origin "$branch"
+done
+git checkout main
+```
+
+**Expected**: Some branches may have "skipped previously applied commits" — this means their content was already on main. Those PRs will auto-close (this is correct behavior, not an error).
+
+### 8. Enable auto-merge on remaining open PRs
+
+```bash
+gh pr list --state open --json number --jq '.[].number' | while read pr; do
+  gh pr merge "$pr" --auto --rebase
+done
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Pushing plugin.json without running validate first | Would have missed that SKILL.md frontmatter was also required | Always run `validate_plugins.py` locally before pushing to main |
+| Enabling auto-merge on PRs that were already closed | `gh pr merge --auto` fails with `Pull request is closed` error | Check PR state first; closed-not-merged PRs had content already on main |
+| Assuming "skipped previously applied commits" is an error | Those branches became empty and auto-closed — the content WAS already on main | Verify skills directory before investigating further |
+
+## Results & Parameters
+
+| Metric | Value |
+|--------|-------|
+| Plugins fixed | 3 (ci-deprecation-enforcement, config-filename-model-id-audit, deprecation-warning-migration) |
+| PRs rebased | 13 branches processed |
+| PRs auto-closed (content already on main) | 4 (#132, #133, #134, #142) |
+| PRs with auto-merge enabled | 9 |
+| PR closed as duplicate | 1 (#145) |
+| Validation result after fix | ALL VALIDATIONS PASSED |
+
+### Minimum plugin.json (required fields only)
+
+```json
+{
+  "name": "kebab-case-name",
+  "version": "1.0.0",
+  "description": "At least 20 characters describing trigger conditions",
+  "skills": "./skills"
+}
+```
+
+### YAML frontmatter template
+
+```yaml
+---
+name: "skill-name"
+description: "Short description"
+category: <one of: training|evaluation|optimization|debugging|architecture|tooling|ci-cd|testing>
+date: YYYY-MM-DD
+user-invocable: false
+---
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | Fixed 3 broken plugins blocking all PR CI | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

- Adds `debugging/fix-ci-broken-main-plugins` skill capturing the workflow for rescuing all open PRs when main CI is broken due to invalid plugins
- Documents the root cause: `validate_plugins.py` fails ALL PR CI when any plugin on main is invalid
- Explains the "skipped previously applied commits" rebase behavior that auto-closes PRs with content already on main
- Provides copy-paste `plugin.json` and YAML frontmatter templates

## Test plan

- [x] `python3 scripts/validate_plugins.py plugins/` passes with ALL VALIDATIONS PASSED
- [x] Plugin has `plugin.json`, `SKILL.md` with frontmatter, and `references/notes.md`
- [x] Failed Attempts table present with concrete examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)