### PR TITLE
docs(notes): Replace machine-specific absolute path with placeholder

### DIFF
--- a/plugins/tooling/gh-implement-issue/references/notes.md
+++ b/plugins/tooling/gh-implement-issue/references/notes.md
@@ -10,8 +10,8 @@ Migrated from plugins/uncategorized/skills/gh-implement-issue/ on 2026-01-02.
 tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh
 ```
 
-Absolute path in ProjectScylla:
-`/home/mvillmow/ProjectScylla/tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh`
+Absolute path in ProjectScylla (replace `<repo-root>` with your local clone path):
+`<repo-root>/tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh`
 
 ## Skill Directory Resolution
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `/home/mvillmow/ProjectScylla/...` path in `plugins/tooling/gh-implement-issue/references/notes.md` with a `<repo-root>` placeholder
- Add instruction to substitute `<repo-root>` with the user's local clone path at runtime
- Fixes issue HomericIntelligence/ProjectScylla#911

## Test plan

- [ ] Verify the file no longer contains any machine-specific absolute paths
- [ ] Confirm the placeholder text clearly explains how to derive the runtime path

🤖 Generated with [Claude Code](https://claude.com/claude-code)