### PR TITLE
feat(skills): Add pr-rebase-pipeline ci-cd skill

### DIFF
--- a/plugins/ci-cd/pr-rebase-pipeline/.claude-plugin/plugin.json
+++ b/plugins/ci-cd/pr-rebase-pipeline/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "pr-rebase-pipeline",
+  "version": "1.0.0",
+  "description": "Fix a systemic CI failure blocking all PRs, then ship 13+ fixes in parallel waves using git worktrees. Use when multiple PRs share the same CI failure, or when you want to clear a backlog of simple issues in parallel.",
+  "category": "ci-cd",
+  "date": "2026-02-23",
+  "tags": [
+    "ci",
+    "rebase",
+    "pipeline",
+    "worktrees",
+    "bulk-triage",
+    "pip-audit",
+    "pixi",
+    "parallel",
+    "wave-based",
+    "pr-management"
+  ]
+}

--- a/plugins/ci-cd/pr-rebase-pipeline/references/notes.md
+++ b/plugins/ci-cd/pr-rebase-pipeline/references/notes.md
@@ -1,0 +1,46 @@
+# References: PR Rebase Pipeline
+
+## Session Context
+
+- **Project**: ProjectScylla
+- **Date**: 2026-02-23
+- **Root Cause**: `pip-audit --min-severity high` is not a valid flag — all Security CI checks failed
+- **Scale**: 71 open issues, 8 open PRs all blocked, 13 issues resolved in one session
+
+## Key Commands Used
+
+```bash
+# Inspect failing CI log
+gh run view <run-id> --log-failed | head -50
+
+# Rebase a branch in its worktree
+git -C <worktree-path> fetch origin
+git -C <worktree-path> rebase origin/main
+
+# Handle pixi.lock conflict during rebase
+git -C <worktree-path> checkout --theirs pixi.lock
+git -C <worktree-path> add pixi.lock
+GIT_EDITOR=true git -C <worktree-path> rebase --continue
+cd <worktree-path> && pixi install
+git -C <worktree-path> add pixi.lock
+git -C <worktree-path> commit -m "fix(deps): regenerate pixi.lock after rebase on main"
+
+# Enable auto-merge immediately after PR creation
+gh pr merge --auto --rebase
+
+# Clean up merged worktrees
+git worktree remove <path>
+git worktree prune
+```
+
+## PR Series
+
+- #1029: Fix pip-audit flag (blocker)
+- #1030–#1040: 13 issue fixes in 5 waves
+
+## pixi.lock Notes
+
+Every branch that changes `pyproject.toml` or that rebases over a commit that did must regenerate `pixi.lock`. The safe pattern:
+1. Take `--theirs` during conflict (main's lock is valid)
+2. Run `pixi install` to update for your branch's deps
+3. Commit the regenerated lock separately

--- a/plugins/ci-cd/pr-rebase-pipeline/skills/pr-rebase-pipeline/SKILL.md
+++ b/plugins/ci-cd/pr-rebase-pipeline/skills/pr-rebase-pipeline/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: pr-rebase-pipeline
+description: Fix a systemic CI failure blocking all PRs, then ship fixes in parallel waves using git worktrees
+category: ci-cd
+date: 2026-02-23
+user-invocable: false
+---
+
 # Skill: PR Rebase Pipeline (Bulk Issue Triage)
 
 | Property | Value |


### PR DESCRIPTION
## Summary

- Documents the bulk issue triage + wave PR workflow used in ProjectScylla session (2026-02-23)
- Captures 6 critical failure patterns with fixes (BATS mock bugs, pixi.lock rebase, pip-audit flag)
- Covers parallel worktree strategy, wave grouping, and auto-merge setup

## Key Findings Captured

- `echo "${VAR:-{...json...}}"` appends extra `}` when var is set — use named variable for default
- BATS mocks must handle `--jq` flag by piping through real `jq`
- Always fix systemic CI blocker before creating new PRs
- `pixi.lock` rebase pattern: `--theirs` + `pixi install` + separate commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)