### PR TITLE
feat(skills): Add e2e-framework-crash-recovery-bugs debugging skill

### DIFF
--- a/skills/debugging/e2e-framework-crash-recovery-bugs/.claude-plugin/plugin.json
+++ b/skills/debugging/e2e-framework-crash-recovery-bugs/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "e2e-framework-crash-recovery-bugs",
+  "version": "1.0.0",
+  "description": "Debugging methodology for E2E framework crash recovery bugs: checkpoint race conditions, resume state machine failures, and LLM judge JSON failures",
+  "category": "debugging",
+  "date": "2026-02-23",
+  "tags": ["checkpoint", "threading", "resume", "judge", "haiku", "race-condition", "e2e"],
+  "author": "ProjectScylla",
+  "skill_file": "skills/e2e-framework-crash-recovery-bugs/SKILL.md"
+}

--- a/skills/debugging/e2e-framework-crash-recovery-bugs/references/notes.md
+++ b/skills/debugging/e2e-framework-crash-recovery-bugs/references/notes.md
@@ -1,0 +1,63 @@
+# Notes: E2E Framework Crash Recovery Bugs
+
+## Source Session
+
+- **Date**: 2026-02-23
+- **Project**: ProjectScylla
+- **PR**: https://github.com/HomericIntelligence/ProjectScylla/pull/1080
+- **Trigger**: dryrun3 batch analysis revealed 21 ENOENT errors and checkpoint failures
+
+## Diagnosis Methodology
+
+### Step 1 — Identify failure signatures
+
+From batch logs:
+- `$0 cost + 8-22s + zero tokens` = Pydantic ValidationError or framework crash on resume
+- `FileNotFoundError: checkpoint.tmp.{pid}.json` = thread-safety race condition
+- `AssertionError` in `action_config_loaded` = missing tier config on resume
+- `ValueError: Could not parse judge response` = Haiku returning conversational text
+
+### Step 2 — Trace the checkpoint race
+
+Inspected `save_checkpoint()`:
+```python
+# BEFORE (buggy):
+temp_path = path.parent / f"{path.stem}.tmp.{os.getpid()}{path.suffix}"
+with open(temp_path, "w") as f:
+    json.dump(checkpoint.model_dump(), f, indent=2)
+temp_path.replace(path)
+# No lock — multiple threads overwrite the same temp file
+```
+
+### Step 3 — Trace the resume AssertionError
+
+State machine in `_run_tier()`:
+1. On fresh run: state = PENDING → `action_pending()` sets `tier_ctx.tier_config`
+2. On resume: state = CONFIG_LOADED → `action_pending()` skipped → `action_config_loaded()` asserts non-None → CRASH
+
+Fix: detect non-PENDING/COMPLETE/FAILED state at `_run_tier()` entry and preload config.
+
+### Step 4 — Trace the Haiku judge JSON failures
+
+Haiku (`claude-haiku-4-5-20251001`) intermittently replies conversationally:
+- "I appreciate you sharing the context, but I need more info to evaluate this."
+- "Here is my assessment: ..." (prose, no JSON)
+
+The `_parse_judge_response()` function raises `ValueError` on non-JSON output. Without retry, the entire judge call fails.
+
+## Key File Locations (ProjectScylla)
+
+| File | Role |
+|------|------|
+| `scylla/e2e/checkpoint.py` | Bug 1 fix: thread-safe temp file naming + lock |
+| `scylla/e2e/runner.py` | Bug 2 fix: preload tier config on resume |
+| `scylla/e2e/llm_judge.py` | Bug 3 fix: retry loop with JSON reminder |
+| `tests/unit/e2e/test_checkpoint.py` | Bug 1 tests: thread safety |
+| `tests/unit/e2e/test_runner.py` | Bug 2 tests: resume preload |
+| `tests/unit/e2e/test_llm_judge.py` | Bug 3 tests: judge retry |
+
+## Test Results
+
+- 2975 tests passing
+- 77.94% coverage
+- All pre-commit hooks pass (ruff, mypy, black)

--- a/skills/debugging/e2e-framework-crash-recovery-bugs/skills/e2e-framework-crash-recovery-bugs/SKILL.md
+++ b/skills/debugging/e2e-framework-crash-recovery-bugs/skills/e2e-framework-crash-recovery-bugs/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: e2e-framework-crash-recovery-bugs
+description: Fix E2E framework crash-recovery bugs including checkpoint thread-safety race conditions, resume state machine AssertionError on tier_config=None, and LLM judge returning conversational text instead of JSON
+category: debugging
+date: 2026-02-23
+tags: [checkpoint, threading, resume, judge, haiku, race-condition, e2e, state-machine, json-parse]
+user-invocable: false
+---
+
+# E2E Framework Crash Recovery Bugs
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-02-23 |
+| **Objective** | Fix three critical bugs causing test failures in dryrun3 batch analysis |
+| **Outcome** | Fixed — 2975 tests pass, 77.94% coverage, all pre-commit hooks pass |
+| **Project** | ProjectScylla |
+| **PR** | [#1080](https://github.com/HomericIntelligence/ProjectScylla/pull/1080) |
+
+## When to Use
+
+Use this skill when you encounter any of the following symptoms in the E2E evaluation framework:
+
+- `FileNotFoundError: [Errno 2] No such file or directory: 'checkpoint.tmp.*.json'` during concurrent tier execution
+- `AssertionError: tier_ctx.tier_config is not None` when resuming an experiment mid-run
+- LLM judge silently producing no score because Haiku returns conversational text instead of JSON
+- Tests in `tier_states` showing `FAILED` with ENOENT errors despite correct input data
+- `ValueError: Could not parse judge response` on retry-less judge calls
+
+## Verified Workflow
+
+### Bug 1 — Checkpoint Thread-Safety Race Condition
+
+**File**: `<project-root>/scylla/e2e/checkpoint.py`
+
+**Root Cause**: `save_checkpoint()` used a PID-only temp filename (`checkpoint.tmp.{pid}.json`). Multiple threads in the same process share the same PID, so concurrent writes collide:
+
+1. Thread A writes to `checkpoint.tmp.1234.json`
+2. Thread B opens the same path, truncates it, writes its data
+3. Thread A calls `rename()` — succeeds, but wrote Thread B's data
+4. Thread B calls `rename()` — ENOENT (file already renamed by Thread A)
+
+**Fix**:
+
+```python
+# Add at module level:
+import threading
+_checkpoint_write_lock = threading.Lock()
+
+# In save_checkpoint():
+tid = threading.get_ident()
+temp_path = path.parent / f"{path.stem}.tmp.{os.getpid()}.{tid}{path.suffix}"
+with _checkpoint_write_lock:
+    with open(temp_path, "w") as f:
+        json.dump(checkpoint.model_dump(), f, indent=2)
+    temp_path.replace(path)
+```
+
+**Impact**: Caused 21 ENOENT errors in dryrun3, leading to test-021, test-010, test-038 failures.
+
+### Bug 2 — Resume AssertionError on tier_config = None
+
+**File**: `<project-root>/scylla/e2e/runner.py`
+
+**Root Cause**: When resuming from a checkpoint where a tier is already past `PENDING` state (e.g., `CONFIG_LOADED`), `action_pending()` is skipped by the state machine. `action_config_loaded()` then asserts `tier_ctx.tier_config is not None` — which fails because `TierContext` is freshly constructed on every `_run_tier()` call with `tier_config=None`.
+
+**Fix** (add before `actions = self._build_tier_actions(...)`):
+
+```python
+_tier_resume_state = tsm.get_state(tier_id.value)
+if _tier_resume_state not in (TierState.PENDING, TierState.COMPLETE, TierState.FAILED):
+    logger.info(
+        f"Resuming {tier_id.value} from {_tier_resume_state.value} "
+        "— pre-loading tier config for resume"
+    )
+    _resume_tier_config = self.tier_manager.load_tier_config(
+        tier_id, self.config.skip_agent_teams
+    )
+    if self.config.max_subtests is not None:
+        _resume_tier_config.subtests = _resume_tier_config.subtests[: self.config.max_subtests]
+    tier_ctx.tier_config = _resume_tier_config
+    if self.experiment_dir:
+        tier_ctx.tier_dir = self.experiment_dir / tier_id.value
+```
+
+**Key Insight**: `TierID.T0.value` is `"T0"` (uppercase). Checkpoint `tier_states` keys must use uppercase (e.g., `"T0"`, not `"t0"`) to match. Using lowercase causes `get_tier_state()` to return `"pending"` (the default), silently skipping the preload block.
+
+### Bug 3 — Haiku Judge Returns Conversational Text Instead of JSON
+
+**File**: `<project-root>/scylla/e2e/llm_judge.py`
+
+**Root Cause**: When `claude-haiku-4-5-20251001` is used as judge, it frequently returns conversational responses instead of structured JSON (e.g., "I appreciate you sharing the context, but I need more info.").
+
+**Fix** (replace single call with a retry loop):
+
+```python
+_max_judge_attempts = 3
+_json_reminder = (
+    "\n\n**IMPORTANT**: Your response MUST be a valid JSON object only. "
+    "Do not include any text, explanation, or markdown before or after the JSON. "
+    "Start your response with `{` and end with `}`."
+)
+last_parse_error: Exception | None = None
+for _attempt in range(_max_judge_attempts):
+    _prompt = judge_prompt if _attempt == 0 else judge_prompt + _json_reminder
+    if _attempt > 0:
+        logger.warning(
+            f"Judge parse failure on attempt {_attempt}/{_max_judge_attempts - 1}, "
+            f"retrying with JSON reminder (model={model})"
+        )
+    stdout, stderr, result = _call_claude_judge(_prompt, model, workspace)
+    try:
+        judge_result = _parse_judge_response(result)
+        break
+    except ValueError as e:
+        last_parse_error = e
+else:
+    assert last_parse_error is not None  # noqa: S101
+    raise last_parse_error
+```
+
+## Failed Attempts
+
+| Attempt | What Failed | Why |
+|---------|-------------|-----|
+| Test: `tier_states={"t0": "config_loaded"}` (lowercase) | Preload block never triggered | `get_tier_state("T0")` uses `dict.get(tier_id, "pending")` — lowercase key `"t0"` is not found, returns default `"pending"`, preload skipped |
+| Test: `E2ERunner(mock_config, mock_tier_manager, Path("/tmp"))` | `mock_tier_manager` passed as `tiers_dir` (a Path) | Constructor signature puts `tiers_dir` before `tier_manager`; runner creates `TierManager(tiers_dir)` internally — must patch `runner.tier_manager` directly after construction |
+| Patching `TierStateMachine.advance_to_completion` post-instantiation | Method called on already-constructed instance, patch had no effect | Must use `patch.object(TierStateMachine, "advance_to_completion", side_effect=noop)` before instantiation |
+| PID-only temp file (`checkpoint.tmp.{pid}.json`) | Race condition between threads sharing same PID | Threads need unique identifiers; solution is `{pid}.{thread_id}` plus a module-level lock |
+
+## Tests Written
+
+### Bug 1: `TestSaveCheckpointThreadSafety` in `tests/unit/e2e/test_checkpoint.py`
+
+| Test | Assertion |
+|------|-----------|
+| `test_concurrent_saves_do_not_raise` | 20 threads writing concurrently, none raise |
+| `test_no_stale_tmp_files_after_concurrent_saves` | No `.tmp.*.json` leftovers after 10 concurrent writes |
+| `test_sequential_saves_still_work` | Regression: single-threaded save still works |
+
+### Bug 2: `TestResumeTierConfigPreload` in `tests/unit/e2e/test_runner.py`
+
+| Test | Assertion |
+|------|-----------|
+| `test_tier_ctx_populated_when_resuming_from_config_loaded` | `load_tier_config` called for `CONFIG_LOADED` state |
+| `test_tier_ctx_not_preloaded_for_pending_state` | `PENDING` state skips preload |
+| `test_tier_ctx_not_preloaded_for_complete_state` | `COMPLETE` state skips preload |
+
+### Bug 3: `TestRunLlmJudgeRetry` in `tests/unit/e2e/test_llm_judge.py`
+
+| Test | Assertion |
+|------|-----------|
+| `test_first_attempt_success_no_retry` | Clean JSON on first try = 1 call total |
+| `test_retry_on_conversational_response` | Bad then good = 2 calls, second has JSON reminder |
+| `test_succeeds_on_third_attempt` | Bad, bad, good = 3 calls |
+| `test_raises_after_all_attempts_exhausted` | All bad = `ValueError` raised |
+| `test_first_attempt_prompt_has_no_reminder` | First prompt is clean (no IMPORTANT tag) |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Max judge retry attempts | 3 |
+| Thread lock scope | Module-level (`_checkpoint_write_lock`) |
+| Temp file naming | `{stem}.tmp.{pid}.{thread_id}{suffix}` |
+| States that skip preload | `PENDING`, `COMPLETE`, `FAILED` |
+| States that trigger preload | Everything else (e.g., `CONFIG_LOADED`, `RUNNING`) |
+| JSON reminder injection | On attempt 2+ (0-indexed attempt >= 1) |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #1080, dryrun3 batch analysis | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

- Adds `skills/debugging/e2e-framework-crash-recovery-bugs/` skill documenting three critical E2E framework bugs and their fixes from ProjectScylla PR #1080
- Covers: checkpoint thread-safety race condition, resume state machine `AssertionError` on `tier_config=None`, and LLM judge (Haiku) returning conversational text instead of JSON
- Includes copy-paste-ready fix patterns, failed attempts table, and test coverage summary

## Test plan

- [ ] Verify `plugin.json` fields match ProjectMnemosyne standards (name, category, date, tags)
- [ ] Verify `SKILL.md` frontmatter is valid YAML with required fields
- [ ] Verify "Failed Attempts" table is present (required by plugin standards)
- [ ] Verify `references/notes.md` contains raw session details
- [ ] Confirm skill appears in correct category: `skills/debugging/`

Generated with [Claude Code](https://claude.com/claude-code)