### PR TITLE
feat(skills): Add resume-checkpoint-bugs debugging skill

### DIFF
--- a/skills/debugging/resume-checkpoint-bugs/.claude-plugin/plugin.json
+++ b/skills/debugging/resume-checkpoint-bugs/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "resume-checkpoint-bugs",
+  "version": "1.0.0",
+  "description": "Patterns for diagnosing and fixing experiment runner resume/checkpoint bugs: uppercase INTERRUPTED state casing, max_subtests ephemeral handling, missing-subtest detection, tier state reset target",
+  "skills": "./skills"
+}

--- a/skills/debugging/resume-checkpoint-bugs/references/notes.md
+++ b/skills/debugging/resume-checkpoint-bugs/references/notes.md
@@ -1,0 +1,64 @@
+# Raw Notes: Resume Checkpoint Bugs (2026-02-26)
+
+## PR
+https://github.com/HomericIntelligence/ProjectScylla/pull/1109
+
+## Bug Analysis
+
+### Issue 3 was the cheapest fix (5 lines)
+The uppercase `"INTERRUPTED"` bug was invisible because the pre-existing test
+`test_sets_experiment_state_to_interrupted` was asserting the buggy value `"INTERRUPTED"`.
+Lesson: when a test documents behavior that seems wrong, check if it's documenting a bug.
+
+### Issue 2 had 4 reinforcing bugs
+Each fix was necessary but not sufficient:
+1. Clearing `max_subtests` on resume lets new runs get all subtests
+2. But `_check_tiers_need_execution` still returned empty set
+3. Add subtest detection to `_check_tiers_need_execution`
+4. But tier resets to `subtests_running` which skips `action_pending`
+5. Reset to `pending` to force `action_pending` re-run
+
+### Issue 1 required a semantic change
+The user explicitly confirmed this was the desired behavior change (not a bug in the
+original design). Moving baseline to experiment level required a new method, a new
+call site, and updating stage_capture_baseline's load order.
+
+## Technical Notes
+
+### Why use ctx.experiment_dir instead of path arithmetic
+The `RunContext` dataclass has `experiment_dir: Path | None` field. Using it directly
+is cleaner and correct. Path arithmetic (`run_dir.parent.parent.parent`) assumes a
+fixed directory depth that tests don't replicate.
+
+### TierState "pending" vs "subtests_running" for reset
+- `"subtests_running"` maps to `TierState.SUBTESTS_RUNNING` which triggers
+  `action_config_loaded()` -> `run_tier_subtests_parallel()`. This action uses
+  `tier_ctx.tier_config` set at pre-population time (limited to old max_subtests).
+- `"pending"` maps to `TierState.PENDING` which triggers `action_pending()` ->
+  loads tier config fresh with current `max_subtests`. Correct choice for expansion.
+
+### Idempotent baseline capture
+The `pipeline_baseline.json` existence check makes `_capture_experiment_baseline`
+safe to call on resume. `action_dir_created` runs at the DIR_CREATED state, which
+on resume is replayed from the beginning of the DIR_CREATED action.
+
+## Ephemeral vs Persistent CLI Fields
+
+Fields that mean "for this run only" (like `--until-*`) should only override if non-None.
+Fields that mean "scope limit" (like `--max-subtests`) need special handling:
+- `None` should clear the saved value (no limit)
+- A value should override the saved value
+
+This distinction matters because:
+- `--until` omitted on resume means "use saved target" (continue to same target)
+- `--max-subtests` omitted on resume means "run all subtests" (no limit = expand)
+
+## Files Modified in ProjectScylla PR #1109
+- `scylla/e2e/runner.py:316-333` - Ephemeral CLI field handling (STEP 2)
+- `scylla/e2e/runner.py:441-524` - `_check_tiers_need_execution()`
+- `scylla/e2e/runner.py:405-454` - Tier state reset logic
+- `scylla/e2e/runner.py:589-628` - `_capture_experiment_baseline()`
+- `scylla/e2e/runner.py:551,561` - `_handle_experiment_interrupt()` INTERRUPTED fix
+- `scylla/e2e/stages.py:269-310` - `stage_capture_baseline()` load order
+- `tests/unit/e2e/test_runner.py` - INTERRUPTED test update + 2 new tests
+- `tests/unit/e2e/test_stages.py` - Baseline tests split into experiment-level + backward-compat

--- a/skills/debugging/resume-checkpoint-bugs/skills/resume-checkpoint-bugs/SKILL.md
+++ b/skills/debugging/resume-checkpoint-bugs/skills/resume-checkpoint-bugs/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: "Skill: Resume Checkpoint Bugs"
+description: "Fix experiment runner resume bugs: uppercase INTERRUPTED state, max_subtests ephemeral handling, missing-subtest detection, and tier state reset target selection"
+category: debugging
+date: 2026-02-26
+user-invocable: false
+---
+# Skill: Fixing Experiment Runner Resume/Checkpoint Bugs
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-02-26 |
+| **Objective** | Fix three bugs preventing correct behavior when re-running experiments with changed CLI args |
+| **Outcome** | All three bugs fixed, 3175 tests passing, PR #1109 merged |
+| **Category** | debugging |
+| **Project** | ProjectScylla |
+
+## When to Use This Skill
+
+Trigger this skill when:
+- An experiment resumed with different `--max-subtests` doesn't execute new subtests
+- A Ctrl+C interrupted experiment doesn't reset properly on next run
+- Pipeline baseline differs between runs of the same experiment
+- Checkpoint state machine appears to skip STEP 3 (failed/interrupted reset)
+- Tier stays COMPLETE even though new subtests should run
+
+## Verified Workflow
+
+### Diagnosing Resume Bugs
+
+1. **Check interrupt state casing first** — the cheapest bug to find:
+   ```python
+   # In _handle_experiment_interrupt, look for string literals
+   current_checkpoint.experiment_state = "INTERRUPTED"  # BUG: uppercase
+   # vs
+   current_checkpoint.experiment_state = ExperimentState.INTERRUPTED.value  # CORRECT
+   ```
+   STEP 3 in `_initialize_or_resume_experiment` only matches lowercase values.
+
+2. **Check ephemeral field handling** — which fields always override vs non-None-only:
+   - `--until-*` fields: non-None only (omitting keeps saved value)
+   - `--max-subtests`: ALWAYS override; `None` = "no limit" (clears saved value)
+   - Pattern: scope-limiting fields need `None`-clearing; run-mode fields don't
+
+3. **Check tier needs-execution detection** — does it see _all_ subtests?
+   - `_check_tiers_need_execution()` originally only checked `run_states` (existing runs)
+   - Missing subtests (not yet in checkpoint) were invisible — extend to compare config vs checkpoint subtest sets
+
+4. **Check tier state reset target**:
+   - Has incomplete runs → reset to `"subtests_running"`
+   - Has missing subtests → reset to `"pending"` (so `action_pending()` reloads full list)
+
+### Pattern: Ephemeral CLI Field Handling on Resume
+
+```python
+# STEP 2: Restore ephemeral CLI args after checkpoint load
+# max_subtests: always restore (None clears saved limit)
+self.config = self.config.model_copy(
+    update={"max_subtests": _cli_ephemeral["max_subtests"]}
+)
+# Other ephemeral fields: only restore if CLI provided a value
+non_none_rest = {
+    k: v for k, v in _cli_ephemeral.items()
+    if k != "max_subtests" and v is not None
+}
+if non_none_rest:
+    self.config = self.config.model_copy(update=non_none_rest)
+```
+
+### Pattern: Detecting Missing Subtests in Checkpoint
+
+```python
+# In _check_tiers_need_execution, after checking run states:
+tier_config = self.tier_manager.load_tier_config(tier_id, self.config.skip_agent_teams)
+config_subtests = {s.id for s in tier_config.subtests}
+if self.config.max_subtests is not None:
+    config_subtests = {s.id for s in tier_config.subtests[:self.config.max_subtests]}
+checkpoint_subtests = set(self.checkpoint.subtest_states.get(tid, {}).keys())
+if config_subtests - checkpoint_subtests:
+    needs_work.add(tid)
+```
+
+### Pattern: Tier State Reset for Missing Subtests
+
+```python
+# Detect missing subtests before choosing reset target
+_has_missing_subtests = False
+try:
+    _tc = self.tier_manager.load_tier_config(TierID(tier_id_str), ...)
+    _config_subs = {s.id for s in _tc.subtests}
+    _ckpt_subs = set(self.checkpoint.subtest_states.get(tier_id_str, {}).keys())
+    _has_missing_subtests = bool(_config_subs - _ckpt_subs)
+except Exception:
+    pass
+
+if _has_missing_subtests:
+    self.checkpoint.tier_states[tier_id_str] = "pending"  # re-run action_pending
+else:
+    self.checkpoint.tier_states[tier_id_str] = "subtests_running"  # skip to subtest exec
+```
+
+### Pattern: Idempotent Experiment-Level Baseline Capture
+
+```python
+def _capture_experiment_baseline(self) -> None:
+    baseline_path = self.experiment_dir / "pipeline_baseline.json"
+    if baseline_path.exists():
+        return  # Idempotent — skip on resume
+
+    worktree_path = self.experiment_dir / "_baseline_worktree"
+    try:
+        self.workspace_manager.create_worktree(worktree_path)
+        result = _run_build_pipeline(workspace=worktree_path, language=self.config.language)
+        _save_pipeline_baseline(self.experiment_dir, result)
+    finally:
+        self.workspace_manager.remove_worktree(worktree_path, branch_name)
+```
+
+### Pattern: Shared Resource Load Order in Stage Functions
+
+```python
+def stage_capture_baseline(ctx):
+    if ctx.pipeline_baseline is not None:
+        return  # already set (shared by runs in SubTestExecutor)
+
+    # Preferred: experiment-level (set once for whole experiment)
+    if ctx.experiment_dir is not None:
+        ctx.pipeline_baseline = _load_pipeline_baseline(ctx.experiment_dir)
+
+    if ctx.pipeline_baseline is None:
+        # Backward compat: subtest-level from older checkpoints
+        ctx.pipeline_baseline = _load_pipeline_baseline(ctx.run_dir.parent)
+
+    if ctx.pipeline_baseline is None:
+        # Fallback: inline capture (should not happen in normal flow)
+        ctx.pipeline_baseline = _run_build_pipeline(...)
+```
+
+## Failed Attempts
+
+| Attempt | What Happened | Why It Failed |
+|---------|--------------|---------------|
+| Computing `experiment_dir` from `run_dir.parent.parent.parent` | `stage_capture_baseline` tests failed with wrong directory | Test fixtures for `stage_capture_baseline` don't use the full 4-level directory hierarchy. Path arithmetic assumes fixed depth that tests don't replicate. Use `ctx.experiment_dir` directly. |
+| Resetting COMPLETE tier to `"subtests_running"` when subtests are missing | New subtests still didn't run | `"subtests_running"` skips `action_pending()`. `action_config_loaded()` uses `tier_ctx.tier_config` pre-populated at resume time — limited to the old `max_subtests` count. Must reset to `"pending"` so `action_pending()` re-runs with full list. |
+| Treating `test_sets_experiment_state_to_interrupted` (asserting `"INTERRUPTED"`) as correct | Fixing production code caused test failure | The test was documenting the bug. When a test documents behavior that seems wrong, check if it's documenting a bug rather than correct behavior. |
+
+## Results and Parameters
+
+### Checkpoint State Flow (resume with expanded subtests)
+
+```
+Before fix:
+  experiment_state=complete -> STEP 3 skips (not failed/interrupted)
+  needs_execution={} -> empty because _check_tiers_need_execution missed subtests
+  Result: experiment stays 'complete', new subtests never run
+
+After fix:
+  experiment_state=complete -> STEP 3 skips (correct, experiment wasn't interrupted)
+  needs_execution={"T0"} -> detects config_subtests - checkpoint_subtests
+  experiment_state reset to "tiers_running"
+  T0 reset to "pending" -> action_pending reloads full subtest list
+```
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `<project-root>/scylla/e2e/runner.py` | Ephemeral CLI field handling (STEP 2), `_check_tiers_need_execution()`, tier state reset logic, `_capture_experiment_baseline()`, `_handle_experiment_interrupt()` INTERRUPTED fix |
+| `<project-root>/scylla/e2e/stages.py` | `stage_capture_baseline()` load order |
+| `<project-root>/tests/unit/e2e/test_runner.py` | INTERRUPTED test update + new tests for ephemeral handling and missing subtest detection |
+| `<project-root>/tests/unit/e2e/test_stages.py` | Baseline tests split into experiment-level + backward-compat |
+
+### Test Patterns
+
+```python
+# Testing ephemeral field clearing
+cli_config = ExperimentConfig(..., max_subtests=None)
+saved_config = ExperimentConfig(..., max_subtests=2)
+# After resume: runner.config.max_subtests must be None
+
+# Testing missing subtest detection
+# tier_manager mock returns 4 subtests, checkpoint has 2
+runner.tier_manager.load_tier_config.return_value = TierConfig(subtests=[...4 items...])
+# After resume: tier_states["T0"] == "pending"
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #1109 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
Captures patterns for diagnosing and fixing experiment runner resume/checkpoint bugs from ProjectScylla session 2026-02-26. Covers: uppercase INTERRUPTED casing, max_subtests ephemeral handling, missing-subtest detection, and tier state reset target selection.

## Summary

- Adds `skills/debugging/resume-checkpoint-bugs/` skill plugin
- Documents 3 bugs fixed in ProjectScylla PR #1109
- Covers: uppercase INTERRUPTED state casing bug, max_subtests ephemeral field handling on resume, missing-subtest detection in `_check_tiers_need_execution()`, and correct tier state reset target (`"pending"` vs `"subtests_running"`) when expanding subtests
- Includes failed attempts table documenting path arithmetic pitfall, wrong tier reset target, and test-documenting-a-bug pattern

## Test plan
- [ ] SKILL.md has YAML frontmatter with all required fields
- [ ] Failed Attempts table is populated
- [ ] Code patterns are copy-paste ready
- [ ] Verified On table references PR #1109

Source: ProjectScylla PR https://github.com/HomericIntelligence/ProjectScylla/pull/1109