### PR TITLE
feat(skills): Add python-version-alignment tooling skill

### DIFF
--- a/skills/tooling/python-version-alignment/.claude-plugin/plugin.json
+++ b/skills/tooling/python-version-alignment/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "python-version-alignment",
+  "version": "1.0.0",
+  "description": "Align Python version across pyproject.toml classifiers, pixi.toml, and Dockerfile when drift is detected",
+  "category": "tooling",
+  "date": "2026-02-27",
+  "tags": [
+    "python",
+    "dockerfile",
+    "version-drift",
+    "pyproject",
+    "pixi",
+    "configuration",
+    "quality-audit"
+  ]
+}

--- a/skills/tooling/python-version-alignment/references/notes.md
+++ b/skills/tooling/python-version-alignment/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: Python Version Alignment (Issue #1118)
+
+**Date**: 2026-02-27
+**Branch**: 1118-auto-impl
+**Repo**: HomericIntelligence/ProjectScylla
+
+## Task Summary
+
+Issue #1118 "[Docs] Standardize Python version specification across configs" flagged that:
+- `pyproject.toml` classifiers list Python 3.10-3.12
+- `pixi.toml` resolves Python >=3.10
+- `docker/Dockerfile` used `python:3.14.2-slim` (drift)
+
+## Tool Call Sequence
+
+1. Read `.claude-prompt-1118.md` — understood task scope
+2. Read `pixi.toml` — confirmed `python = ">=3.10"`, no changes needed
+3. Read `docker/Dockerfile` — found `python:3.14.2-slim` with pinned SHA
+4. `grep` `pyproject.toml` — confirmed classifiers: 3.10, 3.11, 3.12; `requires-python = ">=3.10"`
+5. `docker pull python:3.12-slim` — fetched image, got SHA256 digest
+6. `docker inspect` — extracted `sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c`
+7. Three `Edit` calls on `docker/Dockerfile`:
+   - Stage 1 FROM line (line 15)
+   - Stage 2 FROM line (line 44)
+   - COPY site-packages path (line 53)
+8. `grep` verification — confirmed zero 3.14 references remaining
+9. `pixi run python -m pytest tests/unit/ -v` — 3185 passed, 78.36% coverage
+10. `git add docker/Dockerfile && git commit` — committed with conventional message
+11. `git push -u origin 1118-auto-impl` — pre-push hook ran coverage validation again (passed)
+12. `gh pr create` — PR #1166 created
+13. `gh pr merge --auto --rebase` — auto-merge enabled
+
+## Key Decision Points
+
+**Why python:3.12-slim (not 3.10 or 3.11)?**
+The Dockerfile should use the *highest tested version* from classifiers, which is 3.12.
+Using the minimum (3.10) would not catch compatibility issues with newer Python features.
+Using 3.14 was accidental drift beyond the tested range.
+
+**Why keep pixi.toml unchanged?**
+`pixi.toml` already had `python = ">=3.10"` which is correct — it allows any version >=3.10
+for local development. The actual resolved version depends on the developer's system.
+The issue was only that Dockerfile used a version outside the tested classifier range.
+
+**SHA256 digest sourcing:**
+Used `docker pull` + `docker inspect` to get a fresh, verified digest. Never reuse old digests
+from git history as they may refer to superseded images.
+
+## Error Encountered
+
+Skill tool calls were denied (don't-ask mode). Used raw git/gh commands directly.
+
+## Commit
+
+```
+88a9757 docs(docker): align Dockerfile Python version with pyproject.toml classifiers
+```
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectScylla/pull/1166

--- a/skills/tooling/python-version-alignment/skills/python-version-alignment/SKILL.md
+++ b/skills/tooling/python-version-alignment/skills/python-version-alignment/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: python-version-alignment
+description: "Align Python version across pyproject.toml classifiers, pixi.toml, and Dockerfile when drift is detected"
+category: tooling
+date: 2026-02-27
+user-invocable: false
+---
+
+# Python Version Alignment
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-02-27 |
+| **Issue** | #1118 - [Docs] Standardize Python version specification across configs |
+| **Objective** | Align Python version in `docker/Dockerfile`, `pyproject.toml`, and `pixi.toml` |
+| **Outcome** | ✅ Dockerfile updated from `python:3.14.2-slim` to `python:3.12-slim` (pinned SHA256) |
+| **Root Cause** | Accidental drift — Dockerfile was manually updated to 3.14 without updating classifiers |
+| **Key Learning** | Use `docker pull` to get a fresh pinned SHA256 digest before updating `FROM` lines |
+
+## When to Use
+
+Use this workflow when:
+
+- A quality audit flags version mismatch across config files
+- `pyproject.toml` classifiers don't match the Dockerfile base image Python version
+- `pixi.toml` resolves a different Python than the Dockerfile uses
+- PR review mentions "Python version drift" or "config inconsistency"
+
+Trigger symptoms:
+- Dockerfile `FROM python:X.Y.Z-slim` doesn't match `pyproject.toml` classifier max version
+- CI/CD runs on a different Python than local `pixi` environment
+- `requires-python = ">=3.10"` but Dockerfile uses `3.14.x` (bleeding edge)
+
+## Verified Workflow
+
+### Step 1: Audit all three files
+
+```bash
+# Check pyproject.toml classifiers and requires-python
+grep -n "python\|Python\|3\.[0-9]" pyproject.toml
+
+# Check pixi.toml constraint
+grep -n "python" pixi.toml
+
+# Check Dockerfile FROM lines
+grep -n "FROM python\|python3\." docker/Dockerfile
+```
+
+### Step 2: Determine the canonical version
+
+The canonical version is the **highest version listed in `pyproject.toml` classifiers**.
+`requires-python = ">=3.10"` sets the minimum; the Dockerfile should use the *tested* maximum.
+
+Example:
+```toml
+# pyproject.toml classifiers → canonical max = 3.12
+"Programming Language :: Python :: 3.10",
+"Programming Language :: Python :: 3.11",
+"Programming Language :: Python :: 3.12",
+```
+
+### Step 3: Pull the target image and get its SHA256 digest
+
+```bash
+# Pull the target image (use -slim variant for smaller size)
+docker pull python:3.12-slim
+
+# Get the pinned digest
+docker inspect python:3.12-slim --format='{{index .RepoDigests 0}}'
+# Output: python@sha256:<digest>
+```
+
+### Step 4: Update the Dockerfile
+
+Replace all `FROM` lines and any `python3.X` path references:
+
+```dockerfile
+# Before (drifted):
+FROM python:3.14.2-slim@sha256:<old-digest> AS builder
+...
+COPY --from=builder /root/.local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+
+# After (aligned):
+# Python 3.12 aligns with pyproject.toml classifiers (3.10-3.12); requires-python = ">=3.10"
+FROM python:3.12-slim@sha256:<new-digest> AS builder
+...
+COPY --from=builder /root/.local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+```
+
+**Important**: In multi-stage Dockerfiles, update **both** stages (builder + runtime) and the `COPY` path.
+
+### Step 5: Verify no remaining old-version references
+
+```bash
+grep -rn "3\.14\|python3\.14" docker/ pyproject.toml pixi.toml
+# Should produce no output
+```
+
+### Step 6: Run tests and commit
+
+```bash
+pixi run python -m pytest tests/unit/ -v --tb=short -q
+
+git add docker/Dockerfile
+git commit -m "docs(docker): align Dockerfile Python version with pyproject.toml classifiers"
+```
+
+## Failed Attempts
+
+### ❌ Attempt: Updating only the first `FROM` line in a multi-stage build
+
+**What Went Wrong**:
+
+In a multi-stage Dockerfile, there are two `FROM` lines (builder + runtime). Updating only the
+first one leaves the runtime stage on the old version. Additionally, the `COPY --from=builder`
+path contains the Python version (e.g., `python3.14`) and must also be updated.
+
+**Prevention**: Always grep for ALL version references in the Dockerfile before committing:
+
+```bash
+grep -n "3\.[0-9][0-9]\|python3\.[0-9]" docker/Dockerfile
+```
+
+## Results & Parameters
+
+### Files Changed (Issue #1118)
+
+| File | Change |
+|------|--------|
+| `docker/Dockerfile` line 15 | `python:3.14.2-slim@sha256:1a3c6...` → `python:3.12-slim@sha256:f3fa41d7...` |
+| `docker/Dockerfile` line 44 | Same update for runtime stage |
+| `docker/Dockerfile` line 53 | `python3.14/site-packages` → `python3.12/site-packages` |
+
+### Final State After Fix
+
+```
+pyproject.toml:  requires-python = ">=3.10", classifiers 3.10-3.12  (unchanged)
+pixi.toml:       python = ">=3.10"                                   (unchanged)
+docker/Dockerfile: FROM python:3.12-slim@sha256:f3fa41d7...          (updated)
+```
+
+### Docker SHA256 Digest (as of 2026-02-27)
+
+```
+python:3.12-slim → sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+```
+
+Note: SHA256 digests change when Docker Hub publishes security patches. Re-pull before updating.
+
+### Test Results
+
+- 3185 tests passed, 78.36% coverage (above 75% threshold)
+- Pre-push coverage hook validated and passed
+
+## References
+
+- PR #1166: https://github.com/HomericIntelligence/ProjectScylla/pull/1166
+- Issue #1118: Discovered during February 2026 quality audit (P2)
+- See `references/notes.md` for raw session details
+
+## Tags
+
+`python`, `dockerfile`, `version-drift`, `pyproject`, `pixi`, `configuration`, `quality-audit`


### PR DESCRIPTION
## Summary
- Adds new skill `python-version-alignment` under `skills/tooling/`
- Documents how to detect and fix Python version drift across `pyproject.toml`, `pixi.toml`, and `Dockerfile`
- Captured from ProjectScylla issue #1118 (February 2026 quality audit)

## Skill Contents
- **SKILL.md**: Step-by-step workflow including audit commands, docker pull for SHA256 digest, multi-stage Dockerfile update pattern, and verification
- **plugin.json**: Metadata with tags for discoverability
- **references/notes.md**: Raw session notes with full tool call sequence and decision rationale

## Key Learnings
1. Always update **both** `FROM` lines in multi-stage Dockerfiles + the `COPY` path containing the Python version
2. Use `docker pull` + `docker inspect` to get fresh pinned SHA256 digests — never reuse old hashes from git history
3. `pyproject.toml` classifiers define the canonical tested version range; Dockerfile should use the highest classifier version