### PR TITLE
feat(skills): Add pixi-pypi-upper-bounds tooling skill

### DIFF
--- a/skills/tooling/pixi-pypi-upper-bounds/.claude-plugin/plugin.json
+++ b/skills/tooling/pixi-pypi-upper-bounds/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "pixi-pypi-upper-bounds",
+  "version": "1.0.0",
+  "description": "Add explicit upper version bounds to pixi.toml [pypi-dependencies]. Use when auditing or hardening dependency version constraints to prevent silent breakage on major releases.",
+  "skills": "./skills"
+}

--- a/skills/tooling/pixi-pypi-upper-bounds/references/notes.md
+++ b/skills/tooling/pixi-pypi-upper-bounds/references/notes.md
@@ -1,0 +1,76 @@
+# Raw Session Notes — pixi-pypi-upper-bounds
+
+## Session Details
+
+- **Date**: 2026-02-27
+- **Project**: ProjectScylla
+- **Issue**: #1119 — [Build] Add upper bounds to PyPI dependencies in pixi.toml
+- **Branch**: `1119-auto-impl`
+- **PR**: #1170
+
+## Problem Statement
+
+11 `[pypi-dependencies]` entries in `pixi.toml` had no upper bound (`<`), only lower bounds.
+This means a `pip install --upgrade` or a fresh environment could silently pull in a future
+major version with breaking changes.
+
+Affected: `matplotlib`, `numpy`, `pandas`, `seaborn`, `scipy`, `altair`, `vl-convert-python`,
+`krippendorff`, `statsmodels`, `jsonschema`, `defusedxml`
+
+## What Happened
+
+### Step 1 — Initial edit
+Set all bounds to `<(installed_major)`. For altair, locked at `6.0.0`, set `>=5.0,<6`.
+
+### Step 2 — pixi lock
+Reported "already up-to-date". Lock still showed `altair 6.0.0` — seemed fine.
+
+### Step 3 — pixi install + test
+After reinstall, altair downgraded to `5.5.0`. Tests that import altair failed:
+```
+TypeError: _TypedDictMeta.__new__() got an unexpected keyword argument 'closed'
+```
+Root cause: altair `5.5.0` uses `TypedDict(closed=True)` — a PEP 728 feature not yet
+available in CPython 3.14's `typing` module (available in `typing_extensions` only).
+altair 6.x fixed this by using a compatibility shim.
+
+### Step 4 — Fix altair bound
+Changed to `>=5.0,<7`. Ran `pixi update altair` → resolved to `6.0.0`. All tests passed.
+
+### Step 5 — pixi lock "already up-to-date" mystery
+When `pixi.toml` constraint is `>=5.0,<6` and lock has `5.5.0`, lock thinks it's fine.
+When constraint changes to `>=5.0,<7` and lock has `5.5.0`, lock also thinks it's fine.
+Only `pixi update altair` forces a fresh resolution that picks the latest allowed version.
+
+### Step 6 — Test path bug
+First version of test used `Path(__file__).parents[4]` which in a worktree resolves to
+`.worktrees/` directory, not the project root. Fixed to `parents[3]`.
+
+## Final State
+
+- All 11 packages have upper bounds
+- altair: `>=5.0,<7` (not `<6`)
+- 3209 tests passing, 78.36% coverage
+- Regression test added: `tests/unit/config/test_pixi.py` (24 parametrized tests)
+
+## Commands Used
+
+```bash
+# Check locked versions
+grep -A2 "name: altair" pixi.lock
+
+# Force re-resolution after constraint change
+pixi update altair
+
+# Reinstall after lock change
+pixi install
+
+# Verify installed version
+pixi run python -c "import altair; print(altair.__version__)"
+
+# Run tests
+pixi run python -m pytest tests/ -q
+
+# Verify path depth for test
+python3 -c "from pathlib import Path; p = Path('/path/to/test.py'); [print(i, p.parents[i]) for i in range(6)]"
+```

--- a/skills/tooling/pixi-pypi-upper-bounds/skills/pixi-pypi-upper-bounds/SKILL.md
+++ b/skills/tooling/pixi-pypi-upper-bounds/skills/pixi-pypi-upper-bounds/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pixi-pypi-upper-bounds
+description: "Add explicit upper version bounds to pixi.toml [pypi-dependencies]. Use when auditing or hardening dependency version constraints to prevent silent breakage on major releases."
+mcp_fallback: none
+category: tooling
+tier: 2
+---
+
+# Pixi PyPI Upper Bounds
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-02-27 |
+| Objective | Add `<next-major>` upper bounds to all unbounded `[pypi-dependencies]` entries in `pixi.toml` to prevent silent breakage on major releases |
+| Outcome | Successful — all 11 packages bounded, 3209 tests passing, 78.36% coverage |
+| Issue | ProjectScylla #1119 |
+
+## When to Use
+
+- Auditing `pixi.toml` for missing upper bounds on PyPI dependencies
+- After a quality audit flags unbounded scientific computing packages
+- Before adding a new PyPI dependency (establish bounds from the start)
+- When a CI break is caused by an unexpected major version upgrade
+
+## Key Insight: Match Upper Bound to Installed Version's Major
+
+**The critical rule**: set the upper bound to `<(installed_major + 1)`, NOT to `<(installed_major)`.
+
+Setting `<installed_major` will **downgrade** the package, which can silently introduce
+a different kind of breakage (the older minor may have its own Python-version incompatibilities).
+
+Example that went wrong:
+```
+# altair 6.0.0 was installed and working on Python 3.14
+altair = ">=5.0,<6"   # BAD — downgrades to 5.5.0 which breaks on Python 3.14
+altair = ">=5.0,<7"   # GOOD — keeps 6.0.0
+```
+
+## Python Version Compatibility Pitfall
+
+`altair 5.x` uses `TypedDict(closed=True)` which is not supported in Python 3.14:
+```
+TypeError: _TypedDictMeta.__new__() got an unexpected keyword argument 'closed'
+```
+
+When setting upper bounds, always verify the downgraded version is compatible with
+the project's Python version. Run tests after `pixi install` to catch this.
+
+## Verified Workflow
+
+1. **Audit current bounds**: Read `pixi.toml` [pypi-dependencies] section — identify entries with no `<` constraint
+2. **Check locked versions**: Run `grep "version:" pixi.lock | sort -u` or check `pixi.lock` for current installed versions
+3. **Set bounds to `<(major+1)`**: For each package, use the currently-locked major version + 1 as the upper bound
+4. **Handle special cases**: Check Python version compatibility before choosing the bound (see altair pitfall above)
+5. **Run `pixi update <pkg>`**: After changing `pixi.toml`, `pixi lock` may say "already up-to-date" — use `pixi update <pkg>` to force re-resolution
+6. **Run `pixi install`**: Reinstall the environment to pick up updated lock
+7. **Run full test suite**: `pixi run python -m pytest tests/ -v` — ensure no new failures
+8. **Add regression test**: Write a test that reads `pixi.toml` with `tomllib` and asserts `<` is present in each targeted package's constraint
+
+## Regression Test Pattern
+
+Use `tomllib` (stdlib in Python 3.11+) to parse `pixi.toml` and enforce upper bounds:
+
+```python
+import tomllib
+from pathlib import Path
+import pytest
+
+PACKAGES_REQUIRING_UPPER_BOUND = ["numpy", "pandas", "scipy", "matplotlib", ...]
+_PIXI_TOML = Path(__file__).parents[3] / "pixi.toml"  # adjust depth to project root
+
+def _load_pypi_deps() -> dict[str, str]:
+    with _PIXI_TOML.open("rb") as fh:
+        data = tomllib.load(fh)
+    raw = data.get("pypi-dependencies", {})
+    return {name: spec for name, spec in raw.items() if isinstance(spec, str)}
+
+@pytest.mark.parametrize("package", PACKAGES_REQUIRING_UPPER_BOUND)
+def test_upper_bound_present(package: str) -> None:
+    deps = _load_pypi_deps()
+    spec = deps.get(package, "")
+    assert "<" in spec, f"'{package}' has no upper bound: {spec!r}"
+```
+
+**Path depth**: `parents[N]` where N is the number of directories from the test file
+to the project root. Verify with:
+```python
+from pathlib import Path
+p = Path("/path/to/tests/unit/config/test_pixi.py")
+[print(i, p.parents[i]) for i in range(6)]  # find which index = project root
+```
+
+## `pixi lock` vs `pixi update` Gotcha
+
+After editing `pixi.toml`:
+- `pixi lock` reports "already up-to-date" if the new constraint is still satisfied by the current locked version
+- But if you *tightened* the bound (e.g., `<6` now excludes the locked `6.0.0`), you need `pixi update <package>` to force re-resolution
+- Always run `pixi install` after lock changes to apply them to the active environment
+
+## Reference Bounds Applied (ProjectScylla, 2026-02-27)
+
+```toml
+[pypi-dependencies]
+matplotlib = ">=3.8,<4"
+numpy = ">=1.24,<3"
+pandas = ">=2.0,<3"
+seaborn = ">=0.13,<1"
+scipy = ">=1.11,<2"
+altair = ">=5.0,<7"          # <7 not <6 — altair 5.x breaks on Python 3.14
+vl-convert-python = ">=1.0,<2"
+krippendorff = ">=0.6.0,<1"
+statsmodels = ">=0.14,<1"
+jsonschema = ">=4.0,<5"
+defusedxml = ">=0.7,<1"
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| `altair = ">=5.0,<6"` | Downgraded altair 6.0.0 → 5.5.0; altair 5.x uses `TypedDict(closed=True)` unsupported in Python 3.14 | Always check Python version compatibility before tightening bounds |
+| `pixi lock` after editing toml | Reported "already up-to-date" even when the effective constraint changed | Use `pixi update <pkg>` to force re-resolution, then `pixi install` |
+| `parents[4]` path for test file | Resolved to wrong directory in a git worktree (`.worktrees/` parent) | Always verify `Path(__file__).parents[N]` with a quick Python snippet |


### PR DESCRIPTION
## Summary

Adds a new tooling skill documenting the workflow for adding explicit upper version bounds to `[pypi-dependencies]` in `pixi.toml`.

## Key Learnings Captured

- **Bound to `<(major+1)` not `<major`** — setting `<installed_major` downgrades the package, potentially exposing Python-version incompatibilities in older releases
- **altair 5.x + Python 3.14 pitfall** — `altair 5.x` uses `TypedDict(closed=True)` which is unsupported in Python 3.14's `typing` module; `altair 6.0.0` fixed this, so the correct bound is `<7` not `<6`
- **`pixi lock` vs `pixi update`** — `pixi lock` reports "already up-to-date" even when the effective resolution would change; use `pixi update <pkg>` to force fresh re-resolution
- **Regression test pattern** — `tomllib` + parametrized pytest to enforce `<` is present in all targeted packages
- **`parents[N]` gotcha in worktrees** — always verify the path depth with a quick Python snippet

## Source

ProjectScylla issue #1119, PR #1170 (2026-02-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)