### PR TITLE
feat(skills): Add pytest-pythonpath-scripts-fix skill

### DIFF
--- a/references/pytest-pythonpath-scripts-fix/notes.md
+++ b/references/pytest-pythonpath-scripts-fix/notes.md
@@ -1,0 +1,69 @@
+# Session Notes: pytest-pythonpath-scripts-fix
+
+## Verified Examples
+
+### Example 1: ProjectScylla — Issue #1137
+
+**Date**: 2026-02-27
+**Context**: Issue #1137 — Pre-push hook ran `pixi run pytest -x` with `pythonpath = ["."]`, causing `tests/unit/analysis/test_export_data.py` to fail at collection with `ModuleNotFoundError: No module named 'export_data'`. This silently suppressed 9 test functions and reduced visible count from ~3257 to ~1691.
+
+**Root Cause**: `export_data` lives in `scripts/export_data.py`. pytest's `pythonpath` only included `"."` (repo root), not `"scripts/"`.
+
+**Specific Commands Used**:
+
+```bash
+# Verify collection before fix
+pixi run pytest tests/unit/analysis/test_export_data.py -v --collect-only
+# → ERROR collecting (ModuleNotFoundError)
+
+# Apply fix to pyproject.toml (pythonpath = [".", "scripts"])
+# Remove sys.path.insert workaround from test file
+
+# Verify collection after fix
+pixi run pytest tests/unit/analysis/test_export_data.py -v --collect-only
+# → 9 tests collected, no errors
+
+# Full suite
+pixi run pytest -x
+# → 3257 passed, coverage 78.31%
+
+# Pre-commit
+pre-commit run --all-files
+# → All hooks passed
+```
+
+**Specific Fix Applied**:
+
+`pyproject.toml`:
+```toml
+# Before
+pythonpath = ["."]
+# After
+pythonpath = [".", "scripts"]
+```
+
+`tests/unit/analysis/test_export_data.py`:
+```python
+# Removed lines 4-9:
+import sys
+from pathlib import Path
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+```
+
+**Links**:
+- PR: https://github.com/HomericIntelligence/ProjectScylla/pull/1190
+- Issue: https://github.com/HomericIntelligence/ProjectScylla/issues/1137
+- Commit: d95de48
+
+## Raw Findings
+
+- The pre-push hook's comment explicitly says "coverage flags delegated to pyproject.toml" — this is the canonical signal that any path/coverage fix belongs in `pyproject.toml`, not in the hook script.
+- The test file had a `sys.path.insert` workaround at line 9 that masked the bug for direct test runs but not for hooks that didn't set `PYTHONPATH`. Removing it after the `pyproject.toml` fix is required to avoid confusion.
+- `pixi.lock` changed as a side effect of the pixi environment resolving — include it in the commit.
+- The divergence between hook test count (~1691) and direct pytest count (~3257) is the diagnostic signal: always compare these two numbers when investigating coverage regressions.
+
+## External References
+
+- Related skills: `pytest-coverage-threshold-config`, `mypy-scripts-coverage-extension`, `reenable-precommit-hook`
+- pytest pythonpath docs: https://docs.pytest.org/en/stable/reference/reference.html#confval-pythonpath

--- a/skills/testing/pytest-pythonpath-scripts-fix/SKILL.md
+++ b/skills/testing/pytest-pythonpath-scripts-fix/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: pytest-pythonpath-scripts-fix
+description: "TRIGGER CONDITIONS: When analysis/scripts tests fail to collect due to ImportError on a scripts/ module, or when test count is suspiciously low (~1691 vs expected ~3199+), or when a pre-push hook runs fewer tests than a direct pytest invocation."
+user-invocable: false
+category: testing
+date: 2026-02-27
+---
+
+# pytest-pythonpath-scripts-fix
+
+Fix suppressed test collection caused by scripts/ not being on the pytest Python path.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-02-27 |
+| Objective | Make all analysis unit tests that import `export_data` (a script in `scripts/`) collect and run under pytest, pre-push hooks, and CI |
+| Outcome | Success |
+
+## When to Use
+
+- Analysis tests fail at collection time with `ModuleNotFoundError` for a module in `scripts/`
+- Visible test count is artificially suppressed (e.g., ~1691 vs ~3257 expected)
+- Pre-push hook or CI collects fewer tests than a direct local `pytest` run
+- A test file has a manual `sys.path.insert` workaround pointing at `scripts/`
+- You are auditing why coverage appears lower than expected
+
+## Verified Workflow
+
+1. **Identify the root cause**: Run `pixi run pytest --collect-only 2>&1 | grep ERROR` to see collection errors. Look for `ModuleNotFoundError` on a module that lives in `scripts/`.
+
+2. **Check `pyproject.toml`**: Confirm `pythonpath` in `[tool.pytest.ini_options]` does NOT include `"scripts"`.
+
+3. **Add `"scripts"` to `pythonpath`**:
+
+```toml
+# pyproject.toml — [tool.pytest.ini_options]
+# Before
+pythonpath = ["."]
+# After
+pythonpath = [".", "scripts"]
+```
+
+4. **Remove the manual workaround** in the test file (if present):
+
+```python
+# Remove these lines from the test file:
+import sys
+from pathlib import Path
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+```
+
+Also remove `sys` and `Path` from imports if they are no longer referenced elsewhere.
+
+5. **Verify collection**:
+
+```bash
+pixi run pytest tests/unit/analysis/test_export_data.py -v --collect-only
+# Expect: all test functions listed, no collection errors
+```
+
+6. **Verify full suite**:
+
+```bash
+pixi run pytest -x
+# Expect: full test count collected, coverage threshold met
+```
+
+7. **Run pre-commit** to confirm no ruff/mypy/formatting regressions:
+
+```bash
+pre-commit run --all-files
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Add `PYTHONPATH=scripts` to the pre-push hook shell command | Creates divergence: CI and direct `pytest` runs without the hook still fail; hook comment explicitly says coverage flags delegate to `pyproject.toml` | Use `pyproject.toml` as single source of truth |
+| Make `export_data` an installable package (add to `pixi.toml`) | Requires restructuring `scripts/` with `pyproject.toml` entry points; far broader change than needed; creates unsolvable conflicts per `reenable-precommit-hook` skill | YAGNI — `pythonpath` config is sufficient |
+
+## Results & Parameters
+
+```toml
+# pyproject.toml — exact working config
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = [".", "scripts"]
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--cov=scylla",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    # ...
+]
+```
+
+Test count before fix: ~1691 collected (collection errors silently suppressed)
+Test count after fix: 3257 collected, 3257 passed
+Coverage: 78.31% (threshold 75%)
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1137, PR #1190 | [notes.md](../../references/pytest-pythonpath-scripts-fix/notes.md) |
+
+## References
+
+- Related skills: `pytest-coverage-threshold-config`, `mypy-scripts-coverage-extension`, `reenable-precommit-hook`
+- Issue: https://github.com/HomericIntelligence/ProjectScylla/issues/1137


### PR DESCRIPTION
## Summary

Adds a new skill capturing the pattern for fixing suppressed pytest test collection when a `scripts/` module is not on the Python path.

**Skill**: `skills/testing/pytest-pythonpath-scripts-fix`
**Category**: testing

### Key Learnings

- **Root cause pattern**: `pythonpath = ["."]` in `pyproject.toml` excludes `scripts/`, causing `ImportError` at collection time that silently suppresses tests
- **Canonical fix**: Add `"scripts"` to `pythonpath` in `[tool.pytest.ini_options]` — single source of truth for all invocations (local, CI, pre-push hook)
- **Diagnostic signal**: Compare hook test count vs direct pytest count — a large discrepancy (e.g., 1691 vs 3257) indicates silent collection errors
- **Failed approaches documented**: Adding `PYTHONPATH=scripts` to the hook script (creates divergence); making `export_data` an installable package (YAGNI, too broad)

### Verified On

- ProjectScylla Issue #1137 / PR #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)