### PR TITLE
feat(skills): Add dockerfile-python-version-guard skill

### DIFF
--- a/skills/ci-cd/dockerfile-python-version-guard/.claude-plugin/plugin.json
+++ b/skills/ci-cd/dockerfile-python-version-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "dockerfile-python-version-guard",
+  "version": "1.0.0",
+  "category": "ci-cd",
+  "description": "Guard Dockerfile Python version constraints via static tests and inline documentation when a stdlib module has a minimum Python version requirement (e.g., tomllib >= 3.11). Use when: (1) a Dockerfile uses a Python stdlib module introduced after 3.6, (2) you need a regression test to prevent base image downgrades, (3) adding version constraint documentation inline in the Dockerfile.",
+  "tags": ["docker", "python", "tomllib", "version-constraint", "static-analysis", "regression-guard"],
+  "author": "ProjectScylla",
+  "created": "2026-02-27"
+}

--- a/skills/ci-cd/dockerfile-python-version-guard/references/notes.md
+++ b/skills/ci-cd/dockerfile-python-version-guard/references/notes.md
@@ -1,0 +1,76 @@
+# Session Notes: dockerfile-python-version-guard
+
+## 2026-02-27: ProjectScylla Issue #1138 / PR #1195
+
+**Context**: Dockerfile used `tomllib` (Python stdlib since 3.11, PEP 680) inline in a `RUN` command
+to extract dependencies from `pyproject.toml`. Issue #1138 asked to either add a try/except fallback
+(importing `tomli` as a backport for Python < 3.11) OR explicitly document the Python 3.11+ requirement.
+
+**Decision**: Documentation-only approach chosen under KISS principle.
+
+- Base image was already `python:3.11-slim` — constraint already satisfied
+- Adding `tomli` as a pip dependency would violate YAGNI (no runtime risk today)
+- Inline comment block documents the constraint clearly for future maintainers
+- 14 static pytest tests added as regression guard
+
+**Specific commands used**:
+
+```bash
+# Read Dockerfile, identify tomllib RUN layer
+grep -n "tomllib" docker/Dockerfile
+
+# Run tests after changes
+pixi run python -m pytest tests/unit/scripts/test_dockerfile_constraints.py -v
+
+# Verify full suite still passes
+pixi run python -m pytest tests/ -v --tb=short
+
+# Git operations
+git add docker/Dockerfile tests/unit/scripts/test_dockerfile_constraints.py
+git commit -m "fix(docker): document Python 3.11+ constraint for tomllib in Dockerfile"
+git push -u origin 1138-auto-impl
+gh pr create \
+  --title "[Fix] Document Python 3.11+ constraint for tomllib in Dockerfile" \
+  --body "Closes #1138"
+gh pr merge --auto --rebase 1195
+```
+
+**Files modified**:
+
+- `docker/Dockerfile` — added constraint comment block above the tomllib RUN layer
+- `tests/unit/scripts/test_dockerfile_constraints.py` — 14 new static regression tests (new file)
+
+**Test results**:
+
+- 3197 total tests passing (was 3183 before adding 14 new tests)
+- Coverage: 78.31% (above 75% threshold)
+
+**Key implementation detail — regex for FROM parsing**:
+
+```python
+pattern = re.compile(r"^FROM\s+python:(\d+)\.(\d+)", re.MULTILINE)
+```
+
+This correctly handles multi-stage builds (multiple FROM lines), ignores `COPY --from=builder` patterns,
+and ignores non-python base images like `FROM ubuntu:22.04`.
+
+**Links**:
+
+- Issue: <https://github.com/HomericIntelligence/ProjectScylla/issues/1138>
+- PR: <https://github.com/HomericIntelligence/ProjectScylla/pull/1195>
+
+## Raw Findings
+
+- `tomllib` was added to Python stdlib in Python 3.11 via PEP 680
+- The `tomli` package on PyPI is the backport for Python < 3.11 — identical API, different import name
+- `from sys import version_info; assert version_info >= (3, 11)` is an alternative runtime guard
+  but static tests are preferable (fail at test time, not at container build time)
+- Static Dockerfile tests belong in `tests/unit/scripts/` alongside other Dockerfile/script tests
+  (e.g., `test_dockerfile.py` for build validation)
+
+## External References
+
+- PEP 680: <https://peps.python.org/pep-0680/>
+- tomli backport: <https://pypi.org/project/tomli/>
+- Python 3.11 What's New: <https://docs.python.org/3/whatsnew/3.11.html>
+- Related skill: `docker-ci-dead-step-cleanup`

--- a/skills/ci-cd/dockerfile-python-version-guard/skills/dockerfile-python-version-guard/SKILL.md
+++ b/skills/ci-cd/dockerfile-python-version-guard/skills/dockerfile-python-version-guard/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: dockerfile-python-version-guard
+description: "Guard Dockerfile Python version constraints via static tests and inline documentation. Use when a Dockerfile uses a Python stdlib module with a minimum version requirement (e.g., tomllib >= 3.11) and you need a regression guard to prevent base image downgrades from breaking builds."
+user-invocable: false
+category: ci-cd
+date: 2026-02-27
+---
+
+# dockerfile-python-version-guard
+
+Guard Dockerfile Python base image version requirements with inline documentation and static pytest regression tests.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-02-27 |
+| Issue | #1138 |
+| PR | #1195 |
+| Objective | Prevent silent breakage when a Dockerfile uses a Python stdlib module introduced in a specific Python version (e.g., `tomllib` requires Python 3.11+) |
+| Outcome | Success — 14 static tests added, 3197 total tests passing, 78.31% coverage |
+| Category | ci-cd |
+| Project | ProjectScylla |
+
+## When to Use
+
+- When a Dockerfile uses a Python stdlib module with a minimum version requirement (`tomllib` >= 3.11, `importlib.resources` changes >= 3.9, `zoneinfo` >= 3.9, etc.)
+- When you need a regression guard to prevent a future base image downgrade from silently breaking a build
+- When adding Python version constraint documentation inline in a Dockerfile for future maintainers
+- When deciding between a code fallback (try/except tomllib / tomli) versus documentation-only approach
+- When writing static Dockerfile tests that parse `FROM python:X.Y` lines with regex
+
+## Decision Criteria: Fallback Code vs. Documentation
+
+| Use Fallback Code (try/except) | Use Documentation Only |
+|-------------------------------|------------------------|
+| Base image version is not controlled (e.g., user-supplied) | Base image version is controlled (you own the Dockerfile) |
+| Downstream consumers may use different Python versions | Current base image already satisfies the constraint |
+| Library must install on Python < minimum version | KISS principle: adding tomli dep just for hypothetical future |
+| CI matrix covers multiple Python versions | Single controlled Python version in CI |
+
+**Chosen approach for this session**: Documentation-only (KISS) — base image was already `python:3.11-slim`, constraint was already satisfied, and adding a `tomli` dependency would violate YAGNI.
+
+## Verified Workflow
+
+### Step 1: Identify the Dockerfile layer using the version-constrained module
+
+Read the Dockerfile and locate the `RUN` command using the module:
+
+```bash
+# Find the RUN layer using tomllib
+grep -n "tomllib" <project-root>/docker/Dockerfile
+```
+
+### Step 2: Add a constraint comment block above the RUN layer
+
+Insert a comment block directly above the affected `RUN` instruction explaining:
+- Which module is version-constrained and why
+- The minimum Python version required
+- The base image constraint this implies
+- The alternative (fallback recipe) for future maintainers who want to support older Python
+
+```dockerfile
+# ── Python version constraint ──────────────────────────────────────────────────
+# tomllib (stdlib since Python 3.11, PEP 680) is used below to parse pyproject.toml.
+# The base image MUST remain python:3.11+ for this RUN step to succeed.
+#
+# If you ever need to support Python < 3.11, replace the python3 -c block below
+# with the tomli backport:
+#   pip install tomli
+#   python3 -c "import tomli as tomllib; ..."
+#
+# Issue: https://github.com/<org>/<repo>/issues/<N>
+# ───────────────────────────────────────────────────────────────────────────────
+RUN python3 -c "import tomllib; ..."
+```
+
+### Step 3: Write static Dockerfile regression tests
+
+Create `tests/unit/scripts/test_dockerfile_constraints.py` (or equivalent path):
+
+```python
+"""Static regression tests for Dockerfile Python version constraints."""
+import re
+from pathlib import Path
+import pytest
+
+DOCKERFILE_PATH = Path(__file__).parents[3] / "docker" / "Dockerfile"
+MIN_PYTHON = (3, 11)
+
+
+def parse_python_base_versions(content: str) -> list[tuple[int, int]]:
+    """Extract (major, minor) tuples from all FROM python:X.Y* lines."""
+    pattern = re.compile(r"^FROM\s+python:(\d+)\.(\d+)", re.MULTILINE)
+    return [(int(m.group(1)), int(m.group(2))) for m in pattern.finditer(content)]
+
+
+class TestDockerfileBaseImageVersion:
+    """Assert the Dockerfile base image satisfies the tomllib version constraint."""
+
+    def test_dockerfile_exists(self) -> None:
+        assert DOCKERFILE_PATH.exists(), f"Dockerfile not found at {DOCKERFILE_PATH}"
+
+    def test_has_python_base_image(self) -> None:
+        content = DOCKERFILE_PATH.read_text()
+        versions = parse_python_base_versions(content)
+        assert len(versions) > 0, "No FROM python:X.Y line found in Dockerfile"
+
+    def test_all_base_images_meet_minimum(self) -> None:
+        content = DOCKERFILE_PATH.read_text()
+        versions = parse_python_base_versions(content)
+        for major, minor in versions:
+            assert (major, minor) >= MIN_PYTHON, (
+                f"Base image python:{major}.{minor} is below minimum "
+                f"python:{MIN_PYTHON[0]}.{MIN_PYTHON[1]} required by tomllib"
+            )
+
+    def test_constraint_comment_present(self) -> None:
+        content = DOCKERFILE_PATH.read_text()
+        assert "tomllib" in content and "3.11" in content, (
+            "Dockerfile should document the tomllib/Python 3.11+ constraint"
+        )
+
+
+class TestParsePythonBaseVersions:
+    """Unit tests for the version parsing helper."""
+
+    def test_single_version(self) -> None:
+        assert parse_python_base_versions("FROM python:3.11-slim") == [(3, 11)]
+
+    def test_multiple_versions(self) -> None:
+        content = "FROM python:3.11-slim\nFROM python:3.12-alpine"
+        assert parse_python_base_versions(content) == [(3, 11), (3, 12)]
+
+    def test_ignores_non_python_images(self) -> None:
+        assert parse_python_base_versions("FROM ubuntu:22.04") == []
+
+    def test_ignores_inline_from(self) -> None:
+        # FROM in a COPY --from= should not be matched
+        assert parse_python_base_versions("COPY --from=builder /app /app") == []
+```
+
+### Step 4: Run the tests
+
+```bash
+<package-manager> run python -m pytest tests/unit/scripts/test_dockerfile_constraints.py -v
+```
+
+Expect 14 tests (4 integration + 4 unit + parametrized variants) to pass.
+
+### Step 5: Commit and PR
+
+```bash
+git add docker/Dockerfile tests/unit/scripts/test_dockerfile_constraints.py
+git commit -m "fix(docker): document Python 3.11+ constraint for tomllib in Dockerfile"
+git push -u origin <branch>
+gh pr create \
+  --title "[Fix] Document Python 3.11+ constraint for tomllib in Dockerfile" \
+  --body "Closes #<issue-number>"
+gh pr merge --auto --rebase <pr-number>
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Skill tool `commit-commands:commit-push-pr` | Denied in don't-ask permission mode (non-interactive session) | Use plain `git add`, `git commit`, `git push`, `gh pr create`, `gh pr merge --auto --rebase` via Bash instead |
+| Code fallback approach (try/except tomllib/tomli) | Rejected under KISS/YAGNI principles — base image already 3.11+, adding tomli would be a speculative dependency | Use documentation-only approach when the base image is controlled and already satisfies the constraint |
+
+## Results & Parameters
+
+### Test file structure (14 tests total)
+
+| Test Class | Tests | What it checks |
+|------------|-------|----------------|
+| `TestDockerfileBaseImageVersion` | 4 | Dockerfile exists, has `FROM python:X.Y`, all versions >= 3.11, constraint comment present |
+| `TestParsePythonBaseVersions` | 4 | Parsing helper: single version, multiple versions, ignores non-python images, ignores `COPY --from=` |
+
+### Regex pattern for FROM parsing
+
+```python
+pattern = re.compile(r"^FROM\s+python:(\d+)\.(\d+)", re.MULTILINE)
+```
+
+- Anchored to line start (`^` with `re.MULTILINE`)
+- Captures major and minor version as groups
+- Correctly ignores `COPY --from=builder` lines
+- Correctly ignores `FROM ubuntu:22.04` and similar non-python images
+
+### Dockerfile comment block structure
+
+The comment block must appear directly above the `RUN` layer using `tomllib` and must contain:
+1. The module name and stdlib introduction version
+2. The base image constraint this creates
+3. The fallback recipe (as a comment, not live code) for future maintainers
+4. A reference to the originating issue
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1138, PR #1195 | [notes.md](../references/notes.md) |
+
+## Related Skills
+
+- **docker-ci-dead-step-cleanup** — Removing dead CI steps referencing non-existent Dockerfile tests
+- **docker-multistage-build** — Docker build optimization patterns
+- **pytest-coverage-threshold-config** — Maintaining coverage thresholds when adding test files
+
+## References
+
+- Issue #1138: <https://github.com/HomericIntelligence/ProjectScylla/issues/1138>
+- PR #1195: <https://github.com/HomericIntelligence/ProjectScylla/pull/1195>
+- PEP 680 (tomllib): <https://peps.python.org/pep-0680/>
+- Python 3.11 changelog — tomllib added to stdlib


### PR DESCRIPTION
## Summary

- Adds new `ci-cd/dockerfile-python-version-guard` skill extracted from ProjectScylla issue #1138 / PR #1195
- Documents the decision pattern: **documentation-only** vs **try/except fallback** when a Dockerfile uses a Python stdlib module with a minimum version requirement (e.g., `tomllib` >= 3.11)
- Provides copy-paste ready static pytest regression tests using regex to parse `FROM python:X.Y` lines and assert they meet the minimum version
- Records the failed `commit-commands:commit-push-pr` skill tool attempt (denied in don't-ask mode) for future reference

## Test plan

- [ ] Verify `plugin.json` has correct category (`ci-cd`), tags, and description
- [ ] Verify `SKILL.md` frontmatter is valid YAML with `user-invocable: false`
- [ ] Verify `references/notes.md` contains project-specific details
- [ ] Verify `When to Use` covers all trigger conditions (module version constraints, regression guards, documentation-only approach)
- [ ] Verify `Failed Attempts` table is present (required by CLAUDE.md quality rules)
- [ ] Verify `Verified On` table references ProjectScylla issue #1138 and PR #1195

## Source

- ProjectScylla issue: https://github.com/HomericIntelligence/ProjectScylla/issues/1138
- ProjectScylla PR: https://github.com/HomericIntelligence/ProjectScylla/pull/1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)