### PR TITLE
feat(skills): Add runtime-error-guard-tests skill

### DIFF
--- a/skills/runtime-error-guard-tests/SKILL.md
+++ b/skills/runtime-error-guard-tests/SKILL.md
@@ -1,0 +1,226 @@
+# Skill: Unit Tests for RuntimeError Precondition Guards
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-27 |
+| Project | ProjectScylla |
+| Objective | Add unit tests covering all `if x is None: raise RuntimeError(...)` guards added in #1066 |
+| Outcome | Success — 8 new tests pass, full suite 3265 passed, 78.42% coverage |
+| Issue | HomericIntelligence/ProjectScylla#1144 |
+| PR | HomericIntelligence/ProjectScylla#1210 |
+
+## When to Use
+
+Use this skill when:
+- Adding `if x is None: raise RuntimeError(...)` precondition guards to production code
+- Writing regression tests to prevent guards from being silently removed or weakened
+- Verifying precondition contracts documented via RuntimeError (as opposed to assert)
+- Testing multi-guard functions with parametrize to keep tests DRY
+
+## Key Principle: Guards Over Asserts
+
+ProjectScylla uses `if x is None: raise RuntimeError(...)` instead of `assert x is not None` for precondition checks because:
+- `assert` can be disabled with Python's `-O` flag
+- `RuntimeError` fires unconditionally and is testable with `pytest.raises`
+- The guard pattern documents preconditions as explicit contracts in the error message
+
+## Verified Workflow
+
+### 1. Find Guards to Test
+
+```bash
+grep -n "raise RuntimeError" scylla/e2e/stages.py scylla/e2e/runner.py
+```
+
+Look for the pattern:
+```python
+if ctx.some_field is None:
+    raise RuntimeError("some_field must be set before ...")
+```
+
+### 2. Single-Guard Test (Simple Form)
+
+```python
+class TestMyFunctionGuard:
+    """Tests for the RuntimeError guard in my_function."""
+
+    def test_raises_when_field_is_none(self, my_fixture: MyContext) -> None:
+        """my_function raises RuntimeError when ctx.field is None."""
+        my_fixture.field = None
+
+        with pytest.raises(RuntimeError, match=r"field"):
+            my_function(my_fixture)
+```
+
+**Key**: Use `match=r"field"` (the field name) — the guard message always contains the field name.
+
+### 3. Multi-Guard Test (Parametrized Form)
+
+When a function has multiple sequential guards, use `@pytest.mark.parametrize` to test each one in isolation:
+
+```python
+class TestStageFinalizeRunGuards:
+    """Tests for RuntimeError guards in stage_finalize_run."""
+
+    @pytest.mark.parametrize(
+        "field,expected_match",
+        [
+            ("agent_result", r"agent_result"),
+            ("judgment", r"judgment"),
+        ],
+    )
+    def test_raises_when_field_is_none(
+        self, stage_context: RunContext, field: str, expected_match: str
+    ) -> None:
+        """stage_finalize_run raises RuntimeError when the required field is None."""
+        from scylla.adapters.base import AdapterResult, AdapterTokenStats
+
+        # Set up all fields with valid values first
+        stage_context.agent_result = AdapterResult(
+            exit_code=0, stdout="output", stderr="",
+            token_stats=AdapterTokenStats(), cost_usd=0.0, api_calls=0,
+        )
+        stage_context.judgment = {
+            "score": 0.9, "passed": True, "grade": "A",
+            "reasoning": "ok", "criteria_scores": {},
+        }
+        # Null out the specific field under test
+        setattr(stage_context, field, None)
+
+        with pytest.raises(RuntimeError, match=expected_match):
+            stage_finalize_run(stage_context)
+```
+
+**Key**: Set all required fields to valid values first, then null out only the field being tested. This ensures the guard under test fires (not an earlier guard).
+
+### 4. Dependent-Guard Test (Pre-build then null)
+
+When a guard requires a previous stage to have run (e.g., `write_report` requires `run_result` which is set by `finalize_run`):
+
+```python
+class TestStageWriteReportGuards:
+    @pytest.mark.parametrize(
+        "field,expected_match",
+        [
+            ("run_result", r"run_result"),
+            ("agent_result", r"agent_result"),
+            ("judgment", r"judgment"),
+        ],
+    )
+    def test_raises_when_field_is_none(
+        self, stage_context: RunContext, field: str, expected_match: str
+    ) -> None:
+        # Set up valid state
+        stage_context.agent_result = AdapterResult(...)
+        stage_context.judgment = {"score": 0.9, "passed": True, ...}
+        stage_context.agent_duration = 1.0
+        stage_context.judge_duration = 1.0
+        # Build run_result via the real upstream stage (not a mock)
+        stage_finalize_run(stage_context)
+
+        # Now null out the specific field
+        setattr(stage_context, field, None)
+
+        with pytest.raises(RuntimeError, match=expected_match):
+            stage_write_report(stage_context)
+```
+
+**Key**: Call the real upstream stage to produce dependent state, then null out the field.
+
+### 5. Runner-Level Guard Test (Patching to Force the Guard)
+
+For guards that fire inside complex methods (like `_initialize_or_resume_experiment`), patch intermediate methods to force the guard:
+
+```python
+class TestInitializeOrResumeExperimentGuard:
+    def test_raises_when_experiment_dir_is_none_after_create(
+        self, mock_config: ExperimentConfig, mock_tier_manager: MagicMock
+    ) -> None:
+        """Raises RuntimeError when experiment_dir stays None."""
+        runner = E2ERunner(mock_config, mock_tier_manager, Path("/tmp"))
+        # No existing checkpoint → tries to create fresh experiment.
+        # Patch _create_fresh_experiment as a no-op so experiment_dir stays None.
+        with patch.object(runner, "_find_existing_checkpoint", return_value=None):
+            with patch.object(runner, "_create_fresh_experiment"):
+                with patch.object(runner, "_write_pid_file"):
+                    with pytest.raises(RuntimeError, match=r"experiment_dir"):
+                        runner._initialize_or_resume_experiment()
+```
+
+**Key**: Identify what side-effect sets the field, patch it out as a no-op, and let the guard fire.
+
+### 6. Simple Attribute-Null Guard Test (E2ERunner methods)
+
+For simple guards where self.checkpoint is accessed:
+
+```python
+class TestLogCheckpointResumeGuard:
+    def test_raises_when_checkpoint_is_none(
+        self, mock_config: ExperimentConfig, mock_tier_manager: MagicMock
+    ) -> None:
+        runner = E2ERunner(mock_config, mock_tier_manager, Path("/tmp"))
+        runner.checkpoint = None  # Override the initialized value
+
+        with pytest.raises(RuntimeError, match=r"checkpoint"):
+            runner._log_checkpoint_resume(Path("/tmp/checkpoint.json"))
+```
+
+## Guards Covered in This Session (ProjectScylla #1144)
+
+| Guard Location | Field Tested | Test Class |
+|---|---|---|
+| `runner.py: _log_checkpoint_resume` | `self.checkpoint` | `TestLogCheckpointResumeGuard` |
+| `runner.py: _initialize_or_resume_experiment` | `self.experiment_dir` | `TestInitializeOrResumeExperimentGuard` |
+| `stages.py: stage_execute_agent` | `ctx.adapter_config` | `TestStageExecuteAgentGuard` |
+| `stages.py: stage_finalize_run` | `ctx.agent_result` | `TestStageFinalizeRunGuards` |
+| `stages.py: stage_finalize_run` | `ctx.judgment` | `TestStageFinalizeRunGuards` |
+| `stages.py: stage_write_report` | `ctx.run_result` | `TestStageWriteReportGuards` |
+| `stages.py: stage_write_report` | `ctx.agent_result` | `TestStageWriteReportGuards` |
+| `stages.py: stage_write_report` | `ctx.judgment` | `TestStageWriteReportGuards` |
+
+## Failed Attempts
+
+### 1. Trying to Test All Guards in One Parametrize Call
+
+**Problem**: Attempted to test all 3 `write_report` guards plus all 2 `finalize_run` guards in a single `@pytest.mark.parametrize`. This fails because:
+- `write_report` requires `run_result` (set by `finalize_run`) to be present for `agent_result` and `judgment` guards to fire — you can't set up both contexts in a single fixture teardown.
+- The `run_result` guard fires first, so you can't test `agent_result` guard without a valid `run_result`.
+
+**Fix**: Use separate test classes (`TestStageFinalizeRunGuards` and `TestStageWriteReportGuards`) with different setup logic, calling `stage_finalize_run` as the setup step inside `TestStageWriteReportGuards`.
+
+### 2. Forgetting `criteria_scores` in `judgment` dict
+
+**Problem**: `stage_finalize_run` accesses `judgment["criteria_scores"]` when building the `E2ERunResult`. Tests that omitted this key caused a `KeyError` before reaching the guard.
+
+**Fix**: Always include `"criteria_scores": {}` in the judgment dict used for setup.
+
+### 3. `_find_existing_checkpoint` not patched in runner guard test
+
+**Problem**: Without patching `_find_existing_checkpoint`, the runner checks the real filesystem for a checkpoint file, which doesn't exist in a unit test — it raises `FileNotFoundError` before the guard.
+
+**Fix**: `patch.object(runner, "_find_existing_checkpoint", return_value=None)` to simulate no existing checkpoint.
+
+## Results & Parameters
+
+### Test counts added
+- 1 test in `TestLogCheckpointResumeGuard`
+- 1 test in `TestInitializeOrResumeExperimentGuard`
+- 1 test in `TestStageExecuteAgentGuard`
+- 2 parametrized tests in `TestStageFinalizeRunGuards`
+- 3 parametrized tests in `TestStageWriteReportGuards`
+- **Total: 8 new tests**
+
+### Full suite result
+```
+3265 passed, 9 warnings in 50.37s
+Coverage: 78.42% (threshold: 75%)
+```
+
+### Match pattern convention
+Always use the field name as the match regex — guards follow the pattern:
+```python
+raise RuntimeError(f"{field_name} must be set before {function_name}")
+```
+So `match=r"agent_result"` will always match the guard message for `agent_result`.

--- a/skills/runtime-error-guard-tests/plugin.json
+++ b/skills/runtime-error-guard-tests/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "runtime-error-guard-tests",
+  "version": "1.0.0",
+  "description": "Patterns for testing if-None RuntimeError precondition guards in Python — covers unit test structure, parametrized fixtures, and the guard-firing verification technique used in ProjectScylla.",
+  "category": "testing",
+  "tags": ["unit-tests", "runtime-error", "guards", "preconditions", "pytest", "parametrize", "projectscylla"],
+  "created": "2026-02-27",
+  "project": "ProjectScylla",
+  "issue": "HomericIntelligence/ProjectScylla#1144",
+  "pr": "HomericIntelligence/ProjectScylla#1210",
+  "outcome": "success"
+}


### PR DESCRIPTION
## Summary

Adds a new skill capturing patterns for testing `if x is None: raise RuntimeError(...)` precondition guards in Python.

Derived from ProjectScylla #1144 work (issue: HomericIntelligence/ProjectScylla#1144, PR: HomericIntelligence/ProjectScylla#1210).

## Patterns documented

- **Single-guard test**: Simple attribute null + `pytest.raises(RuntimeError, match=r"field")`
- **Multi-guard parametrized**: `setattr(ctx, field, None)` to isolate each guard in turn
- **Dependent-guard**: Call real upstream stage to build dependent state, then null the field
- **Runner-level**: Patch intermediaries to prevent field from being set, force the guard to fire

## Failed attempts included

- Over-parametrizing across function boundaries (finalize_run vs write_report have different setup)
- Forgetting `criteria_scores` in judgment dict causing `KeyError` before guard
- Not patching `_find_existing_checkpoint` in runner tests