### PR TITLE
feat(skills): Add collaborator-extraction-tdd skill

### DIFF
--- a/plugins/collaborator-extraction-tdd.json
+++ b/plugins/collaborator-extraction-tdd.json
@@ -1,0 +1,8 @@
+{
+  "name": "collaborator-extraction-tdd",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: Extracting method groups from an oversized class into dedicated collaborator classes using TDD. Use when: (1) a class exceeds its target line count (e.g. >800 lines) and has identifiable method groups with shared state, (2) doing pure structural refactoring with zero behavior change, (3) methods need explicit dependency injection to avoid circular coupling, (4) extracted class needs lazy local imports to break circular import cycles.",
+  "category": "refactoring",
+  "date": "2026-02-28",
+  "tags": ["refactoring", "tdd", "collaborator-extraction", "dependency-injection", "circular-import", "pydantic", "mypy", "python", "runner"]
+}

--- a/references/collaborator-extraction-tdd-notes.md
+++ b/references/collaborator-extraction-tdd-notes.md
@@ -1,0 +1,120 @@
+# collaborator-extraction-tdd: Raw Session Notes
+
+## Session Context
+
+- **Date**: 2026-02-28
+- **Project**: ProjectScylla
+- **Issue**: #1146 — [Refactor] runner.py still exceeds 800-line target (1509 lines)
+- **PR**: #1230
+- **Branch**: `1146-auto-impl`
+
+## Objective
+
+Reduce `scylla/e2e/runner.py` from 1527 lines to under 1000 lines by extracting three method groups:
+1. `_build_tier_actions()` + 6 action closures → `TierActionBuilder`
+2. `_execute_tier_groups()`, `_execute_parallel_tier_group()`, `_select_best_baseline_from_group()`, `_execute_single_tier()`, `_create_baseline_from_tier_result()` → `ParallelTierRunner`
+3. `_save_tier_result()`, `_save_final_results()`, `_generate_report()`, `_find_frontier()`, `_aggregate_token_stats()`, `_aggregate_results()` → `ExperimentResultWriter`
+
+## Files Created
+
+- `scylla/e2e/tier_action_builder.py` (~200 lines)
+- `scylla/e2e/parallel_tier_runner.py` (~230 lines)
+- `scylla/e2e/experiment_result_writer.py` (~220 lines)
+- `tests/unit/e2e/test_tier_action_builder.py` (27 tests)
+- `tests/unit/e2e/test_parallel_tier_runner.py` (19 tests)
+- `tests/unit/e2e/test_experiment_result_writer.py` (23 tests)
+
+## Files Modified
+
+- `scylla/e2e/runner.py` (1527 → 1105 lines)
+- `tests/unit/e2e/test_runner.py` (updated patch targets, rewrote 2 test classes)
+- `tests/unit/e2e/test_runner_state_machine.py` (removed unused variable, updated one test)
+
+## Errors Encountered and Solutions
+
+### 1. Pydantic ValidationError for ExperimentConfig
+**Error**: `pydantic_core._pydantic_core.ValidationError` — missing required fields
+**Root cause**: `ExperimentConfig` requires `experiment_id`, `task_repo`, `task_commit`, `task_prompt_file`, `language`
+**Fix**: Added all 5 required fields to every test instantiation
+
+### 2. `wait_for_rate_limit()` Wrong Signature
+**Error**: Called `wait_for_rate_limit(tier_id)` in `action_pending` closure
+**Root cause**: Real signature is `wait_for_rate_limit(retry_after, checkpoint, checkpoint_path)`
+**Fix**: Implemented full rate limit check pattern using `check_api_rate_limit_status()` first, then conditionally calling `wait_for_rate_limit` with correct args
+
+### 3. MagicMock Not Accepted by Pydantic TierResult
+**Error**: `TierResult.subtest_results` validation rejects `MagicMock` values
+**Root cause**: Pydantic validates all dict values against `SubTestResult` schema
+**Fix**: Created `_make_subtest_result()` helper returning real `SubTestResult` instances
+
+### 4. Circular Import
+**Error**: `ImportError: cannot import name 'is_shutdown_requested' from partially initialized module`
+**Root cause**: `parallel_tier_runner.py` has top-level `from scylla.e2e.runner import is_shutdown_requested`; `runner.py` imports `ParallelTierRunner` from `parallel_tier_runner.py`
+**Fix**: Used lazy local import inside `execute_tier_groups()` body (same pattern as `parallel_executor.py`)
+
+### 5. `cost_of_pass` is a Property, Not a Field
+**Error**: `Unexpected keyword argument "cost_of_pass" for "TierResult"`
+**Root cause**: `cost_of_pass` is computed via `@property` from `best_subtest.mean_cost / best_subtest.pass_rate`
+**Fix**: Removed `cost_of_pass=cost_of_pass` from `TierResult()` constructor calls; designed `_make_subtest_result()` so that `mean_cost / pass_rate` computes the desired value
+
+### 6. Patch Target Stale After Extraction
+**Error**: 3 tests in `TestResumeTierConfigPreload` that patched `scylla.e2e.runner.run_tier_subtests_parallel` stopped working
+**Root cause**: After extraction, `run_tier_subtests_parallel` is imported in `tier_action_builder.py`, not `runner.py`
+**Fix**: Changed patch target to `scylla.e2e.tier_action_builder.run_tier_subtests_parallel`
+
+### 7. `_execute_single_tier` Removed
+**Error**: `test_run_tier_calls_advance_to_completion` called `runner._execute_single_tier(TierID.T0, None, None)`
+**Root cause**: `_execute_single_tier` is now internal to `ParallelTierRunner`
+**Fix**: Changed test to call `runner._run_tier(TierID.T0, None, None)` directly (equivalent public API)
+
+### 8. Mypy Type Errors in Test Files
+**Errors (9 total)**:
+- `Item "None" of "TierResult | None" has no attribute "tier_id"/"token_stats"` — accessing `tier_ctx.tier_result` attributes without None guard
+- `Unexpected keyword argument "cost_of_pass"` — property passed as constructor arg
+- `run_tier_fn` type mismatch — `MagicMock | None` hint can't accept plain `Callable`
+- `F841 Local variable assigned to but never used` — `mock_tier_result` created but not used
+
+**Fixes**:
+- Added `assert tier_ctx.tier_result is not None` before attribute access (2 locations)
+- Removed `cost_of_pass=cost_of_pass` from `TierResult()` constructor
+- Changed type hint: `run_tier_fn: Callable[..., TierResult] | MagicMock | None`
+- Added `from collections.abc import Callable` import
+- Removed the unused `mock_tier_result` variable entirely
+
+## Line Count Analysis
+
+Why did we miss the 1000-line target?
+
+The implementation plan projected:
+- PR-A: 1527 → ~1383 (-144 lines)
+- PR-B: 1383 → ~1220 (-163 lines)
+- PR-C: 1220 → ~1000 (-220 lines)
+
+Actual result: 1105 lines. The plan underestimated:
+1. Delegation stubs add back lines (~5-8 lines per extracted method instead of 2-3)
+2. `_result_writer()` helper method adding 8 lines
+3. Import lines for the 3 new modules
+
+The 1105-line result is still a 28% reduction and satisfies the "realistic near-term target" from the issue.
+
+## Key Design Decisions
+
+### Explicit Dependency Injection vs. Full Host Reference
+Each collaborator receives only the state it needs, never `self` (the runner). This:
+- Avoids circular coupling (collaborator → runner → collaborator)
+- Makes collaborator unit tests simpler (only mock what it needs)
+- Makes the extracted class independently testable
+
+### Lazy Import for Circular Dependency
+`is_shutdown_requested` is a module-level function in `runner.py`. Since `runner.py` imports `ParallelTierRunner`, importing from `runner` at the top of `parallel_tier_runner.py` creates a circular import. Lazy import inside the method body breaks the cycle cleanly.
+
+### `_result_writer()` Helper Pattern
+Instead of creating `ExperimentResultWriter` once in `__init__`, we create it lazily per-call:
+```python
+def _result_writer(self) -> ExperimentResultWriter:
+    return ExperimentResultWriter(
+        experiment_dir=self.experiment_dir,
+        tier_manager=self.tier_manager,
+    )
+```
+This avoids issues where `experiment_dir` might change after construction and keeps the delegation wrappers simple.

--- a/skills/collaborator-extraction-tdd/SKILL.md
+++ b/skills/collaborator-extraction-tdd/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: collaborator-extraction-tdd
+description: "TRIGGER CONDITIONS: Extracting method groups from an oversized class (>800 lines) into dedicated collaborator classes using TDD. Use when: (1) a class has grown beyond its target line count and contains identifiable method groups with shared state, (2) extracting without behavior change (pure structural refactoring), (3) avoiding circular imports between the host class and extracted collaborators."
+user-invocable: false
+category: refactoring
+date: 2026-02-28
+---
+
+# collaborator-extraction-tdd
+
+TDD-first pattern for extracting method groups from a large class into dedicated collaborator classes, with explicit dependency injection and zero behavior change.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-02-28 |
+| Objective | Reduce `runner.py` from 1527 lines to <1000 lines by extracting three method groups into collaborator classes |
+| Outcome | Success — 1105 lines (-422 lines, -28%). All 3326 tests pass. All pre-commit hooks pass. |
+
+## When to Use
+
+- A class exceeds its target line count (e.g. 800-line guideline) and has identifiable method groups
+- The method groups share only a subset of the class's state (not the full `self`)
+- You want zero behavior change — pure structural extraction
+- You need to avoid circular imports between the extracted class and its host
+- The host class uses closures or callbacks that can be injection-injected instead
+
+## Verified Workflow
+
+### 1. Measure and Identify Method Groups
+
+```bash
+# Measure current size
+wc -l scylla/e2e/runner.py
+
+# Find largest methods
+python3 -c "
+import ast
+with open('scylla/e2e/runner.py') as f:
+    src = f.read()
+tree = ast.parse(src)
+funcs = []
+for node in ast.walk(tree):
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        end = node.end_lineno or node.lineno
+        funcs.append((end - node.lineno + 1, node.lineno, node.name))
+for size, lineno, name in sorted(funcs, reverse=True)[:15]:
+    print(f'{size:4d} lines  line {lineno:4d}  {name}')
+"
+```
+
+Identify groups where:
+- Methods share a focused subset of the host class's state
+- The group has a clear single responsibility
+- Methods call each other but not the rest of the host class
+
+### 2. Design the Collaborator Interface (Dependency Injection)
+
+Each collaborator receives **only what it needs** as explicit constructor args — never the full host class reference. Map host `self.X` → explicit arg `X`:
+
+```python
+class TierActionBuilder:
+    def __init__(
+        self,
+        tier_id: TierID,
+        config: ExperimentConfig,       # was self.config
+        tier_manager: TierManager,      # was self.tier_manager
+        save_tier_result_fn: Callable,  # was self._save_tier_result (injected callback)
+        ...
+    ) -> None: ...
+```
+
+**Key rule**: For callbacks that would cause circular coupling (host method passed to collaborator), inject them as `Callable` parameters rather than passing a host reference.
+
+### 3. Write Failing Tests First (Red Phase)
+
+```bash
+# Create test file and run - expect ImportError (module doesn't exist yet)
+pixi run python -m pytest tests/unit/e2e/test_tier_action_builder.py -x
+```
+
+**Critical test patterns:**
+
+```python
+# Always create real Pydantic models — MagicMock won't pass validation
+def _make_subtest_result(subtest_id: str = "00", **kwargs) -> SubTestResult:
+    return SubTestResult(
+        subtest_id=subtest_id,
+        tier_id=TierID.T0,
+        runs=[],
+        pass_rate=0.5,
+        mean_cost=0.01,
+        total_cost=0.02,
+        token_stats=TokenStats(),
+        **kwargs,
+    )
+
+# ExperimentConfig requires ALL fields: experiment_id, task_repo, task_commit,
+# task_prompt_file, language — omitting any causes pydantic ValidationError
+config = ExperimentConfig(
+    experiment_id="test-exp",
+    task_repo="https://github.com/test/repo",
+    task_commit="abc123",
+    task_prompt_file=Path("/tmp/prompt.md"),
+    language="python",
+)
+```
+
+### 4. Create the Collaborator Module (Green Phase)
+
+Move closures and methods verbatim. Replace `self.X` with constructor-injected equivalents.
+
+**Circular import avoidance** — if the collaborator needs a function from the host module, use a lazy local import inside the method body:
+
+```python
+# In parallel_tier_runner.py — avoids circular import with runner.py
+def execute_tier_groups(self, ...) -> dict:
+    from scylla.e2e.runner import is_shutdown_requested  # lazy import
+    for group in tier_groups:
+        if is_shutdown_requested():
+            break
+        ...
+```
+
+### 5. Wire Back with Thin Delegation
+
+Replace extracted method bodies in the host class with 1-line delegation:
+
+```python
+def _build_tier_actions(self, tier_id, baseline, scheduler, tier_ctx):
+    return TierActionBuilder(
+        tier_id=tier_id,
+        config=self.config,
+        tier_manager=self.tier_manager,
+        save_tier_result_fn=self._save_tier_result,
+        ...
+    ).build()
+```
+
+### 6. Update Affected Tests
+
+When methods move, update:
+- **Patch targets**: `scylla.e2e.runner.run_tier_subtests_parallel` → `scylla.e2e.tier_action_builder.run_tier_subtests_parallel`
+- **Direct method calls**: `runner._select_best_baseline_from_group()` → `ParallelTierRunner(...).select_best_baseline_from_group()`
+- **Test class rewrites**: If a test class tests a method that moved, rewrite it to instantiate the collaborator directly
+
+### 7. Fix Mypy Issues in Tests
+
+Common mypy errors after extraction:
+
+| Error | Fix |
+|-------|-----|
+| `Item "None" of "X \| None" has no attribute "Y"` | Add `assert obj is not None` before accessing attributes |
+| `Unexpected keyword argument "cost_of_pass"` for `TierResult` | `cost_of_pass` is a `@property`, not a field — remove from constructor |
+| `Argument "run_tier_fn" has incompatible type "Callable"` | Broaden type hint: `Callable[..., TierResult] \| MagicMock \| None` |
+| `F841 Local variable assigned to but never used` | Remove the unused variable entirely |
+
+### 8. Verify
+
+```bash
+# Import smoke test
+pixi run python -c "from scylla.e2e.runner import E2ERunner; print('OK')"
+pixi run python -c "from scylla.e2e.tier_action_builder import TierActionBuilder; print('OK')"
+
+# Full test suite
+pixi run python -m pytest tests/ -x -q --tb=short
+
+# Pre-commit (mypy, ruff, black)
+pre-commit run --all-files
+
+# Final line count
+wc -l scylla/e2e/runner.py
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| `TierResult(cost_of_pass=1.0)` in test fixtures | `cost_of_pass` is a `@property` computed from `best_subtest` — Pydantic rejects unknown fields | Never pass property names to Pydantic model constructors; check model definition first |
+| `MagicMock()` as `SubTestResult` value in `TierResult.subtest_results` | Pydantic validation rejects non-model types even in `dict` values | Create real `SubTestResult` instances via a `_make_subtest_result()` helper |
+| Top-level `from scylla.e2e.runner import is_shutdown_requested` in `parallel_tier_runner.py` | runner.py imports parallel_tier_runner.py → circular import at module load time | Use lazy local import inside the function body |
+| `wait_for_rate_limit(tier_id)` in extracted `action_pending` | Wrong signature — real function requires `(retry_after, checkpoint, checkpoint_path)` | Read the real function signature before wrapping; implement the full rate-limit check pattern |
+| `run_tier_fn: MagicMock \| None` type hint in `_make_runner()` | When a real `Callable` is passed (not a `MagicMock`), mypy rejects it as incompatible | Use `Callable[..., ReturnType] \| MagicMock \| None` or just `Callable \| None` |
+| Patching `scylla.e2e.runner.run_tier_subtests_parallel` after extraction | After the function moved to `tier_action_builder`, the old patch target silently does nothing | Update all `unittest.mock.patch` targets to the new module path |
+
+## Results & Parameters
+
+```text
+# Extraction results for runner.py → 3 collaborators
+runner.py baseline:  1527 lines
+After PR-A (TierActionBuilder):   -~175 lines (includes 34-line stub + docstring)
+After PR-B (ParallelTierRunner):  -~170 lines (includes 24-line stub)
+After PR-C (ExperimentResultWriter): -~77 lines (includes delegation stubs)
+Final runner.py: 1105 lines (-422 lines, -28%)
+
+# Test impact
+New test files: 3
+New tests added: 69 (27 + 19 + 23)
+Total tests: 3326 (was 3257)
+Coverage: 79.27% (threshold: 75%)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1146, PR #1230 | [notes.md](../../references/collaborator-extraction-tdd-notes.md) |
+
+## References
+
+- Related skills: `extract-method-refactoring`, `dry-refactoring-workflow`, `state-machine-wiring`
+- Issue: HomericIntelligence/ProjectScylla#1146
+- PR: HomericIntelligence/ProjectScylla#1230


### PR DESCRIPTION
## Summary

Adds a new skill capturing the TDD collaborator-extraction pattern from ProjectScylla issue #1146, where `runner.py` (1527 lines) was reduced by 28% by extracting three method groups into dedicated collaborator classes.

**Key learnings documented:**
- Explicit dependency injection to avoid circular coupling (pass `Callable` not `self`)
- Lazy local import technique for breaking circular import cycles
- 8 categories of Pydantic/mypy errors with specific fixes
- Why line-count projections overshoot (delegation stubs add back lines)
- Patch target updates when methods move between modules

## Files Added

- `skills/collaborator-extraction-tdd/SKILL.md` — full workflow + failed attempts
- `references/collaborator-extraction-tdd-notes.md` — raw session notes with error details
- `plugins/collaborator-extraction-tdd.json` — plugin metadata

## Test plan

- [ ] SKILL.md follows template structure with all required sections
- [ ] Failed attempts table is populated with real failures from the session
- [ ] Plugin JSON has accurate trigger conditions and tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)