### PR TITLE
feat(skills): Add verify-mypy-compliance-test-annotations skill

### DIFF
--- a/plugins/verify-mypy-compliance-test-annotations.json
+++ b/plugins/verify-mypy-compliance-test-annotations.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-mypy-compliance-test-annotations",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: Test functions missing '-> None' return types causing mypy failures, or a quality audit issue requiring annotation of test files. Use when: (1) annotating test functions with -> None return types, (2) adding parameter type hints to pytest fixtures like tmp_path: Path, (3) verifying pre-completed annotation work from parallel audit waves. Key gotcha: always run mypy first — parallel wave execution may have already applied annotations; use 'git commit --allow-empty' to close the issue with a verification commit.",
+  "category": "testing",
+  "date": "2026-03-02",
+  "tags": ["mypy", "type-annotations", "test-functions", "pytest", "return-type", "quality-audit", "empty-commit", "parallel-waves", "unit-testing"]
+}


### PR DESCRIPTION
## Summary

- Adds skill pattern for verifying and applying `-> None` return type annotations to pytest test functions for mypy compliance
- Captured from ProjectScylla issue #1286 / PR #1314 (quality audit wave)

## Skill: `testing/verify-mypy-compliance-test-annotations`

**When to use:**
- Test functions missing `-> None` causing mypy `no-untyped-def` errors
- Quality audit issues requiring systematic test annotation
- Verifying pre-completed annotation work from parallel audit waves

**Key learnings:**
1. Always run `mypy` before making changes — parallel wave execution may have pre-applied annotations
2. Use `git commit --allow-empty` for verification commits when no code changes are needed
3. `tmp_path: Path` is the most common fixture parameter annotation pattern
4. Two commands verify compliance: `mypy tests/unit/<dir>/` and `pytest tests/unit/<dir>/ -v`

## Files

- `plugins/verify-mypy-compliance-test-annotations.json` — searchable metadata
- `skills/testing/verify-mypy-compliance-test-annotations/SKILL.md` — full workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)