### PR TITLE
feat(skills): Add dockerfile-build-dep-version-guard skill

### DIFF
--- a/skills/dockerfile-build-dep-version-guard/SKILL.md
+++ b/skills/dockerfile-build-dep-version-guard/SKILL.md
@@ -1,0 +1,163 @@
+# Skill: Dockerfile Build-Dependency Version Guard
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-03 |
+| Project | ProjectScylla |
+| Issue | #1208 |
+| Outcome | Success — PR #1342 created |
+| Category | testing |
+
+## Overview
+
+Pattern for extending Dockerfile regression tests to assert that a pinned
+package version in the Dockerfile satisfies the version constraint declared in
+`pyproject.toml [build-system].requires`. Prevents silent drift when a
+build-time dependency (e.g. `hatchling`) is upgraded in one place but not the
+other.
+
+## When to Use
+
+- A Dockerfile pins a build-time dependency with `==` (e.g. `hatchling==1.29.0`)
+- The same dependency also appears in `pyproject.toml [build-system].requires`
+  with a range constraint (e.g. `>=1.27.0,<2`)
+- You want a regression test that fails if the Dockerfile pin drifts outside the
+  declared range
+- Extending an existing pinning-guard test class (follow-on from a pin-presence guard)
+
+## Verified Workflow
+
+### 1. Read the existing test file and pyproject.toml first
+
+Before writing any code, read:
+- The existing test class to understand helpers already present
+- `pyproject.toml [build-system].requires` to understand the constraint format
+- The Dockerfile to confirm the exact pin pattern
+
+```bash
+grep -A3 "\[build-system\]" pyproject.toml
+grep "hatchling" docker/Dockerfile
+```
+
+### 2. Add module-level helpers (stdlib only, no new deps)
+
+```python
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # Python 3.10 fallback
+
+PYPROJECT_TOML = Path(__file__).parents[3] / "pyproject.toml"
+
+
+def _parse_hatchling_specifier(requires: list[str]) -> str | None:
+    """Return the hatchling specifier string from build-system.requires, or None."""
+    for req in requires:
+        if req.lower().startswith("hatchling"):
+            return req
+    return None
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    """Convert '1.29.0' to (1, 29, 0)."""
+    return tuple(int(p) for p in v.split("."))
+```
+
+Key design choices:
+- `tomllib` (stdlib ≥3.11) with `tomli` fallback — no new PyPI dependencies
+- `_parse_hatchling_specifier` is package-agnostic; adapt for other packages by changing the `startswith` check
+- `_version_tuple` avoids `packaging` library for simple X.Y.Z comparison
+- Do NOT use `type: ignore[no-redef]` on the `tomli` fallback — mypy with `warn_unused_ignores=true` will flag it as unused when running on Python ≥3.11. Match the pattern used in other test files in the project.
+
+### 3. Add two new tests to the existing pin-check class
+
+```python
+def test_pyproject_hatchling_requirement_parseable(self) -> None:
+    """pyproject.toml [build-system].requires must include a hatchling entry."""
+    with PYPROJECT_TOML.open("rb") as f:
+        data = tomllib.load(f)
+    requires: list[str] = data.get("build-system", {}).get("requires", [])
+    spec = _parse_hatchling_specifier(requires)
+    assert spec is not None, (
+        "hatchling not found in [build-system].requires in pyproject.toml"
+    )
+
+def test_hatchling_version_matches_pyproject(self) -> None:
+    """Dockerfile hatchling pin must satisfy the constraint in pyproject.toml."""
+    with PYPROJECT_TOML.open("rb") as f:
+        data = tomllib.load(f)
+    requires: list[str] = data.get("build-system", {}).get("requires", [])
+    spec = _parse_hatchling_specifier(requires)
+    assert spec is not None, "hatchling not in pyproject.toml [build-system].requires"
+
+    content = DOCKERFILE.read_text()
+    match = re.search(r"pip install.*?hatchling==(\d+\.\d+\.\d+)", content)
+    assert match is not None, "Could not find hatchling==X.Y.Z in Dockerfile"
+    pinned = match.group(1)
+    pinned_t = _version_tuple(pinned)
+
+    lower_match = re.search(r">=(\d+\.\d+\.\d+)", spec)
+    assert lower_match, f"No >= lower bound found in pyproject.toml specifier: {spec!r}"
+    lower_t = _version_tuple(lower_match.group(1))
+
+    upper_match = re.search(r"<(\d+(?:\.\d+)*)", spec)
+    upper_t = _version_tuple(upper_match.group(1)) if upper_match else None
+
+    assert pinned_t >= lower_t, (
+        f"Dockerfile hatchling=={pinned} is below pyproject.toml lower bound "
+        f"{lower_match.group(1)} (from {spec!r})"
+    )
+    if upper_t is not None:
+        assert pinned_t < upper_t, (
+            f"Dockerfile hatchling=={pinned} violates pyproject.toml upper bound "
+            f"(from {spec!r})"
+        )
+```
+
+The `<(\d+(?:\.\d+)*)` pattern for upper bound handles both `<2` and `<2.0.0` formats.
+
+### 4. Run tests
+
+```bash
+# Quick check on just the test file (expect coverage failure — normal for single-file runs)
+pixi run python -m pytest tests/unit/e2e/test_dockerfile.py -v
+
+# Full suite to confirm no regressions
+pixi run python -m pytest tests/unit/ --override-ini="addopts=" -q
+
+# Pre-commit hooks on the modified file
+pre-commit run --files tests/unit/e2e/test_dockerfile.py
+```
+
+## Failed Attempts / Gotchas
+
+- **`type: ignore[no-redef]` causes mypy failure**: When mypy runs with
+  `warn_unused_ignores = true` on Python ≥3.11, the `# type: ignore[no-redef]`
+  on the `tomli` fallback import line is flagged as an unused ignore comment
+  (because `tomllib` already imported successfully). Other test files in the
+  project omit this comment; follow that pattern. With `ignore_missing_imports =
+  true` in mypy config, the bare `import tomli as tomllib` on the else-branch is
+  silently suppressed anyway.
+
+- **Coverage failure on single-file run is expected**: Running only the
+  Dockerfile test file produces 0% coverage on the scylla/ source tree, which
+  triggers `--cov-fail-under=9`. This is not a real failure — run the full
+  `tests/unit/` suite to verify the threshold is met.
+
+- **`Skill` tool may be blocked in don't-ask mode**: Fall back to direct git/gh
+  CLI commands for commit, push, and PR creation.
+
+- **Upper bound regex must handle bare major version**: `pyproject.toml` may
+  specify `<2` (not `<2.0.0`). The pattern `<(\d+(?:\.\d+)*)` captures both
+  forms, and `_version_tuple` on `"2"` produces `(2,)` which compares correctly
+  with `(1, 29, 0) < (2,)` in Python tuple ordering.
+
+## Results
+
+- 2 new tests added to `TestHatchlingPinned` in `tests/unit/e2e/test_dockerfile.py`
+- 2 new module-level helpers added (pure stdlib, no new deps)
+- 3801 existing tests continue to pass
+- All pre-commit hooks pass (ruff-format, ruff-check, mypy)


### PR DESCRIPTION
## Summary

Adds a new skill capturing the pattern for asserting that a Dockerfile pinned
package version satisfies the version constraint in `pyproject.toml [build-system].requires`.

## Key Learnings

- Do NOT use `# type: ignore[no-redef]` on the `tomli` fallback import — mypy with `warn_unused_ignores=true` flags it as unused on Python ≥3.11
- Upper bound regex must handle bare major version (`<2` vs `<2.0.0`): use `<(\d+(?:\.\d+)*)`
- `_version_tuple` Python tuple ordering handles mixed-length tuples correctly: `(1,29,0) < (2,)` is `True`
- Single-file coverage runs produce 0% (normal); always verify with full `tests/unit/` suite

## Source

- ProjectScylla issue #1208
- PR #1342