### PR TITLE
feat(skills): Add extend-script-test-coverage skill

### DIFF
--- a/references/extend-script-test-coverage-notes.md
+++ b/references/extend-script-test-coverage-notes.md
@@ -1,0 +1,100 @@
+# Reference Notes: Extend Script Test Coverage (Issue #1162)
+
+## Session Details
+
+- **Date**: 2026-03-03
+- **Project**: ProjectScylla
+- **Issue**: #1162 — Extend script test coverage to remaining 17 untested scripts
+- **PR**: #1343 — [Test] Extend script test coverage to 12 additional scripts
+- **Branch**: `1162-auto-impl`
+
+## Starting State
+
+- 10/34 scripts had unit tests (29%)
+- Issue #1113 had previously closed the `manage_experiment.py` cmd_run/cmd_repair gap
+- Goal: ≥17/34 scripts with tests (≥50%)
+- Existing test pattern: mock-only in `tests/unit/scripts/`
+
+## Implementation
+
+### Commit: 65da672
+
+Added 13 new test files with 453 new tests:
+
+```
+tests/unit/scripts/agents/__init__.py
+tests/unit/scripts/agents/test_agent_utils.py       (348 lines)
+tests/unit/scripts/agents/test_validate_agents.py   (290 lines)
+tests/unit/scripts/test_check_coverage.py           (162 lines)
+tests/unit/scripts/test_check_readmes.py            (195 lines)
+tests/unit/scripts/test_check_tier_config_consistency.py (159 lines)
+tests/unit/scripts/test_check_type_alias_shadowing.py    (208 lines)
+tests/unit/scripts/test_common.py                   (103 lines)
+tests/unit/scripts/test_fix_markdown.py             (243 lines)
+tests/unit/scripts/test_fix_table_underscores.py    (104 lines)
+tests/unit/scripts/test_generate_changelog.py       (289 lines)
+tests/unit/scripts/test_merge_prs.py                (173 lines)
+tests/unit/scripts/test_validate_links.py           (209 lines)
+```
+
+### Test Run Result
+
+```
+499 passed in 6.17s
+Coverage: 10.69% (above 9% floor)
+```
+
+## Key Technical Notes
+
+### agents/ subdirectory
+
+`scripts/agents/` needed a parallel `tests/unit/scripts/agents/` with `__init__.py`.
+Without the init file, pytest would not discover the tests.
+
+### Parametrize for Regex Logic
+
+Scripts with pure regex logic (`check_type_alias_shadowing.py`, `generate_changelog.py`)
+benefited heavily from `@pytest.mark.parametrize`. Each commit category (feat, fix, docs,
+etc.) got its own parametrize entry.
+
+### Mock subprocess for merge_prs.py
+
+`merge_prs.py` calls `subprocess.run(["gh", "pr", "merge", ...])`. Patch target:
+`scripts.merge_prs.subprocess.run` (not `subprocess.run` globally).
+
+### MarkdownFixer Class Pattern
+
+`fix_markdown.py` has a `MarkdownFixer` class with ~8 deterministic `fix_*` methods.
+One fixture instantiates the class; each test method calls one fix method with known
+input and checks output.
+
+### check_coverage.py: XML Parsing
+
+`check_coverage.py` reads `coverage.xml`. Tests pass an in-memory XML string via
+`io.StringIO` (or write to `tmp_path`) rather than reading a real coverage file.
+
+## What Remained Untested (12/34)
+
+Scripts not covered in this pass (either too complex, subprocess-heavy, or thin glue):
+
+- `audit_doc_examples.py` — already had tests
+- `docker_build_timing.py` — docker subprocess-only
+- `export_data.py` — complex I/O orchestration
+- `generate_all_results.py` — subprocess orchestration
+- `generate_figures.py` — matplotlib/altair dependencies
+- `generate_tables.py` — complex data pipeline
+- `get_stats.py` — partially testable (deferred)
+- `implement_issues.py` — GitHub API orchestration
+- `lint_configs.py` — ConfigLinter class (deferred, large)
+- `migrate_skills_to_mnemosyne.py` — git/subprocess orchestration
+- `plan_issues.py` — GitHub API orchestration
+- `validation.py` — shared utility (already partly tested via other modules)
+- `check_defaults_filename.py` — thin wrapper
+
+## Coverage Outcome
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Scripts with tests | 10/34 | 22/34 |
+| Percentage | 29% | 65% |
+| Goal met (≥50%) | ❌ | ✅ |

--- a/skills/testing/extend-script-test-coverage/SKILL.md
+++ b/skills/testing/extend-script-test-coverage/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: "Extend Script Test Coverage to 50%+"
+description: "Pattern for systematically adding mock-only unit tests to previously untested Python scripts — prioritizing by testability × impact to reach a coverage threshold"
+category: testing
+date: 2026-03-03
+user-invocable: false
+---
+# Extend Script Test Coverage to 50%+
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-03 |
+| Objective | Raise tested script count from 10/34 (29%) to ≥17/34 (≥50%) with mock-only pytest tests |
+| Outcome | ✅ 22/34 scripts with tests (65%) — exceeded goal; 453 new tests across 13 files |
+| Context | ProjectScylla issue #1162 — follow-up to #1113 which closed the manage_experiment.py gap |
+
+## When to Use This Skill
+
+Use this pattern when:
+
+1. **A repo has many scripts with zero test coverage** and you need to close the gap systematically
+2. **A coverage threshold audit** reveals that scripts/ folder is under-tested vs. the threshold
+3. **A follow-up issue** extends a previous partial fix (e.g., "add tests for the remaining 17 scripts")
+4. **You need to pick the highest-ROI test targets** when you can't test everything at once
+
+**Trigger phrases**:
+- "X% of scripts lack unit tests"
+- "add tests for the remaining untested scripts"
+- "script test coverage audit"
+- "follow-up to close the test gap"
+
+## Verified Workflow
+
+### Step 1: Audit the Test Gap
+
+Enumerate all scripts and existing test files to identify the gap:
+
+```bash
+# List all testable scripts (exclude shell scripts, __init__.py, README)
+ls scripts/*.py scripts/**/*.py | grep -v __init__
+
+# List existing test files for scripts
+ls tests/unit/scripts/
+
+# Compute: scripts without corresponding test file = gap
+```
+
+**Key output**: A ranked list of untested scripts.
+
+### Step 2: Rank Scripts by Testability × Impact
+
+Score each untested script on two axes and multiply:
+
+| Axis | High (3) | Medium (2) | Low (1) |
+|------|----------|-----------|---------|
+| **Testability** | Pure functions, no subprocess | Some mocking needed | Subprocess-heavy, no helpers |
+| **Impact** | Entry point / pre-commit hook | Frequently invoked | Rarely used utility |
+
+Highest scores get tested first. Minimum viable target = half the total scripts.
+
+### Step 3: Choose the Mock-Only Pattern
+
+For every new test file:
+- **No real filesystem writes** — use `tmp_path` or `io.StringIO` for in-memory content
+- **No network calls** — mock `requests`, `urllib`, `gh` subprocess
+- **No subprocess execution** — patch `subprocess.run`, `subprocess.check_output`
+- **Import the module directly** — call functions, assert on return values
+
+Example fixture for a script with a file-reading function:
+
+```python
+def test_parse_file(tmp_path):
+    f = tmp_path / "input.txt"
+    f.write_text("content")
+    result = parse_file(str(f))
+    assert result == expected_value
+```
+
+### Step 4: Test Helper Functions, Not Just `main()`
+
+Each script's internal helper functions carry the highest test value. Structure:
+
+```python
+class TestHelperFunction:
+    """Tests for the_helper_function() pure logic."""
+
+    def test_happy_path(self):
+        assert the_helper_function("valid input") == expected
+
+    def test_edge_case(self):
+        assert the_helper_function("") == default_value
+
+    @pytest.mark.parametrize("inp,expected", [
+        ("case1", "result1"),
+        ("case2", "result2"),
+    ])
+    def test_parametrized(self, inp, expected):
+        assert the_helper_function(inp) == expected
+```
+
+### Step 5: Handle Class-Based Scripts (e.g., MarkdownFixer)
+
+For scripts that define a class, instantiate it in a fixture:
+
+```python
+@pytest.fixture
+def fixer():
+    return MarkdownFixer()
+
+class TestMarkdownFixer:
+    def test_fix_trailing_spaces(self, fixer):
+        result = fixer.fix_trailing_spaces("line   \n")
+        assert result == "line\n"
+```
+
+### Step 6: Handle Subprocess-Invoking Scripts (e.g., merge_prs.py)
+
+Patch `subprocess.run` at the module level where it is imported:
+
+```python
+from unittest.mock import patch, MagicMock
+
+def test_merge_pr_success():
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "Merged"
+
+    with patch("scripts.merge_prs.subprocess.run", return_value=mock_result):
+        result = merge_pr("123")
+
+    assert result is True
+```
+
+### Step 7: Handle Agent Subdirectory Scripts
+
+If the repo has `scripts/agents/*.py`, create a parallel subdirectory:
+
+```
+tests/unit/scripts/agents/__init__.py
+tests/unit/scripts/agents/test_agent_utils.py
+tests/unit/scripts/agents/test_validate_agents.py
+```
+
+Make sure the `__init__.py` exists to allow pytest discovery.
+
+### Step 8: Run and Verify
+
+```bash
+pixi run python -m pytest tests/unit/scripts/ -v --tb=short
+```
+
+All tests should pass. Check that no test calls real external services.
+
+### Step 9: Count and Report
+
+```
+Tested scripts before: N
+Tested scripts after:  N+K
+Total scripts:         M
+Coverage:              (N+K)/M * 100%
+Goal met:              YES / NO
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Testing `main()` directly first | `main()` often calls subprocess, sys.exit, or requires CLI args — hard to isolate | Always start with helper functions; test `main()` last with heavy mocking |
+| Patching at the wrong import path | `from scripts.foo import bar` ≠ `scripts.foo.bar` when function imports inside body | Use `patch("module.where.it.is.used.symbol")`, not where it is defined |
+| Writing integration-style tests with real files | Fails on CI due to missing fixtures / slow I/O | Stick to mock-only — `tmp_path` covers any real-file need |
+| Testing all 34 scripts at once | Many scripts have no extractable helpers or are pure glue code | Rank by testability first; skip scripts that are ≤10 lines of glue with no logic |
+| Creating `tests/unit/scripts/agents/` without `__init__.py` | pytest couldn't discover the subpackage | Always create `__init__.py` when adding a subdirectory under a test package |
+
+## Results & Parameters
+
+### Priority Matrix Used (2026-03-03)
+
+| Priority | Script | Testability | Impact | Score |
+|----------|--------|-------------|--------|-------|
+| 1 | `generate_changelog.py` | 3 | 3 | 9 |
+| 2 | `check_type_alias_shadowing.py` | 3 | 3 | 9 |
+| 3 | `validate_links.py` | 3 | 2 | 6 |
+| 4 | `fix_markdown.py` | 3 | 2 | 6 |
+| 5 | `check_readmes.py` | 3 | 2 | 6 |
+| 6 | `merge_prs.py` | 2 | 3 | 6 |
+| 7 | `check_coverage.py` | 2 | 2 | 4 |
+| 8 | `check_tier_config_consistency.py` | 2 | 2 | 4 |
+| 9 | `agents/agent_utils.py` | 3 | 3 | 9 |
+| 10 | `agents/validate_agents.py` | 2 | 2 | 4 |
+| 11 | `fix_table_underscores.py` | 3 | 1 | 3 |
+| 12 | `common.py` | 3 | 1 | 3 |
+
+### Test Count per File
+
+| Test File | Script | Tests |
+|-----------|--------|-------|
+| `test_generate_changelog.py` | `generate_changelog.py` | 29 |
+| `test_check_type_alias_shadowing.py` | `check_type_alias_shadowing.py` | 29 |
+| `test_validate_links.py` | `validate_links.py` | 19 |
+| `test_fix_markdown.py` | `fix_markdown.py` | 24 |
+| `test_check_coverage.py` | `check_coverage.py` | 15 |
+| `test_check_readmes.py` | `check_readmes.py` | 19 |
+| `test_merge_prs.py` | `merge_prs.py` | 17 |
+| `test_check_tier_config_consistency.py` | `check_tier_config_consistency.py` | ~20 |
+| `agents/test_agent_utils.py` | `agents/agent_utils.py` | 348-line file |
+| `agents/test_validate_agents.py` | `agents/validate_agents.py` | 290-line file |
+| `test_fix_table_underscores.py` | `fix_table_underscores.py` | ~15 |
+| `test_common.py` | `common.py` | ~10 |
+
+### Coverage Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Scripts with tests | 10/34 (29%) | 22/34 (65%) |
+| New test files | 0 | 13 |
+| New tests added | 0 | 453 |
+| Total suite tests | ~3500 | ~3953 |
+| Goal (≥50%) | ❌ | ✅ |
+
+## Verified On
+
+- ProjectScylla (2026-03-03): issue #1162, PR #1343
+- Python 3.10+, pytest 7+, pixi environment


### PR DESCRIPTION
## Summary

- Adds new skill: `testing/extend-script-test-coverage`
- Captures the pattern for systematically closing a script test gap from <50% to 65%+ using mock-only pytest tests
- Includes priority ranking by testability × impact, agents/ subdirectory handling, and parametrize patterns

## Skill Sections

- **Overview**: ProjectScylla issue #1162, 22/34 scripts (65%) covered after implementation
- **When to Use**: Script coverage audits, follow-up test gap issues
- **Verified Workflow**: 9-step process from audit → priority ranking → mock-only pattern → test helpers → run
- **Failed Attempts**: Wrong import patch paths, testing `main()` first, missing `__init__.py` in subdirectories
- **Results**: 453 new tests across 13 files, exceeded ≥50% goal

## Source

ProjectScylla issue #1162 / PR #1343 (2026-03-03)