### PR TITLE
feat(skills): Add dryrun3-completion evaluation skill

### DIFF
--- a/plugins/dryrun3-completion.json
+++ b/plugins/dryrun3-completion.json
@@ -1,0 +1,8 @@
+{
+  "name": "dryrun3-completion",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: Completing interrupted dryrun experiments where some experiments have 0/7 run_results, some are partial, and the batch skip logic fails to re-queue tests after --max-subtests expansion. Use when: (1) batch run left broken experiments with stale git worktrees/branches in ~/dryrun3/repos/, (2) --retry-errors reports 'All tests already completed' after --max-subtests expansion, (3) need to build a loader-compatible fullruns/ symlink tree after re-runs, (4) need to run generate_all_results.py to produce figures, tables, and stats from a complete dryrun dataset.",
+  "category": "evaluation",
+  "date": "2026-03-04",
+  "tags": ["dryrun", "evaluation", "batch", "worktrees", "analysis", "repair", "resume", "manage_experiment"]
+}

--- a/references/dryrun3-completion-notes.md
+++ b/references/dryrun3-completion-notes.md
@@ -1,0 +1,239 @@
+# Session Notes: Dryrun3 Completion
+
+## Context
+
+Working on completing dryrun3 — a batch run of 47 experiments against `~/dryrun3/` using
+`claude-haiku-4-5-20251001` as both the agent model and judge model. Each experiment runs
+7 tiers (T0–T6), 1 run per tier, 1 subtest per tier = 7 run_results per experiment = 329 total runs.
+
+The batch run had previously been interrupted, leaving:
+- 28/47 experiments fully complete (7/7 run_results)
+- 3/47 experiments partially complete (1-6 run_results, missing specific tiers)
+- 16/47 experiments broken (0/7 run_results, entire experiment failed to start or was interrupted immediately)
+
+## Timeline
+
+### Phase 0: Diagnosis (30 minutes)
+
+Used `find` and counting to categorize all 47 experiment directories:
+
+```bash
+for dir in ~/dryrun3/2026-*-test-*/; do
+  test_name=$(basename "$dir" | grep -oE 'test-[0-9]+$')
+  count=$(find "$dir" -name run_result.json 2>/dev/null | wc -l)
+  echo "$test_name: $count/7 $(basename $dir)"
+done | sort
+```
+
+Results confirmed 16 broken, 3 partial, 28 complete. Identified which specific tiers were
+missing in the 3 partial experiments by iterating T0–T6 subdirectories.
+
+### Phase 1: Stale Worktree Cleanup (15 minutes)
+
+Discovered that `~/dryrun3/repos/8aa4a018a8230463/` contained stale branches like
+`test-029_T1_01_run_01` from old broken runs. Running `--fresh` without cleaning these
+caused immediate git failures:
+
+```
+fatal: 'test-029_T1_01_run_01' already exists
+```
+
+Cleaned all stale worktrees and branches:
+
+```bash
+for repo_dir in ~/dryrun3/repos/*/; do
+  git -C "$repo_dir" worktree prune
+  git -C "$repo_dir" branch | grep -E "test-" | sed 's/[+* ]*//' | \
+    xargs -r git -C "$repo_dir" branch -D
+done
+```
+
+Verified: 0 stale worktrees remaining across all repos.
+
+### Phase 2: Fresh Re-runs for 16 Broken Experiments (4 hours)
+
+Ran all 16 broken experiments with `--fresh --threads 2`. The 2-thread limit was necessary
+to avoid overwhelming the rate limits (each run consumes significant API quota during the
+model validation and judgment phases).
+
+Attempted to also run the 3 partial repairs simultaneously — this was a mistake (see Failed
+Attempts). Eventually serialized: Phase 2 first, Phase 3 after.
+
+### Phase 3: Partial Experiment Repairs (45 minutes)
+
+Three partial experiments each had a single tier missing. Used `--tiers <missing>` and
+`--retry-errors` to run only the missing tier in each case:
+
+- test-014: Missing T4
+- test-031: Missing T2
+- test-038: Missing T6
+
+### Phase 4: Build Fullruns Symlink Tree (5 minutes)
+
+The analysis loader requires `data_dir/<exp>/<timestamp>/...`. Built symlinks:
+
+```bash
+mkdir -p ~/fullruns/dryrun3
+for dir in ~/dryrun3/2026-*-test-*/; do
+  entry=$(basename "$dir")
+  test_name=$(echo "$entry" | grep -oE 'test-[0-9]+$')
+  mkdir -p ~/fullruns/dryrun3/$test_name
+  ln -sf "$dir" ~/fullruns/dryrun3/$test_name/$entry
+done
+```
+
+Verified 47 experiment directories, each containing a single symlink to the actual results.
+
+### Phase 5: Generate Analysis (20 minutes)
+
+```bash
+pixi run python scripts/generate_all_results.py \
+  --data-dir ~/fullruns/dryrun3 \
+  --output-dir docs/arxiv/dryrun3
+```
+
+Completed successfully. Outputs: 4 CSVs, 2 JSONs, 56 figures, 10 tables.
+
+## Error Messages Encountered
+
+### Stale Worktree Error (Phase 1 prerequisite)
+
+```
+fatal: 'test-029_T1_01_run_01' already exists
+```
+
+Appeared during `manage_experiment.py run --fresh` before stale worktree cleanup.
+
+### Rate Limit Backoff During Overlapping Phases
+
+```
+[model_validation] Rate limit exceeded. Retrying in 60s... (attempt 2/4)
+[model_validation] Rate limit exceeded. Retrying in 60s... (attempt 3/4)
+[model_validation] Rate limit exceeded. Retrying in 60s... (attempt 4/4)
+```
+
+Appeared when Phase 3 repair started while Phase 2 was still running. Each experiment's
+`--retry-errors` repair had to wait ~4 minutes just for model validation.
+
+### Silent Skip Bug (Attempt 3)
+
+```
+All 47 tests already completed. Nothing to do.
+```
+
+Appeared when re-running with `--max-subtests 3` and `--retry-errors` after completing
+experiments with `--max-subtests 1`. No error was raised — the tool simply exited with
+a success message, having done nothing.
+
+## Bug Details: Batch Skip Logic (PR #1404)
+
+File: `scripts/manage_experiment.py`
+Location: ~line 597 (batch mode skip logic in `cmd_run()`)
+
+**Before fix:**
+```python
+# Load batch summary for this experiment
+batch_summary_path = exp_results_dir / "batch_summary.json"
+if batch_summary_path.exists():
+    with open(batch_summary_path) as f:
+        summary = json.load(f)
+    if summary.get("status") == "complete":
+        log.info(f"Skipping {exp_id}: already complete")
+        continue
+```
+
+**After fix:**
+```python
+# Load batch summary for this experiment
+batch_summary_path = exp_results_dir / "batch_summary.json"
+if batch_summary_path.exists():
+    with open(batch_summary_path) as f:
+        summary = json.load(f)
+    if summary.get("status") == "complete":
+        # If --max-subtests was specified, check if expansion is needed
+        if max_subtests is not None:
+            checkpoint_path = exp_results_dir / "checkpoint.json"
+            if checkpoint_path.exists():
+                with open(checkpoint_path) as f:
+                    checkpoint = json.load(f)
+                subtest_states = checkpoint.get("subtest_states", {})
+                needs_expansion = False
+                for tier_id, tier_subtests in subtest_states.items():
+                    completed = sum(
+                        1 for state in tier_subtests.values()
+                        if state == "aggregated"
+                    )
+                    if completed < max_subtests:
+                        needs_expansion = True
+                        break
+                if not needs_expansion:
+                    log.info(f"Skipping {exp_id}: already complete with {max_subtests} subtests")
+                    continue
+                log.info(f"Re-queuing {exp_id}: needs subtest expansion to {max_subtests}")
+            else:
+                log.info(f"Skipping {exp_id}: already complete")
+                continue
+        else:
+            log.info(f"Skipping {exp_id}: already complete")
+            continue
+```
+
+## Key Observations
+
+### --fresh Flag Behavior
+
+`--fresh` in `manage_experiment.py` creates a new timestamped subdirectory under `--results-dir`:
+```
+~/dryrun3/2026-03-04T15-30-00-test-029/   # new --fresh directory
+~/dryrun3/2026-02-28T09-15-00-test-029/   # old broken directory (left as-is)
+```
+
+It does NOT touch `~/dryrun3/repos/<hash>/` at all. That shared repo directory accumulates
+worktrees and branches across all runs for the same task repo. The old broken run's worktrees
+(`test-029_T1_01_run_01`) remain in the repo until manually removed.
+
+### Rate Limit Patterns
+
+Model validation (`--model claude-haiku-4-5-20251001`) hits rate limits when too many
+`manage_experiment.py` processes run simultaneously. With `--threads 2`, a single batch
+of 16 experiments rarely hits rate limits. With `--threads 4+`, rate limits are frequent.
+
+The repair phase is more sensitive because each `--retry-errors` invocation validates the
+model independently and doesn't share a single validation result across all experiments
+in the batch.
+
+### Loader Directory Structure Requirements
+
+`scylla/analysis/loader.py` walks the directory tree expecting:
+```
+data_dir/
+  <experiment_name>/           # e.g., "test-001"
+    <timestamp>/               # e.g., "2026-03-04T12-00-00-test-001"
+      T0/
+        00/
+          run_01/
+            run_result.json
+          run_02/
+            run_result.json
+      T1/
+        ...
+```
+
+The timestamp directory name is arbitrary (loader just picks the newest one). The experiment
+name directory must exist as a parent. Raw `~/dryrun3/` directories have the timestamp as the
+top-level name — the symlink tree inverts this by putting `<test_name>/<timestamp>` as the
+hierarchy.
+
+## Final Results
+
+- 47/47 experiments complete
+- 329 total runs (47 experiments × 7 tiers × 1 run × 1 subtest)
+- $148.64 total API cost
+- 34.3% overall pass-rate (Haiku 4.5, all 7 tiers combined)
+- 4 CSVs, 2 JSONs, 56 figures, 10 tables generated
+
+## Related Skills
+
+- `evaluation/verify-experiment-completion` — Single-experiment verification (not batch)
+- `evaluation/e2e-checkpoint-resume` — Low-level checkpoint resume mechanics
+- `evaluation/resume-from-failed-experiment` — Resume workflow for individual failed experiments

--- a/skills/evaluation/dryrun3-completion/SKILL.md
+++ b/skills/evaluation/dryrun3-completion/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: "Dryrun3 Completion: Diagnose, Repair, and Analyze Interrupted Batch Experiments"
+description: "Complete interrupted dryrun experiments: diagnose broken/partial runs, clean stale git worktrees, re-run broken experiments, repair partial experiments, build loader-compatible symlink tree, and generate full analysis pipeline output."
+category: evaluation
+date: 2026-03-04
+user-invocable: true
+---
+# Dryrun3 Completion: Diagnose, Repair, and Analyze Interrupted Batch Experiments
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-04 |
+| Objective | Complete all 47 experiments in ~/dryrun3/ to 7/7 run_results each, then generate full analysis pipeline output |
+| Outcome | Operational — 47/47 experiments complete, 329 total runs, $148.64 API cost, 34.3% pass-rate |
+| Key Learning | Stale git worktrees in shared repos block `--fresh` re-runs; `--retry-errors` batch skip logic ignores `--max-subtests` expansion |
+
+## When to Use This Skill
+
+Use this workflow when:
+
+- A batch dryrun left some experiments with 0/7 run_results (broken) and others with partial results
+- `--retry-errors` reports "All tests already completed" even though `--max-subtests` was increased
+- Stale git worktrees or branches from old broken runs exist in `~/dryrun3/repos/<hash>/`
+- You need to build a loader-compatible `~/fullruns/dryrun3/` symlink tree from timestamped experiment directories
+- You need to run `generate_all_results.py` to produce figures, tables, and stats from a complete dataset
+
+## Verified Workflow
+
+### Phase 0: Diagnose Experiment State
+
+Before doing anything, categorize all experiments:
+
+```bash
+# Count run_results per experiment directory
+for dir in ~/dryrun3/2026-*-test-*/; do
+  test_name=$(basename "$dir" | grep -oE 'test-[0-9]+$')
+  count=$(find "$dir" -name run_result.json 2>/dev/null | wc -l)
+  echo "$test_name: $count/7 $(basename $dir)"
+done | sort
+
+# Summarize: broken (0), partial (1-6), complete (7)
+for dir in ~/dryrun3/2026-*-test-*/; do
+  count=$(find "$dir" -name run_result.json 2>/dev/null | wc -l)
+  if [ "$count" -eq 0 ]; then
+    echo "BROKEN: $(basename $dir)"
+  elif [ "$count" -lt 7 ]; then
+    echo "PARTIAL ($count/7): $(basename $dir)"
+  fi
+done
+```
+
+Expected outputs:
+- **Complete**: 28/47 experiments with exactly 7/7 run_results
+- **Partial**: 3/47 experiments with 1-6 run_results (specific tiers missing)
+- **Broken**: 16/47 experiments with 0 run_results (entire experiment failed)
+
+### Phase 1: Clean Stale Worktrees Before Re-running Broken Experiments
+
+**This step is critical and must be done before any `--fresh` re-runs.**
+
+The `--fresh` flag creates a new timestamped directory but does NOT clear old worktrees or branches from the shared `~/dryrun3/repos/<hash>/` directories. These stale references cause the new run to fail immediately when it tries to create worktrees with the same branch names.
+
+```bash
+# Identify which repos have stale worktrees
+for repo_dir in ~/dryrun3/repos/*/; do
+  wt_count=$(git -C "$repo_dir" worktree list 2>/dev/null | grep -v "bare\|$(pwd)" | wc -l)
+  if [ "$wt_count" -gt 0 ]; then
+    echo "=== $repo_dir ==="
+    git -C "$repo_dir" worktree list 2>/dev/null
+  fi
+done
+
+# Remove stale worktrees for specific broken experiments
+# Replace the test-NNN pattern with the actual broken test IDs
+BROKEN_TESTS="test-001|test-003|test-007|test-012|test-019"  # example
+for repo_dir in ~/dryrun3/repos/*/; do
+  # Remove stale worktrees matching broken test IDs
+  git -C "$repo_dir" worktree list 2>/dev/null | \
+    grep -E "($BROKEN_TESTS)/" | awk '{print $1}' | while read wt_path; do
+      echo "Removing worktree: $wt_path"
+      git -C "$repo_dir" worktree remove --force "$wt_path" 2>/dev/null || true
+    done
+
+  # Prune leftover references
+  git -C "$repo_dir" worktree prune 2>/dev/null || true
+
+  # Remove stale branches matching broken test IDs
+  git -C "$repo_dir" branch 2>/dev/null | \
+    grep -E "($BROKEN_TESTS)_" | sed 's/[+* ]*//' | while read branch; do
+      echo "Deleting branch: $branch"
+      git -C "$repo_dir" branch -D "$branch" 2>/dev/null || true
+    done
+done
+```
+
+**Verify cleanup succeeded:**
+```bash
+for repo_dir in ~/dryrun3/repos/*/; do
+  remaining=$(git -C "$repo_dir" worktree list 2>/dev/null | grep -v "bare" | wc -l)
+  echo "$repo_dir: $remaining worktrees remaining"
+done
+```
+
+### Phase 2: Re-run Broken Experiments with --fresh
+
+After cleaning stale worktrees, re-run all broken experiments using `--fresh`. The `--fresh` flag creates a new timestamped directory, avoiding conflicts with the old (broken) directory.
+
+```bash
+# List all broken test config paths
+BROKEN_CONFIGS=(
+  tests/fixtures/tests/test-001
+  tests/fixtures/tests/test-003
+  # ... add all broken tests
+)
+
+# Run all broken experiments together (batch mode)
+pixi run python scripts/manage_experiment.py run \
+  "${BROKEN_CONFIGS[@]/#/--config }" \
+  --model claude-haiku-4-5-20251001 \
+  --judge-model claude-haiku-4-5-20251001 \
+  --tiers T0 T1 T2 T3 T4 T5 T6 \
+  --runs 1 --max-subtests 1 \
+  --results-dir ~/dryrun3 \
+  --fresh --threads 2
+
+# Alternative: pass all configs as a directory if all tests are under one parent
+pixi run python scripts/manage_experiment.py run \
+  --config tests/fixtures/tests \
+  --model claude-haiku-4-5-20251001 \
+  --judge-model claude-haiku-4-5-20251001 \
+  --tiers T0 T1 T2 T3 T4 T5 T6 \
+  --runs 1 --max-subtests 1 \
+  --results-dir ~/dryrun3 \
+  --fresh --threads 2
+```
+
+**Key flags:**
+- `--fresh`: Creates a new timestamped directory, never resumes the old broken one
+- `--threads 2`: Limits parallelism to avoid rate limit errors during API-heavy phases
+
+### Phase 3: Repair Partial Experiments with --retry-errors
+
+For experiments that have some tiers complete but others missing, use surgical repair:
+
+```bash
+# Identify which tier is missing in partial experiment
+for dir in ~/dryrun3/2026-*-test-014/; do
+  for tier in T0 T1 T2 T3 T4 T5 T6; do
+    count=$(find "$dir/$tier" -name run_result.json 2>/dev/null | wc -l)
+    echo "  $tier: $count run_results"
+  done
+done
+
+# Repair by running only the missing tier
+pixi run python scripts/manage_experiment.py run \
+  --config tests/fixtures/tests/test-014 \
+  --model claude-haiku-4-5-20251001 \
+  --judge-model claude-haiku-4-5-20251001 \
+  --tiers T4 \
+  --runs 1 --max-subtests 1 \
+  --results-dir ~/dryrun3 \
+  --retry-errors
+```
+
+**Important**: If rate limits were hit during Phase 2, wait for Phase 2 to fully complete before starting Phase 3 repairs. Running `--retry-errors` while Phase 2 is consuming API will cause model validation to retry 4x with ~60s backoff per attempt (~8 minutes just for validation).
+
+### Phase 4: Build Loader-Compatible Symlink Tree
+
+The analysis loader (`scylla/analysis/loader.py`) expects the structure:
+```
+data_dir/<experiment_name>/<timestamp>/T*/NN/run_*/run_result.json
+```
+
+Build this from the flat timestamped experiment directories in `~/dryrun3/`:
+
+```bash
+mkdir -p ~/fullruns/dryrun3
+
+for dir in ~/dryrun3/2026-*-test-*/; do
+  entry=$(basename "$dir")
+  # Extract test name (e.g., "test-014") from directory name like "2026-03-04T12-00-00-test-014"
+  test_name=$(echo "$entry" | grep -oE 'test-[0-9]+$')
+  if [ -n "$test_name" ]; then
+    mkdir -p ~/fullruns/dryrun3/$test_name
+    ln -sf "$dir" ~/fullruns/dryrun3/$test_name/$entry
+  fi
+done
+
+# Verify structure
+echo "Experiments in fullruns:"
+ls ~/fullruns/dryrun3/ | wc -l
+echo "Sample structure:"
+ls ~/fullruns/dryrun3/test-001/
+```
+
+**Verify loader can read the structure:**
+```bash
+# Each experiment dir should contain T0-T6 subdirectories
+for test_dir in ~/fullruns/dryrun3/*/; do
+  test_name=$(basename "$test_dir")
+  latest=$(ls -t "$test_dir" | head -1)
+  tier_count=$(ls "$test_dir/$latest/" 2>/dev/null | grep -cE '^T[0-6]$' || echo 0)
+  echo "$test_name: $tier_count tiers"
+done
+```
+
+### Phase 5: Generate Full Analysis Pipeline Output
+
+```bash
+pixi run python scripts/generate_all_results.py \
+  --data-dir ~/fullruns/dryrun3 \
+  --output-dir docs/arxiv/dryrun3
+
+# Verify outputs
+echo "CSVs:"
+find docs/arxiv/dryrun3 -name "*.csv" | wc -l
+echo "JSONs:"
+find docs/arxiv/dryrun3 -name "*.json" | wc -l
+echo "Figures:"
+find docs/arxiv/dryrun3 -name "*.png" -o -name "*.svg" | wc -l
+echo "Tables:"
+find docs/arxiv/dryrun3 -name "Table_*.tex" -o -name "Table_*.md" | wc -l
+```
+
+Expected outputs for 47 experiments / 7 tiers:
+- 4 CSV files
+- 2 JSON files
+- 56 figures
+- 10 tables
+
+## Failed Attempts
+
+### Attempt 1: Running --fresh Without Cleaning Stale Worktrees
+
+**What happened:**
+```
+batch run failed immediately with git worktree error:
+  fatal: 'test-029_T1_01_run_01' already exists
+```
+
+**Root cause:**
+The `--fresh` flag creates a new timestamped results directory but does NOT clear old worktrees or branches from the shared `~/dryrun3/repos/<hash>/` directory. When the new run tried to create a worktree with the same branch name as the old broken run, git rejected it.
+
+**Fix**: Always run the stale worktree cleanup (Phase 1) before any `--fresh` re-runs. The cleanup must target the shared repo directories in `~/dryrun3/repos/`, not the experiment result directories.
+
+### Attempt 2: Running --retry-errors While Phase 2 Was In Progress
+
+**What happened:**
+Phase 2 (`--fresh` re-runs for 16 broken experiments) was running and consuming API quota. Simultaneously starting Phase 3 (`--retry-errors` for 3 partial experiments) caused model validation in Phase 3 to hit rate limits. The validation logic retried 4x with ~60s backoff per attempt, resulting in ~8 minutes just to confirm the model name was valid.
+
+**Fix**: Wait for Phase 2 to fully complete before starting Phase 3. Watch for "All N experiments complete" in Phase 2's output before proceeding.
+
+### Attempt 3: Using --retry-errors with --max-subtests Expansion
+
+**What happened:**
+After completing Phase 2 with `--max-subtests 1`, re-running with `--max-subtests 3` and `--retry-errors` reported "All 47 tests already completed" immediately — no work was done.
+
+**Root cause**: The batch mode skip logic in `scripts/manage_experiment.py` (~line 597) only checked `batch_summary.json` status field. It did not check whether the checkpoint's actual subtest count was less than the requested `--max-subtests`. Since all experiments showed status="complete" in `batch_summary.json`, they were all skipped.
+
+**Fix (committed as PR #1404)**: When `--max-subtests` is specified, the batch skip logic now reads each completed experiment's checkpoint and checks if any tier has fewer completed subtests than requested. If so, the experiment is re-queued for expansion.
+
+```python
+# In scripts/manage_experiment.py batch skip logic (~line 597)
+# Before fix: only checked batch_summary.json status
+if batch_status == "complete":
+    continue  # BUG: ignores --max-subtests expansion
+
+# After fix: also check checkpoint subtest counts
+if batch_status == "complete" and max_subtests is not None:
+    checkpoint = load_checkpoint(exp_results_dir)
+    for tier_id, tier_data in checkpoint.get("subtest_states", {}).items():
+        completed_subtests = len([
+            s for s, state in tier_data.items() if state == "aggregated"
+        ])
+        if completed_subtests < max_subtests:
+            # Re-queue for expansion
+            break
+    else:
+        continue  # All tiers have enough subtests, skip
+```
+
+## Results and Parameters
+
+### Experiment Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total experiments | 47 |
+| Experiments broken (0/7 run_results) | 16 |
+| Experiments partial (1-6/7 run_results) | 3 |
+| Experiments complete (7/7 run_results) | 28 |
+| Total runs after completion | 329 (47 x 7 tiers) |
+| Total API cost | $148.64 |
+| Overall pass-rate | 34.3% |
+| Model used | claude-haiku-4-5-20251001 |
+
+### Analysis Pipeline Outputs
+
+| Output Type | Count |
+|-------------|-------|
+| CSV files | 4 |
+| JSON files | 2 |
+| Figures (PNG/SVG) | 56 |
+| Tables (TeX/Markdown) | 10 |
+
+### Key Parameters
+
+```yaml
+model: claude-haiku-4-5-20251001
+judge-model: claude-haiku-4-5-20251001
+tiers: [T0, T1, T2, T3, T4, T5, T6]
+runs: 1
+max-subtests: 1
+threads: 2
+results-dir: ~/dryrun3
+```
+
+## Key Learnings
+
+1. **`--fresh` does not clean shared repos.** The `--fresh` flag only creates a new timestamped results directory. Stale worktrees and branches in `~/dryrun3/repos/<hash>/` from old broken runs must be cleaned manually before re-running. Always clean stale worktrees before any `--fresh` batch run.
+
+2. **Rate limits cascade across simultaneous batch runs.** Running `--retry-errors` for partial experiments while `--fresh` re-runs are consuming API quota causes validation retries with exponential backoff. Serialize Phase 2 (broken re-runs) and Phase 3 (partial repairs) — do not overlap them.
+
+3. **Batch skip logic ignores `--max-subtests` expansion (pre-PR #1404).** The batch mode in `manage_experiment.py` checked only `batch_summary.json` status. After completing experiments with `--max-subtests 1`, re-running with `--max-subtests 3` and `--retry-errors` would silently skip all experiments. The fix reads each experiment's checkpoint to compare actual subtest count against the requested maximum.
+
+4. **Loader expects a specific symlink tree structure.** `scylla/analysis/loader.py` requires `data_dir/<exp>/<timestamp>/T*/NN/run_*/run_result.json`. Timestamped experiment directories from `~/dryrun3/` must be symlinked into `~/fullruns/dryrun3/<test_name>/<timestamp>` before running the analysis pipeline.
+
+5. **Diagnose before acting.** Count run_results per experiment and categorize into broken/partial/complete before starting any repair. Using different strategies (fresh re-run vs. retry-errors) for different failure modes is more efficient and less risky than applying a single strategy to all experiments.
+
+## Files and References
+
+| File | Role |
+|------|------|
+| `scripts/manage_experiment.py` | Batch experiment runner; contains batch skip logic bug fixed in PR #1404 |
+| `scylla/analysis/loader.py` | Analysis data loader; expects `data_dir/<exp>/<timestamp>/T*/NN/run_*/run_result.json` |
+| `scripts/generate_all_results.py` | Master analysis pipeline; produces figures, tables, CSVs, JSONs |
+| `~/dryrun3/repos/` | Shared git repos for worktrees; can accumulate stale branches between runs |
+| `~/fullruns/dryrun3/` | Loader-compatible symlink tree built from `~/dryrun3/` timestamped directories |
+
+**PR**: #1404 — Fix batch skip logic to respect `--max-subtests` expansion


### PR DESCRIPTION
## Summary

- Adds `skills/evaluation/dryrun3-completion/SKILL.md`: full skill documentation covering the verified 5-phase workflow (diagnose, clean stale worktrees, re-run broken experiments, repair partials, build symlink tree, generate analysis)
- Adds `plugins/dryrun3-completion.json`: trigger-condition plugin descriptor for the skill
- Adds `references/dryrun3-completion-notes.md`: raw session notes with timeline, error messages, and bug details

## Key content

The skill documents 3 distinct failure modes encountered during dryrun3:

1. **Stale git worktrees block `--fresh` re-runs** — `--fresh` creates a new timestamped directory but does NOT clear old worktrees/branches from `~/dryrun3/repos/<hash>/`. Must clean stale worktrees manually before any `--fresh` batch run.

2. **Overlapping repair phases hit rate limits** — Running `--retry-errors` for partial experiments while `--fresh` re-runs are consuming API quota causes model validation to retry 4x with ~60s backoff. Phases must be serialized.

3. **Batch skip logic ignored `--max-subtests` expansion (pre-PR #1404)** — `--retry-errors` with `--max-subtests 3` silently reported "All tests already completed" on experiments run with `--max-subtests 1`. Fixed by reading each experiment's checkpoint to compare actual subtest count against requested maximum.

## Results captured

- 47/47 experiments complete, 329 total runs, $148.64 API cost, 34.3% pass-rate (Haiku 4.5)
- Analysis pipeline output: 4 CSVs, 2 JSONs, 56 figures, 10 tables