### PR TITLE
feat: add mojo-extensor-utility-methods skill

### DIFF
--- a/skills/architecture/mojo-extensor-utility-methods/.claude-plugin/plugin.json
+++ b/skills/architecture/mojo-extensor-utility-methods/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-extensor-utility-methods",
+  "version": "1.0.0",
+  "description": "Implement standard utility methods on a Mojo tensor class (ExTensor). Use when: (1) adding Python/NumPy-compatible utility methods to a Mojo struct, (2) implementing __setitem__, __str__, __repr__, __hash__, __int__, __float__ on a type-erased tensor, (3) auditing what methods are already implemented before coding.",
+  "category": "architecture",
+  "date": "2026-03-04",
+  "tags": ["mojo", "tensor", "extensor", "utility-methods", "struct-methods", "type-erased-storage"]
+}

--- a/skills/architecture/mojo-extensor-utility-methods/references/notes.md
+++ b/skills/architecture/mojo-extensor-utility-methods/references/notes.md
@@ -1,0 +1,92 @@
+# Session Notes: Mojo ExTensor Utility Methods
+
+## Session Context
+
+- **Date**: 2026-03-04
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #2722 - [ExTensor] Implement utility methods: copy, clone, item, tolist, __setitem__, __len__, __hash__
+- **Branch**: 2722-auto-impl
+- **PR**: #3161
+
+## What Was Implemented
+
+The issue requested implementing 11 utility methods. Upon audit, most were already present:
+
+### Already Implemented (no changes needed)
+
+| Method | Location in extensor.mojo |
+|--------|--------------------------|
+| `clone()` method | ~line 2648 |
+| `clone(tensor)` module function | ~line 3431 |
+| `item()` method | ~line 2678 |
+| `item(tensor)` module function | ~line 3454 |
+| `tolist()` | ~line 2701 |
+| `__len__` | ~line 2625 |
+| `diff()` method | ~line 2718 |
+| `diff(tensor, n)` module function | ~line 3477 |
+| `is_contiguous()` | ~line 537 |
+| `as_contiguous()` | shape.mojo ~line 59 |
+
+### Newly Implemented
+
+| Method | Location |
+|--------|----------|
+| `__setitem__(mut self, index: Int, value: Float64)` | After last `__getitem__` (~line 881) |
+| `__setitem__(mut self, index: Int, value: Int64)` | After Float64 overload |
+| `__int__(self) -> Int` | After `__len__` |
+| `__float__(self) -> Float64` | After `__int__` |
+| `__str__(self) -> String` | After `__float__` |
+| `__repr__(self) -> String` | After `__str__` |
+| `__hash__(self) -> UInt` | After `__repr__` |
+| `contiguous(self) -> ExTensor` | After `__hash__` |
+
+## ExTensor Architecture Notes
+
+- Storage: `UnsafePointer[UInt8, origin=MutAnyOrigin]` - raw bytes, type-erased
+- Reference counting: `UnsafePointer[Int]` shared across copies
+- `__copyinit__` creates shared view (increments refcount)
+- `clone()` creates deep copy (new allocation, copies all bytes via `_get_float64`/`_set_float64`)
+- `contiguous()` simply delegates to `clone()` since all freshly-created tensors are row-major
+
+## Key Mojo Patterns Used
+
+### Mutable method signature
+```mojo
+fn __setitem__(mut self, index: Int, value: Float64) raises:
+```
+Note: `mut self` is required for methods that modify state.
+
+### Read-only method signature
+```mojo
+fn __str__(self) -> String:
+fn __hash__(self) -> UInt:
+```
+
+### Internal accessors for type-erased reads/writes
+- `_get_float64(index)` - reads any dtype as Float64
+- `_set_float64(index, value)` - writes Float64 to any float dtype
+- `_get_int64(index)` - reads any dtype as Int64
+- `_set_int64(index, value)` - writes Int64 to any integer dtype
+
+### DType to ordinal conversion
+```mojo
+from shared.core.dtype_ordinal import dtype_to_ordinal
+var ord = dtype_to_ordinal(self._dtype)  # returns Int
+```
+
+### DType to string
+```mojo
+var s = String(self._dtype)  # e.g., "float32"
+```
+
+## Errors Encountered
+
+### `Float64.to_bits()` does not exist
+Tried using `val.to_bits()` to get IEEE 754 bit representation for hashing. This method is not available in Mojo v0.26.1. Used `Int(val * 1000000.0)` instead.
+
+### `DType._as_i8()` does not exist
+Tried accessing dtype as integer via private method. Used `dtype_to_ordinal()` from existing utility module instead.
+
+## Test File
+
+Tests live in `tests/shared/core/test_utility.mojo`. The test file imports `clone`, `item`, `diff` from `shared.core` and tests via the existing `assert_*` helpers in `tests/shared/conftest.mojo`. Many tests for `__str__`, `__repr__`, `__hash__` are commented-out placeholders.

--- a/skills/architecture/mojo-extensor-utility-methods/skills/mojo-extensor-utility-methods/SKILL.md
+++ b/skills/architecture/mojo-extensor-utility-methods/skills/mojo-extensor-utility-methods/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: mojo-extensor-utility-methods
+description: "Implement standard utility methods on a Mojo tensor class. Use when: adding Python/NumPy-compatible dunder methods to a Mojo struct, implementing type-erased tensor accessors, or auditing existing methods before implementing new ones."
+category: architecture
+date: 2026-03-04
+user-invocable: false
+---
+
+# Skill: Mojo ExTensor Utility Methods
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-04 |
+| **Objective** | Implement utility methods for ExTensor: `__setitem__`, `__int__`, `__float__`, `__str__`, `__repr__`, `__hash__`, `contiguous()` |
+| **Outcome** | Successfully added 171 lines of implementation; PR #3161 created |
+| **PRs** | [#3161](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3161) |
+
+## Overview
+
+ExTensor is a type-erased, reference-counted tensor in Mojo with `UnsafePointer[UInt8]` storage. Many standard utility methods were already implemented when the issue was filed — the key lesson is to **audit first** before coding. The methods actually missing were `__setitem__`, `__int__`, `__float__`, `__str__`, `__repr__`, `__hash__`, and `contiguous()`.
+
+## When to Use
+
+1. Adding Python/NumPy-compatible dunder methods to a Mojo struct
+2. Implementing mutable indexing (`__setitem__`) on a type-erased storage type
+3. Computing a portable hash over a dynamically-typed tensor
+4. Implementing `__str__`/`__repr__` on structs with runtime DType
+
+## Verified Workflow
+
+### Phase 1: Audit What Already Exists
+
+Before writing a single line, grep for existing implementations:
+
+```bash
+grep -n "fn __setitem__\|fn __int__\|fn __float__\|fn __str__\|fn __repr__\|fn __hash__\|fn contiguous\|fn clone\|fn item\|fn tolist\|fn __len__\|fn diff\|fn is_contiguous" shared/core/extensor.mojo
+```
+
+In this session, `clone()`, `item()`, `tolist()`, `__len__`, `diff()`, and `is_contiguous()` were already present. Only 7 methods were actually missing.
+
+### Phase 2: Implement `__setitem__` (two overloads)
+
+Place after the last `__getitem__` overload. Use existing `_set_float64` / `_set_int64` internal helpers:
+
+```mojo
+fn __setitem__(mut self, index: Int, value: Float64) raises:
+    if index < 0 or index >= self._numel:
+        raise Error("Index out of bounds")
+    self._set_float64(index, value)
+
+fn __setitem__(mut self, index: Int, value: Int64) raises:
+    if index < 0 or index >= self._numel:
+        raise Error("Index out of bounds")
+    self._set_int64(index, value)
+```
+
+### Phase 3: Implement type conversion methods
+
+Delegate to `item()` which already validates single-element requirement:
+
+```mojo
+fn __int__(self) raises -> Int:
+    return Int(self.item())
+
+fn __float__(self) raises -> Float64:
+    return self.item()
+```
+
+### Phase 4: Implement `__str__` and `__repr__`
+
+`String(dtype)` works directly for DType. Build string iterating over `_get_float64`:
+
+```mojo
+fn __str__(self) -> String:
+    var s = String("ExTensor([")
+    for i in range(self._numel):
+        if i > 0:
+            s += ", "
+        s += String(self._get_float64(i))
+    s += "], dtype="
+    s += String(self._dtype)
+    s += ")"
+    return s
+```
+
+### Phase 5: Implement `__hash__`
+
+Use `dtype_to_ordinal()` from `shared.core.dtype_ordinal` (already in the codebase). Avoid `Float64.to_bits()` — it may not exist. Use integer approximation:
+
+```mojo
+fn __hash__(self) -> UInt:
+    from shared.core.dtype_ordinal import dtype_to_ordinal
+    var h: UInt = 0
+    for i in range(len(self._shape)):
+        h = h * 31 + UInt(self._shape[i])
+    h = h * 31 + UInt(dtype_to_ordinal(self._dtype))
+    for i in range(self._numel):
+        var val = self._get_float64(i)
+        var int_bits = Int(val * 1000000.0)
+        h = h * 31 + UInt(int_bits)
+    return h
+```
+
+### Phase 6: Implement `contiguous()`
+
+For ExTensor with reference-counted storage, `contiguous()` can simply delegate to `clone()`:
+
+```mojo
+fn contiguous(self) raises -> ExTensor:
+    return self.clone()
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `Float64.to_bits()` in `__hash__` | Used `val.to_bits()` to get exact IEEE bits | Method does not exist on `Float64` in Mojo v0.26.1 | Use `Int(val * 1000000.0)` as integer approximation, or bitcast via pointer |
+| `DType._as_i8()` for hash ordinal | Called `self._dtype._as_i8().cast[DType.uint8]()` | Private/nonexistent method on DType | Use `dtype_to_ordinal()` from `shared.core.dtype_ordinal` |
+| `Float32` overload for `__setitem__` | Planned both Float32 and Float64 overloads | Redundant — Float64 covers both cases; Float32 adds noise | Use Float64 + Int64 as the two canonical overloads |
+
+## Results & Parameters
+
+**Files modified**: `shared/core/extensor.mojo` (+171 lines)
+
+**Methods added**:
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `__setitem__` | `(mut self, index: Int, value: Float64) raises` | bounds-checked |
+| `__setitem__` | `(mut self, index: Int, value: Int64) raises` | for integer dtypes |
+| `__int__` | `(self) raises -> Int` | delegates to `item()` |
+| `__float__` | `(self) raises -> Float64` | delegates to `item()` |
+| `__str__` | `(self) -> String` | `ExTensor([...], dtype=...)` |
+| `__repr__` | `(self) -> String` | includes shape metadata |
+| `__hash__` | `(self) -> UInt` | shape + dtype + data |
+| `contiguous` | `(self) raises -> ExTensor` | delegates to `clone()` |
+
+**Key import for hash**:
+
+```mojo
+from shared.core.dtype_ordinal import dtype_to_ordinal
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #2722, PR #3161 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the workflow for implementing standard Python/NumPy-compatible utility methods on a Mojo type-erased tensor struct (ExTensor) in ProjectOdyssey.

- Key insight: audit existing methods before coding — 10 of 17 requested methods were already present
- `Float64.to_bits()` does not exist in Mojo v0.26.1; use `Int(val * 1000000.0)` for hash approximation
- Use `dtype_to_ordinal()` from the existing utility module rather than private DType methods
- `contiguous()` can simply delegate to `clone()` for tensors with row-major allocation

## Key Findings

**What Worked**:
- Grepping for existing method implementations before writing anything
- Using `_set_float64`/`_set_int64` internal helpers for `__setitem__`
- Delegating `__int__`/`__float__` to existing `item()` method
- Using `dtype_to_ordinal()` from `shared.core.dtype_ordinal` in `__hash__`

**What Failed**:
- `Float64.to_bits()` → method does not exist in Mojo v0.26.1
- `DType._as_i8()` → private/nonexistent method; use `dtype_to_ordinal()` instead

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with "ExTensor utility" trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
