### PR TITLE
feat: add resolve-skipped-mojo-tests skill

### DIFF
--- a/skills/testing/resolve-skipped-mojo-tests/.claude-plugin/plugin.json
+++ b/skills/testing/resolve-skipped-mojo-tests/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "resolve-skipped-mojo-tests",
+  "version": "1.0.0",
+  "description": "Re-enable disabled Mojo test files by identifying root causes (missing modules, type system issues) and replacing stubs with actual tests. Use when: (1) a Mojo test file prints SKIPPED instead of running tests, (2) a test file has a NOTE saying tests are disabled due to type system issues, (3) a test stub references a non-existent module.",
+  "category": "testing",
+  "date": "2026-03-04",
+  "tags": ["mojo", "testing", "skipped-tests", "cleanup", "type-system"]
+}

--- a/skills/testing/resolve-skipped-mojo-tests/references/notes.md
+++ b/skills/testing/resolve-skipped-mojo-tests/references/notes.md
@@ -1,0 +1,85 @@
+# Session Notes: Resolve Skipped Mojo Tests (Issue #3081)
+
+## Session Details
+
+- **Date**: 2026-03-04
+- **Issue**: #3081 [Cleanup] Enable disabled test_unsigned.mojo tests
+- **Branch**: 3081-auto-impl
+- **PR**: #3175
+
+## What We Found
+
+The test file `tests/shared/core/test_unsigned.mojo` was a complete stub:
+
+```mojo
+"""Tests for unsigned integer type wrappers (UInt8, UInt16, UInt32, UInt64).
+
+NOTE: These tests are temporarily disabled due to type system issues.
+The UInt8/16/32/64 wrapper structs shadow the builtin types, causing:
+1. ImplicitlyCopyable errors when assigning values
+2. Int() constructor failures with SIMD scalar types
+3. Type resolution conflicts in conversions
+
+See follow-up issue for fixing shared/core/types/unsigned.mojo
+"""
+
+fn main() raises:
+    print("\n=== Unsigned Integer Type Tests SKIPPED ===")
+    print("Tests temporarily disabled pending type system fixes.")
+    pass
+```
+
+Key findings:
+1. `shared/core/types/unsigned.mojo` does NOT exist - was never created
+2. The original issues were with custom wrapper structs that shadow builtins
+3. Mojo's built-in `UInt8/16/32/64` types work fine (proven in mxfp4.mojo, nvfp4.mojo)
+4. The file had zero test functions - it was a complete stub
+
+## Investigation Commands
+
+```bash
+# Read the test file
+cat tests/shared/core/test_unsigned.mojo
+
+# Check if referenced module exists
+ls shared/core/types/unsigned.mojo  # Does not exist
+
+# Find existing usage of UInt types
+grep -r "UInt8\|UInt16\|UInt32\|UInt64" shared/ --include="*.mojo"
+# Found in: mxfp4.mojo, nvfp4.mojo - extensively used, proven working
+
+# Read a reference test file for pattern
+cat tests/shared/core/test_constants.mojo
+```
+
+## Environment Constraints
+
+- OS: Debian Buster (GLIBC 2.28)
+- Mojo requires GLIBC 2.32+ → `mojo build` fails locally
+- `pixi run pre-commit run mojo-format` fails for ALL .mojo files (environmental)
+- All other pre-commit hooks pass
+- CI runs in Docker with Debian Bookworm (GLIBC 2.36) where Mojo works
+
+## Solution
+
+Replaced the 19-line stub with 300+ line test file containing:
+- 18 test functions covering all aspects of UInt8/16/32/64
+- Complete `fn main()` runner with try/except per test
+- No imports needed (builtins require no import)
+
+## Pre-commit Results
+
+```
+Check for deprecated List[Type](args) syntax.....Passed
+Check for shell=True (Security)..................Passed
+Ruff Format Python...............................Passed
+Ruff Check Python................................Passed
+Validate Test Coverage...........................Passed
+Markdown Lint....................................Passed
+Trim Trailing Whitespace.........................Passed
+Fix End of Files.................................Passed
+Check YAML.......................................Passed
+Check for Large Files............................Passed
+Fix Mixed Line Endings...........................Passed
+Mojo Format......................................Failed  ← GLIBC issue (environmental)
+```

--- a/skills/testing/resolve-skipped-mojo-tests/skills/resolve-skipped-mojo-tests/SKILL.md
+++ b/skills/testing/resolve-skipped-mojo-tests/skills/resolve-skipped-mojo-tests/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: resolve-skipped-mojo-tests
+description: "Re-enable disabled Mojo test files by identifying root causes and replacing stubs with actual tests. Use when: a Mojo test file prints SKIPPED, has a NOTE about type system issues, or references a non-existent module."
+category: testing
+date: 2026-03-04
+user-invocable: false
+---
+
+# Skill: Resolve Skipped Mojo Tests
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-03-04 |
+| **Category** | testing |
+| **Objective** | Re-enable disabled Mojo test stubs by replacing them with actual test functions |
+| **Outcome** | Successfully re-enabled `test_unsigned.mojo` with 18 test functions |
+| **Context** | Issue #3081 - [Cleanup] Enable disabled test_unsigned.mojo tests |
+
+## When to Use
+
+Use this skill when:
+
+- A Mojo test file has `fn main() raises:` that only prints "SKIPPED"
+- A test file has a `NOTE:` comment saying tests are temporarily disabled
+- The disable comment references type system issues or a missing module
+- You need to determine if the original issue is still present or was abandoned
+
+Do NOT use when:
+
+- Tests are skipped due to an active, unfixed compiler bug (document blocker instead)
+- The referenced module exists and has real type errors needing a separate fix
+- Tests require external resources not available in CI
+
+## Verified Workflow
+
+### 1. Identify What Is Actually Disabled
+
+```bash
+# Read the test file to understand the disable reason
+# Look for: referenced module paths, error descriptions, NOTE markers
+cat tests/shared/core/test_unsigned.mojo
+```
+
+Key questions to answer:
+- Does the referenced module (e.g., `shared/core/types/unsigned.mojo`) actually exist?
+- Was the disable about custom wrapper structs or Mojo builtins?
+- Are there any actual test functions, or is it a complete stub?
+
+### 2. Investigate the Root Cause
+
+```bash
+# Check if referenced module exists
+ls shared/core/types/unsigned.mojo 2>/dev/null || echo "Does not exist"
+
+# Check if the builtin types work in existing code
+grep -r "UInt8\|UInt16\|UInt32\|UInt64" shared/ --include="*.mojo" | head -20
+```
+
+**Pattern discovered**: Often the disable note references a custom wrapper module
+that was abandoned. Mojo's built-in types (`UInt8`, `UInt16`, etc.) work fine —
+only the custom wrappers that shadow them had issues.
+
+### 3. Determine the Fix Strategy
+
+| Scenario | Action |
+|----------|--------|
+| Referenced module doesn't exist, builtins work | Write tests against builtins directly |
+| Referenced module exists with type errors | Fix the module first, then write tests |
+| Active Mojo compiler bug | Document blocker, create tracking issue |
+
+### 4. Write Actual Tests
+
+Use the project's test pattern — plain `fn test_*() raises:` functions:
+
+```mojo
+fn test_uint8_construction() raises:
+    """Test UInt8 construction from literals and boundary values."""
+    var zero: UInt8 = 0
+    var max_val: UInt8 = 255
+
+    if zero != 0:
+        raise Error("UInt8 zero construction failed")
+    if max_val != 255:
+        raise Error("UInt8 max value construction failed")
+```
+
+Coverage checklist for unsigned integer types:
+
+- [ ] Construction from literals (0, 1, max value per type)
+- [ ] Arithmetic: `+`, `-`, `*`, `//`, `%`
+- [ ] Bitwise: `&`, `|`, `^`, `<<`, `>>`
+- [ ] Comparisons: `==`, `!=`, `<`, `<=`, `>`, `>=`
+- [ ] Widening conversions: `.cast[DType.uint16]()` etc.
+- [ ] Conversion to/from `Int`
+- [ ] Zero and boundary operations
+- [ ] Large values (especially for `UInt64`)
+
+### 5. Update `fn main()`
+
+Replace the stub with a test runner:
+
+```mojo
+fn main():
+    """Main test runner."""
+    try:
+        test_uint8_construction()
+        print("OK test_uint8_construction")
+    except e:
+        print("FAIL test_uint8_construction:", e)
+
+    print("\n=== Tests Complete ===")
+```
+
+### 6. Verify (Environment-Dependent)
+
+```bash
+# If Mojo compiler is available locally:
+pixi run mojo build tests/shared/core/test_unsigned.mojo -o /tmp/test_bin
+
+# If GLIBC incompatibility prevents local Mojo execution:
+# Run pre-commit hooks for non-Mojo checks, rely on CI for compilation
+pixi run pre-commit run --all-files
+
+# CI (Docker) handles actual compilation verification
+```
+
+## Key Mojo Type Facts
+
+`UInt8`, `UInt16`, `UInt32`, `UInt64` in Mojo are:
+
+- Aliases for `SIMD[DType.uintX, 1]` / `Scalar[DType.uintX]`
+- Support `.cast[DType.Y]()` for cross-type conversions
+- Support `Int(u8)` for conversion to `Int`
+- Work with all arithmetic, bitwise, and comparison operators
+- **Proven working** in `shared/core/types/mxfp4.mojo` and `nvfp4.mojo`
+
+## Environment Constraint
+
+On Debian Buster (GLIBC 2.28), Mojo requires GLIBC 2.32+, so `mojo build`
+fails locally. This is a known system constraint:
+
+- All non-Mojo pre-commit hooks still pass
+- The `mojo-format` hook fails for ALL files (not just new ones)
+- CI runs in Docker (Debian Bookworm) where Mojo compiles fine
+- Push to CI to verify compilation correctness
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Building test locally | `pixi run mojo build tests/shared/core/test_unsigned.mojo` | GLIBC 2.32+ required, system has 2.28 | This is a pre-existing environment constraint affecting all Mojo files, not a code issue |
+| Running pre-commit mojo-format | `pixi run pre-commit run mojo-format --files test_unsigned.mojo` | Same GLIBC issue - fails for all files | Verify against an existing known-good file; if it also fails, it's environmental |
+| Assuming tests existed but were disabled | Looking for skip decorators or `# SKIP` markers | The file was a complete stub - no test functions at all | Always read the actual file content before assuming the disable pattern |
+
+## Results & Parameters
+
+### Final Test Structure
+
+```text
+tests/shared/core/test_unsigned.mojo
+├── 18 test functions (fn test_*() raises:)
+├── Coverage: construction, arithmetic, bitwise, comparison, conversion
+└── fn main() runner with try/except per test
+```
+
+### Commit Pattern
+
+```bash
+git add tests/shared/core/test_unsigned.mojo
+git commit -m "fix(tests): re-enable unsigned integer type tests
+
+Replace disabled stub with 18 actual tests for Mojo's built-in
+UInt8, UInt16, UInt32, UInt64 types. Original disable note referenced
+a non-existent wrapper module - testing builtins directly is correct.
+
+Closes #3081"
+```


### PR DESCRIPTION
## Summary

Documents the workflow for re-enabling disabled Mojo test files when the original
disable reason (custom wrapper module shadowing builtins) no longer applies.

- Root cause pattern: test stub references a module that was never created
- Resolution: write tests against Mojo built-in types directly
- Environment constraint documented: GLIBC incompatibility on Debian Buster

## Key Findings

**What Worked**:
- Reading the actual test file to understand the exact disable pattern (complete stub vs disabled functions)
- Searching for existing usage of the types in other `.mojo` files to prove builtins work
- Distinguishing between environmental failures (mojo-format on Buster) vs code issues

**What Failed**:
- `pixi run mojo build` → GLIBC 2.32+ required on system with 2.28 (pre-existing constraint)
- Assuming the file had test functions that were disabled → it was a complete stub with zero tests

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `testing` category
- [ ] Check skill activation with "disabled mojo tests" or "test stub" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
