### PR TITLE
feat: add generator-template-placeholder-cleanup skill

### DIFF
--- a/skills/documentation/generator-template-placeholder-cleanup/.claude-plugin/plugin.json
+++ b/skills/documentation/generator-template-placeholder-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "generator-template-placeholder-cleanup",
+  "version": "1.0.0",
+  "description": "Review TODO comments in code generator scripts and reclassify them as TEMPLATE: placeholders or actual work items. Use when: (1) a generator script contains TODO markers in its template strings, (2) you need to distinguish intentional scaffolding from implementation gaps, (3) cleaning up generator scripts as part of a cleanup issue.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["generators", "templates", "cleanup", "todos", "placeholders", "code-generation"]
+}

--- a/skills/documentation/generator-template-placeholder-cleanup/references/notes.md
+++ b/skills/documentation/generator-template-placeholder-cleanup/references/notes.md
@@ -1,0 +1,62 @@
+# Session Notes: generator-template-placeholder-cleanup
+
+## Session Context
+
+- **Date**: 2026-03-04
+- **Project**: ProjectOdyssey
+- **Issue**: #3080 — [Cleanup] Review generator script TODOs
+- **Branch**: `3080-auto-impl`
+- **PR**: #3176
+
+## Objective
+
+Review 31 TODO comments across 4 generator Python scripts and determine whether each is:
+1. An intentional template placeholder (keep, mark with TEMPLATE:)
+2. An actual implementation gap (create separate issue)
+3. Outdated (remove)
+
+## Files Affected
+
+| File | TODOs | Classification |
+|------|-------|----------------|
+| `scripts/generators/generate_tests.py` | 14 | All template placeholders |
+| `scripts/generators/generate_model.py` | 5 | All template placeholders (3 in Mojo template strings, 2 in Python fallback strings) |
+| `scripts/generators/generate_layer.py` | 4 | All template placeholders |
+| `scripts/generators/generate_dataset.py` | 8 | All template placeholders |
+
+## Key Discovery
+
+The generator scripts produce Mojo source code by interpolating Python template strings.
+TODOs inside those template strings are intentional scaffolding in the *output* — they
+signal to the developer that after running the generator, they must fill in module-specific
+logic. They are not gaps in the generator Python code itself.
+
+Two TODOs in `generate_model.py` appear in Python code (lines 266, 293) but are inside
+string return values that get embedded in generated output — also template placeholders.
+
+## Steps Taken
+
+1. Read all 4 scripts in parallel
+2. Classified all 31 TODOs as template placeholders
+3. Made individual Edit calls to replace each `# TODO:` with `# TEMPLATE:`
+4. Added `Template Placeholders:` docstring section to all 4 script module docstrings
+5. Verified with grep: no remaining `# TODO:` in scripts/generators/
+6. Ran pre-commit: all Python hooks passed (mojo format skipped due to GLIBC environment issue)
+7. Committed: `cleanup(generators): mark template placeholders with TEMPLATE: prefix`
+8. Pushed branch, created PR #3176, enabled auto-merge
+
+## Validation
+
+```bash
+# Confirm no TODOs remain
+grep -r "# TODO:" scripts/generators/  # returns empty
+
+# Pre-commit result
+Ruff Format Python.......Passed
+Ruff Check Python........Passed
+Validate Test Coverage...Passed
+Markdown Lint............Passed
+Trim Trailing Whitespace.Passed
+Fix End of Files.........Passed
+Check YAML...............Passed
+```

--- a/skills/documentation/generator-template-placeholder-cleanup/skills/generator-template-placeholder-cleanup/SKILL.md
+++ b/skills/documentation/generator-template-placeholder-cleanup/skills/generator-template-placeholder-cleanup/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: generator-template-placeholder-cleanup
+description: "Review TODO comments in code generator scripts and reclassify as TEMPLATE: markers or actual work items. Use when: cleaning up generator scripts, distinguishing template scaffolding from implementation gaps, or working on TODO-review issues."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | documentation |
+| **Effort** | Low (mechanical substitution) |
+| **Languages** | Python (generator scripts), any generated language |
+| **Project Type** | Projects with code generation scripts that output scaffolded files |
+
+## When to Use
+
+- A GitHub cleanup issue asks to "review TODOs" in generator scripts
+- Generator scripts contain `# TODO:` comments inside template string literals
+- You need to distinguish intentional scaffolding (template placeholders) from actual implementation gaps
+- Pre-commit hooks or linters flag TODO comments in code
+
+## Key Insight: Two Kinds of TODOs in Generator Scripts
+
+Generator scripts contain TODOs in two distinct locations:
+
+1. **In Python logic** (the generator itself) — may be actual implementation gaps
+2. **In Mojo/target-language template strings** — always intentional placeholders for generated output
+
+The classification step is critical: read each TODO in context to determine which category it falls into.
+
+## Verified Workflow
+
+1. **Read all affected generator scripts** in parallel using the Read tool
+2. **Classify each TODO** — check if it is inside a template string literal vs. Python code
+3. **For template placeholders**: replace `# TODO:` with `# TEMPLATE:` in-place
+4. **For actual work items**: create separate GitHub issues and link them
+5. **For outdated items**: remove them
+6. **Update script docstrings**: add a `Template Placeholders:` section to each script's module docstring explaining the `TEMPLATE:` convention
+7. **Verify** with `grep "# TODO:" scripts/generators/` — should return no matches
+8. **Run pre-commit** to confirm formatting/linting passes
+9. **Commit, push, create PR** with `Closes #<issue>`
+
+## Classification Decision Tree
+
+```
+Is the TODO inside a Python string literal (template body)?
+├─ YES → TEMPLATE: placeholder — replace with # TEMPLATE:
+└─ NO (bare Python code) → Is it needed for the script to work?
+    ├─ YES, missing implementation → Create separate issue
+    └─ NO, outdated → Remove it
+```
+
+## Results & Parameters
+
+**Session results** (issue #3080, ProjectOdyssey):
+
+- 4 generator scripts reviewed: `generate_tests.py`, `generate_model.py`, `generate_layer.py`, `generate_dataset.py`
+- 31 TODOs found across all scripts
+- 31/31 classified as template placeholders (0 actual work items, 0 outdated)
+- All `# TODO:` → `# TEMPLATE:` substitutions made
+- All 4 script docstrings updated with `Template Placeholders:` section
+- Pre-commit hooks passed: ruff format, ruff check, markdownlint, trailing-whitespace, yaml
+
+**Commit message format used**:
+```
+cleanup(generators): mark template placeholders with TEMPLATE: prefix
+
+Review all TODO comments in generator scripts and classify each as an
+intentional template placeholder. Replace all # TODO: markers with
+# TEMPLATE: markers in generated Mojo output, and add Template Placeholders
+documentation sections to each script's module docstring.
+
+Closes #<issue>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Batch-replace all TODOs at once | Considered using `replace_all=True` on a single Edit call per file | TODOs had slightly different surrounding context, making single-pattern replacement fragile | Use individual targeted Edit calls per TODO for precision |
+| Running full test suite | Ran `pixi run python -m pytest tests/ -v` expecting generator tests | No `tests/scripts/generators/` directory exists; generator scripts have no pytest tests | Check for test coverage before assuming tests exist; pre-commit is sufficient validation here |
+
+## Notes
+
+- The `# TEMPLATE:` convention is already established in this project (prior commit `e21e00b9` introduced it)
+- When no `# TODO:` remain in generator scripts, grep confirms completeness: `grep -r "# TODO:" scripts/generators/` returns empty
+- GLIBC errors from `mojo format` in pre-commit are a pre-existing environment issue (not caused by these changes) — all Python-targeted hooks still pass


### PR DESCRIPTION
## Summary

Documents the workflow for reviewing TODO comments in code generator scripts and reclassifying them as `TEMPLATE:` markers or actual work items.

- Covers the key insight that TODOs inside Python template string literals are always intentional scaffolding, not implementation gaps
- Provides a classification decision tree for ambiguous cases
- Documents pre-commit validation approach (grep + hooks) when no dedicated tests exist

## Key Findings

**What Worked**:
- Reading all generator scripts in parallel for efficient classification
- Individual targeted Edit calls per TODO (safer than batch replace_all)
- Adding `Template Placeholders:` docstring section to clarify the convention
- `grep -r "# TODO:" scripts/generators/` as a zero-match verification step

**What Failed**:
- Considered batch replace_all but TODOs had different surrounding context — individual edits were cleaner
- Ran full pytest suite expecting generator tests — none exist; pre-commit was the correct validation path

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — passes (375/375)
- [x] Plugin in correct `skills/documentation/` category directory
- [x] SKILL.md has YAML frontmatter, Overview table, Verified Workflow, Failed Attempts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)