### PR TITLE
feat: add remove-unimplemented-mojo-placeholder skill

### DIFF
--- a/skills/documentation/remove-unimplemented-mojo-placeholder/.claude-plugin/plugin.json
+++ b/skills/documentation/remove-unimplemented-mojo-placeholder/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "remove-unimplemented-mojo-placeholder",
+  "version": "1.0.0",
+  "description": "Remove no-op placeholder tests and NOTE comments for unimplemented Mojo features. Use when: (1) a test function contains only a NOTE comment and pass with no assertions, (2) a feature requires stdlib APIs not available in current Mojo version, (3) a cleanup issue requests decision on whether to implement or remove a placeholder.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["mojo", "cleanup", "placeholder", "test-removal", "dead-code"]
+}

--- a/skills/documentation/remove-unimplemented-mojo-placeholder/references/notes.md
+++ b/skills/documentation/remove-unimplemented-mojo-placeholder/references/notes.md
@@ -1,0 +1,48 @@
+# Session Notes: Remove Unimplemented Mojo Placeholder
+
+## Session Context
+
+- **Date**: 2026-03-04
+- **Issue**: ProjectOdyssey #3083 — [Cleanup] Implement RotatingFileHandler in logging
+- **Branch**: 3083-auto-impl
+- **PR**: ProjectOdyssey #3182
+
+## Objective
+
+Resolve a cleanup issue that flagged a no-op placeholder test `test_rotating_file_handler()`
+in `tests/shared/utils/test_logging.mojo:206-214`. The test contained only a `NOTE:` comment
+and `pass` — zero assertions, zero value.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3083.md` to understand the issue.
+2. Searched for `logging.mojo` using Glob to confirm the implementation file exists.
+3. Read `test_logging.mojo` around line 208 to confirm the test was a no-op.
+4. Searched for all references to `test_rotating_file_handler` and `RotatingFileHandler`.
+5. Removed the function definition (9 lines including blank separator).
+6. Removed the call from `main()`.
+7. Verified no references remained with grep.
+8. Ran `pixi run pre-commit run --all-files` — all hooks passed.
+9. Committed and pushed to `3083-auto-impl`.
+10. Created PR #3182 with label `cleanup`, enabled auto-merge.
+
+## Decision Rationale
+
+**Remove, not implement.** RotatingFileHandler requires:
+- `os.stat()` or equivalent to check file size — not in Mojo v0.26.1 stdlib
+- File rename/rotation syscalls — not exposed in Mojo v0.26.1 stdlib
+
+The test was already `pass` with no assertions, so removal loses zero test coverage.
+
+## Environment Details
+
+- Mojo v0.26.1 in pixi environment
+- Linux with GLIBC 2.28 (older than Mojo's required 2.32+)
+- GLIBC warnings appear during pre-commit from Mojo binary but don't block hooks
+
+## Key Observations
+
+- GLIBC warnings during pre-commit are cosmetic on this host — all hooks still `Passed`
+- `just` command was not available; used `pixi run pre-commit run --all-files` directly
+- Removing both the function definition AND its call in `main()` is required
+- The blank line between the removed function and the next function was also removed

--- a/skills/documentation/remove-unimplemented-mojo-placeholder/skills/remove-unimplemented-mojo-placeholder/SKILL.md
+++ b/skills/documentation/remove-unimplemented-mojo-placeholder/skills/remove-unimplemented-mojo-placeholder/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: remove-unimplemented-mojo-placeholder
+description: "Remove no-op placeholder tests and NOTE comments for unimplemented Mojo features. Use when: a test contains only a NOTE comment and pass, or a feature needs stdlib APIs not available in the current Mojo version."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | documentation |
+| **Mojo version** | v0.26.1+ |
+| **Trigger** | Cleanup issue with NOTE: ... not yet implemented in a test file |
+| **Outcome** | Placeholder test function and its call removed; all pre-commit hooks pass |
+
+## When to Use
+
+- A GitHub cleanup issue references a `NOTE: <Feature> not yet implemented` comment in a Mojo test file.
+- The test function body consists entirely of comments and `pass` (zero assertions).
+- The feature requires Mojo stdlib capabilities that do not exist in the current version (e.g., file-size stat, regex, subprocess output capture).
+- The decision has been made to **remove** rather than implement (feature not needed now).
+
+## Verified Workflow
+
+1. **Read the issue** to understand the feature and decision required.
+
+   ```bash
+   gh issue view <number> --comments
+   ```
+
+2. **Locate the placeholder** in the test file (typically flagged by line number in the issue body).
+
+3. **Check the test function** — confirm it is a no-op (body is only comments + `pass`, no assertions).
+
+4. **Decide: implement or remove** — for features requiring unavailable stdlib APIs, choose remove.
+
+5. **Remove the function definition** using the Edit tool:
+   - Delete from `fn test_<feature>():` through the closing `pass` line.
+   - Delete the blank line separator before the next function.
+
+6. **Remove the call** from `main()`:
+   - Delete the `test_<feature>()` call line.
+
+7. **Verify no references remain**:
+
+   ```bash
+   grep -n "FeatureName\|test_feature_name" path/to/test_file.mojo
+   ```
+
+8. **Run pre-commit hooks**:
+
+   ```bash
+   pixi run pre-commit run --all-files 2>&1 | tail -20
+   ```
+
+   All hooks should show `Passed`. GLIBC version warnings from Mojo binary are cosmetic — ignore them.
+
+9. **Commit** with conventional commits format including `Closes #<issue>`.
+
+10. **Push and create PR** with `gh pr create`, then enable auto-merge with `gh pr merge --auto --rebase`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Keeping the placeholder | Leaving `pass`-only test in place | Does not satisfy "Either implemented or test removed" success criterion | A no-op test with zero assertions provides no value and should be removed |
+| Implementing RotatingFileHandler | Considered full implementation | Mojo v0.26.1 lacks file-size stat (`os.stat`) and rename/rotation APIs in stdlib | Check stdlib availability before committing to implementation; removal is valid |
+
+## Results & Parameters
+
+**Environment**: Mojo v0.26.1, pixi environment, Linux (GLIBC 2.28 — older than required 2.32+)
+
+**GLIBC warning handling**: The Mojo binary emits GLIBC version warnings on older systems during pre-commit. These are warnings from the binary loader, not hook failures. All hooks still report `Passed`. Safe to proceed.
+
+**Commit message template**:
+
+```text
+cleanup(<scope>): remove unimplemented <Feature> placeholder
+
+Remove test_<feature>() function and its call from main().
+<Feature> requires <missing stdlib capability> not available in
+Mojo v0.26.1's stdlib. The test body was already a no-op (pass
+with no assertions), so removing it eliminates dead code without
+losing test coverage.
+
+Closes #<issue-number>
+```
+
+**PR label**: `cleanup`
+
+**Auto-merge**: Always enable with `gh pr merge --auto --rebase <pr-number>` after creation.


### PR DESCRIPTION
## Summary

- Documents the workflow for resolving Mojo cleanup issues that flag no-op placeholder tests
- Covers decision process: implement vs. remove for features requiring unavailable stdlib APIs
- Includes GLIBC warning handling guidance for pre-commit on older Linux hosts

## Key Findings

**What Worked**:
- Removing both the function definition AND its `main()` call eliminates dead code cleanly
- `pixi run pre-commit run --all-files` works even when `just` is not in PATH
- GLIBC warnings from Mojo binary during pre-commit are cosmetic — hooks still report `Passed`

**What Failed**:
- Keeping the placeholder: no-op test with zero assertions provides zero value
- Attempting to implement RotatingFileHandler: requires `os.stat` and file rename APIs absent from Mojo v0.26.1 stdlib

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [x] SKILL.md at correct path: `skills/documentation/remove-unimplemented-mojo-placeholder/skills/remove-unimplemented-mojo-placeholder/SKILL.md`
- [x] plugin.json has all required fields: name, version, description, category, date, tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)