### PR TITLE
feat: add placeholder-note-to-status-tracking skill

### DIFF
--- a/skills/documentation/placeholder-note-to-status-tracking/.claude-plugin/plugin.json
+++ b/skills/documentation/placeholder-note-to-status-tracking/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "placeholder-note-to-status-tracking",
+  "version": "1.0.0",
+  "description": "Clarify ambiguous NOTE: runtime print statements as intentional placeholders by converting them to STATUS: messages that reference GitHub tracking issues. Use when: (1) example or demo scripts print NOTE messages that confuse users into thinking something is broken, (2) cleanup issues require disambiguating placeholder code from unimplemented code.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["cleanup", "documentation", "placeholder", "github-issues", "examples"]
+}

--- a/skills/documentation/placeholder-note-to-status-tracking/references/notes.md
+++ b/skills/documentation/placeholder-note-to-status-tracking/references/notes.md
@@ -1,0 +1,75 @@
+# Session Notes: placeholder-note-to-status-tracking
+
+## Session Summary
+
+- **Date**: 2026-03-04
+- **Issue**: ProjectOdyssey #3084 — [Cleanup] Track backward pass implementation NOTEs in examples
+- **Branch**: 3084-auto-impl
+- **PR**: #3189
+
+## Conversation Flow
+
+### Step 1: Read issue context
+Ran `gh issue view 3084 --comments` — found a detailed implementation plan in the comments
+specifying exact lines to change, the triage strategy (docstring vs runtime print), and the
+decision to clarify rather than implement.
+
+### Step 2: Read affected files in parallel
+Read all three `train.mojo` files at the relevant line ranges simultaneously to verify
+the exact current state before proposing edits.
+
+Also read README files with grep to find the Implementation Status sections.
+
+### Step 3: Created GitHub tracking issues
+Before editing any code, created three GitHub issues:
+- `gh issue create` for ResNet-18 → #3181
+- `gh issue create` for GoogLeNet → #3184
+- `gh issue create` for MobileNetV1 → #3187
+
+Labels: `implementation`. Body follows project GitHub issue template with Objective,
+Deliverables, Estimated Scope, Dependencies, Notes.
+
+### Step 4: Updated runtime print statements
+Used `Edit` tool with `old_string`/`new_string` for exact replacements.
+
+Key pattern: `NOTE:` → `STATUS:` + "documented placeholder" + issue number reference.
+
+For googlenet and mobilenetv1, also collapsed the multi-line `print(\n    "..."\n)` format
+into single-line prints for consistency.
+
+### Step 5: Updated README files
+- ResNet-18: Added one bullet under existing `### Pending (Blocked)` section
+- GoogLeNet: Added new `### Pending (Intentional Placeholder)` section between Planned and Future Enhancements
+- MobileNetV1: Same new section pattern as GoogLeNet
+
+### Step 6: Pre-commit validation
+Ran `pixi run pre-commit run --all-files`. All 12 hooks passed on first try.
+(Note: mojo format errors appeared in stderr but these are GLIBC version compatibility
+warnings on this host — the mojo format hook itself passed.)
+
+### Step 7: Commit and PR
+```
+git add examples/*/train.mojo examples/*/README.md
+git commit -m "docs(examples): clarify backward pass NOTEs..."
+git push -u origin 3084-auto-impl
+gh pr create --label "documentation,cleanup"
+gh pr merge --auto --rebase
+```
+
+## Key Observations
+
+1. **Issue comments are the plan** — The implementation plan was fully specified in the
+   issue comments, not just the body. Always run `gh issue view <N> --comments`.
+
+2. **Triage before editing** — Classify each NOTE occurrence as docstring vs runtime print
+   before touching anything. Only runtime prints are the problem.
+
+3. **Create tracking issues before edits** — You need the issue numbers to include in the
+   STATUS messages. Creating them first means you can write the full reference in one pass.
+
+4. **Cleanup ≠ implementation** — The issue explicitly chose the "clarify" path over the
+   "implement" path. Don't scope creep into writing 3500 lines of backward pass code.
+
+5. **Multi-line print() → single-line** — The existing `print(\n    "long string"\n)` style
+   was inconsistent with the surrounding code style. Collapsed to `print("...")` which also
+   removes a black/ruff formatting concern.

--- a/skills/documentation/placeholder-note-to-status-tracking/skills/placeholder-note-to-status-tracking/SKILL.md
+++ b/skills/documentation/placeholder-note-to-status-tracking/skills/placeholder-note-to-status-tracking/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: placeholder-note-to-status-tracking
+description: "Clarify ambiguous NOTE: runtime print statements as intentional placeholders by converting them to STATUS: messages with GitHub tracking issue links. Use when: (1) example/demo scripts print confusing NOTE messages during execution, (2) cleanup issues require disambiguating placeholder code from bugs."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+# Skill: placeholder-note-to-status-tracking
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-04 |
+| Objective | Resolve GitHub issue #3084 — clarify backward pass NOTEs in ML example training scripts |
+| Outcome | Success — 3 files updated, 3 GitHub tracking issues created, PR #3189 merged |
+| Category | documentation |
+
+## When to Use
+
+Use this skill when:
+
+- Example or demo scripts contain `print("NOTE: ...")` statements at runtime that imply
+  something is broken or incomplete, but the behavior is actually intentional
+- A cleanup issue (e.g., `[Cleanup] Track backward pass NOTEs`) asks you to disambiguate
+  placeholder code from unimplemented code
+- In-docstring `# NOTE:` comments are appropriate, but runtime `print("NOTE: ...")` calls
+  are not — the latter run during execution and confuse users
+- The fix strategy is to *clarify* (not implement) — i.e., the backward passes are
+  intentional simplifications, not bugs
+
+**Key distinction**: `# NOTE:` in docstrings is fine (documentation). `print("NOTE: ...")` at runtime
+is confusing because it appears as if something failed during execution.
+
+## Verified Workflow
+
+### 1. Read issue context first
+
+```bash
+gh issue view <number> --comments
+```
+
+The issue comments often contain a fully detailed implementation plan (see issue #3084).
+Read it before starting — it specifies which lines to change and what approach to take.
+
+### 2. Triage the NOTE occurrences
+
+Enumerate all occurrences across affected files. Classify each as:
+
+- **In-docstring** `# NOTE:` — appropriate; leave as-is
+- **Runtime `print("NOTE: ...")`** — confusing; replace with `STATUS:` + issue link
+
+For issue #3084, the affected files were:
+
+| File | Line | Type | Action |
+|------|------|------|--------|
+| `examples/resnet18-cifar10/train.mojo` | 313 | Runtime print | Replace |
+| `examples/googlenet-cifar10/train.mojo` | 97 | Docstring | Leave |
+| `examples/googlenet-cifar10/train.mojo` | 436 | Runtime print | Replace |
+| `examples/mobilenetv1-cifar10/train.mojo` | 65 | Docstring | Leave |
+| `examples/mobilenetv1-cifar10/train.mojo` | 215 | Runtime print | Replace |
+
+### 3. Create GitHub tracking issues first
+
+Before editing files, create one tracking issue per model/component:
+
+```bash
+gh issue create \
+  --title "[Implementation] Full backward pass for <Model> training script" \
+  --body "$(cat <<'EOF'
+## Objective
+Implement the full backward pass...
+
+## Estimated Scope
+~N lines
+
+## Dependencies
+- Depends on #<parent>
+- Tracked in #<cleanup-issue>
+EOF
+)" \
+  --label "implementation"
+```
+
+Record the issue numbers returned. These go into the STATUS prints and README links.
+
+### 4. Replace runtime NOTE prints with STATUS prints
+
+Pattern:
+
+```mojo
+# Before (confusing — implies something is broken):
+print("NOTE: Full backward pass implementation would require ~3500 lines.")
+print("      This is a placeholder showing the structure.")
+print(
+    "      For actual training, consider using automatic differentiation."
+)
+
+# After (clear — explains intent and points to tracking issue):
+print("STATUS: Backward pass shown above is a documented placeholder (~3500 lines for full impl).")
+print("        Full implementation tracked in GitHub issue #3184.")
+print("        For actual training, consider using automatic differentiation.")
+```
+
+Key changes:
+- `NOTE:` → `STATUS:` (communicates information, not warning)
+- Add "documented placeholder" language (explicit that this is intentional)
+- Add GitHub issue number so users know where to follow progress
+- Remove the multi-line `print(...)` style in favor of plain `print("...")` for consistency
+
+### 5. Update README Implementation Status sections
+
+For each affected model's README, add a `### Pending (Intentional Placeholder)` section:
+
+```markdown
+### Pending (Intentional Placeholder)
+
+- [ ] **Full backward pass**: ~N lines — tracked in [GitHub issue #XXXX](URL)
+  - The training script demonstrates the structure but uses a placeholder backward pass
+  - For actual training, consider using automatic differentiation
+```
+
+Place this section between the completed items list and `### Future Enhancements`.
+
+### 6. Run pre-commit hooks
+
+```bash
+pixi run pre-commit run --all-files
+```
+
+All hooks should pass. Changes are string replacements only — no logic changes.
+
+### 7. Commit and PR
+
+```bash
+git add examples/*/train.mojo examples/*/README.md
+git commit -m "docs(examples): clarify backward pass NOTEs as intentional placeholders
+
+Replace ambiguous NOTE print statements with STATUS messages that
+clearly communicate these are documented placeholders, not bugs.
+Update README files to link to tracking issues.
+
+Closes #<issue>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+git push -u origin <branch>
+gh pr create --title "..." --body "..." --label "documentation,cleanup"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Changing in-docstring `# NOTE:` comments | Considered replacing `# NOTE:` at lines 97 (googlenet) and 65 (mobilenetv1) | These are appropriate documentation comments; changing them adds no value | In-docstring NOTEs are fine — only runtime `print("NOTE: ...")` calls confuse users |
+| Generic STATUS message without issue link | Drafting "This is a documented placeholder" without a GitHub issue number | Users have no way to track when the implementation will happen | Always create tracking issues *before* editing prints so you can include the issue number in the message |
+| Implementing the backward passes | Considered actually writing ~2000-3500 lines of backward pass code | Out of scope for a `[Cleanup]` issue; issue explicitly says "If not needed: update NOTEs to clarify" | Cleanup issues ask for documentation clarity, not full implementations |
+
+## Results & Parameters
+
+### Issue Numbers (for ProjectOdyssey)
+
+| Model | Tracking Issue | Lines |
+|-------|---------------|-------|
+| ResNet-18 | #3181 | ~2000 |
+| GoogLeNet | #3184 | ~3500 |
+| MobileNetV1 | #3187 | ~2000 |
+
+### Files Changed
+
+```text
+examples/resnet18-cifar10/train.mojo     (line 313)
+examples/googlenet-cifar10/train.mojo    (lines 436-438)
+examples/mobilenetv1-cifar10/train.mojo  (lines 215-219)
+examples/resnet18-cifar10/README.md      (Implementation Status section)
+examples/googlenet-cifar10/README.md     (Implementation Status section)
+examples/mobilenetv1-cifar10/README.md   (Implementation Status section)
+```
+
+### Commit Message Template
+
+```text
+docs(examples): clarify backward pass NOTEs as intentional placeholders
+
+Replace ambiguous NOTE print statements with STATUS messages that
+clearly communicate these are documented placeholders, not bugs.
+Update README files to link to tracking issues.
+
+- examples/<model>/train.mojo: NOTE -> STATUS with issue #XXXX
+- Created GitHub tracking issues for full backward pass impl
+- README.md: added Pending section with tracking issue links
+
+Closes #<cleanup-issue>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for clarifying ambiguous `NOTE:` runtime print statements in ML
example scripts as intentional placeholders by converting them to `STATUS:` messages
with GitHub tracking issue links.

- Resolves ProjectOdyssey #3084 — 3 example training scripts, 5 NOTE occurrences
- Pattern: `print("NOTE: ...")` → `print("STATUS: ... (tracked in GitHub issue #N)")`
- Created tracking issues #3181, #3184, #3187 for full backward pass implementations

## Key Findings

**What Worked**:
- Reading issue comments first — the full implementation plan was in the comments, not the body
- Creating GitHub tracking issues *before* editing code so the issue numbers are available for the STATUS messages
- Classifying each NOTE as docstring vs runtime before touching anything

**What Failed**:
- Changing in-docstring `# NOTE:` comments → these are appropriate documentation, not confusing
- Considering full backward pass implementation → out of scope for a `[Cleanup]` issue
- Generic STATUS messages without issue links → users need a place to track progress

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers on relevant cleanup issue prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
