### PR TITLE
feat: add cleanup-issue-doc-only-change skill

### DIFF
--- a/skills/documentation/cleanup-issue-doc-only-change/.claude-plugin/plugin.json
+++ b/skills/documentation/cleanup-issue-doc-only-change/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "cleanup-issue-doc-only-change",
+  "version": "1.0.0",
+  "description": "Pattern for implementing documentation-only cleanup issues: expand bare NOTE/TODO markers with structured deferred-item format and add user-facing workaround sections to READMEs. Use when: (1) a cleanup issue tracks an unresolved limitation with no code change needed, (2) a bare comment marker needs Status/Why Deferred/Workaround/Acceptance Criteria structure, (3) a README needs a Limitations section with a Python interop workaround snippet.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": [
+    "documentation",
+    "cleanup",
+    "deferred",
+    "note-marker",
+    "workaround",
+    "readme",
+    "mojo",
+    "python-interop"
+  ]
+}

--- a/skills/documentation/cleanup-issue-doc-only-change/references/notes.md
+++ b/skills/documentation/cleanup-issue-doc-only-change/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: cleanup-issue-doc-only-change
+
+## Session Context
+
+- **Date**: 2026-03-04
+- **Issue**: HomericIntelligence/ProjectOdyssey#3087
+- **Parent Issue**: #3059
+- **Branch**: `3087-auto-impl`
+- **PR**: HomericIntelligence/ProjectOdyssey#3193
+
+## Objective
+
+Implement a documentation-only cleanup issue tracking the PNG/JPEG image loading limitation
+in `examples/lenet-emnist/run_infer.mojo`. No code changes required — only expand an inline
+NOTE comment and add a README section with a Python PIL workaround.
+
+## Files Changed
+
+- `examples/lenet-emnist/run_infer.mojo:340` — expanded bare NOTE to structured deferred-item
+- `examples/lenet-emnist/README.md` — added "Image Loading Limitations" section before "Contributing"
+
+## Steps Taken
+
+1. Read `.claude-prompt-3087.md` to understand the task
+2. Ran `gh issue view 3087 --comments` to get the planner's prescribed structured comment format
+3. Read `run_infer.mojo` around line 340 to see context (3 existing bare comment lines)
+4. Read full `README.md` to find insertion point (before "Contributing" section)
+5. Confirmed `cleanup` label exists with `gh label list`
+6. Edited `run_infer.mojo` — replaced 3 bare comment lines with 7-line structured block
+7. Edited `README.md` — inserted new section with workaround snippet before "Contributing"
+8. Ran `pixi run pre-commit run --all-files` — markdownlint and all non-mojo hooks passed
+9. Committed with `SKIP=mojo-format` due to GLIBC incompatibility in this environment
+10. Pushed, created PR #3193 with `cleanup` label, enabled auto-merge
+
+## Environment Notes
+
+- **GLIBC issue**: The Docker host runs Debian Buster (glibc 2.28). Mojo requires GLIBC_2.32+.
+  This causes `mojo format` to fail in pre-commit. Use `SKIP=mojo-format` for all commits
+  in this environment. CI (Docker) handles mojo formatting separately.
+- **`just` not on PATH**: The `justfile` runner is not available outside Docker. Use
+  `pixi run pre-commit run --all-files` directly.
+
+## Key Learnings
+
+1. **Documentation-only issues are fast** — no test phase needed, just inline comment + README
+2. **Always read the planner comment** — the issue comments contain the exact structured format
+   to use; don't invent your own
+3. **Use "Contributing" as anchor for README insertion** — it's always the last major section
+   before License/Acknowledgments, making it a reliable insertion point
+4. **SKIP=mojo-format is expected** on this host — not a code quality issue
+5. **pixi run pre-commit** not `just pre-commit-all` — `just` is Docker-only in this project

--- a/skills/documentation/cleanup-issue-doc-only-change/skills/cleanup-issue-doc-only-change/SKILL.md
+++ b/skills/documentation/cleanup-issue-doc-only-change/skills/cleanup-issue-doc-only-change/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: cleanup-issue-doc-only-change
+description: "Pattern for documentation-only cleanup issues: expand bare NOTE/TODO markers with structured deferred-item format and add README Limitations sections. Use when: a cleanup issue has no code implementation needed, only inline comment expansion and user-facing docs."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | cleanup-issue-doc-only-change |
+| **Category** | documentation |
+| **Use Case** | Implementing cleanup issues that are documentation-only (no code changes) |
+| **Trigger** | Issue body says "documentation-only", contains a bare NOTE/TODO marker, lists options but no implementation is required yet |
+| **Output** | Expanded inline comment + README Limitations section + PR |
+
+## When to Use
+
+- A GitHub cleanup issue tracks an unresolved external dependency (e.g. Mojo lacks native image IO)
+- The issue's NOTE/FIXME/TODO comment is a single bare line and needs structured deferred-item format
+- The README needs a "Limitations" or "Known Limitations" section with a workaround
+- No Mojo tests are required — only markdown linting needs to pass
+- The implementation plan says "documentation-only change"
+
+## Verified Workflow
+
+1. **Read the issue plan** — `gh issue view <number> --comments` to get the exact structured comment format prescribed by the planner
+2. **Read the target file** around the NOTE marker to see exact indentation and surrounding context
+3. **Read the README** fully to find the best insertion point (before "Contributing" or after "References")
+4. **Expand the inline comment** — replace the bare NOTE with the structured block:
+
+   ```text
+   # NOTE: <original one-liner>
+   # Status: Deferred (not implemented in <language>)
+   # Why deferred: <reason — missing stdlib feature, external blocker, etc.>
+   # Workaround: <brief description>. See <path/to/README.md>.
+   # Acceptance criteria: When <condition that resolves the deferral>
+   # Tracked in: GitHub issue #<number> (part of #<parent>)
+   ```
+
+5. **Add README section** — insert a new `## <Feature> Limitations` section with:
+   - One-paragraph description of what is not supported and why
+   - `### Workaround: Python Interop` subsection with a copy-paste Python snippet
+   - `### Future Support` subsection linking to the tracking issue
+6. **Run pre-commit** (`pixi run pre-commit run --all-files`) — only markdownlint and general hooks matter; skip mojo-format if GLIBC is incompatible
+7. **Commit with `SKIP=mojo-format`** if the Mojo formatter cannot run due to environment constraints (GLIBC mismatch on older distros)
+8. **Push, create PR, enable auto-merge**
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command runner | `just` not on PATH in this environment | Fall back to `pixi run pre-commit run --all-files` directly |
+| Committing without SKIP | Ran full pre-commit including mojo-format | mojo-format fails with GLIBC_2.32/2.33/2.34 not found on Debian Buster host | Use `SKIP=mojo-format git commit` — this is a known env constraint, not a code issue |
+| Inserting README section after "References" | Tried appending after the references section | "Contributing" section already existed and the insertion point was between References and Contributing | Use Edit with the "Contributing" header as the anchor to insert before it |
+
+## Results & Parameters
+
+### Inline Comment Structure (copy-paste template)
+
+```mojo
+# NOTE: <Original one-liner>
+# Status: Deferred (not implemented in Mojo)
+# Why deferred: Mojo lacks <feature>; no stdlib support as of v0.26.1
+# Workaround: Use Python interop (<library>) to <action>.
+#   See <examples/path/README.md>.
+# Acceptance criteria: When Mojo stdlib ships <feature>, or a Python interop wrapper is added
+# Tracked in: GitHub issue #<number> (part of #<parent>)
+```
+
+### README Limitations Section Template
+
+```markdown
+## <Feature> Limitations
+
+<One-sentence description of what is unsupported and why (Mojo version, missing stdlib feature)>.
+
+The <pipeline/component> currently supports **<supported format> only**.
+
+### Workaround: Python Interop
+
+Use Python <library> to preprocess <input> before <action>:
+
+\`\`\`python
+from PIL import Image
+import numpy as np
+
+# <minimal working example>
+\`\`\`
+
+Then pass `<output file>` as the input to `<mojo script>`.
+
+### Future Support
+
+Tracked in [#<number>](https://github.com/homericintelligence/projectodyssey/issues/<number>) (part of #<parent>).
+Will be resolved when Mojo stdlib adds <feature> or a Python interop wrapper is added.
+```
+
+### Pre-commit Invocation
+
+```bash
+# Full run (use this — not `just pre-commit-all`)
+pixi run pre-commit run --all-files
+
+# Commit when mojo-format can't run due to GLIBC mismatch
+SKIP=mojo-format git commit -m "docs(...): ..."
+```
+
+### PR Creation
+
+```bash
+gh pr create \
+  --title "docs(<scope>): <summary>" \
+  --body "$(cat <<'EOF'
+## Summary
+- Expanded bare NOTE comment with structured deferred-item format
+- Added <Feature> Limitations section to README with Python interop workaround
+
+## Changes
+- `<path>/run_infer.mojo` — structured NOTE comment
+- `<path>/README.md` — new Limitations section
+
+## Verification
+- [x] markdownlint passes
+- [x] All other pre-commit hooks pass
+- [x] Documentation-only — no Mojo tests required
+
+Closes #<number>
+Part of #<parent>
+EOF
+)" \
+  --label "cleanup"
+
+gh pr merge --auto --rebase <pr-number>
+```


### PR DESCRIPTION
## Summary

Documents the pattern for implementing documentation-only cleanup issues in the ML Odyssey project.

- Expand bare NOTE/TODO markers with structured deferred-item format (Status/Why Deferred/Workaround/Acceptance Criteria/Tracked in)
- Add README Limitations sections with Python interop workaround snippets
- No Mojo tests required — only markdownlint needs to pass

## Key Findings

**What Worked**:
- Reading the planner's issue comments to get the exact structured comment format to prescribe
- Using the "Contributing" heading as a reliable README insertion anchor
- `pixi run pre-commit run --all-files` (not `just pre-commit-all` which requires Docker)

**What Failed**:
- `just pre-commit-all` → `just` not on PATH outside Docker container
- `git commit` without SKIP → mojo-format fails with GLIBC_2.32+ required on Debian Buster host

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with "documentation-only cleanup issue" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
