### PR TITLE
feat: add fp16-precision-test-documentation skill

### DIFF
--- a/skills/documentation/fp16-precision-test-documentation/.claude-plugin/plugin.json
+++ b/skills/documentation/fp16-precision-test-documentation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fp16-precision-test-documentation",
+  "version": "1.0.0",
+  "description": "Document Float16 precision limitations in ML test file headers with technical detail. Use when: (1) test files have inline FP16 precision NOTEs needing consolidation into file headers, (2) cleanup issues require documenting known Float16 arithmetic limitations, (3) reviewers ask why Float16 tests are skipped or use FP32 compute.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["float16", "precision", "mojo", "testing", "documentation", "cleanup"]
+}

--- a/skills/documentation/fp16-precision-test-documentation/references/notes.md
+++ b/skills/documentation/fp16-precision-test-documentation/references/notes.md
@@ -1,0 +1,64 @@
+# Session Notes: Float16 Precision Test Documentation
+
+## Context
+
+- **Date**: 2026-03-04
+- **Issue**: #3089 [Cleanup] Document Float16 precision limitations in tests
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3089-auto-impl
+- **PR**: #3200
+
+## Objective
+
+Review and document Float16 precision limitation NOTEs in model tests. Determine
+if each NOTE represents an expected limitation or a potential bug, then document
+expected limitations in test file headers.
+
+## Affected Files
+
+| File | Line | Description | Classification |
+|------|------|-------------|----------------|
+| tests/models/test_alexnet_layers.mojo | 1101 | Conv1 Float16 insufficient for 11x11 kernel | Expected limitation |
+| tests/models/test_alexnet_layers.mojo | 1114 | Conv2 Float16 insufficient for 5x5 kernel, 64ch | Expected limitation |
+| tests/models/test_alexnet_layers.mojo | 1128 | Conv3 Float16 insufficient for 3x3 kernel, 192ch | Expected limitation |
+| tests/models/test_lenet5_fc_layers.mojo | 186 | FC3 test sensitive to Float16 precision | Expected limitation |
+| tests/shared/core/test_gradient_checking.mojo | 431 | Conv2D FP16 gradient checking unstable | Expected limitation |
+
+## Approach
+
+All five NOTEs were already well-documented inline with clear technical rationale
+and references to issue #3009. The cleanup task required consolidating these into
+file-level docstring sections for better discoverability.
+
+Each file received a `Float16 Precision Limitations` section in the module docstring
+with:
+1. Technical explanation (multiplication counts, mantissa bits, decimal precision)
+2. Specific per-layer/per-test impact
+3. Practical context (mixed-precision training behavior)
+4. Reference to tracking issue #3009
+
+No code logic was changed — documentation only.
+
+## Key Technical Detail
+
+Float16 properties:
+- 11-bit mantissa (implicit leading 1)
+- ~3.3 decimal digits of precision
+- Safe accumulation limit: ~100-200 multiplications for FP-representable inputs
+
+AlexNet convolution accumulation counts:
+- Conv1 (11×11 × 3 channels): 363 multiplications → exceeds safe range
+- Conv2 (5×5 × 64 channels): 1,600 multiplications → far exceeds safe range
+- Conv3 (3×3 × 192 channels): 1,728 multiplications → far exceeds safe range
+
+Gradient checking constraint:
+- epsilon=1e-5 requires distinguishing changes at 5th decimal digit
+- Float16 only has ~3.3 digits of precision → cannot resolve perturbations
+
+## Changes Made
+
+1. `tests/models/test_alexnet_layers.mojo`: Added 18-line Float16 section to module docstring
+2. `tests/models/test_lenet5_fc_layers.mojo`: Added 9-line Float16 section to module docstring
+3. `tests/shared/core/test_gradient_checking.mojo`: Added 15-line Float16 section to module docstring
+
+Total: +42 lines of documentation, 0 lines of code changed.

--- a/skills/documentation/fp16-precision-test-documentation/skills/fp16-precision-test-documentation/SKILL.md
+++ b/skills/documentation/fp16-precision-test-documentation/skills/fp16-precision-test-documentation/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: fp16-precision-test-documentation
+description: "Document Float16 precision limitations in ML test file headers. Use when: consolidating inline FP16 precision NOTEs into file-level docstrings, documenting why Float16 tests are skipped or use FP32 compute, or addressing cleanup issues for known numerical precision limitations."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Skill Name** | fp16-precision-test-documentation |
+| **Category** | documentation |
+| **Issue Type** | [Cleanup] document Float16 precision limitations |
+| **Files Affected** | Test files with Float16 precision NOTEs |
+| **Key Pattern** | Consolidate inline NOTEs into file-level docstring sections |
+
+## When to Use
+
+- A GitHub issue requests reviewing and documenting Float16 precision NOTEs in test files
+- Test files have scattered inline `# NOTE: Float16 precision insufficient...` comments
+- Reviewers or CI require a canonical explanation of why Float16 tests are skipped
+- Cleanup phase of an ML model implementation requires documenting known limitations
+- Test file headers lack explanation of why certain dtype variants are SKIPPED
+
+## Verified Workflow
+
+1. **Read the issue** to identify all affected files and line numbers
+2. **Read each affected file** (both the header and the noted lines) in parallel
+3. **Assess each NOTE**: determine if it's an expected limitation or a potential bug
+   - Expected: large kernel accumulations, insufficient mantissa bits for epsilon perturbations
+   - Bug candidate: unexpected NaN/Inf in small kernels, inconsistent behavior across runs
+4. **For expected limitations**: add a `Float16 Precision Limitations` section to the file docstring
+5. **Include in the section**:
+   - Title: `Float16 Precision Limitations` with `=` underline
+   - List each skipped test with: kernel size, input channels, multiplication count per output
+   - Explain the root cause (~3.3 decimal digit precision from 11-bit mantissa)
+   - Note the practical mixed-precision training strategy (FP32 compute, FP16 storage)
+   - Reference the tracking issue (e.g., `See issue #3009 for detailed analysis.`)
+6. **Do NOT change any code logic** - documentation only in cleanup issues
+7. **Commit and create PR** with `Closes #<issue>` in message
+
+## Key Technical Facts for Float16 Precision Documentation
+
+| Float16 Property | Value |
+|-----------------|-------|
+| Mantissa bits | 11 (implicit) |
+| Decimal precision | ~3.3 digits |
+| Max safe accumulations | ~100-200 for FP-representable inputs |
+| Risk threshold | >300 multiplications per output element |
+
+### Multiplication counts by layer type:
+- Conv (K×K kernel, C_in channels): `K² × C_in` multiplications per output
+- Conv1 AlexNet (11×11, 3ch): 363 — exceeds safe range
+- Conv2 AlexNet (5×5, 64ch): 1,600 — far exceeds safe range
+- FC3 LeNet (84 in_features): 84 — borderline, test runs but accuracy reduced
+- Gradient checking (epsilon=1e-5): requires >5 digits precision — FP16 insufficient
+
+### Mixed-precision training context:
+In real training, convolutions compute in FP32 for numerical stability while storing
+activations/weights in FP16 for memory efficiency. Tests that "use FP32 compute" are
+faithfully modeling this pattern.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Changing code to skip FP16 tests programmatically | Adding conditional dtype checks in test body | Out of scope for a [Cleanup] documentation issue | Documentation-only issues require ONLY docstring changes, no code logic changes |
+| Creating separate investigation issues for all NOTEs | Treating all FP16 NOTEs as potential bugs | All NOTEs were well-reasoned expected limitations, not bugs | Read existing NOTE context carefully before escalating — most are already explained |
+| Adding inline comments at noted lines | Adding more inline comments alongside existing NOTEs | Inline comments don't help file-level discoverability | Consolidate into file header docstring for canonical reference |
+
+## Results & Parameters
+
+### Documentation section template:
+
+```
+Float16 Precision Limitations
+==============================
+<Layer/operation type> accumulates <N> multiplications per output element.
+Float16's ~3.3 decimal digit precision (~11-bit mantissa) is insufficient
+for <specific reason: large kernel accumulations / finite-difference epsilon /
+etc.>.
+
+<Additional context about what the test does instead and why it's valid.>
+This is an expected, fundamental limitation of Float16 arithmetic (not a bug).
+In practice, mixed-precision training <context about real-world usage>.
+See issue #<tracking-issue> for detailed analysis.
+```
+
+### Commit message format:
+```
+docs(tests): document Float16 precision limitations in test headers
+
+Add Float16 Precision Limitations sections to test file docstrings for:
+- tests/models/test_X.mojo: <brief explanation>
+- tests/shared/core/test_Y.mojo: <brief explanation>
+
+All limitations reference issue #NNNN for detailed analysis.
+
+Closes #<issue>
+```


### PR DESCRIPTION
## Summary

Documents the Float16 precision limitation documentation pattern for ML test files in Mojo/ML projects.

- Captures how to consolidate inline FP16 precision NOTEs into canonical file-level docstrings
- Documents Float16 arithmetic limits (11-bit mantissa, ~3.3 decimal digits, safe accumulation thresholds)
- Explains when to use FP32 compute in "FP16 tests" (gradient checking, large conv kernels)

## Key Findings

**What Worked**:
- Adding a named `Float16 Precision Limitations` section to module docstrings with `=` underline
- Including quantitative details (multiplication counts, mantissa bits) for each skipped test
- Referencing a tracking issue for deeper analysis
- Documentation-only approach for [Cleanup] issues (no code logic changes)

**What Failed**:
- Adding programmatic dtype skips → out of scope for cleanup documentation issues
- Adding more inline comments alongside existing NOTEs → doesn't help file-level discoverability

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under documentation category
- [ ] Check skill activation with "Float16" and "precision limitation" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
