### PR TITLE
feat: add update-blocker-note skill

### DIFF
--- a/skills/documentation/update-blocker-note/.claude-plugin/plugin.json
+++ b/skills/documentation/update-blocker-note/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "update-blocker-note",
+  "version": "1.0.0",
+  "description": "Update blocked feature NOTE comments with issue tracking references and resolution path. Use when: (1) a NOTE comment lacks a tracking issue number, (2) a blocker NOTE needs a resolution path documented, (3) cleanup issues require linking NOTEs to parent tracking issues.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["notes", "tracking", "blockers", "comments", "cleanup"]
+}

--- a/skills/documentation/update-blocker-note/references/notes.md
+++ b/skills/documentation/update-blocker-note/references/notes.md
@@ -1,0 +1,43 @@
+# Session Notes: update-blocker-note
+
+## Session Context
+
+- **Date**: 2026-03-04
+- **Issue**: HomericIntelligence/ProjectOdyssey#3092
+- **Branch**: 3092-auto-impl
+- **PR**: HomericIntelligence/ProjectOdyssey#3205
+
+## Objective
+
+Implement GitHub issue #3092: update a `NOTE` comment in
+`shared/training/__init__.mojo:411` to include issue tracking references
+for a batch iteration blocker tied to Track 4 (Python-Mojo interop).
+
+## Steps Taken
+
+1. Read `.claude-prompt-3092.md` to get issue context
+2. Read `shared/training/__init__.mojo` at offset 400 to see the NOTE
+3. Searched for Track 4 tracking issue via `gh issue list`
+4. Found that #3076 is the parent "Python interop blocker NOTEs" issue
+5. Attempted Edit without reading worktree file first — got tool error
+6. Read the worktree copy at `.worktrees/issue-3092/shared/training/__init__.mojo`
+7. Applied edit: added `(#3092)` to NOTE marker and appended tracking line
+8. Verified diff, committed, pushed, created PR, enabled auto-merge
+9. Posted completion comment to issue #3092
+
+## Key Learnings
+
+- The Edit tool requires you to have Read the exact file path in this conversation — reading a sibling copy (main repo vs worktree) does NOT count
+- Worktree file path is `.worktrees/issue-3092/<relative-path>`, not the main repo path
+- These cleanup "track blocker NOTE" issues are minimal: 2 comment lines changed, no logic
+- Pattern: `NOTE(#N):` for the marker + one new line `# Track resolution via #parent. Implement when <condition>.`
+- `gh issue list --search "..."` is fast for finding the parent tracking issue number
+
+## Parameters
+
+- File: `shared/training/__init__.mojo`
+- Line: 411
+- Marker before: `NOTE:`
+- Marker after: `NOTE(#3092):`
+- Parent tracking issue: #3076
+- Epic: #3059

--- a/skills/documentation/update-blocker-note/skills/update-blocker-note/SKILL.md
+++ b/skills/documentation/update-blocker-note/skills/update-blocker-note/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: update-blocker-note
+description: "Update blocked feature NOTE comments with issue tracking references and resolution path. Use when: a NOTE comment lacks a tracking issue number, a blocker needs a resolution path, or cleanup issues require linking NOTEs to parent tracking issues."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | update-blocker-note |
+| **Category** | documentation |
+| **Trigger** | Cleanup issue for a NOTE/FIXME/TODO comment that references a blocker |
+| **Output** | Updated comment with issue number + resolution path line |
+| **Scope** | Single-file, comment-only change |
+
+## When to Use
+
+- A GitHub cleanup issue asks you to "link to Track N tracking" for a NOTE comment
+- A NOTE comment says "blocked by X" but has no issue number for traceability
+- A parent tracking issue (e.g. `#3076`) collects all interop blocker NOTEs
+- The success criteria include "NOTE updated with tracking reference"
+
+## Verified Workflow
+
+1. **Read the issue** to identify: file path, line number, current NOTE text, related parent issue
+2. **Read the target file** at the specified line range to see exact comment text
+3. **Search for the parent tracking issue** if not specified:
+   ```bash
+   gh issue list --search "Track 4 interop" --state open --limit 10
+   ```
+4. **Edit the comment** — make two targeted changes:
+   - Add `(#<issue-number>)` to the `NOTE:` marker → `NOTE(#3092):`
+   - Append a tracking line referencing the parent issue and resolution condition:
+     ```
+     # Track resolution via #<parent>. Implement when <condition>.
+     ```
+5. **Verify the diff** with `git diff` — confirm only comment lines changed
+6. **Commit** with `fix(scope): update NOTE with tracking reference` format
+7. **Push + PR** linked to the cleanup issue with "Closes #N"
+8. **Enable auto-merge**: `gh pr merge --auto --rebase`
+9. **Post completion comment** to the issue with before/after diff
+
+### Example Edit
+
+Before:
+```mojo
+# NOTE: Batch iteration blocked by Track 4 (Python↔Mojo interop).
+# The data_loader is currently a PythonObject, but step() requires ExTensor.
+# Once Track 4 data loading infrastructure is ready, integrate batching here.
+```
+
+After:
+```mojo
+# NOTE(#3092): Batch iteration blocked by Track 4 (Python↔Mojo interop).
+# The data_loader is currently a PythonObject, but step() requires ExTensor.
+# Once Track 4 data loading infrastructure is ready, integrate batching here.
+# Track resolution via #3076. Implement when Python↔Mojo interop is available.
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Edit without Read | Called Edit tool directly on the file | Tool requires file to be read first in the conversation | Always Read the target file before Edit, even if you already saw its content from a sibling file |
+| Reading main repo copy | Read `/home/mvillmow/Odyssey2/shared/training/__init__.mojo` | Worktree has its own copy at `.worktrees/issue-3092/` path | Always edit the worktree path, not the main repo path |
+
+## Results & Parameters
+
+### Commit message format
+
+```
+fix(training): update NOTE with Track 4 tracking reference
+
+Add issue #<N> to the NOTE comment for <feature> blocked by Track 4
+to improve traceability. Also document resolution path via #<parent>.
+
+Closes #<N>
+Part of #<parent-epic>
+```
+
+### PR body format
+
+```markdown
+## Summary
+- Updated NOTE comment in `<file>:<line>` to reference issue #<N>
+- Added tracking line referencing #<parent> as the resolution path
+- No logic changes — comment-only update
+```
+
+### Success criteria checklist
+
+- Linked to Track 4 tracking (via parent issue reference in comment)
+- Workaround documented (existing `_ = var` or equivalent noted)
+- NOTE updated with issue number in marker: `NOTE(#N):`


### PR DESCRIPTION
## Summary

- Documents the workflow for updating blocked feature NOTE comments with issue tracking references
- Captures the key gotcha: Edit tool requires reading the exact worktree file path, not a sibling copy
- Provides copy-paste commit/PR message format for these minimal cleanup issues

## Key Findings

**What Worked**:
- Read file at worktree path → Edit → verify diff → commit/push/PR/auto-merge
- `gh issue list --search` to quickly find parent tracking issue number
- Pattern: append `(#N)` to NOTE marker + one new resolution tracking line

**What Failed**:
- Edit without Read → tool error (must Read the exact file path first)
- Reading main repo copy instead of worktree copy → wrong path for Edit

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 375/375 PASS
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with blocker NOTE cleanup triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)