### PR TITLE
feat: add worktree-path-awareness skill

### DIFF
--- a/skills/documentation/worktree-path-awareness/.claude-plugin/plugin.json
+++ b/skills/documentation/worktree-path-awareness/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "worktree-path-awareness",
+  "version": "1.0.0",
+  "description": "Identifies and edits files in the correct git worktree path. Use when: (1) editing files inside a git worktree and the main repo has the same file path, (2) a commit shows no staged changes after editing a file, (3) working in .worktrees/ subdirectories where file paths shadow the main repo.",
+  "category": "documentation",
+  "date": "2026-03-04",
+  "tags": ["worktree", "git", "file-editing", "path", "disambiguation"]
+}

--- a/skills/documentation/worktree-path-awareness/references/notes.md
+++ b/skills/documentation/worktree-path-awareness/references/notes.md
@@ -1,0 +1,39 @@
+# Session Notes: worktree-path-awareness
+
+## Date
+2026-03-04
+
+## Session Context
+
+Implementing issue #3094 in ProjectOdyssey:
+- Task: Remove stale NOTE marker from `tests/shared/training/test_training_loop.mojo`
+- Branch: `3094-auto-impl`
+- Worktree: `/home/mvillmow/Odyssey2/.worktrees/issue-3094/`
+
+## What Happened
+
+1. Read issue prompt file at `.claude-prompt-3094.md`
+2. Read file referenced in issue: `/home/mvillmow/Odyssey2/tests/shared/training/test_training_loop.mojo` (MAIN REPO PATH)
+3. Made edit to that path — edit succeeded with no error
+4. Attempted `git add` + `git commit` — git reported "nothing added to commit but untracked files present"
+5. Realized: the CWD was the worktree, which has its own copy of the file at a different absolute path
+6. Read the correct worktree path: `/home/mvillmow/Odyssey2/.worktrees/issue-3094/tests/shared/training/test_training_loop.mojo`
+7. Applied the edit to the worktree path — commit succeeded
+
+## Root Cause
+
+Git worktrees maintain an independent checkout. Files under the worktree root are NOT the same as files under the main repo root, even though the relative paths are identical. Editing the main repo file has no effect on the worktree branch.
+
+## Impact
+
+- One extra round-trip (read + failed commit + re-edit + successful commit)
+- No actual harm; the main repo edit was on a different branch and did not affect the worktree PR
+
+## Fix Applied
+
+- Added an extra `ls` check to verify the file exists at the worktree path before editing
+- Used `git diff HEAD <file>` to confirm changes are staged before committing
+
+## PR Created
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/3213

--- a/skills/documentation/worktree-path-awareness/skills/worktree-path-awareness/SKILL.md
+++ b/skills/documentation/worktree-path-awareness/skills/worktree-path-awareness/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: worktree-path-awareness
+description: "Identifies and edits files in the correct git worktree path. Use when: editing files inside a git worktree, commits show no staged changes after editing, or working in .worktrees/ subdirectories."
+category: documentation
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Category | documentation |
+| Trigger | File edit produces no staged changes on commit |
+| Root Cause | Edited main repo path instead of worktree path |
+| Fix | Always resolve working directory and edit the absolute worktree path |
+
+## When to Use
+
+- You are working inside a git worktree (e.g., `/repo/.worktrees/issue-NNN/`)
+- After editing a file and attempting `git commit`, git reports "nothing to commit"
+- The task prompt references a file path under the main repo root (e.g., `/home/user/ProjectOdyssey/tests/...`) but your CWD is the worktree
+- Any situation where `git status` shows no changes but you believe you made edits
+
+## Verified Workflow
+
+1. **Determine actual working directory** before any file edit:
+   ```bash
+   pwd
+   # or
+   git rev-parse --show-toplevel
+   ```
+
+2. **Construct the correct absolute path** using the worktree root, not the main repo root:
+   ```
+   # WRONG: /home/user/ProjectOdyssey/tests/shared/training/test_training_loop.mojo
+   # RIGHT: /home/user/ProjectOdyssey/.worktrees/issue-3094/tests/shared/training/test_training_loop.mojo
+   ```
+
+3. **Verify the file exists at the worktree path** before editing:
+   ```bash
+   ls /path/to/worktree/tests/shared/training/
+   ```
+
+4. **Edit the file at the worktree-absolute path** using the Read then Edit tools.
+
+5. **Confirm changes are staged** before committing:
+   ```bash
+   git diff HEAD <file>
+   # or
+   git status
+   ```
+
+6. **Commit only after confirming staged changes are present.**
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Edit main repo file | Called Edit on `/home/mvillmow/Odyssey2/tests/shared/training/test_training_loop.mojo` | The worktree at `.worktrees/issue-3094/` has its own copy; the main repo edit was unrelated to the current branch | Always resolve `git rev-parse --show-toplevel` or use `pwd` to determine the worktree root before editing |
+| Commit after wrong edit | Ran `git add <file> && git commit` | Git reported "nothing to commit" because the staged file was from the main repo, not the worktree branch | Verify `git diff HEAD <file>` shows changes before committing |
+
+## Results & Parameters
+
+### Correct Pattern
+
+```bash
+# Step 1: Find your actual root
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+# e.g., /home/mvillmow/Odyssey2/.worktrees/issue-3094
+
+# Step 2: Construct file path
+FILE="$WORKTREE_ROOT/tests/shared/training/test_training_loop.mojo"
+
+# Step 3: Verify file exists
+ls "$FILE"
+
+# Step 4: Edit with Read→Edit tools using $FILE as absolute path
+
+# Step 5: Confirm and commit
+git diff HEAD "$FILE"
+git add "$FILE"
+git commit -m "docs: update file"
+```
+
+### Key Rule
+
+When a task prompt gives a file path like `/home/user/ProjectOdyssey/tests/...` but you are working in a worktree at `/home/user/ProjectOdyssey/.worktrees/issue-NNN/`, **the correct path is the worktree-prefixed version**, not the main repo path.


### PR DESCRIPTION
## Summary

- Documents the failure pattern of editing files at the main repo path instead of the worktree path in git worktrees
- Provides a verified workflow for resolving the correct absolute path before editing
- Includes a Failed Attempts table with root cause analysis

## Key Findings

**What Worked**:
- Using `git rev-parse --show-toplevel` to determine the actual worktree root before editing
- Verifying staged changes with `git diff HEAD <file>` before committing

**What Failed**:
- Editing `/repo/tests/file.mojo` (main repo) when CWD was in `.worktrees/issue-NNN/` → `git commit` reported "nothing to commit" because the worktree branch was unaffected
- Attempting `git add + commit` before verifying the correct path → silent no-op

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — PASS
- [ ] Install plugin and verify skill appears in registry
- [ ] Confirm skill activates on "nothing to commit" worktree scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)