### PR TITLE
feat: add standardize-matmul-calls skill

### DIFF
--- a/skills/architecture/standardize-matmul-calls/.claude-plugin/plugin.json
+++ b/skills/architecture/standardize-matmul-calls/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "standardize-matmul-calls",
+  "version": "1.0.0",
+  "description": "Convert A.__matmul__(B) dunder method calls to matmul(A, B) function syntax for consistency. Use when: (1) codebase has mixed matmul call patterns, (2) standardizing operator vs function syntax in Mojo/ML code, (3) refactoring dunder method calls to idiomatic function syntax.",
+  "category": "architecture",
+  "date": "2026-03-04",
+  "tags": ["mojo", "refactoring", "matmul", "standardization", "ml-odyssey"]
+}

--- a/skills/architecture/standardize-matmul-calls/references/notes.md
+++ b/skills/architecture/standardize-matmul-calls/references/notes.md
@@ -1,0 +1,45 @@
+# Session Notes: standardize-matmul-calls
+
+## Date
+
+2026-03-04
+
+## Context
+
+- Repository: HomericIntelligence/ProjectOdyssey
+- Issue: #3112 "Standardize matrix multiplication: Convert A.__matmul__(B) to matmul(A, B)"
+- Branch: 3112-auto-impl
+- PR created: #3214
+
+## Objective
+
+Standardize all `A.__matmul__(B)` dunder method call sites to `matmul(A, B)` function syntax
+for consistency with the rest of the Mojo codebase, which already used function syntax.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3112.md` to understand the issue requirements
+2. Ran `Grep` for `__matmul__` across all `.mojo` files
+3. Found 5 matches — categorized each:
+   - 2 call sites in `tests/shared/integration/test_packaging.mojo` (lines 408, 542) — **converted**
+   - 1 method definition in `shared/core/extensor.mojo` — left unchanged
+   - 1 trait definition in `examples/mojo-patterns/trait_example.mojo` — left unchanged
+   - 2 docstring references in `tests/shared/core/test_matrix.mojo` — left unchanged
+4. Verified `matmul` was already imported in both affected functions (no import changes needed)
+5. Made 2 targeted `Edit` calls to convert the call sites
+6. Verified no remaining `__matmul__` call sites with follow-up `Grep`
+7. Committed and pushed, created PR #3214 with auto-merge enabled
+
+## Key Learnings
+
+- When standardizing call syntax, **distinguish call sites from definitions** first
+- In Mojo, `__matmul__` as a definition enables the `@` operator — removing it would break operator syntax
+- Tests that specifically test operator overloading (`a @ b`) should NOT be converted
+- Imports were already present in both affected functions — always verify before adding
+- Operand order must be preserved: `A.__matmul__(B)` → `matmul(A, B)`, not `matmul(B, A)`
+
+## Parameters
+
+- Tool used for changes: `Edit` (targeted string replacement)
+- Search tool: `Grep` with `**/*.mojo` glob
+- Commit format: `refactor(tests): standardize matmul calls to function syntax`

--- a/skills/architecture/standardize-matmul-calls/skills/standardize-matmul-calls/SKILL.md
+++ b/skills/architecture/standardize-matmul-calls/skills/standardize-matmul-calls/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: standardize-matmul-calls
+description: "Convert A.__matmul__(B) dunder method calls to matmul(A, B) function syntax. Use when: codebase has mixed matmul call patterns or standardizing operator syntax in Mojo ML code."
+category: architecture
+date: 2026-03-04
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | standardize-matmul-calls |
+| **Category** | architecture |
+| **Language** | Mojo |
+| **Scope** | Test files, application code using `__matmul__` dunder calls |
+
+## When to Use
+
+- Codebase has mixed `A.__matmul__(B)` and `matmul(A, B)` patterns
+- Standardizing dunder method calls to explicit function syntax
+- Responding to GitHub issues requesting matmul call site consistency
+- Code review reveals direct dunder method invocations that should be function calls
+
+## Verified Workflow
+
+1. **Search for call sites** (not definitions):
+
+   ```bash
+   grep -rn "__matmul__" --include="*.mojo" tests/ shared/ papers/
+   ```
+
+2. **Distinguish call sites from definitions**:
+
+   - **Convert**: `A.__matmul__(B)` in test/application code (call sites)
+   - **Leave unchanged**: `fn __matmul__(self, other: ...)` method definitions
+   - **Leave unchanged**: `a @ b` operator syntax in tests specifically testing the `@` operator
+   - **Leave unchanged**: docstring/comment references like `"a @ b should work via __matmul__"`
+
+3. **Check imports before replacing**:
+
+   ```bash
+   grep -n "from shared.core.matrix import matmul" <file>
+   ```
+
+   If `matmul` is not imported, add the import. In this codebase it was already present in both affected functions.
+
+4. **Preserve operand order** — `A.__matmul__(B)` → `matmul(A, B)` (A is left operand, B is right):
+
+   ```mojo
+   # Before
+   var hidden = data.__matmul__(weights1)
+
+   # After
+   var hidden = matmul(data, weights1)
+   ```
+
+5. **Verify no `__matmul__` call sites remain**:
+
+   ```bash
+   grep -rn "\.__matmul__(" --include="*.mojo" tests/ shared/ papers/
+   ```
+
+6. **Commit with conventional commit format**:
+
+   ```text
+   refactor(tests): standardize matmul calls to function syntax
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Modifying definition in extensor.mojo | Considered changing `fn __matmul__` | Not a call site; removing it would break `@` operator | Only convert call sites, not definitions |
+| Modifying test_dunder_matmul | Considered rewriting `a @ b` test | The test specifically validates `@` operator; comments referencing `__matmul__` are documentation | Skip tests whose purpose is testing the dunder/operator directly |
+
+## Results & Parameters
+
+**Files changed in this session**:
+
+- `tests/shared/integration/test_packaging.mojo`
+  - Line 408: `data.__matmul__(weights1)` → `matmul(data, weights1)`
+  - Line 542: `train_data.__matmul__(w1)` → `matmul(train_data, w1)`
+
+**Files intentionally left unchanged**:
+
+- `shared/core/extensor.mojo` — contains `fn __matmul__` definition (operator implementation)
+- `examples/mojo-patterns/trait_example.mojo` — contains `fn __matmul__` trait definition
+- `tests/shared/core/test_matrix.mojo` — uses `a @ b` operator form and only references `__matmul__` in docstrings
+
+**Key insight**: In this codebase, `matmul` was already imported in every function where `__matmul__` was called directly — no import changes were needed.


### PR DESCRIPTION
## Summary

Documents the workflow for converting `A.__matmul__(B)` dunder method call sites to `matmul(A, B)` function syntax in Mojo codebases.

- Captures the key distinction between call sites (convert) and definitions (leave unchanged)
- Documents the operand-order preservation requirement
- Includes failed attempts that clarify common pitfalls

## Key Findings

**What Worked**:
- Grep for `__matmul__` then categorize each match (call site vs definition vs docstring)
- Check imports before modifying — they were already present in this case
- Targeted `Edit` calls (2 changes total) with no import changes needed

**What Failed**:
- Considered modifying `fn __matmul__` definition in extensor.mojo — wrong target, it's the operator implementation
- Considered rewriting the `test_dunder_matmul` test — that test specifically validates `@` operator behavior

## Test Plan

- [x] Validated plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with matmul standardization triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)