### PR TITLE
feat: add resolve-blocked-todos skill

### DIFF
--- a/skills/testing/resolve-blocked-todos/.claude-plugin/plugin.json
+++ b/skills/testing/resolve-blocked-todos/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "resolve-blocked-todos",
+  "version": "1.0.0",
+  "description": "Resolve TODO markers blocked by a now-closed issue: verify the blocking issue is closed, cherry-pick or implement missing functionality, enable disabled tests, and remove TODO markers. Use when: (1) a tracking issue references TODO(#N) markers and issue #N has been closed, (2) disabled tests have TODO comments referencing a merged PR, (3) cleanup issues require resolving accumulated technical debt once a dependency closes.",
+  "category": "testing",
+  "date": "2026-03-05",
+  "tags": ["todo", "cleanup", "technical-debt", "cherry-pick", "disabled-tests", "mojo"]
+}

--- a/skills/testing/resolve-blocked-todos/references/notes.md
+++ b/skills/testing/resolve-blocked-todos/references/notes.md
@@ -1,0 +1,62 @@
+# Session Notes: Resolve Blocked TODOs (Issue #3077)
+
+## Date
+2026-03-05
+
+## Context
+
+- **Repo**: HomericIntelligence/ProjectOdyssey (Mojo ML platform)
+- **Tracking Issue**: #3077 - "[Cleanup] Track TODOs blocked by #2722 (utility functions)"
+- **Blocking Issue**: #2722 - "Implement utility methods for ExTensor"
+- **Branch**: 3077-auto-impl
+- **PR Created**: #3232
+
+## Objective
+
+Resolve 7 `TODO(#2722)` markers across test files, now that #2722 was closed.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `shared/core/extensor.mojo` | Cherry-pick 171 lines: `__str__`, `__repr__`, `__hash__`, `contiguous()`, `__setitem__`, `__int__`, `__float__` |
+| `shared/testing/assertions.mojo` | Add `assert_contiguous()` helper |
+| `tests/shared/conftest.mojo` | Export `assert_contiguous` |
+| `tests/shared/core/test_utility.mojo` | Enable 6 disabled tests, add imports |
+| `tests/shared/core/test_shape.mojo` | Remove TODO(#2722) from line 184 comment |
+
+## Key Discovery: Blocking Issue Closed but Implementation Not in Main
+
+The tracking issue description said "wait until #2722 is resolved" but:
+1. `gh issue view 2722 --json state -q '.state'` returned `"CLOSED"`
+2. The implementation was in branch `2722-auto-impl` (commit `20ddaee6`)
+3. The commit was NOT in current `main` (verified with `git log --oneline --all`)
+
+**Solution**: Cherry-pick the commit with `--no-commit` to get the files staged without creating a commit, then incorporate into a new commit that also enables the tests.
+
+## TODO Locations Resolved
+
+| File | Line | TODO | Resolution |
+|------|------|------|------------|
+| test_utility.mojo | 139 | `assert_contiguous(t)` | Added to assertions.mojo + called |
+| test_utility.mojo | 152 | `transpose()` | Cherry-picked, imported from matrix.mojo |
+| test_utility.mojo | 172 | `contiguous()` | Used `.contiguous()` method (no module-level fn) |
+| test_utility.mojo | 356 | `__str__` | Cherry-picked, used `String(t)` |
+| test_utility.mojo | 368 | `__repr__` | Cherry-picked, used `repr(t)` |
+| test_utility.mojo | 385 | `__hash__` | Cherry-picked, used `hash(a)` |
+| test_shape.mojo | 184 | View implementation | Removed TODO, updated comment |
+
+## Pitfalls Encountered
+
+1. **`contiguous()` naming**: The test comments used `contiguous(b)` suggesting a module-level function. Only `as_contiguous()` (in shape.mojo) and `tensor.contiguous()` (method) exist. Used the method form.
+
+2. **Import additions needed**: Had to add `from shared.core.matrix import transpose` and `assert_true`, `assert_false` imports to the test file.
+
+3. **Mojo can't run locally**: GLIBC version incompatibility means `mojo test` and `mojo format` fail locally. Pre-commit hooks still pass (mojo format hook gracefully skips). Tests verified only in CI.
+
+## PR Result
+
+- PR #3232: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3232
+- Auto-merge enabled
+- All pre-commit hooks passed
+- 5 files changed, 207 insertions(+), 23 deletions(-)

--- a/skills/testing/resolve-blocked-todos/skills/resolve-blocked-todos/SKILL.md
+++ b/skills/testing/resolve-blocked-todos/skills/resolve-blocked-todos/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: resolve-blocked-todos
+description: "Resolve TODO markers blocked by a now-closed issue. Use when: (1) a tracking issue has TODO(#N) markers and issue #N is now closed, (2) disabled tests have TODO comments waiting on a dependency, (3) cleanup issues need to be resolved after a blocking PR merges."
+category: testing
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Category** | testing |
+| **Trigger** | Blocking issue closed; TODO(#N) markers remain in code |
+| **Outcome** | All TODO markers removed, disabled tests enabled, functionality implemented |
+| **Scope** | Test files, assertion helpers, implementation files |
+
+## When to Use
+
+- A tracking issue documents `TODO(#N)` or `TODO: ... #N` markers waiting on another issue
+- `gh issue view N --json state -q '.state'` returns `"CLOSED"` for the blocking issue
+- Tests are commented out with TODO markers and the dependency is now resolved
+- You need to resolve accumulated technical debt after a blocking PR merges
+
+## Verified Workflow
+
+### Phase A: Verify blocking issue is closed
+
+```bash
+gh issue view <BLOCKING_ISSUE_NUMBER> --json state -q '.state'
+# Must return "CLOSED" before proceeding
+```
+
+If still `"OPEN"`: post an audit comment to the tracking issue and stop. Do not implement.
+
+### Phase B: Locate all TODO markers
+
+```bash
+grep -rn "TODO.*#<N>\|TODO(#<N>)" --include="*.mojo" .
+# Verify count matches the tracking issue table
+```
+
+### Phase C: Check if implementation exists elsewhere
+
+Before writing new code, check if a feature branch already has the implementation:
+
+```bash
+git branch --all | grep "<issue-number>"
+git log --oneline --all | grep "<issue-number>"
+```
+
+If an implementation branch exists, cherry-pick rather than re-implementing:
+
+```bash
+git log --oneline <branch-name> --not main | head -5
+# Find the implementation commit hash
+git cherry-pick <commit-hash> --no-commit
+git status  # Verify only expected files changed
+```
+
+### Phase D: Add missing helpers
+
+For each TODO that referenced a missing assertion/helper function, add it following the existing pattern:
+
+```mojo
+fn assert_contiguous(tensor: ExTensor, message: String = "") raises:
+    """Assert tensor has contiguous memory layout."""
+    if not tensor.is_contiguous():
+        var error_msg = message if message else "Tensor should be contiguous"
+        raise Error(error_msg)
+```
+
+Export from conftest if tests need it:
+
+```mojo
+# In tests/shared/conftest.mojo
+from shared.testing.assertions import (
+    ...,
+    assert_contiguous,  # Add here
+)
+```
+
+### Phase E: Enable disabled tests
+
+For each commented-out test block, uncomment and update:
+
+1. Remove `# TODO(#N): ...` comment
+2. Uncomment the actual test code
+3. Replace `pass  # Placeholder` with real assertions
+4. Add imports for any newly-available functions (`transpose`, `contiguous`, etc.)
+
+Example transformation:
+
+```mojo
+# BEFORE
+fn test_is_contiguous_true() raises:
+    var t = ones(shape, DType.float32)
+    # TODO(#2722): assert_contiguous(t)
+    var _ = t.is_contiguous()
+    pass  # Placeholder
+
+# AFTER
+fn test_is_contiguous_true() raises:
+    var t = ones(shape, DType.float32)
+    assert_contiguous(t, "Newly created tensor should be contiguous")
+```
+
+### Phase F: Update tracking comments
+
+For any TODO comments that can't be fully resolved (e.g., view semantics deferred):
+
+```mojo
+# BEFORE
+# Should be 1D view of same data (currently copies, TODO(#2722): implement views)
+
+# AFTER
+# Currently returns a 1D copy (view semantics deferred to future work)
+```
+
+### Phase G: Verify no TODO markers remain
+
+```bash
+grep -rn "TODO.*#<N>" --include="*.mojo" .
+# Expected: no output
+```
+
+### Phase H: Run pre-commit and commit
+
+```bash
+pixi run pre-commit run --all-files
+git add <changed-files>
+git commit -m "cleanup(tests): resolve TODOs blocked by #<N> ..."
+git push -u origin <branch>
+gh pr create --title "..." --body "Closes #<tracking-issue>"
+gh pr merge --auto --rebase
+```
+
+## Key Patterns
+
+### Checking if implementation commit already exists
+
+When a blocking issue has been closed via a PR that hasn't merged to main yet:
+
+```bash
+# Find branch
+git branch --all | grep "<issue-number>"
+
+# Find what the implementation commit changed
+git show <commit-hash> -- shared/core/extensor.mojo | grep "^+fn " | head -20
+
+# Cherry-pick just the implementation (without committing)
+git cherry-pick <commit-hash> --no-commit
+```
+
+This avoids re-implementing what was already written.
+
+### Enabling __str__, __repr__, __hash__ tests
+
+When these string/hash methods are newly available:
+
+```mojo
+# Minimal test - just verify non-empty
+var s = String(t)
+assert_true(len(s) > 0, "String representation should be non-empty")
+
+var r = repr(t)
+assert_true(len(r) > 0, "Repr should be non-empty")
+
+# Hash consistency test
+var hash_a = hash(a)
+var hash_b = hash(b)
+assert_equal_int(hash_a, hash_b, "Equal tensors should have same hash")
+```
+
+### Adding module-level function imports in test files
+
+```mojo
+# At top of test file, add specific import
+from shared.core.matrix import transpose
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Check if blocking issue is open before acting | Assumed blocking issue #2722 was still open because the tracking issue said to wait | Issue had been closed (merged) since the tracking issue was created | Always verify `gh issue view N --json state` first - don't trust the tracking issue description |
+| Wait for methods to appear in main | Expected `__str__`, `__repr__`, `__hash__` to be in the current main branch after #2722 closed | The implementation PR existed on a feature branch (`2722-auto-impl`) not yet merged to main | Check git branches and cherry-pick from the feature branch instead of waiting |
+| Use `contiguous(b)` as a module-level function | Test code had `# var c = contiguous(b)` implying a module-level function | No module-level `contiguous()` exists; only `tensor.contiguous()` method and `as_contiguous()` function | Always verify function signatures with grep before enabling commented-out test code |
+
+## Results & Parameters
+
+### Typical file changes for a TODO(#N) resolution
+
+```text
+shared/core/extensor.mojo          - cherry-pick or add missing methods
+shared/testing/assertions.mojo     - add assert_* helper functions
+tests/shared/conftest.mojo         - export new assertions
+tests/shared/core/test_utility.mojo - enable 5-7 disabled tests
+tests/shared/core/test_shape.mojo  - update stale TODO comments
+```
+
+### Commit message format
+
+```
+cleanup(tests): resolve TODOs blocked by #<N> <brief description>
+
+- Cherry-pick/implement: <list methods added>
+- Add <helper function> to shared/testing/assertions.mojo
+- Enable <N> previously-disabled tests: <list test names>
+- Update stale TODO comments
+
+Closes #<tracking-issue>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for resolving `TODO(#N)` markers once a blocking issue closes.
Captured from implementing issue #3077 in ProjectOdyssey (Mojo ML platform).

- Verify blocking issue is closed before acting
- Cherry-pick implementations from feature branches not yet merged to main
- Enable disabled tests with correct function signatures
- Remove TODO markers and update stale comments

## Key Findings

**What Worked**:
- `gh issue view N --json state -q '.state'` to confirm blocking issue closed
- `git cherry-pick <commit> --no-commit` to stage implementation without committing
- Checking `git branch --all | grep "<issue>"` to find orphaned implementation branches
- Using method form `tensor.contiguous()` when no module-level function exists

**What Failed**:
- Assuming the blocking issue was still open (it had already closed) — always verify
- Assuming `contiguous(b)` existed as a module-level function (only `.contiguous()` method exists) — always grep for function signatures before uncommenting test code
- Expecting the implementation to be in `main` after a PR was "merged" — the branch was still separate

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates on "TODO" + "blocked" + "closed issue" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
