### PR TITLE
feat: add fix-flaky-glob-ordering skill

### DIFF
--- a/skills/debugging/fix-flaky-glob-ordering/.claude-plugin/plugin.json
+++ b/skills/debugging/fix-flaky-glob-ordering/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-flaky-glob-ordering",
+  "version": "1.0.0",
+  "description": "Fix flaky tests caused by non-deterministic filesystem glob ordering. Use when: (1) a test passes on some CI runs but fails on others with identical code, (2) test loads files from a directory and asserts ordering, (3) pathlib.glob() or os.listdir() results are iterated without sorting.",
+  "category": "debugging",
+  "date": "2026-03-05",
+  "tags": ["flaky-tests", "glob", "pathlib", "non-deterministic", "mojo", "python-interop"]
+}

--- a/skills/debugging/fix-flaky-glob-ordering/references/notes.md
+++ b/skills/debugging/fix-flaky-glob-ordering/references/notes.md
@@ -1,0 +1,38 @@
+# Session Notes: Fix Flaky Glob Ordering
+
+## Session Date
+2026-03-05
+
+## Repository
+HomericIntelligence/ProjectOdyssey
+
+## Problem
+`test_named_tensor_collection` in `tests/shared/test_serialization.mojo` failed on CI (Feb 14)
+but passed previously (Feb 10) with identical code and Mojo version `0.26.1.0.dev2025122805`.
+
+Root cause: `load_named_tensors()` in `shared/utils/serialization.mojo` used `p.glob("*.weights")`
+without sorting. `pathlib.glob()` does not guarantee ordering. Test asserted `loaded[0].name == "weights"`
+which worked when OS returned `weights.weights` first, but failed when `bias.weights` came first.
+
+## Steps Taken
+
+1. Read `shared/utils/serialization.mojo:311-329` and `tests/shared/test_serialization.mojo:185-203`
+2. Identified `var weight_files = p.glob("*.weights")` as the non-deterministic line
+3. First fix attempt: `var weight_files = sorted(p.glob("*.weights"))` — Mojo compile error
+4. Searched codebase for `builtins` usage — found pattern in `config.mojo` and `toml_loader.mojo`
+5. Correct fix: import builtins, call `builtins.sorted(p.glob("*.weights"))`
+6. Updated test assertions: alphabetical order means `bias` (index 0) before `weights` (index 1)
+7. Created PR #3239, CI passed compilation after second commit
+
+## CI Failures Encountered
+
+- `Mojo Package Compilation`: `error: use of unknown declaration 'sorted'`
+  - Fix: use `Python.import_module("builtins").sorted()`
+- `link-check`: pre-existing failures on all PRs (root-relative links, not my change)
+
+## Files Changed
+- `shared/utils/serialization.mojo:318` — added builtins import + sorted() call
+- `tests/shared/test_serialization.mojo:192-198` — swapped assertion order
+
+## PR
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/3239

--- a/skills/debugging/fix-flaky-glob-ordering/skills/fix-flaky-glob-ordering/SKILL.md
+++ b/skills/debugging/fix-flaky-glob-ordering/skills/fix-flaky-glob-ordering/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: fix-flaky-glob-ordering
+description: "Fix flaky tests caused by non-deterministic filesystem glob ordering. Use when: test passes sometimes and fails other times with identical code, and the test asserts on the order of files loaded from a directory."
+category: debugging
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Tests fail intermittently due to non-deterministic `pathlib.glob()` ordering |
+| **Root Cause** | Filesystem glob order is OS/filesystem-dependent and not guaranteed |
+| **Fix** | Sort glob results before iterating; update test assertions to match sorted order |
+| **Mojo Gotcha** | `sorted()` is a Python builtin — use `Python.import_module("builtins").sorted()` |
+
+## When to Use
+
+- A test fails on some CI runs but passes on others with **identical code and compiler version**
+- The test loads multiple files from a directory and asserts on index-based ordering (e.g. `loaded[0].name == "weights"`)
+- The loading function uses `pathlib.glob()`, `os.listdir()`, or similar without sorting
+- Failure is intermittent (e.g. passed Feb 10, failed Feb 14 — same code)
+
+## Verified Workflow
+
+1. **Confirm the root cause**: Check if the loading function iterates glob results without sorting
+2. **Fix the source function** (not just the test):
+   - In pure Python: `sorted(p.glob("*.weights"))`
+   - In Mojo with Python interop: `Python.import_module("builtins").sorted(p.glob("*.weights"))`
+3. **Determine the sorted order**: Alphabetically, `"bias.weights" < "weights.weights"`
+4. **Update test assertions** to match the now-deterministic sorted order:
+   - `loaded[0]` → first alphabetically (e.g. `"bias"`)
+   - `loaded[1]` → second alphabetically (e.g. `"weights"`)
+5. **Verify no other callers** of the fixed function are affected by the new ordering
+
+### Mojo Python Interop Pattern
+
+```mojo
+# WRONG - sorted() is not a Mojo builtin
+var weight_files = sorted(p.glob("*.weights"))
+
+# CORRECT - access Python's sorted() via builtins module
+var builtins = Python.import_module("builtins")
+var weight_files = builtins.sorted(p.glob("*.weights"))
+```
+
+This pattern matches existing usage in the codebase (e.g. `shared/utils/config.mojo`, `shared/utils/toml_loader.mojo`).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `sorted(p.glob("*.weights"))` | Called `sorted()` directly in Mojo as if it were a builtin | Mojo compiler error: `use of unknown declaration 'sorted'` — `sorted()` is a Python builtin, not Mojo | In Mojo, Python builtins must be accessed via `Python.import_module("builtins")` |
+| Fix only the test assertions | Reorder test to match observed CI output | Doesn't fix the non-determinism; different filesystems may return different orders | Always fix the source of non-determinism, not just the test |
+
+## Results & Parameters
+
+### The Fix (two files)
+
+**`shared/utils/serialization.mojo`** (source fix):
+
+```mojo
+# Before (non-deterministic)
+var weight_files = p.glob("*.weights")
+
+# After (deterministic)
+var builtins = Python.import_module("builtins")
+var weight_files = builtins.sorted(p.glob("*.weights"))
+```
+
+**`tests/shared/test_serialization.mojo`** (test fix):
+
+```mojo
+# Before (assumed filesystem ordering)
+assert_equal(loaded[0].name, "weights", ...)  # numel=6
+assert_equal(loaded[1].name, "bias", ...)     # numel=3
+
+# After (matches alphabetical sorted order: "bias" < "weights")
+assert_equal(loaded[0].name, "bias", ...)     # numel=3
+assert_equal(loaded[1].name, "weights", ...)  # numel=6
+```
+
+### Diagnosing Flaky CI
+
+Key signal: same commit hash passing on one date and failing on another is almost always ordering/timing non-determinism, not logic bugs.
+
+```bash
+# Check if a test is the culprit by looking at CI history
+gh run list --workflow "Comprehensive Tests" --branch main --limit 5
+```


### PR DESCRIPTION
## Summary

- Documents how to fix intermittent CI test failures caused by non-deterministic `pathlib.glob()` ordering
- Captures the Mojo Python interop gotcha: `sorted()` must be called via `Python.import_module("builtins").sorted()`
- Provides copy-paste fix patterns for both the source function and test assertions

## Key Findings

**What Worked**:
- Importing Python `builtins` module and calling `builtins.sorted()` on glob results
- Updating test assertions to reflect alphabetical sorted order (`bias` before `weights`)
- Fixing at the source function level so all callers benefit

**What Failed**:
- `sorted(p.glob("*.weights"))` → Mojo compile error: `use of unknown declaration 'sorted'`
- Fixing only the test without fixing the source → non-determinism remains for all callers

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — passes
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)