### PR TITLE
feat(skills): add bulk-pr-json-repair-and-automerge skill

### DIFF
--- a/skills/ci-cd/bulk-pr-json-repair-and-automerge/.claude-plugin/plugin.json
+++ b/skills/ci-cd/bulk-pr-json-repair-and-automerge/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "bulk-pr-json-repair-and-automerge",
+  "version": "1.0.0",
+  "description": "Repair bulk-corrupted JSON files and enable auto-merge on many PRs. Use when a batch edit left invalid JSON (orphaned array contents, trailing commas) in many files, or when you need to enable auto-merge across 20+ open PRs.",
+  "category": "ci-cd",
+  "date": "2026-03-05"
+}

--- a/skills/ci-cd/bulk-pr-json-repair-and-automerge/references/notes.md
+++ b/skills/ci-cd/bulk-pr-json-repair-and-automerge/references/notes.md
@@ -1,0 +1,119 @@
+# Notes: Bulk PR JSON Repair and Auto-Merge
+
+## Session Context
+
+**Date**: 2026-03-05
+**Repository**: ProjectMnemosyne
+**Trigger**: PR #306 had 181 JSON parse errors from a previous session that removed `"tags"` field
+by deleting only the `"tags": [` line, leaving array contents orphaned.
+
+## Exact Error Messages
+
+```
+FAIL: docker-multistage-build
+  Errors:
+    - Invalid JSON in plugin.json: Expecting ':' delimiter: line 7 column 13 (char 258)
+
+FAIL: github-bulk-housekeeping
+  Errors:
+    - Invalid JSON in plugin.json: Expecting ':' delimiter: line 7 column 13 (char 429)
+
+FAIL: dockerfile-layer-caching
+  Errors:
+    - Invalid JSON in plugin.json: Expecting property name enclosed in double quotes: line 7 column 1 (char 307)
+```
+
+Total: 181 plugins with errors initially, grew to 184 after first pass (some fixed files exposed
+previously-hidden errors in files that were double-broken).
+
+## Corruption Examples
+
+### Type 1: Trailing comma
+```json
+{
+  "name": "issue-triage-and-fix",
+  "date": "2026-02-22",   <- trailing comma, no more properties
+}
+```
+
+### Type 2: Orphaned array (no subsequent fields)
+```json
+{
+  "name": "github-actions-ci-speedup",
+  "date": "2026-01-01",
+    "github",              <- orphaned tag items
+    "actions",
+    "speedup"
+  ]                        <- orphaned closing bracket
+}
+```
+
+### Type 3: Orphaned array (with subsequent valid fields)
+```json
+{
+  "name": "e2e-artifact-deduplication",
+  "created": "2026-01-11",
+    "e2e-evaluation",      <- orphaned tag items
+    "deduplication",
+    "optimization",
+    "file-structure",
+    "judge-prompts",
+    "artifact-consolidation"
+  ],                       <- closes orphaned block
+  "triggers": [            <- valid field follows
+    "duplicate files...",
+  ],
+  "related_files": [...]
+}
+```
+
+## Fix Script Evolution
+
+### Attempt 1: xargs + jq
+```bash
+find skills/ plugins/ -name "plugin.json" | xargs -I{} sh -c 'jq "del(.tags)" "{}" > /tmp/plugin_tmp.json && mv /tmp/plugin_tmp.json "{}"'
+```
+**Blocked by Safety Net**: `xargs -I{} sh -c` pattern flagged.
+
+### Attempt 2: Python json.loads pass
+Fixed 225 valid-JSON files. 184 remained broken (couldn't parse).
+
+### Attempt 3: Regex trailing comma pass
+Fixed 44 more. 140 remained.
+
+### Attempt 4: First orphaned-block state machine
+Issue: treated ALL bare strings as orphaned, including legitimate array items in `triggers: [...]`.
+Fixed 121. Left 19 broken.
+
+### Attempt 5: Improved state machine with `in_valid_array` tracking
+Fixed all remaining 19. Key insight: track whether we're inside a `"key": [` context to distinguish
+legitimate array contents from orphaned ones.
+
+## Git Staging Mistake
+
+First commit accidentally included nested untracked directories:
+- `skills/testing/fix-flaky-sleep-mock/fix-flaky-sleep-mock/` (entire ProjectMnemosyne clone)
+- `skills/testing/rubric-conflict-detection/rubric-conflict-detection/`
+
+Result: 1227 files in commit instead of 184.
+
+**Root cause**: `git add skills/` picks up untracked content under the path.
+
+**Fix**: `git reset HEAD~1` then `git add $(git diff --name-only)` to stage only modified files.
+
+## PR Auto-Merge Results
+
+| PR Range | Method | Result |
+|----------|--------|--------|
+| #330, #329, #327, #325, #324, #322, #321, #319-#317, #316-#315, #313, #312, #309-#307, #304 | `gh pr merge --auto --rebase` | auto-merge enabled |
+| #328, #323, #320, #314, #311, #310 | `gh pr merge --rebase` | merged directly (already clean) |
+| #306 | auto-merge was pre-enabled; triggered by fix push | merged automatically after CI pass |
+| #331 | `gh pr merge --auto --rebase` then immediately `--rebase` | merged (was clean) |
+
+## Repository Merge Settings
+
+- Squash merging: **disabled**
+- Merge commits: **disabled**
+- Rebase merging: **enabled** (only option)
+
+Discovered by trial and error — try `--squash` → `--merge` → `--rebase` in that order.

--- a/skills/ci-cd/bulk-pr-json-repair-and-automerge/skills/bulk-pr-json-repair-and-automerge/SKILL.md
+++ b/skills/ci-cd/bulk-pr-json-repair-and-automerge/skills/bulk-pr-json-repair-and-automerge/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: bulk-pr-json-repair-and-automerge
+description: Repair bulk-corrupted JSON files and enable auto-merge on many open PRs
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Bulk PR JSON Repair and Auto-Merge
+
+## Overview
+
+| Field | Details |
+|-------|---------|
+| Date | 2026-03-05 |
+| Objective | Fix 181 JSON-invalid plugin.json files caused by botched batch tag removal, then enable auto-merge on 25 open PRs |
+| Outcome | Success — all 184 broken files fixed, all 25 PRs merged or set to auto-merge |
+
+## When to Use
+
+- A batch edit removed a JSON key's opening line (e.g., `"tags": [`) but left array contents and closing `]` behind
+- Many JSON files have trailing commas after a removed last property
+- You need to enable auto-merge across 20+ open PRs at once
+- A PR branch has corrupted JSON that blocks CI; auto-merge was already enabled but waiting
+
+## Verified Workflow
+
+### Step 1: Diagnose the JSON corruption patterns
+
+Run validation first to understand scope:
+
+```bash
+python3 scripts/validate_plugins.py skills/ plugins/ 2>&1 | grep -c "Invalid JSON"
+```
+
+Examine a few broken files to identify the pattern(s):
+
+```bash
+cat <broken-file>.json
+```
+
+Common patterns after botched key removal:
+1. **Trailing comma** — last remaining property has a trailing comma before `}`
+2. **Orphaned array items (no subsequent fields)** — bare string items + lone `]` with nothing after
+3. **Orphaned array items (with subsequent fields)** — bare string items + `],` followed by other valid keys
+
+### Step 2: Fix with Python (NOT xargs/shell)
+
+Use Python's `json` module for a safe, idempotent fix. The Safety Net blocks `xargs -I{} sh -c` patterns.
+
+**Phase 1 — Fix files that are already valid JSON (just remove the key):**
+
+```python
+import json, pathlib, subprocess
+
+result = subprocess.run(['find', 'skills/', 'plugins/', '-name', 'plugin.json'],
+                       capture_output=True, text=True)
+files = result.stdout.strip().split('\n')
+
+for f in files:
+    p = pathlib.Path(f)
+    try:
+        data = json.loads(p.read_text())
+        if 'tags' in data:
+            del data['tags']
+            p.write_text(json.dumps(data, indent=2) + '\n')
+    except Exception:
+        pass  # Handle broken JSON separately
+```
+
+**Phase 2 — Fix trailing commas (regex):**
+
+```python
+import re
+fixed_text = re.sub(r',(\s*[}\]])', r'\1', text)
+```
+
+**Phase 3 — Fix orphaned array blocks (line-by-line state machine):**
+
+Track whether you're inside a valid `key: [` array vs. an orphaned block:
+
+```python
+in_orphaned_block = False
+in_valid_array = False
+
+for line in lines:
+    stripped = line.strip()
+
+    # Valid array start: "key": [
+    if re.match(r'"[^"]+"\s*:\s*\[', stripped):
+        in_valid_array = True
+        in_orphaned_block = False
+        new_lines.append(line)
+        if stripped.endswith(']') or stripped.endswith('],'):
+            in_valid_array = False
+        continue
+
+    # Closing bracket
+    if stripped in (']', '],'):
+        if in_valid_array:
+            new_lines.append(line)
+            in_valid_array = False
+        elif in_orphaned_block:
+            in_orphaned_block = False  # skip the closing bracket
+        else:
+            new_lines.append(line)
+        continue
+
+    # Bare string detection (orphaned tag item)
+    is_bare_string = (stripped.startswith('"') and
+                      not re.match(r'"[^"]+"\s*:', stripped) and
+                      (stripped.endswith('",') or stripped.endswith('"')))
+
+    if is_bare_string:
+        if in_valid_array:
+            new_lines.append(line)  # legitimate array item
+        else:
+            in_orphaned_block = True  # skip orphaned tag
+        continue
+
+    new_lines.append(line)
+```
+
+### Step 3: Verify before committing
+
+```bash
+python3 scripts/validate_plugins.py skills/ plugins/ 2>&1 | tail -5
+```
+
+### Step 4: Stage only modified files (not untracked dirs)
+
+```bash
+# Safe: only stages modified tracked files
+git add $(git diff --name-only)
+```
+
+Do NOT use `git add skills/` or `git add -A` — this picks up any nested untracked directories.
+
+### Step 5: Enable auto-merge on many PRs
+
+```bash
+# Try rebase first (squash/merge-commit may be disabled)
+for pr in 330 329 328 ...; do
+  gh pr merge --auto --rebase $pr && echo "OK: #$pr" || echo "FAIL: #$pr"
+done
+```
+
+PRs that report "Pull request is in clean status" are already ready — merge them directly:
+
+```bash
+gh pr merge --rebase <number>
+```
+
+## Failed Attempts
+
+| Attempt | What Happened | Why It Failed |
+|---------|--------------|---------------|
+| `xargs -I{} sh -c 'jq ...'` | Safety Net blocked immediately | Pattern flagged as arbitrary command execution risk |
+| `--squash` auto-merge | GraphQL error on all PRs | Repo has squash merging disabled |
+| `--merge` auto-merge | GraphQL error on all PRs | Repo has merge commits disabled |
+| `git add skills/` | Accidentally staged nested untracked directories (1227 files in commit) | Picks up any untracked content under the path |
+| Single-pass Python fix | Fixed 225 files, left 184 broken | Files with invalid JSON can't be parsed by `json.loads` — need regex pre-pass first |
+| Regex-only pass | Fixed 44 trailing-comma files | Can't handle orphaned array blocks |
+| First orphaned-block fix | Fixed 121/184, left 19 broken | Logic didn't distinguish valid array items (in `triggers: [...]`) from orphaned items |
+
+## Results & Parameters
+
+### Corruption patterns and fix counts (this run)
+
+| Pattern | Count | Fix Method |
+|---------|-------|------------|
+| Valid JSON with `tags` key | 225 | `json.loads` + `del data['tags']` |
+| Trailing comma only | 44 | Regex: `re.sub(r',(\s*[}\]])', r'\1', text)` |
+| Orphaned array (no subsequent fields) | 121 | Line-by-line state machine |
+| Orphaned array (with subsequent fields like `triggers`) | 19 | Line-by-line state machine with `in_valid_array` tracking |
+| **Total fixed** | **184** | |
+
+### GitHub merge method discovery
+
+```bash
+# Test in order until one works:
+gh pr merge --auto --squash <pr>   # Usually fails if squash disabled
+gh pr merge --auto --merge <pr>    # Usually fails if merge commits disabled
+gh pr merge --auto --rebase <pr>   # Rebase-only repos: this works
+```
+
+### Handling "clean status" PRs
+
+"Pull request is in clean status" means CI already passed — auto-merge can't be enabled (it has nothing to wait for). Just merge directly:
+
+```bash
+gh pr merge --rebase <number>
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | PR #306 fix + 25 PRs auto-merge | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

- Documents how to fix bulk-corrupted JSON (orphaned array contents, trailing commas) using a Python line-by-line state machine
- Captures the Safety Net block on shell-based batch file processing and the Python workaround
- Documents GitHub merge method discovery (squash/merge disabled → rebase only)
- Covers the `git add $(git diff --name-only)` pattern to avoid accidentally staging nested untracked directories
- Includes handling for PRs in "clean status" that must be merged directly rather than via auto-merge

## Key Learnings

Three distinct JSON corruption patterns each require a different fix approach; the most subtle is orphaned array items followed by legitimate array fields, which requires tracking `in_valid_array` state to avoid incorrectly stripping valid content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
