### PR TITLE
feat: add batch-norm-gradient-test-fix skill

### DIFF
--- a/skills/testing/batch-norm-gradient-test-fix/.claude-plugin/plugin.json
+++ b/skills/testing/batch-norm-gradient-test-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "batch-norm-gradient-test-fix",
+  "version": "1.0.0",
+  "description": "Fix batch normalization backward pass gradient tests that fail with uniform (ones) upstream gradients due to sum(x_norm)=0 cancellation. Use when: (1) batch_norm_backward gradient check fails with analytical~=0 but numerical!=0, (2) normalization layer backward tests fail with pathological cancellation, (3) gradient checking with ones upstream gradient gives false negatives.",
+  "category": "testing",
+  "date": "2026-03-05",
+  "tags": ["batch-norm", "gradient-checking", "backward-pass", "mojo", "normalization", "false-failure"]
+}

--- a/skills/testing/batch-norm-gradient-test-fix/references/notes.md
+++ b/skills/testing/batch-norm-gradient-test-fix/references/notes.md
@@ -1,0 +1,64 @@
+# Session Notes: batch-norm-gradient-test-fix
+
+## Context
+
+- **Issue**: #2724 - Fix gradient computation for matmul, batch_norm2d, conv2d
+- **Branch**: 2724-auto-impl
+- **PR**: #3169
+
+## What Was Happening
+
+The branch had un-skipped `test_batch_norm2d_backward_gradient_input` in
+`tests/shared/core/test_normalization.mojo`. The test was previously marked:
+```
+# TODO(#2724): batch_norm2d_backward still has gradient issues - needs more investigation
+print("⚠ test_batch_norm2d_backward_gradient_input - SKIPPED")
+```
+
+After un-skipping, CI showed:
+```
+Analytical: -3.62789904784222e-07
+Numerical:  0.008940696716308594
+Difference: 0.008941059506213378
+Tolerance:  9.940696716308594e-05
+```
+
+## Investigation
+
+1. Read `shared/core/normalization.mojo:463-854` - batch_norm2d_backward
+2. Formula used: `(grad_output - k/N - x_norm * dotp/N) * gamma * invstd`
+3. Verified this IS the standard PyTorch formula (correct)
+4. Traced through test: `grad_output = ones_like(output)`, N=8 per channel
+5. Computed: `k = 8 = N`, `dotp = sum(x_norm) = 0` (batch norm property)
+6. Formula gives: `(1 - 1 - x_norm * 0) * gamma * invstd = 0` ← correct!
+7. But numerical gradient: 0.00894 (float32 precision artifact)
+
+## Root Cause Confirmed
+
+The backward implementation is mathematically correct. The test design is flawed:
+- `loss = sum(batch_norm2d(x))` has zero derivative w.r.t. x (always)
+- But float32 forward pass doesn't perfectly cancel → numerical gives ~0.009
+
+## Fix Applied
+
+Changed test to:
+1. Use varied `grad_output = [i%4 * 0.25 - 0.3 for i in range(16)]`
+2. `forward_for_grad` computes `sum(output * grad_output)` (weighted sum)
+3. Both analytical and numerical now give same non-zero values
+4. Test now genuinely validates the backward implementation
+
+## Other Issues Fixed
+
+- `test_conv.mojo`: mojo-format violation (line too long for `conv2d_no_bias_backward` call)
+  - Pre-commit hook reformats: single-line → multi-line with args on separate lines
+
+## matmul_backward Status
+
+Already fixed in PR #2799 (merged). Added dedicated 2D×2D gradient functions:
+- `_matmul_2d_2d_grad_a_impl`: grad_a = grad_output @ B^T
+- `_matmul_2d_2d_grad_b_impl`: grad_b = A^T @ grad_output
+
+## conv2d_backward Status
+
+Already working (Conv2dBackwardResult made Copyable as GradientTriple in earlier work).
+Tests just needed to be un-commented.

--- a/skills/testing/batch-norm-gradient-test-fix/skills/batch-norm-gradient-test-fix/SKILL.md
+++ b/skills/testing/batch-norm-gradient-test-fix/skills/batch-norm-gradient-test-fix/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: batch-norm-gradient-test-fix
+description: "Fix batch norm backward gradient tests failing with uniform upstream gradients. Use when: batch_norm_backward gradient check fails with analytical~=0 but numerical!=0 due to sum(x_norm)=0 cancellation."
+category: testing
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Problem | `test_batch_norm2d_backward_gradient_input` fails: Analytical ~0, Numerical ~0.009 |
+| Root Cause | Using `grad_output = ones_like(output)` causes analytical gradient to cancel to exactly zero |
+| Fix | Use non-uniform `grad_output` and compute weighted sum in `forward_for_grad` |
+| Applies To | Any normalization layer backward pass using gradient checking |
+
+## When to Use
+
+1. Batch norm (or layer norm) backward gradient check fails with near-zero analytical but non-zero numerical
+2. CI shows: "Analytical: ~1e-7, Numerical: ~0.009, Tolerance: ~1e-4" for normalization backward test
+3. After un-skipping a normalization backward test that was previously commented out
+4. When `grad_output = ones_like(output)` is used in normalization gradient checking
+
+## The Pathological Cancellation Problem
+
+Batch normalization has a structural property: the sum of normalized values is always zero:
+
+```
+sum(x_norm) = sum((x - mean) / std) = 0
+```
+
+The PyTorch backward formula for batch norm is:
+```
+dL/dx_i = gamma/sigma * [g_i - k/N - x_norm_i * dotp/N]
+```
+where `k = sum(g)` and `dotp = sum(g * x_norm)`.
+
+**When `g = ones` (uniform gradient)**:
+- `k = N`
+- `dotp = sum(1 * x_norm) = sum(x_norm) = 0`
+- Result: `(1 - N/N - x_norm * 0/N) * gamma/sigma = 0`
+
+The **analytical gradient is exactly zero** — which is mathematically correct.
+
+BUT in float32, the forward pass has rounding errors that make `sum(x_norm) ≠ 0` exactly.
+When you perturb `x[i]` by ε=1e-4 for the numerical gradient:
+- The mean shifts slightly: `delta_mean = ε/N`
+- The variance shifts
+- Floating-point cancellation is incomplete
+- Numerical gradient ≈ 0.009 (not 0)
+
+This creates a **false test failure**: both implementations are correct, but the test
+incorrectly reports a 1000x mismatch.
+
+## Verified Workflow
+
+### Step 1: Diagnose the failure pattern
+
+Look for this signature in CI logs:
+```
+Analytical: -3.62789904784222e-07
+Numerical:  0.008940696716308594
+Difference: 0.008941059506213378
+Tolerance:  9.940696716308594e-05
+```
+
+Analytical is near-zero (correct!), Numerical is non-zero (float32 rounding artifact).
+
+### Step 2: Verify the backward implementation is correct
+
+Check the formula. PyTorch's consolidated formula:
+```mojo
+grad_input[i] = (grad_output[i] - k/N - x_norm[i] * dotp/N) * gamma * invstd
+```
+where:
+- `k = sum(grad_output)`
+- `dotp = sum(grad_output * x_norm)`
+- `invstd = 1 / sqrt(var + eps)`
+
+This is the correct formula — DO NOT change the backward implementation.
+
+### Step 3: Fix the test
+
+Replace `grad_output = ones_like(output)` with a non-uniform gradient:
+
+```mojo
+# BEFORE (pathological - causes cancellation):
+var grad_output = ones_like(output)
+
+fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    var out = batch_norm2d(inp, ...)[0]
+    var result = out
+    while result.dim() > 0:
+        result = reduce_sum(result, axis=0, keepdims=False)
+    return result
+```
+
+```mojo
+# AFTER (correct - non-uniform gradient breaks symmetry):
+var grad_output = zeros_like(output)
+for i in range(output.numel()):
+    # Pattern that avoids uniform/symmetric values
+    var val = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+    grad_output._data.bitcast[Float32]()[i] = val
+
+fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    var out = batch_norm2d(inp, ...)[0]
+    # Compute weighted sum matching our non-uniform grad_output
+    var weighted = multiply(out, grad_output)
+    var result = weighted
+    while result.dim() > 0:
+        result = reduce_sum(result, axis=0, keepdims=False)
+    return result
+```
+
+The `forward_for_grad` must compute `sum(output * grad_output)` (weighted sum)
+so the numerical gradient matches `dL/dx` with `dL/d(output) = grad_output`.
+
+### Step 4: Verify the fix works
+
+With non-uniform `grad_output`:
+- `k = sum(grad_output) ≠ N` (breaks cancellation)
+- `dotp = sum(grad_output * x_norm) ≠ 0` (breaks cancellation)
+- `grad_input[i]` is genuinely non-zero
+- Numerical gradient matches analytical (both ~same non-zero values)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Change tolerance | Increase `atol` from 1e-5 to 1e-2 | Hides the real issue without validating correctness | Masking float32 noise doesn't test the backward |
+| Fix backward formula | Modify the grad_input formula to produce non-zero output for uniform grad | The formula IS correct; ~0 for uniform grad is mathematically right | Don't change correct code to pass a bad test |
+| Use epsilon=1e-6 | Smaller perturbation for numerical gradient | Worsens float32 rounding; analytical vs numerical gap grows | Smaller epsilon increases numerical error in float32 |
+| Debug forward pass | Investigate why sum(x_norm) ≠ 0 | Float32 accumulation error is inherent; fixing it would require float64 | Accept float32 precision limits; design tests that avoid pathological cases |
+
+## Results & Parameters
+
+### Working Test Configuration
+
+```mojo
+# Grad output pattern that avoids cancellation
+var grad_output = zeros_like(output)
+for i in range(output.numel()):
+    var val = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+    # This gives: [-0.3, -0.05, 0.2, 0.45, -0.3, -0.05, ...]
+    grad_output._data.bitcast[Float32]()[i] = val
+```
+
+### Tolerance Settings
+
+```mojo
+assert_gradients_close(
+    grad_input,
+    numerical_grad,
+    rtol=1e-2,   # 1% relative tolerance (appropriate for float32 batch norm)
+    atol=1e-5,   # absolute tolerance
+    message="Batch norm gradient w.r.t. input",
+)
+```
+
+### Key Numbers
+
+- Shape: (2, 2, 2, 2) — small enough for O(n²) gradient checking
+- Epsilon for numerical gradient: 1e-4 (optimal for float32)
+- Expected analytical gradient magnitude: ~0.01-0.1 (non-trivially non-zero)
+
+## General Principle
+
+**For any normalization layer (BatchNorm, LayerNorm, GroupNorm):**
+
+> When gradient checking a normalization backward pass, NEVER use `grad_output = ones_like(output)` as the upstream gradient. The normalization property `sum(x_norm) = 0` causes perfect cancellation in the backward formula, making the test insensitive to implementation errors.
+
+Instead, use a non-uniform gradient that produces non-zero testable gradients, and ensure `forward_for_grad` computes `sum(output * grad_output)` (not just `sum(output)`).


### PR DESCRIPTION
## Summary

Documents the pathological cancellation problem in batch norm backward gradient tests.

- batch_norm property `sum(x_norm)=0` causes analytical gradient to cancel to zero when `grad_output=ones`
- float32 forward-pass noise makes numerical gradient ~0.009 (not zero)
- Fix: use non-uniform `grad_output` and compute `sum(output * grad_output)` in the forward function

## Key Findings

**What Worked**:
- Non-uniform `grad_output` (varied pattern like `[i%4 * 0.25 - 0.3]`) breaks the sum(x_norm)=0 symmetry
- `forward_for_grad` computing `sum(output * grad_output)` matches what the backward computes
- The backward formula `(g - k/N - x_norm * dotp/N) * gamma * invstd` is mathematically correct

**What Failed**:
- `grad_output = ones_like(output)` → causes analytical gradient = 0 due to `sum(x_norm)=0` property
- Changing tolerance → hides the issue without actually testing correctness
- Modifying the backward formula to produce non-zero output → wrong approach (formula is correct)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (batch_norm gradient test failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
