### PR TITLE
feat: add cleanup-deprecated-stub skill

### DIFF
--- a/skills/tooling/cleanup-deprecated-stub/.claude-plugin/plugin.json
+++ b/skills/tooling/cleanup-deprecated-stub/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "cleanup-deprecated-stub",
+  "version": "1.0.0",
+  "description": "Delete deprecated stub files safely after verifying no remaining references. Use when: (1) a file is marked DEPRECATED or contains only a redirect comment, (2) a module was reorganized into a subdirectory leaving a stub behind, (3) a cleanup issue requests file deletion with import verification.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["cleanup", "deprecated", "stub", "mojo", "imports", "refactoring"]
+}

--- a/skills/tooling/cleanup-deprecated-stub/references/notes.md
+++ b/skills/tooling/cleanup-deprecated-stub/references/notes.md
@@ -1,0 +1,57 @@
+# Session Notes: cleanup-deprecated-stub
+
+## Context
+
+- **Date**: 2026-03-05
+- **Issue**: HomericIntelligence/ProjectOdyssey#3060
+- **PR**: HomericIntelligence/ProjectOdyssey#3250
+- **Branch**: 3060-auto-impl
+
+## Task
+
+Delete `shared/training/schedulers.mojo` — a deprecated 12-line stub left behind when the
+training schedulers module was reorganized into a `schedulers/` subdirectory.
+
+## File Contents (Before Deletion)
+
+```python
+"""DEPRECATED: This file has been reorganized.
+
+The scheduler implementations have been moved to the schedulers/ directory:
+- StepLR, CosineAnnealingLR, WarmupLR are now in schedulers/lr_schedulers.mojo
+- Pure function implementations remain in schedulers/step_decay.mojo
+- All exports are handled by schedulers/__init__.mojo
+
+All imports should use:
+    from shared.training.schedulers import StepLR, CosineAnnealingLR, WarmupLR
+
+This file is kept for reference only and will be removed in a future version
+"""
+```
+
+## Verification Steps Performed
+
+1. `Glob("**/schedulers.mojo")` — found both `shared/training/schedulers.mojo` (target)
+   and `shared/autograd/schedulers.mojo` (unrelated, keep)
+2. `Grep("schedulers", path="shared/")` — confirmed all imports use `from shared.training.schedulers`
+   which resolves to directory, not file
+3. `Grep("from shared.training.schedulers.mojo")` — no matches (Mojo doesn't use file extensions in imports)
+4. Read `shared/training/__init__.mojo:69` — confirmed it imports from `shared.training.schedulers`
+   (directory resolution)
+5. Confirmed `shared/training/schedulers/__init__.mojo` exists
+
+## Environment Notes
+
+- `pixi run mojo build shared` fails with GLIBC version mismatch — pre-existing constraint
+- Mojo requires Docker environment on this system
+- Build validation skipped; import analysis sufficient to confirm safety
+
+## Git Operations
+
+```bash
+git rm shared/training/schedulers.mojo
+git commit -m "cleanup(training): delete deprecated schedulers.mojo stub\n\nCloses #3060"
+git push -u origin 3060-auto-impl
+gh pr create --title "cleanup(training): delete deprecated schedulers.mojo stub" --label "cleanup"
+gh pr merge --auto --rebase 3250
+```

--- a/skills/tooling/cleanup-deprecated-stub/skills/cleanup-deprecated-stub/SKILL.md
+++ b/skills/tooling/cleanup-deprecated-stub/skills/cleanup-deprecated-stub/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cleanup-deprecated-stub
+description: "Delete deprecated stub files safely after verifying no remaining references. Use when: a file is marked DEPRECATED, a module was reorganized leaving a stub behind, or a cleanup issue requests deletion with import verification."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | cleanup-deprecated-stub |
+| **Category** | tooling |
+| **Trigger** | File is marked DEPRECATED or is a post-reorganization stub |
+| **Output** | File deleted, PR created, auto-merge enabled |
+
+## When to Use
+
+- A `[Cleanup]` issue requests deletion of a deprecated `.mojo` file
+- A module was reorganized into a subdirectory and a stub redirect file remains
+- The stub contains only docstring/comments (no actual exports or implementations)
+- You need to verify no imports reference the file before deleting
+
+## Verified Workflow
+
+1. **Read the deprecated file** to confirm it contains no actual exports (only docstring/comments/redirect text).
+
+2. **Search for direct references** using two parallel searches:
+   - `Glob` to confirm the file exists and find its path
+   - `Grep` on the module name to see all import references
+
+3. **Distinguish directory vs file imports**: In Mojo, `from shared.training.schedulers import X`
+   resolves to `schedulers/__init__.mojo` if `schedulers/` directory exists, NOT to `schedulers.mojo`.
+   Verify the directory exists with its own `__init__.mojo`.
+
+4. **Verify no file uses explicit file path** (e.g., `from shared.training.schedulers.mojo import`
+   which doesn't exist in Mojo but confirm via grep).
+
+5. **Delete the file**: `git rm <path>` (stages deletion for commit).
+
+6. **Attempt build** to validate: `pixi run mojo build shared`. Note: GLIBC mismatch or Docker-only
+   environments may block local build — this is a pre-existing environment constraint, not caused
+   by the deletion. Confirm by checking whether mojo works at all in the environment.
+
+7. **Commit with conventional message**:
+   ```
+   cleanup(<scope>): delete deprecated <name>.mojo stub
+
+   Closes #<number>
+   ```
+
+8. **Push and create PR**:
+   ```bash
+   git push -u origin <branch>
+   gh pr create --title "..." --body "Closes #<number>" --label "cleanup"
+   gh pr merge --auto --rebase <pr-number>
+   ```
+
+## Key Insight: Mojo Directory vs File Resolution
+
+When both `schedulers.mojo` and `schedulers/` directory exist, Mojo resolves
+`from shared.training.schedulers import X` to the **directory's `__init__.mojo`**.
+The `.mojo` file stub is shadowed and unused. This makes stubs safe to delete
+as long as the directory and its `__init__.mojo` exist.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `pixi run mojo build shared` to validate | Executed build after deletion to confirm no breakage | GLIBC version mismatch prevented mojo from running at all (pre-existing env issue, not related to deletion) | Check if mojo is runnable in the environment first; GLIBC mismatch is a Docker-only env constraint |
+| Searching for `.mojo` file-specific imports | Grepped for `from shared.training.schedulers.mojo` | No matches found (Mojo doesn't use file extensions in imports) | File-extension imports don't exist in Mojo — directory resolution is the relevant check |
+
+## Results & Parameters
+
+**Verified safe deletion criteria:**
+- File contains only docstring/comments (zero executable code, zero exports)
+- A `schedulers/` directory with `__init__.mojo` exists at the same level
+- No grep matches for `<module>.mojo` style imports anywhere in the codebase
+
+**Commit message template:**
+```
+cleanup(<scope>): delete deprecated <name>.mojo stub
+
+The file was a placeholder left after reorganization. All implementations
+live in <module>/ and all imports already resolve to that directory. No
+references to this file exist.
+
+Closes #<issue>
+```


### PR DESCRIPTION
## Summary

Documents the safe deletion workflow for deprecated stub files in Mojo codebases
after module reorganization.

- Captures how Mojo resolves directory vs file imports (directory wins when both exist)
- Provides grep-based import verification pattern as substitute for build validation
- Includes conventional commit and PR workflow for cleanup issues

## Key Findings

**What Worked**:
- Parallel Glob + Grep to verify file existence and import usage simultaneously
- Checking for `schedulers/` directory with `__init__.mojo` to confirm directory resolution
- Using `git rm` to stage deletion atomically with commit

**What Failed**:
- `pixi run mojo build shared` — GLIBC mismatch prevented mojo from running (pre-existing env constraint, not related to the change)
- Grepping for `.mojo`-extension imports — Mojo doesn't use file extensions in import statements

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with cleanup issue triggers

Generated with [Claude Code](https://claude.com/claude-code)
