### PR TITLE
feat: add deprecated-file-cleanup skill

### DIFF
--- a/skills/tooling/deprecated-file-cleanup/.claude-plugin/plugin.json
+++ b/skills/tooling/deprecated-file-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "deprecated-file-cleanup",
+  "version": "1.0.0",
+  "description": "Safely delete deprecated stub files after verifying no active imports reference them. Use when: (1) a file is marked DEPRECATED with a consolidation notice, (2) a cleanup issue asks you to delete a helper/utility file, (3) you need to verify zero consumers before deletion.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["cleanup", "deprecated", "deletion", "imports", "refactoring"]
+}

--- a/skills/tooling/deprecated-file-cleanup/references/notes.md
+++ b/skills/tooling/deprecated-file-cleanup/references/notes.md
@@ -1,0 +1,53 @@
+# Session Notes: deprecated-file-cleanup
+
+## Issue
+
+GitHub issue #3061 — `[Cleanup] Delete deprecated gradient_checking.mojo`
+
+## File Deleted
+
+`tests/helpers/gradient_checking.mojo` — 18-line docstring-only stub. Content:
+
+```
+"""DEPRECATED: This module has been consolidated into shared.testing.
+All gradient checking utilities have been moved to shared/testing/gradient_checker.mojo...
+This file is kept as a stub for reference only. Do not use in new code.
+"""
+```
+
+## Import Search Results
+
+Searched for `gradient_checking` across the entire repo. Files found:
+- `.claude-prompt-3061.md` — prompt file (not an import)
+- `tests/shared/testing/test_gradient_check.mojo` — references `gradient_checker` (new location, not deprecated)
+- `tests/shared/training/test_precision_config.mojo` — unrelated
+- `tests/shared/core/test_gradient_checking.mojo` — tests the new location
+- `tests/README.md` — documentation
+- `docs/dev/mojo-test-failure-patterns.md` — documentation
+- `docs/integration/integration-guide.md` — documentation
+- `docs/adr/ADR-004-testing-strategy.md` — listed file in structure diagram (updated)
+- `.github/workflows/comprehensive-tests.yml` — workflow
+- `.github/workflows/test-gradients.yml` — workflow
+
+Also searched `helpers/gradient_checking` specifically — only found doc references, no imports.
+
+## Doc Updates
+
+`docs/adr/ADR-004-testing-strategy.md`:
+- Removed `gradient_checking.mojo` from directory tree diagram (line ~144)
+- Removed `tests/helpers/gradient_checking.mojo: Numerical gradient utilities` from key files list (line ~326)
+
+## Pre-commit Results
+
+- `mojo-format`: FAILED (GLIBC_2.32/2.33/2.34 not found) — environment issue, not our change
+- All other hooks: PASSED (with `SKIP=mojo-format`)
+
+## PR
+
+PR #3251: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3251
+Branch: `3061-auto-impl`
+Auto-merge: enabled (rebase)
+
+## Timing
+
+Fast task: ~5 minutes end-to-end.

--- a/skills/tooling/deprecated-file-cleanup/skills/deprecated-file-cleanup/SKILL.md
+++ b/skills/tooling/deprecated-file-cleanup/skills/deprecated-file-cleanup/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: deprecated-file-cleanup
+description: "Safely delete deprecated stub files after verifying no active imports reference them. Use when: a file is marked DEPRECATED, a cleanup issue asks to delete a helper/utility, or you need to verify zero consumers before deletion."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | deprecated-file-cleanup |
+| **Category** | tooling |
+| **Effort** | Low (< 10 min) |
+| **Risk** | Low — verify imports first |
+
+Workflow for safely deleting deprecated stub files in a codebase. The key insight is that
+deprecated stubs are often docstring-only placeholders pointing to the new location; no code
+actually imports them. Verify this before deleting.
+
+## When to Use
+
+- Issue title contains `[Cleanup] Delete deprecated`
+- File body contains `DEPRECATED` marker with consolidation notice
+- File to delete is in a `helpers/` or similar utility directory
+- You need to confirm zero consumers before removal
+
+## Verified Workflow
+
+1. **Read the deprecated file** — confirm it is a stub (no real code, only a docstring or
+   redirect comment). If it has real code, stop and escalate.
+
+2. **Search for imports** — use Grep to find any file that imports from the deprecated path:
+
+   ```bash
+   Grep pattern="helpers/gradient_checking|from tests.helpers.gradient" --output_mode=content
+   ```
+
+   Check ALL matches: docs, workflow files, test files, conftest. Only `.md` docs and the
+   prompt file itself are acceptable matches. Any `.mojo`/`.py` import is a blocker.
+
+3. **Delete the file**:
+
+   ```bash
+   rm path/to/deprecated_file.mojo
+   ```
+
+4. **Update documentation** — search for references in `.md` files (ADRs, READMEs, integration
+   guides) and remove or update lines that list the now-deleted file. Do NOT remove references
+   that explain the migration history; only remove file-listing entries.
+
+5. **Run pre-commit** (skip mojo-format if GLIBC incompatible in the environment):
+
+   ```bash
+   SKIP=mojo-format pixi run pre-commit run --all-files
+   ```
+
+   All non-mojo hooks must pass (markdown lint, trailing whitespace, YAML, etc.).
+
+6. **Commit with conventional message**:
+
+   ```
+   cleanup(tests): delete deprecated <filename>
+
+   The <path> file was a deprecated stub pointing to <new location>.
+   No files imported from it. Remove the file and update <doc> to
+   reflect current state.
+
+   Closes #<issue>
+   ```
+
+7. **Push and create PR** with auto-merge enabled.
+
+## Results & Parameters
+
+```bash
+# Verify no imports (adapt pattern to file being deleted)
+Grep pattern="helpers/<filename>|from <module_path>" output_mode=content
+
+# Skip mojo-format when GLIBC incompatible
+SKIP=mojo-format pixi run pre-commit run --all-files
+
+# Commit
+git commit -m "cleanup(tests): delete deprecated <filename>"
+
+# Auto-merge PR
+gh pr merge --auto --rebase <pr-number>
+```
+
+**Observed outcome**: 2 files changed, 20 deletions. PR #3251 created and auto-merge enabled.
+All non-mojo pre-commit hooks passed.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running full pre-commit | `pixi run pre-commit run --all-files` without SKIP | mojo-format fails with GLIBC_2.32/2.33/2.34 not found — environment incompatibility, not our change | Use `SKIP=mojo-format` when mojo binary cannot run locally; CI will still validate Mojo format |
+| Checking only .mojo files for imports | Grepped only `*.mojo` files | Would miss Python imports or workflow references | Always search all file types with no glob filter first |


### PR DESCRIPTION
## Summary

Documents workflow for safely deleting deprecated stub files after verifying no active imports reference them.

- Verified grep approach across all file types (not just target language)
- Documents `SKIP=mojo-format` workaround for GLIBC-incompatible environments
- Covers ADR/doc update pattern (remove file listings, preserve migration history)

## Key Findings

**What Worked**:
- Grep all file types for import references before deleting
- Use `SKIP=mojo-format` when mojo binary fails due to GLIBC mismatch; CI validates format separately
- Only update doc file-listing entries; do not remove migration history prose

**What Failed**:
- Running full pre-commit without SKIP: mojo-format fails on GLIBC_2.32/2.33/2.34 incompatibility in this environment (not caused by the change)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "delete deprecated" / "[Cleanup]" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)