### PR TITLE
feat: add flaky-ci-crash-diagnosis skill

### DIFF
--- a/skills/debugging/flaky-ci-crash-diagnosis/.claude-plugin/plugin.json
+++ b/skills/debugging/flaky-ci-crash-diagnosis/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "flaky-ci-crash-diagnosis",
+  "version": "1.0.0",
+  "description": "Diagnose whether CI test crashes are caused by code changes or pre-existing flakiness. Use when: (1) CI jobs show 'execution crashed' failures on a PR but the same tests previously passed on main, (2) widespread test crashes affect files unrelated to the PR changes, (3) need to distinguish introduced regressions from infrastructure flakiness.",
+  "category": "debugging",
+  "date": "2026-03-05",
+  "tags": ["ci", "flaky-tests", "crash-diagnosis", "mojo", "regression-detection"]
+}

--- a/skills/debugging/flaky-ci-crash-diagnosis/references/notes.md
+++ b/skills/debugging/flaky-ci-crash-diagnosis/references/notes.md
@@ -1,0 +1,107 @@
+# Session Notes: ExTensor Utility Methods PR #2722
+
+## Date
+2026-03-05
+
+## Context
+Implementing GitHub issue #2722 for ExTensor utility methods in ML Odyssey (Mojo codebase).
+Working directory: `/home/mvillmow/Odyssey2/.worktrees/issue-2722`
+Branch: `2722-auto-impl`
+
+## What Was Done
+
+### Previous Work (already in repo)
+Commit `20ddaee6` already implemented all required utility methods:
+- `__setitem__` (Float64 + Int64 overloads)
+- `__int__`, `__float__`
+- `__str__`, `__repr__`
+- `__hash__`
+- `contiguous()`
+
+Already implemented before the issue was opened:
+- `clone()` / module-level `clone(tensor)`
+- `item()` / module-level `item(tensor)`
+- `tolist()`
+- `__len__`
+- `diff()` / module-level `diff(tensor, n)`
+- `is_contiguous()`
+
+### PR Status
+PR #3161 was already created: `feat(extensor): implement utility methods for ExTensor`
+
+## CI Investigation
+
+### Initial Failures (Run 22705922550)
+- Core Tensors: FAILED
+- Core Initializers: FAILED
+- Shared Infra: FAILED (test_serialization.mojo — pre-existing)
+- Test Report: FAILED
+
+### Analysis Process
+1. Checked what files Core Tensors tests cover:
+   `test_tensors.mojo test_arithmetic.mojo test_arithmetic_contiguous.mojo ...`
+   None of these use the new utility methods.
+
+2. Checked PR diff — only `shared/core/extensor.mojo` was changed.
+
+3. Grep confirmed: none of the failing test files reference `__str__`, `__hash__`, `__setitem__`, etc.
+
+4. Looked at last successful main run (21873211512, from 2026-02-10):
+   - Core Tensors: success
+   - Core Initializers: success
+   - Shared Infra: success (test_serialization might have been added later)
+
+5. Crash type analysis:
+   - `error: execution crashed` with Mojo runtime library stack frames
+   - No user code in stack traces
+   - Crashes happen very early in test execution (before first test result printed)
+
+6. Re-ran failed jobs: `gh run rerun 22705922550 --failed`
+
+### Re-run Results
+- Core Tensors: SUCCESS
+- Core Initializers: SUCCESS
+- Shared Infra: FAILED (only test_serialization.mojo — pre-existing on main)
+- Test Report: FAILED (because Shared Infra failed)
+
+### Conclusion
+Flaky CI environment. The crashes in Core Tensors/Initializers were not caused by the PR.
+The only genuine failure (test_serialization.mojo) is pre-existing on main.
+
+## Key Commands Used
+
+```bash
+# Check PR CI runs
+gh run list --workflow "Comprehensive Tests" --branch 2722-auto-impl --limit 3 --json status,conclusion,databaseId
+
+# Get failed jobs
+gh run view 22705922550 --json jobs | python3 -c "..."
+
+# Check main branch history
+gh run list --branch main --workflow "Comprehensive Tests" --limit 5 --json conclusion,databaseId
+
+# Get crash logs
+gh run view 22705922550 --log-failed 2>&1 | grep -E "Core Tensors.*FAILED|crash" | head -20
+
+# Re-run failed jobs
+gh run rerun 22705922550 --failed
+```
+
+## Lessons Learned
+
+1. **Re-run early**: The fastest way to diagnose flaky vs. real failures is just re-running.
+   Don't spend time analyzing crash stack traces in stripped Mojo runtime libraries.
+
+2. **Check test file coverage**: If the failing CI job's test files don't use any of the
+   new/changed code, it's almost certainly flakiness.
+
+3. **Compare with main**: Always check if the same test jobs passed on the last successful
+   main run. If they did, and the PR crashes are in unrelated code, re-run is the answer.
+
+4. **`error: execution crashed` in Mojo**: This typically means a Mojo runtime segfault
+   in `libKGENCompilerRTShared.so`. Without debug symbols, you can't trace the cause from
+   CI logs alone. If the crash is in a test that doesn't use your code, it's flaky.
+
+5. **New tests pass = implementation correct**: If the test group covering your new
+   functionality (Core Utilities in this case) passes, your implementation is correct
+   even if other test groups have flaky crashes.

--- a/skills/debugging/flaky-ci-crash-diagnosis/skills/flaky-ci-crash-diagnosis/SKILL.md
+++ b/skills/debugging/flaky-ci-crash-diagnosis/skills/flaky-ci-crash-diagnosis/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: flaky-ci-crash-diagnosis
+description: "Diagnose whether CI test crashes are caused by code changes or pre-existing flakiness. Use when: widespread 'execution crashed' failures appear on a PR but affect tests unrelated to the changes."
+category: debugging
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Category | debugging |
+| Complexity | Medium |
+| Time to Apply | 10-20 minutes |
+| Risk | Low (read-only analysis) |
+| Mojo Version | 0.26.1+ |
+
+Diagnose CI test crashes on a PR to determine if they are regressions introduced by the
+changes or pre-existing flakiness. Guides systematic comparison between PR CI results and
+historical main branch results to reach a confident verdict.
+
+## When to Use
+
+1. A PR has CI jobs showing `error: execution crashed` failures
+2. The crashing tests are in files that do NOT use any of the newly added/changed code
+3. You need to decide whether to investigate a fix or simply re-run CI
+4. Multiple unrelated test groups crash simultaneously on the PR
+
+## Verified Workflow
+
+### Step 1: Identify failing CI jobs
+
+```bash
+# Get the run ID for the PR's CI
+gh run list --workflow "Comprehensive Tests" --branch <branch> --limit 3 --json status,conclusion,databaseId
+
+# List all failed jobs
+gh run view <run-id> --json jobs 2>&1 | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for job in data.get('jobs', []):
+    if job.get('conclusion') == 'failure':
+        print(f'FAILED: {job[\"name\"]}')
+"
+```
+
+### Step 2: Check if failures are in test groups related to the changes
+
+Key question: **Do the failing test groups cover files touched by the PR?**
+
+```bash
+# See what the PR actually changed
+git show <commit-hash> --stat
+
+# For each failing test group, check what test files it covers
+grep -A3 '"<Failing Job Name>"' .github/workflows/comprehensive-tests.yml
+```
+
+If failing jobs test files completely unrelated to the PR diff → strong flakiness signal.
+
+### Step 3: Compare against last successful main branch run
+
+```bash
+# Find recent main branch runs
+gh run list --branch main --workflow "Comprehensive Tests" --limit 5 --json conclusion,databaseId
+
+# Check job statuses on the most recent SUCCESSFUL main run
+gh run view <successful-main-run-id> --json jobs 2>&1 | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for job in data.get('jobs', []):
+    print(f'{job.get(\"conclusion\", \"N/A\")}: {job[\"name\"]}')
+" | grep -E "failure|<Failing Job Name>"
+```
+
+If the same jobs PASSED on main recently → our PR is a candidate. If they also failed on
+main → pre-existing issue.
+
+### Step 4: Inspect the crash type
+
+```bash
+# Get detailed crash output
+gh run view <run-id> --log-failed 2>&1 | grep -E "<Job Name>.*FAILED|<Job Name>.*crash|<Job Name>.*error" | head -20
+```
+
+**Runtime crash signatures:**
+- `error: execution crashed` — Mojo runtime segfault, usually in `libKGENCompilerRTShared.so`
+- Stack traces with only library frames (no user code) — infrastructure issue
+- Crash before any test output — crash in static initialization or first function call
+
+**Introduced regression signatures:**
+- `error: compilation failed` — our code broke the build
+- Test-specific failure messages — our code logic is wrong
+- Crash only in tests that directly call new methods
+
+### Step 5: Re-run failed jobs to confirm flakiness
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+Wait for completion, then check results:
+
+```bash
+# After re-run completes
+gh run view <run-id> --json jobs 2>&1 | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+failures = [j for j in data.get('jobs', []) if j.get('conclusion') == 'failure']
+print('FAILURES:', [j['name'] for j in failures])
+"
+```
+
+**Verdict:**
+- If previously failing jobs now pass → **flaky CI**, no code fix needed
+- If failures persist with same crashes → **investigate root cause** in PR changes
+- If only pre-existing failures remain (known broken tests on main) → **PR is clean**
+
+### Step 6: Confirm new-method tests pass
+
+Always verify the tests specific to the new functionality passed:
+
+```bash
+# Find which CI job covers the new test file
+grep -B2 -A5 "<test_file_name>" .github/workflows/comprehensive-tests.yml
+
+# Check that job's result
+gh run view <run-id> --json jobs | python3 -c "..." | grep "<Job Name>"
+```
+
+## Results & Parameters
+
+### Example: ExTensor utility methods PR (#2722)
+
+**Scenario**: PR added `__str__`, `__hash__`, `contiguous()` etc. to ExTensor. CI showed:
+- `Core Tensors` FAILED — crashes in `test_tensors.mojo`, `test_arithmetic.mojo`, etc.
+- `Core Initializers` FAILED
+- `Shared Infra` FAILED (one test, pre-existing)
+
+**Analysis**:
+- `test_tensors.mojo` does NOT use any new methods (`grep` confirmed zero references)
+- Last successful main run (run ID `21873211512`) had Core Tensors: SUCCESS
+- Crash type: `error: execution crashed` with only Mojo runtime library frames
+- `Core Utilities` (which contains `test_utility.mojo`) PASSED — new methods work
+
+**Re-run result**: Core Tensors and Core Initializers both PASSED on re-run. Only
+`test_serialization.mojo` in Shared Infra remained failed — confirmed pre-existing on main.
+
+**Verdict**: Flaky CI environment crashes, not caused by PR changes.
+
+### Diagnostic Decision Tree
+
+```
+CI job fails on PR
+    |
+    v
+Is the failing job's test files touched by the PR diff?
+    |
+    YES -> Likely introduced regression. Debug specific test.
+    NO  -> Check last successful main run
+            |
+            Same jobs passed on main? -> Re-run CI
+                |
+                Re-run passes? -> Flaky CI, no fix needed
+                Re-run fails?  -> Infrastructure problem, check with team
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Analyzing crash stack traces directly | Tried to identify crash cause from `libKGENCompilerRTShared.so` frame addresses | Stack frames are in stripped libraries with no symbols — no useful info | Runtime crashes in Mojo stdlib libs are not debuggable without symbolicated builds |
+| Checking if `__str__` conformance causes issues | Hypothesized adding `__str__` changes Mojo trait resolution and causes downstream crashes | Could not confirm — tests that don't call `__str__` still crashed | Cannot infer crash cause from Mojo trait changes without being able to run the code locally |
+| Comparing crash timestamps to identify common cause | Looked for timing correlation between crashes | Multiple crashes happened in parallel jobs — no useful pattern | Parallel CI jobs don't share state; crashes in unrelated jobs indicate infrastructure flakiness |
+| Waiting for CI to complete before re-running | First attempt was to fully analyze before re-running | Wasted time on inconclusive analysis | Re-run should be triggered early as the fastest flakiness signal |


### PR DESCRIPTION
## Summary

Documents how to diagnose whether CI test crashes on a PR are caused by code changes
or pre-existing flakiness in the CI environment.

- Provides a systematic decision tree for distinguishing regressions from flaky crashes
- Documents the re-run-first strategy as the fastest diagnostic approach
- Captures specific Mojo runtime crash signatures and what they mean

## Key Findings

**What Worked**:
- Re-running failed CI jobs is the fastest way to confirm flakiness
- Checking if failing test groups cover files touched by the PR diff is definitive
- Comparing against the last successful main branch run provides clear baseline

**What Failed**:
- Analyzing `libKGENCompilerRTShared.so` stack traces → No symbols in stripped Mojo runtime libs
- Trying to infer crash cause from trait conformance changes → Cannot confirm without running code
- Waiting for full analysis before re-running → Wastes time on inconclusive investigation

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with CI failure diagnosis triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
