### PR TITLE
feat(skills): Add ruff-c901-mccabe-complexity skill

### DIFF
--- a/references/ruff-c901-mccabe-complexity-notes.md
+++ b/references/ruff-c901-mccabe-complexity-notes.md
@@ -1,0 +1,78 @@
+# ruff-c901-mccabe-complexity — Raw Notes
+
+## Session: 2026-03-05
+
+### Context
+
+Issue #1377 — follow-up from #1356 where `# noqa: C901` directives were removed as
+unused (C901 was not in the ruff select list). This exposed that the codebase has
+many complex functions that need to be addressed.
+
+### Key Discovery: noqa placement for multi-line def signatures
+
+Ruff reports C901 at the line number of the `def` keyword. For single-line defs,
+the noqa comment can go anywhere on that line. For multi-line signatures:
+
+```python
+# WORKS
+def my_func(  # noqa: C901  # rationale here
+    arg1: str,
+    arg2: int,
+) -> str:
+
+# FAILS silently (violation persists)
+def my_func(
+    arg1: str,
+    arg2: int,
+) -> str:  # noqa: C901
+```
+
+This burned one iteration — two violations remained after the initial pass because
+`validate_frontmatter` and `run_subtest` had their noqa on the closing line.
+
+### Threshold decision: 12 vs 10
+
+- 65 violations at threshold 10
+- 43 violations at threshold 12 (need suppression)
+- 22 violations at threshold 11-12 (accepted without suppression)
+- Rationale: complexity 11-12 is common for real orchestration/validation logic
+  and doesn't meaningfully benefit from extraction. Threshold 12 was the sweet
+  spot to enforce meaningful simplification without noise.
+
+### ruff CLI does not support --max-complexity flag
+
+Attempted: `ruff check scylla/ scripts/ --select C901 --max-complexity 10`
+Result: `error: unexpected argument '--max-complexity' found`
+Fix: must be in pyproject.toml `[tool.ruff.lint.mccabe]` section.
+
+### Suppression rationale taxonomy
+
+Used consistent rationale phrases across suppressions to make future searches easy:
+- `orchestration with many retry/outcome paths`
+- `pipeline with sequential conditional stages`
+- `CLI dispatch with many command branches`
+- `validation with many independent rule checks`
+- `config loader with many format/version branches`
+- `workspace state detection with many file patterns`
+- `action map with many tier state branches`
+- `text report formatting with many conditional branches`
+- `AST traversal with many node type branches`
+- `pairwise comparison with many metric types`
+- `table generation with many criteria branches`
+- `TUI rendering with many display states`
+- `grade mapping with many score thresholds`
+
+### Files touched (29 source files + pyproject.toml)
+
+scripts/: agent_stats.py, check_frontmatter.py, validate_agents.py,
+  check_doc_config_consistency.py, check_model_config_consistency.py,
+  check_type_alias_shadowing.py, filter_audit.py, fix_markdown.py,
+  generate_figures.py, manage_experiment.py, migrate_skills_to_mnemosyne.py
+
+scylla/: analysis/loader.py, analysis/tables/comparison.py,
+  automation/curses_ui.py, automation/implementer.py, config/loader.py,
+  e2e/checkpoint.py, e2e/llm_judge.py, e2e/parallel_executor.py,
+  e2e/regenerate.py, e2e/rerun.py, e2e/rerun_judges.py,
+  e2e/run_report_sections.py, e2e/runner.py, e2e/subtest_executor.py,
+  e2e/tier_action_builder.py, e2e/tier_manager.py, judge/evaluator.py (not needed,
+  was at 11), reporting/scorecard.py

--- a/skills/ruff-c901-mccabe-complexity/SKILL.md
+++ b/skills/ruff-c901-mccabe-complexity/SKILL.md
@@ -1,0 +1,140 @@
+# Skill: ruff-c901-mccabe-complexity
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-05 |
+| Category | tooling |
+| Objective | Enable C901 McCabe complexity rule in ruff with a pragmatic threshold |
+| Outcome | Success — C901 enabled at max-complexity=12, all 65 violations resolved |
+| Issue | #1377 (follow-up from #1356) |
+
+## When to Use
+
+- Enabling a new ruff lint rule across a large codebase with existing violations
+- Deciding between refactoring complex functions vs. annotated suppression
+- Setting a McCabe complexity threshold that balances strictness with practicality
+- Documenting intentional complexity suppressions so future developers understand rationale
+
+## Verified Workflow
+
+### 1. Audit violations at candidate threshold
+
+```bash
+# Count violations at complexity=10 (default)
+pixi run ruff check scylla/ scripts/ --select C901 2>&1 | grep "C901"
+
+# Get file:line locations for all violations
+pixi run ruff check scylla/ scripts/ --select C901 2>&1 | grep -E "C901|-->" | paste - -
+```
+
+### 2. Choose threshold
+
+- Default threshold (10) produced 65 violations
+- Threshold 12 accepted 22 functions (complexity 11–12) as within bounds
+- Threshold 12 flagged 43 functions (complexity > 12) for suppression
+- Rule: accept complexity 11–12 for orchestration/CLI code; suppress > 12 with rationale
+
+### 3. Update pyproject.toml
+
+```toml
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "D", "UP", "S101", "B", "SIM", "C4", "C901", "RUF"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+```
+
+### 4. Add annotated suppressions
+
+Place `# noqa: C901  # <rationale>` on the **first line** of the function def (the `def` line), not on the return type annotation line. For multi-line signatures this is critical.
+
+```python
+# CORRECT — noqa on the def line
+def run_subtest(  # noqa: C901  # orchestration with many retry/outcome paths
+    self,
+    tier_id: TierID,
+    ...
+) -> SubTestResult:
+
+# WRONG — noqa on closing paren/return type line (ruff ignores it)
+def run_subtest(
+    self,
+    ...
+) -> SubTestResult:  # noqa: C901  # this does NOT suppress the violation
+```
+
+### 5. Rationale categories used
+
+| Rationale | Functions |
+|-----------|-----------|
+| `orchestration with many retry/outcome paths` | `run`, `run_subtest`, `_implement_all`, `_run_batch`, `cmd_run`, `rerun_experiment`, `rerun_judges_experiment` |
+| `pipeline with sequential conditional stages` | `_run_mojo_pipeline`, `_run_python_pipeline` |
+| `CLI dispatch with many command branches` | `main` (multiple), `cmd_run`, `cmd_visualize` |
+| `validation with many independent rule checks` | `validate_frontmatter`, `check_configs` |
+| `config loader with many format/version branches` | `load`, `load_run`, `load_rubric_weights` |
+| `workspace state detection with many file patterns` | `_get_workspace_state`, `_get_workspace_files`, `_merge_tier_resources` |
+| `action map with many tier state branches` | `build` (TierActionBuilder) |
+| `text report formatting with many conditional branches` | `format_text` |
+| `AST traversal with many node type branches` | `detect_shadowing` |
+
+### 6. Verify and run tests
+
+```bash
+# Verify C901 only
+pixi run ruff check scylla/ scripts/ --select C901
+
+# Verify all rules
+pixi run ruff check scylla/ scripts/
+
+# Run full test suite
+pixi run python -m pytest tests/ -v
+```
+
+## Failed Attempts
+
+### Placing noqa on return type line of multi-line signatures
+
+**What was tried:** For multi-line function signatures, placed `# noqa: C901` on the closing `) -> ReturnType:` line.
+
+**Why it failed:** Ruff reports C901 violations at the line where `def` appears. For multi-line signatures, the `def` keyword is on a different line than the return type. Ruff only checks noqa on the line it reports the error, so the suppression was silently ignored and the violation persisted.
+
+**Fix:** Always place `# noqa: C901` on the `def` line itself.
+
+### Using --max-complexity CLI flag
+
+**What was tried:** `pixi run ruff check scylla/ scripts/ --select C901 --max-complexity 10`
+
+**Why it failed:** Ruff does not accept `--max-complexity` as a CLI flag. The threshold must be configured in `pyproject.toml` under `[tool.ruff.lint.mccabe]`.
+
+## Results & Parameters
+
+### Final pyproject.toml config
+
+```toml
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "D", "UP", "S101", "B", "SIM", "C4", "C901", "RUF"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+```
+
+### Violation summary
+
+| Complexity Range | Count | Action |
+|-----------------|-------|--------|
+| > 12 (suppressed) | 43 | `# noqa: C901` with rationale |
+| 11–12 (accepted) | 22 | No change needed |
+| Total at threshold 10 | 65 | — |
+
+### Files modified
+
+- `pyproject.toml` — add C901 to select, add mccabe section
+- 29 source files — add annotated `# noqa: C901` suppressions
+
+### Test results
+
+- 4434 passed, 1 skipped
+- Combined coverage: 75.23%
+- All ruff checks clean


### PR DESCRIPTION
## Summary

- Documents the end-to-end workflow for enabling the C901 McCabe complexity rule in ruff across a large codebase
- Records the critical **noqa placement gotcha** for multi-line function signatures (noqa must be on the `def` line, not the return type line)
- Provides a threshold-selection rationale (12 vs 10) and a reusable taxonomy of suppression rationale phrases
- Includes raw session notes with exact commands and the `--max-complexity` CLI flag failure

## Skill location

`skills/ruff-c901-mccabe-complexity/SKILL.md`

## Key learnings captured

1. `# noqa: C901` must be on the `def` line for multi-line signatures — placement on the closing `) -> ReturnType:` line is silently ignored
2. `--max-complexity` is not a ruff CLI flag; threshold must be set in `[tool.ruff.lint.mccabe]` in pyproject.toml
3. Complexity 12 is a practical threshold for orchestration-heavy codebases (65 violations at 10 → 43 suppressions at 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)