### PR TITLE
feat: add deprecated-file-cleanup-workflow skill

### DIFF
--- a/skills/tooling/deprecated-file-cleanup-workflow/.claude-plugin/plugin.json
+++ b/skills/tooling/deprecated-file-cleanup-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "deprecated-file-cleanup-workflow",
+  "version": "1.0.0",
+  "description": "Workflow for safely deleting deprecated files from a Mojo/Python codebase. Use when: (1) a file is marked DEPRECATED and consolidated elsewhere, (2) cleaning up legacy modules after migration, (3) removing files as part of a cleanup GitHub issue.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["cleanup", "deprecated", "delete", "mojo", "github-issue", "worktree"]
+}

--- a/skills/tooling/deprecated-file-cleanup-workflow/references/notes.md
+++ b/skills/tooling/deprecated-file-cleanup-workflow/references/notes.md
@@ -1,0 +1,70 @@
+# Session Notes: deprecated-file-cleanup-workflow
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3066 `[Cleanup] Delete deprecated benchmarks/__init__.mojo`
+- **Branch**: `3066-auto-impl`
+- **PR**: #3263
+
+## Objective
+
+Delete `/benchmarks/__init__.mojo` which was marked DEPRECATED and redirected
+users to `shared.benchmarking`. The benchmarks module had been consolidated.
+
+## File Contents Summary
+
+`benchmarks/__init__.mojo` (45 lines) contained only a module-level docstring:
+- Marked `DEPRECATED`
+- Message: "Use shared.benchmarking for all new code"
+- Listed what to import from `shared.benchmarking`
+- No actual code/functions — purely a migration guide docstring
+
+## Steps Taken
+
+1. Read `.claude-prompt-3066.md` to understand the task
+2. Globbed `benchmarks/**/*` to see the full directory structure
+3. Grepped for `benchmarks.__init__|from benchmarks import|import benchmarks` in `*.mojo` files
+   - Only match: the file itself (self-reference in usage example)
+4. Confirmed no other files import `benchmarks.__init__`
+5. Deleted: `rm benchmarks/__init__.mojo`
+6. Verified: `ls benchmarks/` confirmed deletion
+7. Ran `pixi run pre-commit run --all-files` — all hooks passed
+   - Note: mojo binary GLIBC errors are pre-existing, not caused by this change
+8. Committed with `git rm benchmarks/__init__.mojo` + conventional commit message
+9. Pushed to `origin/3066-auto-impl`
+10. Created PR #3263 with `gh pr create`
+11. Enabled auto-merge with `gh pr merge --auto --rebase`
+
+## Key Observations
+
+### GLIBC Environment Issue
+`pixi run mojo build` fails in this environment with:
+```
+/path/mojo: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.32' not found
+```
+This is a pre-existing infrastructure issue (OS too old for the mojo binary).
+Pre-commit hooks still pass because the mojo format hook gracefully handles
+the binary failure.
+
+### Self-referencing Grep
+The `__init__.mojo` file contained usage examples that included:
+```mojo
+from benchmarks import stats, reporter
+```
+This causes the file to appear in grep results for its own module name.
+Filter these out with `grep -v "__init__.mojo"` or check that
+all matches are within the file being deleted.
+
+### Verification Strategy
+When `mojo build` is unavailable (environment issue), use pre-commit hooks
+as the primary signal that code quality is maintained:
+- `pixi run pre-commit run --all-files` → all hooks pass = good to proceed
+
+## Deliverables Completed
+
+- [x] Verified no imports reference this module
+- [x] Deleted the file
+- [x] Pre-commit hooks pass
+- [x] PR created and linked to issue #3066

--- a/skills/tooling/deprecated-file-cleanup-workflow/skills/deprecated-file-cleanup-workflow/SKILL.md
+++ b/skills/tooling/deprecated-file-cleanup-workflow/skills/deprecated-file-cleanup-workflow/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: deprecated-file-cleanup-workflow
+description: "Workflow for safely deleting deprecated files from a Mojo/Python codebase. Use when: (1) a file is marked DEPRECATED and consolidated elsewhere, (2) cleaning up legacy modules after migration, (3) removing files as part of a cleanup GitHub issue."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Safely delete a deprecated file by verifying no active imports reference it before deletion |
+| Outcome | File deleted, pre-commit passes, PR created and auto-merged |
+
+Workflow for removing deprecated Mojo (or other) files that have been consolidated into a
+shared module. Emphasizes verifying no imports reference the file before deletion to avoid
+breaking builds.
+
+## When to Use
+
+- A file is marked `DEPRECATED` and has a comment like "Use X for all new code"
+- Cleaning up a module that was migrated to `shared.*` or another package
+- Implementing a `[Cleanup]`-labeled GitHub issue asking to delete a specific file
+- After verifying the migration is complete and no code still depends on the old module
+
+## Verified Workflow
+
+1. **Read the issue**: `gh issue view <issue> --comments` — understand the file, context, and deliverables
+2. **Find the file**: Confirm it exists and read it to understand what it contained
+3. **Grep for imports** — search all `.mojo`, `.py`, and `.md` files for references:
+   ```bash
+   # Search for any import of the module
+   grep -rn "from benchmarks import\|import benchmarks" . --include="*.mojo" --include="*.py"
+   # Also grep for the filename pattern
+   grep -rn "benchmarks/__init__" . --include="*.mojo" --include="*.md"
+   ```
+4. **If no active imports found**: Delete the file with `git rm <file>`
+5. **Run pre-commit hooks**: `pixi run pre-commit run --all-files` — verify all hooks pass
+6. **Commit**: `git commit -m "chore(scope): delete deprecated <file>\n\nCloses #<issue>"`
+7. **Push and PR**: `git push -u origin <branch>` then `gh pr create`
+8. **Enable auto-merge**: `gh pr merge --auto --rebase`
+
+## Key Observations
+
+- `__init__.mojo` files for deprecated packages often only contain docstrings with migration
+  guidance — no actual functionality. Safe to delete without behavior changes.
+- GLIBC version mismatches (`version 'GLIBC_2.32' not found`) in `pixi run mojo build` are
+  a pre-existing environment issue, not caused by file deletion. Pre-commit hooks still
+  pass because the `mojo format` hook gracefully skips when mojo binary fails.
+- Grep the file itself last — it may self-reference in examples (`from benchmarks import stats`
+  inside `benchmarks/__init__.mojo`) and produce false positives.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `pixi run mojo build` as verification | Ran build to confirm nothing broke | GLIBC version mismatch caused mojo binary to fail — pre-existing environment issue, unrelated to changes | Use pre-commit hooks as the verification signal, not raw mojo build in this environment |
+
+## Results & Parameters
+
+```bash
+# Full workflow (from worktree)
+gh issue view 3066 --comments          # Read full context
+
+# Verify no imports (adjust patterns for your module)
+grep -rn "from benchmarks import\|import benchmarks" . \
+  --include="*.mojo" --include="*.py" | grep -v "__init__.mojo"
+
+# Delete and commit
+git rm benchmarks/__init__.mojo
+git commit -m "$(cat <<'EOF'
+chore(benchmarks): delete deprecated benchmarks/__init__.mojo
+
+Remove deprecated file redirecting to shared.benchmarking.
+No Mojo files import this module.
+
+Closes #3066
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+
+# Push and PR
+git push -u origin <branch>
+gh pr create --title "chore(scope): delete deprecated <file>" \
+  --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3066 - cleanup benchmarks/__init__.mojo | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the workflow for safely deleting deprecated Mojo files that have been consolidated into shared modules.

- Verified no active imports reference the file before deletion
- Identified that GLIBC mojo binary failures are pre-existing env issues, not deletion-caused
- Established pre-commit hooks as the verification signal when `mojo build` is unavailable

## Key Findings

**What Worked**:
- Grep for imports with `grep -rn "from <module> import\|import <module>"` filtered by `grep -v` the file being deleted
- `pixi run pre-commit run --all-files` as build verification when mojo binary fails
- `git rm` + conventional commit + `gh pr merge --auto --rebase` workflow

**What Failed**:
- `pixi run mojo build` for verification → GLIBC version mismatch (`GLIBC_2.32` not found) — pre-existing environment issue on Debian 10; use pre-commit hooks instead

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant cleanup triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
