### PR TITLE
feat(testing): add tier-fixture-schema-coverage skill

### DIFF
--- a/skills/testing/tier-fixture-schema-coverage/.claude-plugin/plugin.json
+++ b/skills/testing/tier-fixture-schema-coverage/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "tier-fixture-schema-coverage",
+  "version": "1.0.0",
+  "description": "Add YAML fixture files for each testing tier (t2-t6) to extend schema validation coverage. Use when: (1) a test parametrizes over tier fixture files but only t0/t1 exist, (2) new tier-specific fields (uses_tools, uses_delegation, uses_hierarchy) need schema validation, (3) expanding parametrized pytest tests to cover the full tier range. Verified on ProjectScylla issue #1381.",
+  "author": {
+    "name": "ProjectScylla Team"
+  },
+  "skills": "./skills"
+}

--- a/skills/testing/tier-fixture-schema-coverage/references/notes.md
+++ b/skills/testing/tier-fixture-schema-coverage/references/notes.md
@@ -1,0 +1,37 @@
+# Session Notes: tier-fixture-schema-coverage
+
+## Context
+
+- **Project**: ProjectScylla
+- **Issue**: #1381 — Add tier fixture files for t2-t6
+- **PR**: #1423
+- **Branch**: `1381-auto-impl`
+- **Date**: 2026-03-05
+
+## What Was Found
+
+When the session started, the implementation was already complete:
+- Fixture files t2.yaml through t6.yaml had been created in commit `2012621`
+- The parametrize list in `tests/unit/config/test_json_schemas.py:154` already included all 7 tiers
+- PR #1423 was already open and linked to issue #1381
+- All 505 tier-related tests passed
+
+## Key Files
+
+- `tests/fixtures/config/tiers/t{0-6}.yaml` — fixture files
+- `tests/unit/config/test_json_schemas.py` — schema validation tests (line 154: parametrize list)
+- `schemas/tier.schema.json` — the schema being validated
+
+## Key Insight: Check Before Implementing
+
+The main lesson: when working from a `.claude-prompt-*.md` file on a pre-existing branch,
+always check `git log` and existing files before implementing. Automated prior runs may
+have already completed the work. The correct action is to verify tests pass and confirm
+the PR exists, not to re-implement.
+
+## Test Command Used
+
+```bash
+pixi run python -m pytest tests/ -v -k "tier" --tb=short
+# Result: 505 passed, 3935 deselected
+```

--- a/skills/testing/tier-fixture-schema-coverage/skills/tier-fixture-schema-coverage/SKILL.md
+++ b/skills/testing/tier-fixture-schema-coverage/skills/tier-fixture-schema-coverage/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: tier-fixture-schema-coverage
+description: "TRIGGER CONDITIONS: Use when schema validation tests parametrize over tier fixture files but only early tiers exist (e.g. t0/t1), or when new tier-specific boolean fields need coverage across the full tier range."
+user-invocable: false
+category: testing
+date: 2026-03-05
+---
+
+# tier-fixture-schema-coverage
+
+How to extend schema coverage by adding YAML fixture files for each testing tier with distinct field combinations.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Add fixture files for t2-t6 so schema tests parametrize over the full tier range, each exercising distinct boolean capability fields |
+| Outcome | Success — 7 fixture files (t0-t6) all validate against tier.schema.json; 505 tier-related tests pass |
+
+## When to Use
+
+- Schema validation tests use `@pytest.mark.parametrize("fixture_file", ["t0.yaml", "t1.yaml"])` and need expansion
+- New tier-specific boolean fields (`uses_tools`, `uses_delegation`, `uses_hierarchy`) are added to the schema
+- `tests/fixtures/config/tiers/` has gaps (missing t2-t6) while t0/t1 exist
+- You want each tier fixture to exercise a distinct combination of capability flags
+
+## Verified Workflow
+
+### Step 1 — Check which fixtures are missing
+
+```bash
+ls tests/fixtures/config/tiers/
+# If only t0.yaml and t1.yaml exist, proceed
+```
+
+### Step 2 — Create one fixture per tier with distinct field combinations
+
+Each fixture should set tier-specific boolean flags to exercise distinct schema paths:
+
+```yaml
+# t2.yaml — Tooling tier: only uses_tools
+tier: "t2"
+name: "Tooling"
+description: "External tools and MCP servers"
+uses_tools: true
+uses_delegation: false
+uses_hierarchy: false
+```
+
+```yaml
+# t3.yaml — Delegation tier: only uses_delegation
+tier: "t3"
+name: "Delegation"
+description: "Flat multi-agent with specialist agents"
+uses_tools: false
+uses_delegation: true
+uses_hierarchy: false
+```
+
+```yaml
+# t4.yaml — Hierarchy tier: only uses_hierarchy
+tier: "t4"
+name: "Hierarchy"
+description: "Nested orchestration with orchestrator agents"
+uses_tools: false
+uses_delegation: false
+uses_hierarchy: true
+```
+
+```yaml
+# t5.yaml — Hybrid tier: tools + delegation
+tier: "t5"
+name: "Hybrid"
+description: "Best combinations and permutations"
+uses_tools: true
+uses_delegation: true
+uses_hierarchy: false
+```
+
+```yaml
+# t6.yaml — Super tier: all enabled
+tier: "t6"
+name: "Super"
+description: "Everything enabled at maximum capability"
+uses_tools: true
+uses_delegation: true
+uses_hierarchy: true
+```
+
+### Step 3 — Expand the parametrize list in the schema test
+
+```python
+# Before
+@pytest.mark.parametrize("fixture_file", ["t0.yaml", "t1.yaml"])
+
+# After
+@pytest.mark.parametrize("fixture_file", ["t0.yaml", "t1.yaml", "t2.yaml", "t3.yaml", "t4.yaml", "t5.yaml", "t6.yaml"])
+```
+
+### Step 4 — Run tests to verify
+
+```bash
+pixi run python -m pytest tests/ -v -k "tier"
+# Expect all tests to pass
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| None — the fixture files were created in a prior automated run | The branch already had commit `2012621` with t2-t6 fixtures and the parametrize list already updated | Always check git log before implementing; prior automated runs may have already completed the work |
+
+## Results & Parameters
+
+**Boolean flag coverage matrix** (ensures each tier exercises unique schema paths):
+
+| Tier | uses_tools | uses_delegation | uses_hierarchy |
+|------|-----------|----------------|----------------|
+| t0   | —         | —              | —              |
+| t1   | —         | —              | —              |
+| t2   | true      | false          | false          |
+| t3   | false     | true           | false          |
+| t4   | false     | false          | true           |
+| t5   | true      | true           | false          |
+| t6   | true      | true           | true           |
+
+**File layout:**
+```
+tests/fixtures/config/tiers/
+├── t0.yaml   # Vanilla (no capability flags)
+├── t1.yaml   # Prompted (no capability flags)
+├── t2.yaml   # Tooling (uses_tools only)
+├── t3.yaml   # Delegation (uses_delegation only)
+├── t4.yaml   # Hierarchy (uses_hierarchy only)
+├── t5.yaml   # Hybrid (tools + delegation)
+└── t6.yaml   # Super (all enabled)
+```
+
+**Test reference:** `tests/unit/config/test_json_schemas.py:154` — `test_real_tier_fixture_is_valid`
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1381, PR #1423 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

- Adds `skills/testing/tier-fixture-schema-coverage/` skill documenting the pattern for extending schema test coverage across all ablation tiers (t0-t6)
- Documents the boolean flag coverage matrix: each tier exercises a unique combination of `uses_tools`, `uses_delegation`, `uses_hierarchy`
- Captures key insight: always check `git log` before implementing on a pre-existing branch — prior automated runs may have completed the work

## Test plan

- [ ] Skill follows required directory structure (`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `references/notes.md`)
- [ ] `plugin.json` has specific trigger conditions in description
- [ ] `SKILL.md` includes required Failed Attempts table
- [ ] Verified On section links to ProjectScylla PR #1423

Derived from ProjectScylla issue #1381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)