### PR TITLE
feat: add auto-impl-already-done-detection skill

### DIFF
--- a/skills/tooling/auto-impl-already-done-detection/.claude-plugin/plugin.json
+++ b/skills/tooling/auto-impl-already-done-detection/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "auto-impl-already-done-detection",
+  "version": "1.0.0",
+  "description": "Detect when an auto-impl worktree arrives with work already completed on main and a PR already open. Use when: (1) invoked in a worktree with branch pattern '<issue>-auto-impl', (2) worktree branch is clean with no staged changes, (3) issue is still open but recent git log shows a 'Closes #<issue>' commit on main.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["workflow", "github", "worktree", "auto-impl", "pre-flight", "idempotency"]
+}

--- a/skills/tooling/auto-impl-already-done-detection/references/notes.md
+++ b/skills/tooling/auto-impl-already-done-detection/references/notes.md
@@ -1,0 +1,87 @@
+# Session Notes: Issue #3065 Auto-Impl Detection
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Working directory**: `/home/mvillmow/Odyssey2/.worktrees/issue-3065`
+- **Branch**: `3065-auto-impl`
+- **Issue**: #3065 - [Cleanup] Remove deprecated Linear backward result type aliases
+
+## Issue Description
+
+Remove `LinearBackwardResult` and `LinearNoBiasBackwardResult` type aliases from
+`shared/core/linear.mojo`. Replace usages with `GradientTriple` and `GradientPair`.
+
+## What Actually Happened
+
+1. Read `.claude-prompt-3065.md` - standard issue implementation prompt
+2. Read `shared/core/linear.mojo` to find the deprecated aliases - file had NO aliases,
+   only canonical `GradientTriple`/`GradientPair` types
+3. Grep'd entire codebase for `LinearBackwardResult` - zero matches
+4. Checked `git log --oneline -10` - saw commit `e226d73f` with message
+   "cleanup(linear): remove deprecated LinearBackwardResult type aliases"
+5. `git show e226d73f --stat` confirmed the commit addressed exactly what issue #3065 required
+6. `gh pr list --search "3065"` found PR #3262 already open with auto-merge enabled
+
+## Key Commit Details
+
+```
+commit e226d73f9627e031089a4ece8fcd66698b216b54
+Author: Micah Villmow <micah@villmow.us>
+Date:   Thu Mar 5 08:06:36 2026 -0800
+
+    cleanup(linear): remove deprecated LinearBackwardResult type aliases
+
+    Remove the 2 deprecated type aliases from shared/core/linear.mojo:
+    - LinearBackwardResult (replaced by GradientTriple)
+    - LinearNoBiasBackwardResult (replaced by GradientPair)
+
+    Update all usages in linear.mojo to use canonical types directly.
+    Remove alias exports from shared/core/__init__.mojo.
+    Remove linear alias tests from test_backward_compat_aliases.mojo.
+
+    Closes #3065
+    Part of #3059
+
+Files changed:
+  shared/core/__init__.mojo                          |  2 -
+  shared/core/linear.mojo                            | 23 ++-----
+  tests/shared/core/test_backward_compat_aliases.mojo| 73 ++----
+```
+
+## PR Details
+
+```
+PR #3262: cleanup(linear): remove deprecated LinearBackwardResult type aliases
+State: OPEN
+Auto-merge: enabled (rebase)
+URL: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3262
+```
+
+## Optimal Tool Call Sequence
+
+What I actually did (suboptimal - read source files first):
+1. Read `.claude-prompt-3065.md` (useful)
+2. Read `shared/core/linear.mojo` (premature - file already clean)
+3. Grep for `LinearBackwardResult` (confirmed no usages)
+4. `git log --oneline -10` (found the answer)
+5. `git show e226d73f --stat` (confirmed)
+6. `gh pr list --search "3065"` (found PR)
+
+Optimal sequence (check git history first):
+1. Read `.claude-prompt-3065.md`
+2. `git log --oneline -10` -> sees Closes #3065 commit -> stop
+3. `gh pr list --search "3065"` -> confirm PR exists -> report to user
+
+## Why This Pattern Occurs
+
+Auto-impl worktrees (`<N>-auto-impl`) are created automatically when issues are filed.
+A prior Claude Code session may have already:
+1. Implemented the changes
+2. Committed with "Closes #<N>"
+3. Pushed the branch
+4. Created a PR with auto-merge
+
+The worktree persists as an artifact of the automation but has no new work to do.
+The git history on `main` has the answer - the worktree branch just hasn't been cleaned up.

--- a/skills/tooling/auto-impl-already-done-detection/skills/auto-impl-already-done-detection/SKILL.md
+++ b/skills/tooling/auto-impl-already-done-detection/skills/auto-impl-already-done-detection/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: auto-impl-already-done-detection
+description: "Detect when an auto-impl worktree arrives with work already completed on main and a PR already open. Use when: invoked via .claude-prompt-<N>.md in a clean worktree where recent git log shows 'Closes #<N>' already on main."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+# Auto-Impl Already-Done Detection
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-05 |
+| **Objective** | Implement GitHub issue #3065 (remove deprecated type aliases) |
+| **Outcome** | Work was already complete - detected via git log, confirmed via PR search |
+| **Root Cause** | A prior Claude Code session already committed + pushed + opened the PR |
+| **Key Learning** | Always check `git log --oneline -10` and `gh pr list --search "<N>"` BEFORE reading any source files |
+
+## When to Use
+
+Use this pre-flight check **first** when invoked in a worktree context:
+
+1. Working directory is `<repo>/.worktrees/<issue>-auto-impl` (or similar branch pattern)
+2. `git status` shows a clean working tree with no staged changes
+3. Branch name contains an issue number (e.g., `3065-auto-impl`)
+4. A `.claude-prompt-<N>.md` file exists describing the work to do
+
+These signals suggest a prior session may have already completed the work.
+
+## Verified Workflow
+
+### Step 1: Read the prompt file and check git log simultaneously
+
+```bash
+# Read prompt to understand what issue number to check
+cat .claude-prompt-<N>.md
+
+# Check recent commits for "Closes #<N>" or issue number
+git log --oneline -10
+```
+
+**Key signal**: If `git log` shows a commit like `cleanup(foo): remove deprecated X - Closes #<N>`,
+the work is done. Stop here.
+
+### Step 2: Confirm with PR search
+
+```bash
+# Find all PRs (open or merged) associated with the issue
+gh pr list --search "<issue-number>" --state all
+```
+
+**Expected**: You will find an open PR with auto-merge enabled, or a merged PR.
+
+### Step 3: Inspect what was already done
+
+```bash
+# Verify the commit removed the right things
+git show <commit-hash> --stat
+
+# Check issue state
+gh issue view <N> --json state,title
+```
+
+### Step 4: Report and stop
+
+If work is complete:
+- Note the existing PR URL
+- Report status to user
+- Do NOT create a duplicate PR or commit
+- Optionally close the issue if it remains open but all work is merged
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Reading source files before checking git history | Read `linear.mojo` to find deprecated aliases | File had no aliases - already removed | Check `git log` before reading any source files |
+| Searching codebase for deprecated symbols | Grep for `LinearBackwardResult` across all `.mojo` files | No results - already deleted | A clean grep with no results is itself a signal the work is done |
+| Assuming the worktree always has new work to do | Started planning implementation steps | Wasted tool calls on work already complete | Worktrees created by automation may lag behind main |
+
+## Results & Parameters
+
+### Minimum Pre-Flight Sequence (2 commands)
+
+```bash
+# 1. Check git log for issue number commits
+git log --oneline -10
+
+# 2. If suspicious, search for PRs
+gh pr list --search "<N>" --state all
+```
+
+**Time cost**: < 3 seconds, 2 tool calls
+
+**Decision tree**:
+- `git log` shows `Closes #<N>` on main -> Work done, find existing PR, report
+- `gh pr list` shows open PR with auto-merge -> Work done, PR will merge when CI passes
+- Neither signal found -> Proceed with normal implementation workflow
+
+### Success Indicators
+
+- Detected already-complete work in 2 tool calls (vs 5+ if source files read first)
+- Existing PR #3262 identified with auto-merge enabled
+- No duplicate commits or PRs created
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3065, worktree `3065-auto-impl` | [notes.md](../references/notes.md) |
+
+## Related Skills
+
+- `verify-issue-before-work` - General issue state verification before starting
+- `issue-completion-verification` - Closing orphaned open issues after work is merged
+- `gh-check-ci-status` - Monitoring PR CI after detecting existing work


### PR DESCRIPTION
## Summary

Documents the pattern of detecting when an auto-impl worktree arrives with work already
committed to `main` and a PR already open — avoiding wasted tool calls reading source files
for already-removed code.

- Captures the "auto-impl worktree with nothing to do" scenario from ProjectOdyssey issue #3065
- Provides a 2-command pre-flight check (git log + gh pr list) that takes < 3 seconds
- Distinguishes from existing `verify-issue-before-work` (which checks issue state) by
  focusing on git history as the primary signal

## Key Findings

**What Worked**:
- `git log --oneline -10` immediately revealed the "Closes #3065" commit on main
- `gh pr list --search "3065" --state all` confirmed existing PR #3262 with auto-merge

**What Failed**:
- Reading `linear.mojo` before checking git history (file was already clean - aliases gone)
- Grep for deprecated symbols (zero results, but this came after unnecessary file reads)
- Assuming the worktree always has new work to do

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers correctly for `<N>-auto-impl` worktree context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
