### PR TITLE
feat: add verify-implementation-completeness skill

### DIFF
--- a/skills/documentation/verify-implementation-completeness/.claude-plugin/plugin.json
+++ b/skills/documentation/verify-implementation-completeness/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-implementation-completeness",
+  "version": "1.0.0",
+  "description": "Verify that a GitHub issue's implementation is already complete before re-doing work. Use when: (1) assigned to implement an issue on an existing branch, (2) a prompt file says 'implement issue #N', (3) suspecting prior session already completed the work.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["github", "verification", "idempotency", "cleanup", "pr"]
+}

--- a/skills/documentation/verify-implementation-completeness/references/notes.md
+++ b/skills/documentation/verify-implementation-completeness/references/notes.md
@@ -1,0 +1,37 @@
+# Session Notes — verify-implementation-completeness
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Branch**: `3070-auto-impl`
+- **Issue**: #3070 — [Cleanup] Document template TODO placeholders
+
+## What Happened
+
+The session was invoked via `.claude-prompt-3070.md` with instructions to "Implement GitHub issue #3070."
+The branch `3070-auto-impl` already existed with the implementation complete.
+
+### Steps Taken
+
+1. Read `.claude-prompt-3070.md` — confirmed task was to mark `# TEMPLATE:` placeholders in 5 files
+2. Read all 5 target template files — all already had correct `# TEMPLATE:` markers and header comments
+3. Ran `git log --oneline -5` — found commit `9567628f` with message matching the issue title exactly
+4. Ran `gh pr list --head 3070-auto-impl` — found PR #3268 open and linked
+
+### Outcome
+
+No implementation needed. PR #3268 was already created and ready for review.
+
+## Files Verified
+
+- `.templates/layer_template.mojo` — 4 TEMPLATE markers, header comment present
+- `.templates/dataset_template.mojo` — 2 TEMPLATE markers, header comment present
+- `.templates/tests_template.mojo` — 7 TEMPLATE markers, header comment present
+- `.claude/skills/phase-test-tdd/templates/unit_test_mojo.mojo` — 5 TEMPLATE markers, header comment present
+- `.claude/skills/phase-test-tdd/templates/integration_test.py` — 7 TEMPLATE markers, header comment present
+
+## Lesson
+
+Always check `git log`, target files, and `gh pr list` before starting implementation on an existing branch.
+A clean `git status` alone is not sufficient — it only shows unstaged changes, not whether prior commits fulfilled the issue.

--- a/skills/documentation/verify-implementation-completeness/skills/verify-implementation-completeness/SKILL.md
+++ b/skills/documentation/verify-implementation-completeness/skills/verify-implementation-completeness/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: verify-implementation-completeness
+description: "Verify that a GitHub issue's implementation is already complete before re-doing work. Use when: assigned to an existing branch for an issue, suspecting prior session completed the work, or a .claude-prompt file says 'implement issue #N'."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | documentation |
+| **Trigger** | Assigned to implement issue on existing branch |
+| **Outcome** | Avoid duplicate work; confirm PR exists if done |
+| **Time saved** | Prevents re-implementing already-merged or committed work |
+
+## When to Use
+
+- A `.claude-prompt-<N>.md` file instructs you to "implement issue #N"
+- You are working on a branch named `<N>-auto-impl` or similar
+- The branch already has commits beyond the base
+- `git log` shows a commit message referencing the issue
+- You want to confirm state before starting implementation
+
+## Verified Workflow
+
+1. **Check git log** for existing commits referencing the issue:
+
+   ```bash
+   git log --oneline -10
+   ```
+
+2. **Read all target files** listed in the issue to see if changes are already applied.
+
+3. **Check for an open PR** on the current branch:
+
+   ```bash
+   gh pr list --head <branch-name>
+   ```
+
+4. **If already complete**: Report findings to the user — commit hash, PR number, and that no further action is needed.
+
+5. **If incomplete**: Proceed with implementation per issue requirements.
+
+## Results & Parameters
+
+### Issue #3070 — Template TODO Placeholders
+
+- **Branch**: `3070-auto-impl`
+- **Completion commit**: `9567628f docs(templates): mark intentional TODO placeholders with TEMPLATE: prefix`
+- **PR**: `#3268` (open, linked to issue)
+- **Files verified**: 5 template files — all had `# TEMPLATE:` prefix and header comments
+
+### Key Signals That Work Is Done
+
+| Signal | Command |
+|--------|---------|
+| Commit message matches issue title | `git log --oneline -5` |
+| PR exists on branch | `gh pr list --head <branch>` |
+| Target files contain expected changes | `Read` each file |
+| `git status` shows clean working tree | `git status` |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Skipping file verification | Trusting commit message alone | Commit could exist but be partial | Always read target files to confirm |
+| Re-running implementation | Starting changes without checking history | Would duplicate already-committed work | Check `git log` first on any existing branch |
+| Checking only `git status` | Looking at untracked/modified files | Clean status doesn't prove issue is done | Must check log AND files AND PR existence |


### PR DESCRIPTION
## Summary

Documents the pattern of verifying implementation completeness before starting work on an existing branch.

- Check `git log`, target files, and `gh pr list` before implementing on any existing branch
- A clean `git status` is not sufficient to confirm an issue is done
- Commit messages matching issue titles are strong signals of prior completion

## Key Findings

**What Worked**:
- `git log --oneline -5` immediately revealed the prior commit matching the issue
- Reading all 5 target files confirmed `# TEMPLATE:` markers were already in place
- `gh pr list --head <branch>` confirmed PR #3268 already existed

**What Failed**:
- Relying solely on `git status` — shows clean tree but not whether issue work was committed
- Trusting commit message alone without reading files — commit could be partial
- Starting implementation without checking history — would duplicate committed work

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)