### PR TITLE
feat: add mojo-limitation-note-standardization skill

### DIFF
--- a/skills/documentation/mojo-limitation-note-standardization/.claude-plugin/plugin.json
+++ b/skills/documentation/mojo-limitation-note-standardization/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-limitation-note-standardization",
+  "version": "1.0.0",
+  "description": "Standardize Mojo language/compiler limitation NOTEs to use consistent format `# NOTE (Mojo vX.Y.Z):`. Use when: (1) cleaning up documentation NOTEs that lack version info, (2) auditing Mojo codebases for inconsistent limitation comment formats, (3) implementing cleanup issues that require NOTE standardization across multiple files.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["mojo", "documentation", "cleanup", "notes", "comments", "version-tagging"]
+}

--- a/skills/documentation/mojo-limitation-note-standardization/references/notes.md
+++ b/skills/documentation/mojo-limitation-note-standardization/references/notes.md
@@ -1,0 +1,39 @@
+# Session Notes: Mojo Limitation NOTE Standardization
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Issue**: ProjectOdyssey #3071 — [Cleanup] Document Mojo language limitation NOTEs
+- **Branch**: `3071-auto-impl`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3269
+
+## Objective
+
+Review and standardize NOTEs that document Mojo language/compiler limitations.
+Ensure all such NOTEs include version info in the format `# NOTE (Mojo v0.26.1):`.
+
+## Steps Taken
+
+1. Read the prompt file (`.claude-prompt-3071.md`) to understand the task
+2. Searched all `.mojo` files for "NOTE" (case-insensitive) — result was too large (39KB)
+3. Narrowed to `# NOTE` pattern and read specific lines in affected files
+4. Read context around each NOTE to understand its purpose
+5. Identified 6 files needing changes and 5+ already correctly formatted
+6. Applied targeted edits to each file using the Edit tool
+7. Ran `pixi run pre-commit run --all-files` — all relevant hooks passed
+8. Committed changes and confirmed existing PR #3269 was already open
+9. Enabled auto-merge on PR #3269
+
+## Key Observations
+
+- The issue listed only 5 files but said "(others to be discovered during implementation)"
+- Actual count: 6 files needed changes (found `benchmarks/` and `examples/` files not in original list)
+- `mojo format` hook fails due to GLIBC version incompatibility on this system — this is a known environment issue, not caused by the changes
+- The Edit tool requires reading a file before editing — attempting to edit `trainer_interface.mojo` without reading first caused an error
+
+## Environment Notes
+
+- System: Linux 5.10.0-37-amd64 (Debian Buster-era GLIBC)
+- Mojo requires GLIBC >= 2.32 but system has older version
+- Pre-commit `mojo format` hook is non-blocking for documentation-only changes
+- `pixi run pre-commit run --all-files` is the correct command (not `just pre-commit-all`)

--- a/skills/documentation/mojo-limitation-note-standardization/skills/mojo-limitation-note-standardization/SKILL.md
+++ b/skills/documentation/mojo-limitation-note-standardization/skills/mojo-limitation-note-standardization/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: mojo-limitation-note-standardization
+description: "Standardize Mojo language/compiler limitation NOTEs to use consistent `# NOTE (Mojo vX.Y.Z):` format. Use when: cleaning up docs with inconsistent NOTE formats, auditing Mojo codebases, or implementing cleanup issues requiring NOTE standardization."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Purpose** | Standardize Mojo limitation comment format across codebase |
+| **Target Pattern** | `# NOTE (Mojo vX.Y.Z):` |
+| **Scope** | All `.mojo` files with limitation NOTEs |
+| **Issue Type** | Cleanup issues (e.g., GitHub `[Cleanup]` label) |
+
+## When to Use
+
+- A GitHub issue requests documenting or standardizing Mojo language limitation NOTEs
+- Pre-commit or code review flags inconsistent NOTE comment formats
+- Auditing Mojo codebase for comments that lack version information
+- Cleanup phase of a development section that introduced many limitation workarounds
+
+## Verified Workflow
+
+1. **Read the issue** to identify affected files and NOTE locations:
+   ```bash
+   gh issue view <number> --comments
+   ```
+
+2. **Search for all NOTE variants** in `.mojo` files:
+   ```
+   Grep pattern="# NOTE" glob="**/*.mojo" output_mode="content"
+   ```
+   Look for variants missing version info:
+   - `# NOTE:` (no version)
+   - `# NOTE: Mojo v0.26.1` (inline version, non-standard)
+   - `# NOTE (Mojo v0.26.1):` (correct — skip these)
+
+3. **Read each affected file** before editing (required by Edit tool).
+
+4. **Apply standardization** using Edit tool — change `# NOTE:` or `# NOTE: Mojo vX.Y.Z` to `# NOTE (Mojo vX.Y.Z):`:
+   - Pattern: `# NOTE:` → `# NOTE (Mojo v0.26.1):`
+   - Pattern: `# NOTE: Mojo v0.26.1 ...` → `# NOTE (Mojo v0.26.1): ...`
+
+5. **Verify no regressions** — files already using `# NOTE (Mojo vX.Y.Z):` need NO changes.
+
+6. **Run pre-commit hooks**:
+   ```bash
+   pixi run pre-commit run --all-files
+   ```
+   The `mojo format` hook may fail due to GLIBC version issues in some environments — this is expected and not caused by the documentation changes. All other hooks (markdownlint, ruff, yaml, trailing-whitespace) must pass.
+
+7. **Commit and push**:
+   ```bash
+   git add <files>
+   git commit -m "docs(cleanup): document Mojo language limitation NOTEs with version info\n\nCloses #<number>"
+   git push -u origin <branch>
+   ```
+
+8. **Check for existing PR** before creating a new one:
+   ```bash
+   gh pr create ...
+   # If PR exists: gh pr merge <number> --auto --rebase
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Grepping for all NOTEs broadly | Used case-insensitive grep on all `.mojo` files for "NOTE" | Output was 39KB+ with many irrelevant matches (docstring `Note:`, print statements, etc.) | Narrow the grep pattern to `# NOTE` (with hash) to exclude prose and docstrings |
+| Assuming all NOTEs need changes | Planned to edit all NOTE occurrences found | Many NOTEs already used correct `# NOTE (Mojo vX.Y.Z):` format | Always read target lines first; skip already-correct entries |
+| Using `replace_all` on multi-file patterns | Considered batch replace across all files | Edit tool requires the file to be read first; `replace_all` is per-file, not cross-file | Read each file individually before editing; do targeted per-file edits |
+
+## Results & Parameters
+
+**Standard NOTE format** (canonical):
+```mojo
+# NOTE (Mojo v0.26.1): <description of limitation>
+```
+
+**Variants that need updating**:
+```mojo
+# NOTE: <description>                    # Missing version
+# NOTE: Mojo v0.26.1 <description>       # Version inline, not in parens
+```
+
+**Files affected in ProjectOdyssey issue #3071** (for reference):
+- `shared/training/mixed_precision.mojo` (2 NOTEs — FP16 SIMD limitation)
+- `shared/utils/file_io.mojo` (1 NOTE — missing `os.remove()`)
+- `benchmarks/scripts/compare_results.mojo` (1 NOTE — argv parsing)
+- `examples/lenet-emnist/run_infer.mojo` (1 NOTE — image decoding)
+- `shared/training/__init__.mojo` (1 NOTE — Track 4 interop)
+- `shared/training/trainer_interface.mojo` (1 NOTE — Track 4 interop)
+
+**Files already correct** (no changes needed):
+- `shared/core/broadcasting.mojo`
+- `shared/__init__.mojo`
+- `shared/training/precision_config.mojo`
+- `tests/shared/core/test_unsigned.mojo`
+- `tests/shared/core/test_conv.mojo`


### PR DESCRIPTION
## Summary

Documents the workflow for standardizing Mojo language/compiler limitation NOTEs
to use the consistent `# NOTE (Mojo vX.Y.Z):` format across a Mojo codebase.

- Captures grep strategy to find non-standard NOTE variants efficiently
- Documents which NOTE variants need changes vs which are already correct
- Records the Edit tool constraint (file must be read before editing)

## Key Findings

**What Worked**:
- Narrowing grep to `# NOTE` (with hash) filters out prose `Note:` in docstrings
- Reading each file individually before editing (required by Edit tool)
- Checking for existing PRs before creating new ones (`gh pr create` errors helpfully)
- `pixi run pre-commit run --all-files` is the correct pre-commit command

**What Failed**:
- Broad case-insensitive grep for "NOTE" across all `.mojo` files — 39KB+ output with noise
- Attempting to edit `trainer_interface.mojo` without reading it first — Edit tool error
- Assuming all NOTEs need changes — many already had correct `# NOTE (Mojo vX.Y.Z):` format

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
