### PR TITLE
feat: add check-issue-already-implemented skill

### DIFF
--- a/skills/tooling/check-issue-already-implemented/.claude-plugin/plugin.json
+++ b/skills/tooling/check-issue-already-implemented/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "check-issue-already-implemented",
+  "version": "1.0.0",
+  "description": "Check if a GitHub issue was already implemented in a previous session before starting work. Use when: (1) implementing an issue whose branch already exists, (2) the branch has recent commits, (3) a PR already exists for the issue.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["github", "issue", "worktree", "pr", "deduplication", "idempotency"]
+}

--- a/skills/tooling/check-issue-already-implemented/references/notes.md
+++ b/skills/tooling/check-issue-already-implemented/references/notes.md
@@ -1,0 +1,48 @@
+# Session Notes: Issue #3076
+
+## Date
+2026-03-05
+
+## Repository
+HomericIntelligence/ProjectOdyssey
+
+## Issue
+#3076 — [Cleanup] Clean up Python interop blocker NOTEs
+
+## Objective
+Update 3 NOTE comments in `shared/training/` that document Python/Mojo data loader
+integration blocked by Track 4. Since Track 4 is still active, add issue references
+(#3076 / #3059) to make the blockers properly tracked.
+
+## Files Changed (in prior session)
+- `shared/training/trainer_interface.mojo:391` — added `#3076`/`#3059` reference
+- `shared/training/__init__.mojo:404-413` — added references in docstring and inline comment
+- `shared/training/script_runner.mojo:95-100` — added references in docstring and inline comment
+
+## Branch State at Session Start
+- Branch: `3076-auto-impl`
+- Latest commit: `af39dfda docs(training): add issue references to Track 4 Python interop NOTEs`
+- Working tree: clean (only untracked `.claude-prompt-3076.md`)
+
+## PR State
+- PR #3168 was already open
+- Title: `docs(training): add issue refs to Track 4 Python interop NOTEs`
+- Labels: `cleanup`
+- Auto-merge: enabled (rebase)
+- Closes: #3076
+
+## Key Observation
+The `impl` skill was invoked but the work was already done in a prior session.
+The correct action was to detect this state and report it rather than reimplementing.
+
+## Git Commands Used to Detect State
+```bash
+git log --oneline -5        # showed af39dfda with issue reference
+git status                  # clean working tree
+gh pr list --head 3076-auto-impl  # showed PR #3168
+gh pr view 3168             # confirmed auto-merge enabled
+```
+
+## Lesson
+Always check git log and pr list at the start of impl runs. If the most recent commit
+references the issue number and a PR exists, the work is done.

--- a/skills/tooling/check-issue-already-implemented/skills/check-issue-already-implemented/SKILL.md
+++ b/skills/tooling/check-issue-already-implemented/skills/check-issue-already-implemented/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: check-issue-already-implemented
+description: "Check if a GitHub issue was already implemented in a previous session. Use when: starting work on a branch that already exists, running an impl skill that finds clean working tree with recent commits, or when a PR already exists for the issue."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Name** | check-issue-already-implemented |
+| **Category** | tooling |
+| **Trigger** | Before spending effort reimplementing work on an issue branch |
+| **Output** | Status report: already done / partially done / not started |
+
+## When to Use
+
+Invoke this check at the start of any `impl` skill run on a branch that already exists:
+
+1. Branch `<issue-number>-*` already exists and is checked out
+2. `git log --oneline -5` shows commits referencing the issue number
+3. `git status` shows a clean working tree (no uncommitted changes)
+4. A PR already exists for the branch (`gh pr list --head <branch>`)
+
+If all four conditions are true, the issue is already implemented. Skip reimplementation and
+verify the PR state instead.
+
+## Verified Workflow
+
+```bash
+# Step 1: Check branch state
+git log --oneline -5
+git status
+
+# Step 2: Check for existing PR
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)"
+
+# Step 3: If PR exists, verify its state
+gh pr view <pr-number>
+
+# Step 4: Confirm auto-merge is enabled
+# If auto-merge is not enabled:
+gh pr merge --auto --rebase
+
+# Step 5: Report status to user — no reimplementation needed
+```
+
+### Decision Matrix
+
+| git log mentions issue? | git status clean? | PR exists? | Action |
+|------------------------|-------------------|------------|--------|
+| Yes | Yes | Yes | Verify PR state, confirm auto-merge, done |
+| Yes | Yes | No | Create PR, enable auto-merge |
+| Yes | No | No | Commit uncommitted work, create PR |
+| No | Yes | No | Issue not yet implemented — proceed with impl |
+
+## Context: Issue #3076
+
+This skill was extracted from implementing issue #3076 (`[Cleanup] Clean up Python interop
+blocker NOTEs`) in the ProjectOdyssey repository.
+
+The `impl` skill was invoked, but investigation revealed:
+
+- The branch `3076-auto-impl` already existed with a recent commit
+  `af39dfda docs(training): add issue references to Track 4 Python interop NOTEs`
+- `git status` showed a clean working tree (only an untracked prompt file)
+- PR #3168 already existed, was open, labeled `cleanup`, with auto-merge enabled
+
+The correct response was to **report the existing state** rather than reimplementing.
+
+## Results & Parameters
+
+### Detecting Already-Done Work
+
+```bash
+# Run these checks in parallel at the start of any impl run
+git log --oneline -5 &
+git status &
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" &
+wait
+```
+
+### Reporting Template
+
+When an issue is already implemented:
+
+```
+Status: Already Done
+
+- Commit: <sha> <message>
+- PR: #<number> — <state>, auto-merge: <enabled/disabled>
+- Files changed: <list from git show --stat>
+
+No reimplementation needed.
+PR URL: <url>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Starting full reimplementation | Began searching for NOTE comments to update | Files were already updated in prior session; `git log` showed `af39dfda` already had the changes | Always check `git log` and `gh pr list` before implementing |
+| Grep for NOTE patterns | Ran `Grep` on `shared/training/` | No matches because prior session already removed/updated the NOTEs | Check branch state before running searches |


### PR DESCRIPTION
## Summary

Documents the pattern for detecting when an `impl` skill run finds that a GitHub issue
was already implemented in a prior session, saving time and avoiding duplicate work.

- Check `git log`, `git status`, and `gh pr list` before implementing
- If the latest commit references the issue and a PR exists, the work is done
- Report current state rather than reimplementing

## Key Findings

**What Worked**:
- Reading `git log --oneline -5` immediately reveals prior session commits
- `gh pr list --head <branch>` confirms PR existence in one command
- `gh pr view <number>` shows auto-merge state and labels

**What Failed**:
- Starting implementation (grep for NOTEs) before checking branch state
- Files showed no matches because prior session already updated them

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers correctly when branch has prior impl commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
