### PR TITLE
feat: add check-impl-before-starting skill

### DIFF
--- a/skills/tooling/check-impl-before-starting/.claude-plugin/plugin.json
+++ b/skills/tooling/check-impl-before-starting/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "check-impl-before-starting",
+  "version": "1.0.0",
+  "description": "Check if an issue's implementation already exists before starting work. Use when: (1) implementing a GitHub issue on a pre-existing branch, (2) resuming work that may have been partially done, (3) verifying PR status before creating a new one.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["github", "issue", "pr", "git", "workflow", "idempotency"]
+}

--- a/skills/tooling/check-impl-before-starting/references/notes.md
+++ b/skills/tooling/check-impl-before-starting/references/notes.md
@@ -1,0 +1,55 @@
+# Session Notes: check-impl-before-starting
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3080 [Cleanup] Review generator script TODOs
+- **Branch**: 3080-auto-impl
+- **Working directory**: /home/mvillmow/Odyssey2/.worktrees/issue-3080
+
+## What Happened
+
+The session was invoked to implement GitHub issue #3080, which required reviewing TODO comments
+in 4 generator scripts and marking template placeholders with `# TEMPLATE:` prefix.
+
+Upon reading the prompt file, the approach was to check the generator scripts for TODOs and
+process them. The key insight came from reading git log first:
+
+```
+e21e00b9 cleanup(generators): mark template placeholders with TEMPLATE: prefix
+```
+
+This commit had already done all the work. A Grep search confirmed all 31 TODOs had already
+been converted to `# TEMPLATE:` markers. A check of `gh pr list --head 3080-auto-impl` showed
+PR #3176 was already open with auto-merge enabled.
+
+## Time Saved
+
+By checking git log and PR status immediately, the session avoided:
+- Re-reading all 4 generator scripts
+- Re-planning the TODO classification
+- Making redundant edits
+- Creating a duplicate PR
+
+## Key Commands That Revealed Completed State
+
+```bash
+git log --oneline -5
+# → e21e00b9 cleanup(generators): mark template placeholders with TEMPLATE: prefix
+
+gh pr list --head 3080-auto-impl
+# → 3176  cleanup(generators): mark template placeholders...  OPEN
+
+gh pr view 3176
+# → auto-merge: enabled, Closes #3080
+```
+
+## Recommended Practice
+
+For any issue implementation on a pre-existing branch, run these 3 commands FIRST before
+reading files or planning implementation:
+
+1. `git log --oneline -10`
+2. `gh pr list --head $(git branch --show-current)`
+3. If PR exists: `gh pr view <number>`

--- a/skills/tooling/check-impl-before-starting/skills/check-impl-before-starting/SKILL.md
+++ b/skills/tooling/check-impl-before-starting/skills/check-impl-before-starting/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: check-impl-before-starting
+description: "Check if an issue's implementation already exists before starting work. Use when: implementing an issue on a pre-existing branch, resuming interrupted work, or verifying PR status before creating duplicates."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Name | check-impl-before-starting |
+| Category | tooling |
+| Trigger | Before implementing any GitHub issue |
+| Outcome | Avoids duplicate work; discovers existing commits and PRs |
+
+## When to Use
+
+- When assigned to implement a GitHub issue and the branch already exists
+- Before creating a new commit to check if the work is already done
+- Before creating a PR to check if one already exists
+- When resuming work after an interruption or session restart
+
+## Verified Workflow
+
+1. Check git log for recent commits on the current branch:
+
+   ```bash
+   git log --oneline -10
+   ```
+
+2. Check git status for any pending changes:
+
+   ```bash
+   git status
+   ```
+
+3. Check if a PR already exists for the current branch:
+
+   ```bash
+   gh pr list --head <branch-name>
+   ```
+
+4. If PR exists, view it to understand current state:
+
+   ```bash
+   gh pr view <pr-number>
+   ```
+
+5. If work is already done (commits exist + PR open), report status and skip implementation.
+
+6. If PR is missing but commits exist, create the PR:
+
+   ```bash
+   gh pr create --title "..." --body "Closes #<issue>"
+   ```
+
+7. If neither commits nor PR exist, proceed with implementation.
+
+## Results & Parameters
+
+**Key check commands** (run these first for any issue implementation):
+
+```bash
+# Step 1: What's on this branch already?
+git log --oneline -5
+
+# Step 2: Is there a PR?
+gh pr list --head $(git branch --show-current)
+
+# Step 3: What's the PR state?
+gh pr view <number>
+```
+
+**Decision matrix**:
+
+| Commits exist | PR exists | Action |
+|--------------|-----------|--------|
+| Yes | Yes | Report done, skip |
+| Yes | No | Create PR |
+| No | No | Implement from scratch |
+| No | Yes | Investigate — unusual state |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Jump straight to implementation | Started reading issue and planning without checking git log | Found PR #3176 was already open and commit `e21e00b9` had done all the work | Always check `git log --oneline -5` and `gh pr list --head <branch>` before any implementation work |
+| Assume clean state because git status is clean | Relied on `git status` showing clean working tree as signal that work hasn't started | Clean status just means nothing unstaged — prior commits can have done all the work | `git status` clean != implementation not started; check `git log` too |


### PR DESCRIPTION
## Summary

Documents the pattern of checking if an issue's implementation already exists before starting work, to avoid redundant effort.

- Captures the lesson: always check `git log` and `gh pr list` before assuming work hasn't started
- Clean `git status` does not mean no prior commits — always check the log
- Provides a 3-command preflight check that takes seconds and can save significant rework

## Key Findings

**What Worked**:
- Checking `git log --oneline -5` immediately reveals prior commits on the branch
- `gh pr list --head <branch>` quickly shows if a PR already exists
- Recognizing complete state early avoids unnecessary file reads and re-implementation

**What Failed**:
- Jumping straight to implementation without checking git log → found all work was already done in commit `e21e00b9`
- Relying on `git status` being clean as a signal that work hadn't started → misleading, only shows unstaged changes

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)