### PR TITLE
feat: add re-enable-disabled-mojo-tests skill

### DIFF
--- a/skills/testing/re-enable-disabled-mojo-tests/.claude-plugin/plugin.json
+++ b/skills/testing/re-enable-disabled-mojo-tests/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "re-enable-disabled-mojo-tests",
+  "version": "1.0.0",
+  "description": "Re-enable disabled/skipped Mojo test files by investigating root cause, verifying builtin types work, and replacing stubs with real tests. Use when: (1) a .mojo test file has a NOTE saying tests are disabled due to type system issues, (2) a test file is a stub that only prints SKIPPED, (3) cleanup issues ask to re-enable previously disabled tests.",
+  "category": "testing",
+  "date": "2026-03-05",
+  "tags": ["mojo", "testing", "re-enable", "disabled-tests", "unsigned-types", "cleanup"]
+}

--- a/skills/testing/re-enable-disabled-mojo-tests/references/notes.md
+++ b/skills/testing/re-enable-disabled-mojo-tests/references/notes.md
@@ -1,0 +1,65 @@
+# Session Notes: Re-enabling test_unsigned.mojo (Issue #3081)
+
+## Date
+2026-03-05
+
+## Repository
+HomericIntelligence/ProjectOdyssey
+
+## Issue
+#3081 - [Cleanup] Enable disabled test_unsigned.mojo tests
+
+## What Was Done
+
+The session was invoked to implement GitHub issue #3081. Upon investigation:
+
+1. Read the test file - it was a complete stub with NO test functions, just a main() printing "SKIPPED"
+2. Read issue comments - a prior planning session had already analyzed the situation
+3. Prior commit `b3de2062 fix(tests): re-enable unsigned integer type tests` had already implemented all test functions
+4. PR #3175 was already open with auto-merge enabled
+
+The session confirmed everything was already done from a prior run.
+
+## Root Cause Analysis
+
+The original disable note in the stub file said:
+> "NOTE: These tests are temporarily disabled due to type system issues."
+
+Investigation revealed:
+- `shared/core/types/unsigned.mojo` was NEVER created (it was referenced but abandoned)
+- The type system issues were with custom wrapper structs, NOT with Mojo's built-in UInt types
+- Mojo's built-in `UInt8`, `UInt16`, `UInt32`, `UInt64` work perfectly fine
+- Other files (`mxfp4.mojo`, `nvfp4.mojo`) already use these builtins extensively
+
+## Fix Applied
+
+Replaced the stub with 18 comprehensive test functions covering:
+- Construction from literals and boundary values
+- Arithmetic operations (+, -, *, //, %)
+- Bitwise operations (&, |, ^, <<, >>)
+- Comparison operators (==, !=, <, <=, >, >=)
+- Widening conversions via .cast[DType.uintN]()
+- Int to/from unsigned type conversions
+- Large value UInt64 operations
+- Near-boundary arithmetic
+
+## PR
+#3175 - https://github.com/HomericIntelligence/ProjectOdyssey/pull/3175
+
+## Commands Used
+
+```bash
+gh issue view 3081 --comments
+git log --oneline -5
+git status
+gh pr list --head 3081-auto-impl
+gh pr view 3175
+```
+
+## Key Insight
+
+When a test file has "temporarily disabled due to type system issues" and the referenced module
+was NEVER CREATED, the fix is:
+1. Test the builtins directly (don't create the custom module)
+2. Write all test functions from scratch (there's nothing to "re-enable")
+3. Document in PR why the custom module approach was abandoned

--- a/skills/testing/re-enable-disabled-mojo-tests/skills/re-enable-disabled-mojo-tests/SKILL.md
+++ b/skills/testing/re-enable-disabled-mojo-tests/skills/re-enable-disabled-mojo-tests/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: re-enable-disabled-mojo-tests
+description: "Re-enable disabled Mojo test files by investigating root cause and replacing stubs with real tests. Use when: a .mojo test file has a NOTE saying tests are disabled, a test file only prints SKIPPED, or cleanup issues ask to re-enable tests."
+category: testing
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | re-enable-disabled-mojo-tests |
+| **Category** | testing |
+| **Trigger** | Test file with disable NOTE or SKIPPED stub |
+| **Outcome** | Full test suite replacing the stub |
+
+## When to Use
+
+- A `.mojo` test file contains `NOTE: These tests are temporarily disabled`
+- The test file only has a `main()` that prints "SKIPPED" with no actual test functions
+- A GitHub cleanup issue asks to re-enable or investigate disabled tests
+- You need to verify whether a Mojo type system issue from an older version is now resolved
+
+## Verified Workflow
+
+1. **Read the disabled test file** - Check whether it has real test functions or is just a stub
+2. **Read the issue comments** with `gh issue view <N> --comments` - Prior planning may already be done
+3. **Search for what the tests were supposed to test** - Check if referenced modules exist:
+   ```bash
+   # Look for the module referenced in the disable note
+   find . -name "*.mojo" | xargs grep -l "UInt8\|uint8" 2>/dev/null
+   ```
+4. **Check if builtins work** - If the original issue was with custom wrapper structs that shadow builtins, verify the builtins are used in other working files:
+   ```bash
+   grep -r "UInt8\|UInt16\|UInt32\|UInt64" shared/core/ --include="*.mojo" -l
+   ```
+5. **Determine correct target** - If the custom module was never created, test the Mojo builtins directly
+6. **Write test functions** using the pattern from other test files in the same directory:
+   - Plain `fn test_*() raises:` functions
+   - `if condition: raise Error("message")` assertions (no testing framework import needed)
+   - `fn main()` that calls each test in a try/except block and prints OK/FAIL
+7. **Test coverage for unsigned integer types** - Include:
+   - Construction from literals and boundary values (0, max for each type)
+   - Arithmetic: `+`, `-`, `*`, `//`, `%`
+   - Bitwise: `&`, `|`, `^`, `<<`, `>>`
+   - Comparisons: `==`, `!=`, `<`, `<=`, `>`, `>=`
+   - Widening conversions via `.cast[DType.uintN]()`
+   - Conversions to/from `Int`
+   - Large value operations (especially for UInt64)
+   - Near-boundary arithmetic
+8. **Verify with mojo build** before committing:
+   ```bash
+   pixi run mojo build tests/shared/core/test_unsigned.mojo
+   ```
+9. **Run pre-commit** and commit:
+   ```bash
+   just pre-commit-all
+   git add tests/shared/core/test_unsigned.mojo
+   git commit -m "fix(tests): re-enable unsigned integer type tests"
+   ```
+
+## Key Findings
+
+### The "disabled" test file may be an empty stub
+
+When investigating issue #3081, the test file `test_unsigned.mojo` was not just "disabled" - it
+had NO test functions at all. The entire file was a stub that only printed SKIPPED. The fix was
+to write all test functions from scratch, not to remove a skip guard.
+
+### Custom wrapper structs vs builtins
+
+The original disable note said "type system issues with unsigned integer types." Investigation
+revealed the issue was with custom wrapper structs (`shared/core/types/unsigned.mojo`) that
+were NEVER created. Mojo's built-in `UInt8`, `UInt16`, `UInt32`, `UInt64` types work fine.
+The correct fix was to test the builtins directly.
+
+### Conversion syntax for Mojo builtins
+
+Widening conversions between unsigned types use `.cast[]()` not implicit casting:
+```mojo
+var u8: UInt8 = 200
+var u16: UInt16 = u8.cast[DType.uint16]()  # Correct
+# var u16: UInt16 = u8  # May or may not work depending on Mojo version
+```
+
+Conversion to `Int` works via constructor:
+```mojo
+var i = Int(u8)  # Correct
+```
+
+Conversion FROM `Int` to unsigned types works via implicit assignment:
+```mojo
+var i: Int = 42
+var u8: UInt8 = i  # Works in current Mojo
+```
+
+### Mojo format GLIBC issue in dev environment
+
+Pre-commit hook `mojo format` fails locally due to GLIBC incompatibility in the dev environment.
+This is pre-existing and expected - CI runs in Docker where it passes. Document this in PR body
+so reviewers understand the hook failure is environmental, not a code issue.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assuming tests existed but were "disabled" | Expected to find a skip guard or `@disabled` annotation to remove | The file had zero test functions - it was a complete stub | Always `Read` the actual file before assuming its structure from the issue description |
+| Looking for `shared/core/types/unsigned.mojo` | Searched for the custom wrapper module the disable note referenced | File never existed - was abandoned before being created | When a module is referenced in a note but doesn't exist, test the builtins instead |
+| Using `List[Int](1, 2, 3)` constructor syntax | Tried older Mojo list construction pattern | Mojo v0.26.1+ uses list literals `[1, 2, 3]` | Compiler is truth - use `mojo build` to verify syntax |
+
+## Results & Parameters
+
+### Test file structure (copy-paste template)
+
+```mojo
+"""Tests for Mojo's built-in unsigned integer types (UInt8, UInt16, UInt32, UInt64).
+
+These tests verify the behavior of Mojo's native unsigned integer builtins,
+including arithmetic, bitwise operations, comparisons, boundary values,
+and conversions.
+"""
+
+
+fn test_uint8_construction() raises:
+    """Test UInt8 construction from literals and zero value."""
+    var zero: UInt8 = 0
+    var one: UInt8 = 1
+    var max_val: UInt8 = 255
+
+    if zero != 0:
+        raise Error("UInt8 zero construction failed")
+    if one != 1:
+        raise Error("UInt8 one construction failed")
+    if max_val != 255:
+        raise Error("UInt8 max value construction failed")
+
+
+fn main():
+    """Main test runner."""
+    try:
+        test_uint8_construction()
+        print("OK test_uint8_construction")
+    except e:
+        print("FAIL test_uint8_construction:", e)
+
+    print("\n=== Tests Complete ===")
+```
+
+### PR description template for mojo format GLIBC issue
+
+```markdown
+## Verification
+
+- Pre-commit hooks pass (trailing whitespace, end-of-file, YAML, markdown, Python linting)
+- Mojo format hook fails for all files on this system due to GLIBC incompatibility -
+  this is a pre-existing environment issue, CI runs in Docker where it passes
+
+Closes #<issue-number>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for re-enabling disabled Mojo test files, specifically when the original
disable reason was with abandoned custom wrapper structs rather than Mojo builtins.

- Skill captures investigation steps for "test disabled" issues in Mojo projects
- Documents the pattern of testing builtins directly when custom module was never created
- Includes copy-paste test file template and PR description template

## Key Findings

**What Worked**:
- Reading the actual test file first (not assuming structure from issue description)
- Checking if referenced custom module exists before implementing alternatives
- Testing Mojo builtins directly (`UInt8`, `UInt16`, etc.) when wrapper structs were abandoned
- Using `.cast[DType.uintN]()` for widening conversions between unsigned types

**What Failed**:
- Assuming "disabled tests" means there are skip guards to remove (file was a complete stub)
- Looking for `shared/core/types/unsigned.mojo` that was referenced but never created
- Assuming older Mojo list constructor syntax `List[Int](1, 2, 3)` still works

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
