### PR TITLE
feat: add mojo-docstring-format-precommit skill

### DIFF
--- a/skills/testing/mojo-docstring-format-precommit/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-docstring-format-precommit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-docstring-format-precommit",
+  "version": "1.0.0",
+  "description": "Fix Mojo docstring formatting to pass mojo format pre-commit hook. Use when: (1) pre-commit CI fails with mojo format diff showing single-line docstrings being split, (2) long single-line docstrings exceed mojo format line length threshold, (3) adding docstrings to Mojo functions that will be reformatted by mojo format.",
+  "category": "testing",
+  "date": "2026-03-05",
+  "tags": ["mojo", "docstring", "pre-commit", "formatting", "ci"]
+}

--- a/skills/testing/mojo-docstring-format-precommit/references/notes.md
+++ b/skills/testing/mojo-docstring-format-precommit/references/notes.md
@@ -1,0 +1,56 @@
+# Session Notes: mojo-docstring-format-precommit
+
+## Session Context
+
+- **Issue**: #3082 — Re-enable disabled test_validation_loop.mojo tests
+- **Branch**: `3082-auto-impl`
+- **PR**: #3177
+- **Date**: 2026-03-05
+
+## What Was Done
+
+The validation loop test file had been previously disabled with a stub `main()` that just
+printed "SKIPPED". A prior session had already re-enabled it with full tests. This session
+was invoked to check status and found:
+
+1. The implementation was already complete (commit `2fdffa2b`)
+2. PR #3177 was open with auto-merge enabled
+3. Only the `pre-commit` CI job was failing
+
+## Pre-commit Failure Analysis
+
+Read the CI log via `gh run view 22726745112 --log-failed` and found three diffs:
+
+```
+@@ -51,7 +51,8 @@ fn simple_loss(...)
+-    """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10."""
++    """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10.
++    """
+
+@@ -99,7 +100,8 @@ fn test_validation_step_returns_float()
+-    """Test validation_step completes without error (forward-only, no backward)."""
++    """Test validation_step completes without error (forward-only, no backward).
++    """
+
+@@ -160,7 +162,8 @@ fn test_validation_loop_run_updates_metrics()
+-    """Test run_subset(max_batches=2) with 5-batch loader processes only 2 batches."""
++    """Test run_subset(max_batches=2) with 5-batch loader processes only 2 batches.
++    """
+```
+
+All three were single-line docstrings that `mojo format` wanted to split because they
+exceeded the line length threshold.
+
+## Fix Applied
+
+Used Edit tool to change each of the three docstrings to the multi-line form that
+`mojo format` produces. Committed as `a1672725`.
+
+## Notable Observation
+
+The worktree file path is distinct from the main repo path:
+- Main repo: `/home/mvillmow/Odyssey2/tests/shared/training/test_validation_loop.mojo`
+- Worktree: `/home/mvillmow/Odyssey2/.worktrees/issue-3082/tests/shared/training/test_validation_loop.mojo`
+
+Reading the main repo path and trying to Write the worktree path caused a "File has not
+been read yet" error. Must read the exact path being written.

--- a/skills/testing/mojo-docstring-format-precommit/skills/mojo-docstring-format-precommit/SKILL.md
+++ b/skills/testing/mojo-docstring-format-precommit/skills/mojo-docstring-format-precommit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: mojo-docstring-format-precommit
+description: "Fix Mojo docstring formatting to pass mojo format pre-commit hook. Use when: single-line docstrings trigger mojo format CI failures."
+category: testing
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `mojo format` reformats long single-line docstrings by splitting the closing `"""` to its own line |
+| **Symptom** | Pre-commit CI fails with diff showing `"""..."""` changed to multiline form |
+| **Root Cause** | `mojo format` enforces a line length limit; single-line docstrings exceeding it are split |
+| **Fix** | Pre-emptively write the closing `"""` on its own line for any long docstring |
+
+## When to Use
+
+- Pre-commit CI fails with a `mojo format` diff that converts single-line docstrings to two-line form
+- Writing new Mojo docstrings longer than ~80 characters
+- Reviewing Mojo test files before committing to catch docstring length issues early
+
+## Verified Workflow
+
+1. **Identify the failures** by reading the CI log diff:
+   ```
+   -    """Long single-line docstring that exceeds limit."""
+   +    """Long single-line docstring that exceeds limit.
+   +    """
+   ```
+
+2. **Apply the fix** — move the closing `"""` to its own line for any affected docstring:
+   ```mojo
+   # Before (causes mojo format to reformat)
+   fn my_func() raises:
+       """This is a long docstring that exceeds the mojo format line length threshold."""
+
+   # After (matches what mojo format produces)
+   fn my_func() raises:
+       """This is a long docstring that exceeds the mojo format line length threshold.
+       """
+   ```
+
+3. **Use Edit tool** with exact old_string/new_string matching (one fix per Edit call):
+   ```
+   old_string: '    """Long description."""'
+   new_string:  '    """Long description.\n    """'
+   ```
+
+4. **Commit and push** — CI re-runs and passes.
+
+## Threshold
+
+`mojo format` splits single-line docstrings when they exceed approximately **80–90 characters** including the indentation and triple-quote markers. In practice, any docstring over ~70 characters of content is at risk.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Write file directly without re-reading worktree file | Called `Write` tool on worktree file after reading main repo copy | Write tool requires reading the exact file path before writing; worktree files are separate from main repo files | Always read the worktree path (`/.worktrees/<branch>/`) not the main repo path before editing |
+| Skip pre-commit CI check | Assumed all checks passed since main Comprehensive Tests all succeeded | `pre-commit` is a separate workflow job; it can fail independently | Always check all workflow jobs, not just the main test suite |
+
+## Results & Parameters
+
+**Exact diff from CI failure:**
+```diff
+-    """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10."""
++    """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10.
++    """
+```
+
+**Three docstrings fixed in one session** — all were helper/test function docstrings that described parameters in the single line.
+
+**Pattern**: `fn <name>(<params>) raises -> <type>:` with a descriptive docstring tends to be the longest since the parameters are often restated.


### PR DESCRIPTION
## Summary

Documents the `mojo format` docstring reformatting behavior that causes pre-commit CI failures
when single-line docstrings exceed the line length threshold.

- `mojo format` splits long single-line docstrings by moving the closing `"""` to its own line
- Pre-emptively writing the multi-line form avoids the CI failure
- Worktree file paths must be read before editing (distinct from main repo paths)

## Key Findings

**What Worked**:
- Reading CI failure logs via `gh run view <run-id> --log-failed` to find exact diffs
- Using Edit tool with exact old/new strings to fix each docstring individually
- Committing the fix and rebasing on top of remote changes before pushing

**What Failed**:
- Reading main repo path then trying to Write to worktree path — "File has not been read yet" error
- Assuming all CI passed because Comprehensive Tests succeeded — pre-commit is a separate job

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with mojo formatting triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
