### PR TITLE
feat: add fix-mojo-format-line-length skill

### DIFF
--- a/skills/ci-cd/fix-mojo-format-line-length/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-mojo-format-line-length/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-mojo-format-line-length",
+  "version": "1.0.0",
+  "description": "Fix mojo format CI failures caused by print() strings exceeding 88-char line limit when mojo cannot run locally. Use when: (1) pre-commit mojo-format hook fails in CI reformatting print() calls, (2) mojo binary is unavailable locally due to GLIBC incompatibility, (3) need to manually apply mojo format line-wrapping rules to print statements.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["mojo", "mojo-format", "pre-commit", "line-length", "print", "glibc"]
+}

--- a/skills/ci-cd/fix-mojo-format-line-length/references/notes.md
+++ b/skills/ci-cd/fix-mojo-format-line-length/references/notes.md
@@ -1,0 +1,69 @@
+# Session Notes: Fix Mojo Format Line Length
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Project**: ProjectOdyssey (HomericIntelligence/ProjectOdyssey)
+- **Issue**: #3084 — [Cleanup] Track backward pass implementation NOTEs in examples
+- **PR**: #3189
+
+## Objective
+
+Issue #3084 required clarifying backward pass `NOTE` comments in three example training
+scripts (resnet18, googlenet, mobilenetv1) by replacing runtime `print("NOTE: ...")` with
+clearer `print("STATUS: ...")` messages. The implementation was already committed in a prior
+session. This session focused on fixing CI failures on PR #3189.
+
+## CI Failures Encountered
+
+### 1. pre-commit / mojo-format
+
+**Symptom**: CI pre-commit hook reformatted 3 files:
+- `examples/googlenet-cifar10/train.mojo`
+- `examples/mobilenetv1-cifar10/train.mojo`
+- `examples/resnet18-cifar10/train.mojo`
+
+**Root cause**: The STATUS print strings exceeded 88 characters (mojo format line limit):
+
+```
+print("STATUS: Backward pass shown above is a documented placeholder (~3500 lines for full impl).")
+# ^ 100 chars — too long
+```
+
+**Fix applied**: Manually edit files to match exactly what `mojo format` would produce
+(extracted from CI log via `gh run view <run-id> --log-failed`).
+
+### 2. link-check
+
+**Symptom**: lychee link checker failed.
+
+**Root cause**: Pre-existing failure on `main` branch (confirmed via `gh run list --branch main
+--workflow "Check Markdown Links"` — all recent runs show `conclusion: failure`). Not caused
+by this PR. A separate commit `3a5c1dad fix(ci): exclude root-relative links from lychee link
+check` was already present on the remote branch addressing this.
+
+## Why Mojo Cannot Run Locally
+
+The dev host runs Debian Buster (glibc 2.31). Mojo requires GLIBC_2.32, GLIBC_2.33,
+GLIBC_2.34. Running `pixi run mojo format` produces:
+
+```
+/path/to/mojo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
+```
+
+This affects: `mojo format`, `mojo build`, `mojo test`, `just pre-commit-all`.
+
+## Workflow That Worked
+
+1. `gh run view <run-id> --log-failed` → extract exact diff from "All changes made by hooks"
+2. `Edit` tool → apply each diff hunk manually
+3. `git add` specific files → `git commit` → `git pull --rebase` → `git push`
+
+Note: Remote branch had diverged (another session had pushed `14a9de24`), so `git pull --rebase`
+was needed before push succeeded.
+
+## Key Numbers
+
+- Mojo format line limit: **88 characters**
+- Files modified in this session: 3
+- Commits added: 1 (`1be9b841 fix(examples): apply mojo format to backward pass STATUS prints`)

--- a/skills/ci-cd/fix-mojo-format-line-length/skills/fix-mojo-format-line-length/SKILL.md
+++ b/skills/ci-cd/fix-mojo-format-line-length/skills/fix-mojo-format-line-length/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: fix-mojo-format-line-length
+description: "Fix mojo format CI failures caused by print() strings exceeding 88-char line limit when mojo cannot run locally. Use when: pre-commit mojo-format hook fails in CI reformatting print() calls, mojo binary unavailable due to GLIBC incompatibility."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Fix Mojo Format Line Length Skill
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Fix pre-commit `mojo-format` CI failures when mojo cannot run locally due to GLIBC version incompatibility |
+| Outcome | Success — manually applied formatter changes match CI diff exactly |
+| Project | ProjectOdyssey (Mojo ML framework) |
+
+## When to Use
+
+- `pre-commit` CI check fails with `mojo-format` hook reformatting files
+- `mojo` binary unavailable locally (GLIBC version mismatch: requires GLIBC_2.32/2.33/2.34)
+- `print()` statements with string literals exceed 88-character line limit
+- CI diff shows formatter splitting long `print("...")` into multi-line `print(\n    "..."\n    "..."\n)`
+
+## Verified Workflow
+
+1. **Get the exact CI diff** from the failed pre-commit run:
+
+   ```bash
+   gh run view <run-id> --log-failed 2>&1 | grep -A 50 "All changes made by hooks"
+   ```
+
+2. **Identify reformatted lines** — mojo format splits long print strings at ~88 chars using
+   implicit string concatenation:
+
+   ```mojo
+   # Before (>88 chars — fails mojo format):
+   print("STATUS: Backward pass is a documented placeholder (full implementation tracked in GitHub issue #3181)")
+
+   # After (mojo format output):
+   print(
+       "STATUS: Backward pass is a documented placeholder (full"
+       " implementation tracked in GitHub issue #3181)"
+   )
+   ```
+
+3. **Apply changes manually using Edit tool** — match the CI diff exactly:
+   - Wrap `print("...")` → `print(\n    "part1"\n    " part2"\n)`
+   - Note the leading space on continuation strings (mojo formatter convention)
+   - Indentation matches surrounding code (4 spaces for top-level fn body)
+
+4. **Commit and push** the formatting fix
+
+5. **Verify CI re-runs** cleanly:
+
+   ```bash
+   gh pr checks <pr-number>
+   ```
+
+## Mojo Format Line-Wrapping Rules
+
+| Rule | Detail |
+|------|--------|
+| Line limit | 88 characters |
+| String splitting | Implicit concatenation with leading space on continuation |
+| Wrap style | `print(\n    "first part"\n    " continuation"\n)` |
+| Long args | Same rule applies to any function call argument, not just print |
+| Indentation | Continuation strings indented 4 extra spaces from `print(` call |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run `pixi run mojo format` locally | Execute mojo formatter to auto-fix files | GLIBC_2.32/2.33/2.34 not found on host OS (Debian Buster, glibc 2.31) | Mojo requires newer GLIBC than some CI/dev hosts have |
+| Run `just pre-commit-all` locally | Apply all pre-commit hooks including mojo-format | Same GLIBC incompatibility blocks mojo binary | Pre-commit hooks using mojo also fail on incompatible hosts |
+| Skip and rely on CI to auto-fix | Let CI apply the format and commit back | CI does not commit back — it just fails | Must apply formatting fixes manually when mojo unavailable |
+
+## Results & Parameters
+
+**Key insight**: The CI pre-commit failure log includes the complete diff of what `mojo format`
+would apply. Extract it with:
+
+```bash
+gh run view <run-id> --log-failed 2>&1 | grep -A 100 "All changes made by hooks:"
+```
+
+This gives you the exact changes to make manually via `Edit` tool.
+
+**GLIBC check** — verify if mojo can run locally before attempting:
+
+```bash
+pixi run mojo --version 2>&1 | grep -i glibc
+# If you see "version GLIBC_2.3x not found" — use manual Edit approach
+```
+
+**Mojo format column limit**: 88 characters (not 79 like Black, not 120 like some configs).
+Strings are split using implicit concatenation (adjacent string literals):
+
+```mojo
+print(
+    "First 88 chars or less"
+    " rest of string starting with a space"
+)
+```


### PR DESCRIPTION
## Summary

Documents how to fix `mojo-format` pre-commit CI failures when the mojo binary is
unavailable locally due to GLIBC version incompatibility.

- Mojo format enforces an 88-char line limit; long `print()` strings get wrapped using implicit string concatenation
- The CI log from `gh run view --log-failed` contains the exact formatter diff — apply it manually with the Edit tool
- Mojo requires GLIBC_2.32/2.33/2.34 and fails on Debian Buster (glibc 2.31)

## Key Findings

**What Worked**:
- Extracting the exact formatter diff from `gh run view <run-id> --log-failed` under "All changes made by hooks"
- Applying each diff hunk manually via the Edit tool to match CI exactly
- `git pull --rebase` when remote branch had diverged before pushing

**What Failed**:
- `pixi run mojo format` — GLIBC_2.32 not found on host
- `just pre-commit-all` — same GLIBC incompatibility blocks mojo
- Relying on CI to auto-commit fixes — CI fails but does not push back

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation triggers on mojo-format CI failure scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
