### PR TITLE
feat: add impl-already-committed-and-pr-open skill

### DIFF
--- a/skills/documentation/impl-already-committed-and-pr-open/.claude-plugin/plugin.json
+++ b/skills/documentation/impl-already-committed-and-pr-open/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "impl-already-committed-and-pr-open",
+  "version": "1.0.0",
+  "description": "Detect and handle auto-impl worktrees where all work is already committed and a PR is already open. Use when: (1) branch is named <number>-auto-impl, (2) git status is clean with no staged changes, (3) recent git log shows a commit matching the issue title.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["auto-impl", "pre-committed", "idempotent", "worktree", "pr"]
+}

--- a/skills/documentation/impl-already-committed-and-pr-open/references/notes.md
+++ b/skills/documentation/impl-already-committed-and-pr-open/references/notes.md
@@ -1,0 +1,36 @@
+# Session Notes: impl-already-committed-and-pr-open
+
+## Raw Session Details
+
+**Date**: 2026-03-05
+**Repo**: HomericIntelligence/ProjectOdyssey
+**Issue**: #3087 — [Cleanup] Track image loading external dependency
+**Branch**: 3087-auto-impl
+**Worktree**: /home/mvillmow/Odyssey2/.worktrees/issue-3087
+
+## Sequence of Events
+
+1. Received `.claude-prompt-3087.md` asking to "Implement GitHub issue #3087"
+2. Read the prompt: documentation-only cleanup task — add structured NOTE to run_infer.mojo and Image Loading section to README.md
+3. Read `gh issue view 3087 --comments` to get the implementation plan
+4. Read `run_infer.mojo` around line 340 — found the full structured NOTE already present (lines 340-346)
+5. Read `README.md` — found the full "Image Loading Limitations" section already present (lines 253-277)
+6. Ran `git log --oneline -5` — top commit was `f320de3d docs(lenet-emnist): document image loading limitation...`
+7. Ran `git status` — clean, only untracked `.claude-prompt-3087.md`
+8. Ran `gh pr list --head 3087-auto-impl` — found PR #3193 already open
+9. Ran `gh pr view 3193` — confirmed auto-merge enabled, Closes #3087, cleanup label
+10. Reported status to user — no further action needed
+
+## Why This Matters
+
+Auto-impl worktrees are created by automation. In many cases the automation:
+- Creates the worktree AND the branch AND makes the initial commit in a single pipeline run
+- The Claude session in the worktree is a "verify and create PR" step, not a "from scratch" implementation
+
+When the automation runs end-to-end without interruption, the PR already exists by the time Claude opens the session.
+
+## Related Skill
+
+`quality-audit-issue-already-fixed` (documentation) covers the case where the issue is CLOSED and
+the fix landed in main. This skill covers the complementary case where the fix is committed on a
+feature branch with an open PR.

--- a/skills/documentation/impl-already-committed-and-pr-open/skills/impl-already-committed-and-pr-open/SKILL.md
+++ b/skills/documentation/impl-already-committed-and-pr-open/skills/impl-already-committed-and-pr-open/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: impl-already-committed-and-pr-open
+description: "Detect and handle auto-impl worktrees where all changes are already committed and a PR is already open. Use when: branch is named <number>-auto-impl, git status is clean, and git log HEAD shows a commit matching the issue title."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+# impl-already-committed-and-pr-open
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-05 |
+| Category | documentation |
+| Objective | Recognize that an auto-impl session has nothing left to do because work was pre-committed |
+| Outcome | SUCCESS — read files, confirmed both target files already had changes, found existing open PR, reported state |
+| Issue | #3087 ([Cleanup] Track image loading external dependency) |
+
+## When to Use
+
+Trigger this skill when ALL of the following are true:
+
+- You are in a worktree branch named `<number>-auto-impl`
+- `git status` shows clean working tree (only untracked `.claude-prompt-*.md`)
+- `git log --oneline -1` shows a commit message matching the issue title
+- `gh pr list --head <branch>` returns an open PR
+
+**Do NOT use this skill** when:
+
+- `git status` shows staged or unstaged changes
+- The files referenced in the issue are missing the expected content
+- No PR exists yet
+
+## Verified Workflow
+
+### Step 1: Check git status immediately
+
+```bash
+git log --oneline -3
+git status
+```
+
+If the log already contains a commit matching the issue title and status is clean, the work is done.
+
+### Step 2: Read target files to confirm content is present
+
+```bash
+# Read the specific lines cited in the issue
+```
+
+Verify the expected changes are actually in the files. Do not trust the commit message alone.
+
+### Step 3: Check for an existing PR
+
+```bash
+gh pr list --head <branch-name>
+```
+
+If an open PR exists, it will include the PR number, title, and URL.
+
+### Step 4: Optionally verify PR details
+
+```bash
+gh pr view <pr-number>
+```
+
+Confirm `auto-merge` is enabled and the PR description includes `Closes #<number>`.
+
+### Step 5: Report and stop
+
+Report the PR URL to the user. Do **not**:
+
+- Create a duplicate commit
+- Push again (branch is already up to date with remote)
+- Create a second PR
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| (None in this session) | N/A | N/A | The verify-first pattern was followed correctly; no spurious actions taken |
+| Anticipated failure: re-committing | Staging `.claude-prompt-*.md` or re-editing target files to "have something to commit" | Creates noise commit with unrelated files or duplicate changes | Never commit prompt files; verify file content matches issue requirements before touching anything |
+| Anticipated failure: creating duplicate PR | Running `gh pr create` without first checking `gh pr list --head <branch>` | Creates a second open PR for the same branch, causing CI confusion | Always check for existing PRs before creating one |
+
+## Results & Parameters
+
+### Session Summary
+
+- **Issue**: #3087 — "[Cleanup] Track image loading external dependency"
+- **Branch**: `3087-auto-impl`
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3087`
+- **Files checked**: `examples/lenet-emnist/run_infer.mojo:340-346`, `examples/lenet-emnist/README.md:253-277`
+- **Finding**: Both files already contained the full structured NOTE comment and README section
+- **Confirming commit**: `f320de3d docs(lenet-emnist): document image loading limitation and Python interop workaround`
+- **PR found**: #3193 (OPEN, auto-merge enabled, `cleanup` label, `Closes #3087`)
+- **Action taken**: None (correct)
+
+### Key Decision Points
+
+1. **Read files before assuming work is needed.** The `.claude-prompt-*.md` file says "implement" but the branch may already be fully implemented.
+2. **Check `gh pr list --head <branch>` before `gh pr create`.** A previous session may have already created the PR.
+3. **`git status` clean + matching commit = done.** No need to look further unless file content verification fails.
+
+### Diagnostic Commands
+
+```bash
+# Check commit history
+git log --oneline -5
+
+# Check working tree state
+git status
+
+# Verify target file content
+# (use Read tool with line range from issue)
+
+# Check for existing PR
+gh pr list --head "$(git branch --show-current)"
+
+# View PR details
+gh pr view <number>
+```


### PR DESCRIPTION
## Summary

Documents the pattern where an auto-impl worktree session finds all work already committed and a PR already open before any implementation action is taken.

- Covers the case where automation commits AND creates a PR in a single pipeline run
- Distinguishes from `quality-audit-issue-already-fixed` (fix in main) — this is fix on feature branch with open PR
- Provides diagnostic commands to quickly detect and report this state

## Key Findings

**What Worked**:
- Check `git log --oneline -1` first — a matching commit at HEAD means work is done
- Verify actual file content (don't trust commit message alone)
- Run `gh pr list --head <branch>` before any `gh pr create` to avoid duplicates

**What Failed**:
- N/A — verify-first pattern was followed correctly from the start
- Anticipated pitfalls documented: re-committing unrelated files, creating duplicate PRs

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with auto-impl worktree triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
