### PR TITLE
feat: add auto-impl-partial-completion-check skill

### DIFF
--- a/skills/documentation/auto-impl-partial-completion-check/.claude-plugin/plugin.json
+++ b/skills/documentation/auto-impl-partial-completion-check/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "auto-impl-partial-completion-check",
+  "version": "1.0.0",
+  "description": "Verify auto-impl issue completion when commit and PR already exist. Use when: (1) worktree branch is named <number>-auto-impl and git log shows a prior commit closing the issue, (2) an open PR already exists for the branch, (3) need to check whether implementation plan was fully executed vs partially done.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["auto-impl", "issue-verification", "pr-workflow", "completion-check"]
+}

--- a/skills/documentation/auto-impl-partial-completion-check/references/notes.md
+++ b/skills/documentation/auto-impl-partial-completion-check/references/notes.md
@@ -1,0 +1,49 @@
+# Session Notes — Issue #3089
+
+## Raw Session Details
+
+**Date**: 2026-03-05
+**Repository**: HomericIntelligence/ProjectOdyssey
+**Worktree**: /home/mvillmow/Odyssey2/.worktrees/issue-3089
+**Branch**: 3089-auto-impl
+
+## What Happened
+
+1. Received `.claude-prompt-3089.md` auto-impl prompt asking to implement issue #3089
+2. Read the prompt — issue was about documenting Float16 precision limitations in 3 test files
+3. Read `gh issue view 3089 --comments` — found a detailed implementation plan in comments
+4. The plan listed 4 files to modify: 3 test files + docs/dev/testing-strategy.md
+5. Read each test file header — all 3 already had `Float16 Precision Limitations` sections
+6. Checked `git log --oneline -5` — saw commit `ad271e9c` with "Closes #3089"
+7. Checked `gh pr list --head 3089-auto-impl` — found PR #3200 already open
+8. Read testing-strategy.md to check for missing Float16 subsection — not present
+9. Compared missing item against issue Success Criteria — not required
+10. Concluded: PR is complete and ready for review
+
+## Files Examined
+
+- `/home/mvillmow/Odyssey2/.worktrees/issue-3089/.claude-prompt-3089.md`
+- `tests/models/test_alexnet_layers.mojo` (lines 1-46, 1090-1148)
+- `tests/models/test_lenet5_fc_layers.mojo` (lines 1-20, 180-199)
+- `tests/shared/core/test_gradient_checking.mojo` (lines 1-25, 425-472)
+- `docs/dev/testing-strategy.md` (searched for Float16 sections)
+
+## Key Insight
+
+The issue prompt said "Implement GitHub issue #3089" without indicating the work was already done.
+The only way to discover the work was complete was to:
+1. Read the actual files cited in the issue
+2. Check git log for a closing commit
+3. Check for an existing PR
+
+This is distinct from `quality-audit-issue-already-fixed` which handles cases where the fix
+was done in a completely separate prior session and the issue was already CLOSED.
+In this case:
+- The issue was still OPEN
+- The PR was open (not merged yet)
+- The commit existed on the current branch
+- Some plan items were absent but not required by Success Criteria
+
+## Outcome
+
+No additional changes were made. PR #3200 is complete and ready for review.

--- a/skills/documentation/auto-impl-partial-completion-check/skills/auto-impl-partial-completion-check/SKILL.md
+++ b/skills/documentation/auto-impl-partial-completion-check/skills/auto-impl-partial-completion-check/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: auto-impl-partial-completion-check
+description: "Verify auto-impl issue completion when commit and PR already exist. Use when: prior session committed work and created a PR, but implementation plan may have had additional items not captured in the commit."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+# Auto-Impl Partial Completion Check
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-05 |
+| Category | documentation |
+| Objective | Verify that a prior auto-impl session completed all required steps, and identify any gaps between the implementation plan and actual commits |
+| Outcome | SUCCESS — confirmed 3/4 planned file changes were committed; identified 1 missing item (testing-strategy.md update); PR already open |
+| Issue | #3089 (document Float16 precision limitations in tests) |
+
+## When to Use
+
+Trigger this skill when:
+
+- The worktree branch is named `<number>-auto-impl`
+- `git log --oneline -5` shows a recent commit with "Closes #<number>"
+- `gh pr list --head <branch>` shows an open PR already exists
+- The issue has a detailed implementation plan (e.g., in issue comments) with multiple files to modify
+- Need to determine if all plan items were executed or if some were skipped
+
+**Do NOT use this skill** when:
+
+- No commit exists yet (issue has not been implemented at all)
+- The issue has no structured plan to compare against
+- The PR was already merged
+
+## Verified Workflow
+
+### Step 1: Orient — check git log and PR state
+
+```bash
+git log --oneline -5
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)"
+```
+
+If a commit with "Closes #N" exists AND an open PR exists, prior session did substantial work. Proceed to Step 2.
+
+### Step 2: Read the implementation plan from the issue
+
+```bash
+gh issue view <number> --comments
+```
+
+Extract the list of files to modify from the plan. Note each file and what change was planned.
+
+### Step 3: Verify each planned file
+
+For each file in the plan, read the relevant section to confirm the change was made:
+
+```bash
+# Read file header or changed section
+```
+
+Compare actual state against plan. Create a checklist:
+
+- [x] File A — change present
+- [x] File B — change present
+- [ ] File C — change MISSING
+
+### Step 4: For missing items, assess importance
+
+Ask: Is the missing item in the issue's **Success Criteria** (required) or only in the implementation plan's Notes section (optional)?
+
+- If in Success Criteria: implement the missing change
+- If only in plan notes: document the gap in a PR comment and proceed
+
+### Step 5: Handle the gap
+
+**Option A — Implement the missing change:**
+
+```bash
+# Make the edit
+# Run pre-commit
+cd /path/to/worktree && just pre-commit-all
+# Amend commit or create new commit
+git add <file>
+git commit -m "docs: add missing <description> from implementation plan
+
+Part of #<number>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push
+```
+
+**Option B — Document the gap:**
+
+```bash
+gh issue comment <number> --body "## Completion Review
+
+Implementation is mostly complete (commit <sha>). One item from the plan was not included:
+
+- docs/dev/testing-strategy.md Float16 subsection — this was in the plan notes but not in the issue Success Criteria. The core documentation objective (test file headers) is complete.
+
+PR #<pr-number> is ready for review."
+```
+
+### Step 6: Verify PR is linked correctly
+
+```bash
+gh pr view <pr-number> --json body -q '.body'
+```
+
+Confirm "Closes #<number>" appears in the PR body. If not, edit the PR:
+
+```bash
+gh pr edit <pr-number> --body "$(gh pr view <pr-number> --json body -q '.body')
+
+Closes #<number>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | No failed attempts in this session — pattern was followed correctly | N/A | The key risk is over-implementing: adding changes beyond what Success Criteria require, or re-implementing things already done |
+
+## Results & Parameters
+
+### Session Summary — Issue #3089
+
+- **Issue**: #3089 — "Document Float16 precision limitations in tests"
+- **Branch**: `3089-auto-impl`
+- **Prior commit**: `ad271e9c docs(tests): document Float16 precision limitations in test headers`
+- **Open PR**: #3200 (already created by prior session)
+- **Plan items**: 4 files (3 test files + 1 docs/dev file)
+- **Completed**: 3/4 — all 3 test file headers updated
+- **Missing**: `docs/dev/testing-strategy.md` Float16 subsection (in plan notes, NOT in Success Criteria)
+- **Action taken**: Verified existing state; determined PR was complete for the issue's stated Success Criteria
+
+### Key Decision Point
+
+The implementation plan (in issue comments) listed 4 files to modify. The commit only touched 3. However, reading the issue's **Success Criteria** section showed:
+
+```
+- [ ] All Float16 precision NOTEs reviewed
+- [ ] Limitations documented in test headers
+- [ ] Tests appropriately handle Float16 cases
+```
+
+None of the success criteria mentioned `testing-strategy.md`. The missing file was only in the plan's "nice to have" section. Therefore the PR was already complete for the issue's requirements.
+
+**Pattern**: Always compare missing items against Success Criteria, not just the plan notes.
+
+### Diagnostic Commands
+
+```bash
+# Check what was committed vs plan
+git show --stat HEAD
+
+# Verify file header was updated
+head -50 tests/models/test_alexnet_layers.mojo
+
+# Check PR state and body
+gh pr view <number> --json state,body,url
+
+# Check issue success criteria
+gh issue view <number> --json body -q '.body'
+```


### PR DESCRIPTION
## Summary

Documents the pattern for handling auto-impl worktrees where a prior session already committed work and created a PR, but the implementation plan listed more files than were actually changed.

- Verifies commit + PR existence before doing any file reads
- Compares missing plan items against issue Success Criteria (not implementation plan notes)
- Provides decision framework: implement missing items only if required by Success Criteria

## Key Findings

**What Worked**:
- Check `git log --oneline -5` and `gh pr list --head <branch>` immediately on session start
- Reading Success Criteria separately from the implementation plan notes to assess gaps
- Not making spurious commits when the PR already satisfies all stated requirements

**What Failed**:
- No failures in this session; the verify-first pattern avoided over-implementation

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with auto-impl worktree trigger conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
