### PR TITLE
feat: add verify-issue-already-implemented skill

### DIFF
--- a/skills/documentation/verify-issue-already-implemented/.claude-plugin/plugin.json
+++ b/skills/documentation/verify-issue-already-implemented/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-issue-already-implemented",
+  "version": "1.0.0",
+  "description": "Check whether a GitHub issue is already implemented before starting work. Use when: (1) handed an issue via .claude-prompt-NNNN.md with branch already checked out, (2) git log shows a recent commit matching the issue title, (3) an open PR already exists for the branch.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["github", "issue", "verification", "idempotency", "auto-impl", "pr", "worktree"]
+}

--- a/skills/documentation/verify-issue-already-implemented/references/notes.md
+++ b/skills/documentation/verify-issue-already-implemented/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: verify-issue-already-implemented
+
+## Session Context
+
+**Date**: 2026-03-05
+**Project**: ProjectOdyssey
+**Issue**: #3090 - [Cleanup] Document epsilon values in gradient checking
+**Branch**: 3090-auto-impl
+**Worktree**: /home/mvillmow/Odyssey2/.worktrees/issue-3090
+
+## What Happened
+
+The session was invoked via `.claude-prompt-3090.md` which instructed implementation of issue #3090.
+The issue required:
+
+1. Verify epsilon values are still appropriate
+2. Convert inline NOTEs to proper docstrings
+3. Reference #2704 in docstrings for context
+4. Consider adding constants for epsilon values
+
+### Discovery
+
+After reading the prompt file, `git log --oneline -5` immediately revealed:
+
+```
+47f87aba docs(testing): document epsilon values in gradient checking
+```
+
+This matched the issue title exactly. `git status` showed a clean tree. `gh pr list --head
+3090-auto-impl` returned PR #3201, already open.
+
+### Verification
+
+Grep confirmed all three issue-listed sites were already updated:
+
+- Line 613: `# Epsilon selection for float32: see GRADIENT_CHECK_EPSILON_FLOAT32 and issue #2704.`
+- Line 771: `# Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)`
+- Line 933: `# Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)`
+
+Named constants were added at module scope (lines 93-99):
+
+```mojo
+alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
+alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
+```
+
+### Conclusion
+
+No re-implementation was needed. Session terminated after reporting status.
+
+## The `document-magic-number-constants` Skill Connection
+
+The actual implementation work from this issue is documented in the existing
+`skills/documentation/document-magic-number-constants/` skill, which covers:
+
+- How to extract magic numbers into named constants
+- Mojo `alias` patterns with rationale comments
+- The epsilon selection analysis (1e-5 → 1e-4 → 3e-4 progression)
+
+This `verify-issue-already-implemented` skill is complementary — it covers the meta-workflow
+of detecting when a dispatched issue is already complete before starting duplicate work.

--- a/skills/documentation/verify-issue-already-implemented/skills/verify-issue-already-implemented/SKILL.md
+++ b/skills/documentation/verify-issue-already-implemented/skills/verify-issue-already-implemented/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: verify-issue-already-implemented
+description: "Check whether a GitHub issue is already implemented before starting work. Use when: (1) handed an issue via .claude-prompt-NNNN.md with branch already checked out, (2) git log shows a recent commit matching the issue title, (3) an open PR already exists for the branch."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+# Verify Issue Already Implemented
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-03-05 |
+| **Objective** | Confirm a GitHub issue is already done before re-doing the work |
+| **Outcome** | Detected that issue #3090 was fully implemented (commit `47f87aba`, PR #3201 open); no duplicate work performed |
+| **Related Issues** | ProjectOdyssey #3090, #2704 |
+
+## When to Use This Skill
+
+Use this skill immediately when:
+
+- You receive a `.claude-prompt-NNNN.md` prompt file telling you to implement an issue
+- The working branch name is `<N>-auto-impl` or similar, suggesting automated issue dispatch
+- The repo/worktree was pre-configured before you were invoked (branch already checked out)
+
+These are signs that the issue may have been dispatched to a fresh agent even though a previous
+agent already completed the work.
+
+**Triggers:**
+
+- `git log --oneline -5` shows a commit with a message that matches the issue title
+- `git status` shows a clean tree with no outstanding work
+- `gh pr list --head <branch>` returns an open PR number
+
+## Verified Workflow
+
+### Step 1: Read the Prompt File
+
+```bash
+cat .claude-prompt-<N>.md
+```
+
+Note the issue number, branch name, and expected deliverables.
+
+### Step 2: Check git log
+
+```bash
+git log --oneline -5
+```
+
+If the top commit message matches the issue title (e.g., "docs(testing): document epsilon values
+in gradient checking"), the implementation is already done.
+
+### Step 3: Check git status
+
+```bash
+git status
+```
+
+A clean tree (no staged/unstaged changes, only untracked `.claude-prompt-*.md`) confirms
+no pending work remains.
+
+### Step 4: Check for existing PR
+
+```bash
+gh pr list --head <branch-name>
+```
+
+If a PR is open and linked to the branch, the full workflow (implement → commit → push → PR)
+is already complete.
+
+### Step 5: Verify the implementation
+
+Quickly read the affected files to confirm the changes match the issue requirements:
+
+```bash
+# Read the specific lines mentioned in the issue
+grep -n "GRADIENT_CHECK_EPSILON\|epsilon=3e-4" shared/testing/layer_testers.mojo
+```
+
+Confirm the success criteria from the issue are met.
+
+### Step 6: Report and stop
+
+Report the findings to the user:
+
+- Which commit implemented the issue (hash + message)
+- Which PR is open (number + URL)
+- That all success criteria are met
+- No further action is needed
+
+Do NOT:
+
+- Re-implement anything already done
+- Create a second commit or PR
+- Modify files that are already correct
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Starting implementation immediately | Reading the prompt and jumping to implementation without checking git log | Would have created duplicate commits and a second PR | Always check `git log` and `gh pr list` before touching any files |
+| Assuming the branch is new | Treating a pre-checked-out branch as a fresh workspace | The branch `3090-auto-impl` already had a commit and open PR | A pre-configured worktree does not mean the work is pending |
+
+## Results & Parameters
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Detection signal | `git log --oneline -5` | Top commit message matches issue title |
+| Confirmation signal | `gh pr list --head <branch>` | Returns an open PR number |
+| False-positive risk | Low | Only skip if BOTH signals are positive and code matches requirements |
+| Time saved | ~5-10 minutes | Avoided re-implementing a 3-location documentation update |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3090, PR #3201 | Branch `3090-auto-impl`; commit `47f87aba` already done |


### PR DESCRIPTION
## Summary

Documents the workflow for detecting when a GitHub issue dispatched via
`.claude-prompt-NNNN.md` is already fully implemented before performing duplicate work.

- Defines clear detection signals: matching commit in git log + clean status + open PR
- Complementary to the existing `document-magic-number-constants` skill (the actual implementation)
- Derived from ProjectOdyssey issue #3090 where the work was already done when the agent was invoked

## Key Findings

**What Worked**:
- `git log --oneline -5` immediately reveals if the top commit matches the issue title
- `gh pr list --head <branch>` confirms the full workflow (commit + push + PR) is complete
- Reading the affected files with grep confirms the code matches the success criteria

**What Failed**:
- Starting implementation immediately without checking git log → would create duplicate commits and a second PR
- Assuming a pre-checked-out branch means work is pending → a pre-configured worktree does NOT mean the work is pending

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with trigger: "implement issue" + pre-configured branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
