### PR TITLE
feat: add detect-already-implemented-issue skill

### DIFF
--- a/skills/documentation/detect-already-implemented-issue/.claude-plugin/plugin.json
+++ b/skills/documentation/detect-already-implemented-issue/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "detect-already-implemented-issue",
+  "version": "1.0.0",
+  "description": "Detect when a GitHub issue was already implemented in a previous session and has an open PR. Use when: (1) implementing a GitHub issue, (2) session starts on a branch that already has commits for the issue, (3) a PR already exists for the issue.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["github", "pr", "idempotency", "issue-tracking", "session-resume"]
+}

--- a/skills/documentation/detect-already-implemented-issue/references/notes.md
+++ b/skills/documentation/detect-already-implemented-issue/references/notes.md
@@ -1,0 +1,46 @@
+# Session Notes: detect-already-implemented-issue
+
+## Session Date
+
+2026-03-05
+
+## Context
+
+Working in worktree `/home/mvillmow/Odyssey2/.worktrees/issue-3091` on branch `3091-auto-impl`.
+
+Task: Implement GitHub issue #3091 — [Cleanup] Document callback import limitations
+in `shared/training/__init__.mojo`.
+
+## What Happened
+
+1. Read the `.claude-prompt-3091.md` file to understand the task.
+2. Read `shared/training/__init__.mojo` to see the current state — the file appeared
+   to NOT have the Note section, since the worktree was checked out at the branch tip.
+3. Ran `gh pr view 3206` — found an open PR titled
+   "docs(training): document callback import limitation" with state OPEN and
+   auto-merge enabled, closing #3091.
+4. Ran `git log --oneline -5` — the very first commit was
+   `8c64d500 docs(training): document callback import limitation in __init__.mojo`.
+5. Ran `git diff HEAD~1 HEAD -- shared/training/__init__.mojo` to confirm what the
+   commit added: a 25-line `Note:` section in the module docstring documenting the
+   Mojo re-export limitation for callbacks.
+
+## Key Insight
+
+When a worktree is clean and the branch is named `<issue-number>-*`, check `git log`
+**before** reading source files. The file in the working tree reflects the current HEAD
+which already included the changes — but the diff confirmed the work was done.
+
+Also, checking `gh pr view <number>` directly (when you can guess the PR number from
+context or the issue history) is the fastest way to confirm prior work.
+
+## Files Changed in Prior Session
+
+- `shared/training/__init__.mojo`: Added `Note:` section to module docstring (25 lines)
+  documenting Mojo re-export limitation for callbacks.
+
+## Success Criteria Met
+
+- [x] Limitation documented in docstring
+- [x] Example imports provided (broken + correct patterns)
+- [x] PR #3206 open with auto-merge, closes #3091

--- a/skills/documentation/detect-already-implemented-issue/skills/detect-already-implemented-issue/SKILL.md
+++ b/skills/documentation/detect-already-implemented-issue/skills/detect-already-implemented-issue/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: detect-already-implemented-issue
+description: "Detect when a GitHub issue was already implemented in a previous session and has an open PR. Use when: implementing a GitHub issue, session starts on a branch with commits, or a PR already exists for the issue."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Avoid duplicate work by detecting pre-existing implementation before starting |
+| **Trigger** | Starting implementation of a GitHub issue |
+| **Outcome** | Either confirm PR exists and report status, or proceed with fresh implementation |
+| **Time saved** | Prevents re-implementing already-complete work |
+
+## When to Use
+
+- When `gh issue view <number> --comments` shows a previous session's work
+- When `git log --oneline` shows commits referencing the issue number
+- When `git status` is clean on a branch named `<issue-number>-*`
+- When starting any `impl` or `gh-implement-issue` workflow
+
+## Verified Workflow
+
+1. **Check git log for prior commits** referencing the issue:
+
+   ```bash
+   git log --oneline -10
+   ```
+
+   If the most recent commit message references the issue (e.g., `docs(training): document callback import limitation`), prior work exists.
+
+2. **Check for an open PR** linked to the issue:
+
+   ```bash
+   gh pr list --search "Closes #<issue-number>" --state open
+   # or directly:
+   gh pr view <pr-number>
+   ```
+
+3. **If PR exists and is open** with auto-merge enabled:
+   - Report the PR URL and status to the user
+   - Do NOT re-implement — the work is done
+   - Confirm auto-merge is enabled so it will merge when CI passes
+
+4. **If no PR exists** but commits are present:
+   - Review the commits with `git diff HEAD~N HEAD -- <file>` to understand what was done
+   - Create the PR if it is missing: `gh pr create --title "..." --body "Closes #<issue>"`
+
+5. **If nothing exists** (clean branch, no commits):
+   - Proceed with normal implementation workflow
+
+## Results & Parameters
+
+### Detection commands (copy-paste)
+
+```bash
+# Step 1: Check git log
+git log --oneline -5
+
+# Step 2: Check for open PR
+gh pr list --search "closes:#<ISSUE_NUMBER>" --state open
+
+# Step 3: If PR number is known
+gh pr view <PR_NUMBER>
+```
+
+### Output interpretation
+
+| Scenario | `git log` | `gh pr list` | Action |
+|----------|-----------|--------------|--------|
+| Already done | Recent commit for issue | Open PR found | Report PR URL, done |
+| Partial | Commits present | No PR | Create PR from existing commits |
+| Fresh start | No issue commits | No PR | Implement normally |
+
+### Example session (issue #3091)
+
+```
+git log --oneline -5
+# 8c64d500 docs(training): document callback import limitation in __init__.mojo
+
+gh pr view 3206
+# title: docs(training): document callback import limitation
+# state: OPEN
+# auto-merge: enabled
+```
+
+Result: Work was already complete from a prior session. PR #3206 open with auto-merge.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Reading file directly | Read `__init__.mojo` to see if Note was present | File on current branch didn't show the Note (it was on the PR branch) | Check `git log` first to see if a prior commit exists before reading files |
+| Assuming fresh start | Preparing to add documentation | Would have duplicated work already done | Always run `git log --oneline -5` at session start |


### PR DESCRIPTION
## Summary

Documents the pattern for detecting when a GitHub issue was already implemented
in a previous Claude Code session and has an open PR.

- Saves time by identifying pre-existing work before re-implementing
- Provides a 3-scenario decision table (done / partial / fresh start)
- Includes copy-paste detection commands and real session example

## Key Findings

**What Worked**:
- `git log --oneline -5` at session start reveals prior commits for the issue
- `gh pr view <number>` quickly confirms PR state and auto-merge status
- `git diff HEAD~1 HEAD -- <file>` shows exactly what the prior session added

**What Failed**:
- Reading source files first without checking git log → file appeared unchanged (Note section was on the PR branch, not visible in working tree context)
- Assuming a clean working tree means fresh start → it means the prior session already committed and pushed

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — PASSED (387/387)
- [x] SKILL.md has required sections: Overview table, Verified Workflow, Failed Attempts table, Results & Parameters
- [x] plugin.json has all required fields: name, version, description, category, date, tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
