### PR TITLE
feat: add verify-already-implemented-issues skill

### DIFF
--- a/skills/tooling/verify-already-implemented-issues/.claude-plugin/plugin.json
+++ b/skills/tooling/verify-already-implemented-issues/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-already-implemented-issues",
+  "version": "1.0.0",
+  "description": "Verify issue implementation status before starting work by checking git log, branch state, and open PRs. Use when: (1) assigned to implement a GitHub issue in a pre-created worktree branch, (2) unsure if work is already done, (3) starting issue implementation and want to avoid duplicate work.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["github", "issues", "worktree", "git", "pr", "duplicate-work"]
+}

--- a/skills/tooling/verify-already-implemented-issues/references/notes.md
+++ b/skills/tooling/verify-already-implemented-issues/references/notes.md
@@ -1,0 +1,44 @@
+# Session Notes: verify-already-implemented-issues
+
+## Session Date: 2026-03-05
+
+## Context
+
+Working in `/home/mvillmow/Odyssey2/.worktrees/issue-3093` on branch `3093-auto-impl`.
+Prompt file: `.claude-prompt-3093.md` instructed implementation of GitHub issue #3093.
+
+## Issue Summary
+
+**Issue #3093**: [Cleanup] Review commented-out imports in shared/__init__.mojo
+- File: `shared/__init__.mojo`
+- Task: uncomment implemented imports, annotate unimplemented ones, document `__all__` limitation
+
+## What Was Found
+
+1. `git log --oneline -5` showed:
+   ```
+   de97cd8a fix(shared): review commented-out imports in __init__.mojo
+   ```
+   This commit was already on the branch, committed before this session started.
+
+2. `gh pr list --head 3093-auto-impl` returned:
+   ```
+   3217  fix(shared): review commented-out imports in __init__.mojo  3093-auto-impl  OPEN  2026-03-05T07:26:19Z
+   ```
+
+3. `gh pr view 3217` confirmed:
+   - PR body contains `Closes #3093`
+   - Auto-merge enabled (rebase)
+   - 65 additions, 91 deletions matching the expected scope
+
+## Key Observations
+
+- The `.claude-prompt-NNNN.md` file is injected into the worktree as agent context
+  but is NOT a reliable indicator of pending work.
+- `git status` showed the worktree as "clean" (only untracked `.claude-prompt-3093.md`)
+  which could be misread as "nothing done yet."
+- The actual implementation history is in `git log`, not `git status`.
+
+## Conclusion
+
+Always run the verification snippet before implementing any issue to avoid duplicate work.

--- a/skills/tooling/verify-already-implemented-issues/skills/verify-already-implemented-issues/SKILL.md
+++ b/skills/tooling/verify-already-implemented-issues/skills/verify-already-implemented-issues/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: verify-already-implemented-issues
+description: "Verify issue implementation status before starting work. Use when: assigned to implement a GitHub issue in a pre-created worktree, starting issue work, or suspecting duplicate effort."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | tooling |
+| **Trigger** | Before implementing any GitHub issue in a worktree branch |
+| **Outcome** | Avoid duplicate work when prior commits already address the issue |
+| **Time saved** | Entire implementation session (if already done) |
+
+## When to Use
+
+- You are given a `.claude-prompt-NNNN.md` file instructing you to implement issue #NNNN
+- The branch name is `NNNN-auto-impl` or similar pre-created branch
+- You want to confirm no prior agent session already completed the work
+- The git log or branch status looks "clean" but you're unsure
+
+## Verified Workflow
+
+### Step 1: Check git log for issue-related commits
+
+```bash
+git log --oneline -10
+```
+
+Look for commits mentioning the issue number or key terms from the issue title.
+
+### Step 2: Read the target file(s) from the issue description
+
+Read the file(s) listed in the issue to see if they already reflect the desired state.
+The issue description typically names specific files and line numbers.
+
+### Step 3: Check for an existing open PR on this branch
+
+```bash
+gh pr list --head <branch-name>
+```
+
+If a PR exists with the issue number in the title or `Closes #NNNN` in the body,
+the work is already done.
+
+### Step 4: Verify PR auto-merge status
+
+```bash
+gh pr view <PR-number>
+```
+
+If auto-merge is enabled, no further action is needed — just report the PR URL.
+
+### Decision Matrix
+
+| git log has issue commit | Open PR exists | Action |
+|--------------------------|----------------|--------|
+| Yes | Yes | Report PR URL, no work needed |
+| Yes | No | Create PR if missing |
+| No | No | Implement the issue |
+| No | Yes | Investigate PR content |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Immediately starting implementation | Jumped straight to reading the file and planning changes without checking git log | Would have duplicated work already committed in `de97cd8a` | Always check `git log --oneline -10` and `gh pr list --head <branch>` first |
+| Trusting branch "cleanliness" | Saw `git status` showed only untracked `.claude-prompt-NNNN.md` and assumed no work done | The commit was already in history, not in staging | `git status` shows uncommitted changes; `git log` shows committed history |
+
+## Results & Parameters
+
+### Copy-Paste Verification Snippet
+
+```bash
+# Run these before starting any issue implementation
+ISSUE_NUM=3093
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "=== Recent commits ==="
+git log --oneline -10
+
+echo ""
+echo "=== Open PRs on this branch ==="
+gh pr list --head "$BRANCH"
+
+echo ""
+echo "=== Git status ==="
+git status
+```
+
+### Session Example (Issue #3093)
+
+- **Branch**: `3093-auto-impl`
+- **Issue**: `[Cleanup] Review commented-out imports in shared/__init__.mojo`
+- **Finding**: Commit `de97cd8a` already addressed the issue; PR #3217 was open with auto-merge enabled
+- **Action taken**: Reported PR URL `https://github.com/HomericIntelligence/ProjectOdyssey/pull/3217`
+- **Time saved**: Full implementation session
+
+### Why Pre-Created Worktrees Can Be Pre-Populated
+
+In ML Odyssey, worktrees are created by orchestration agents that may also run an initial
+implementation pass. When a second agent session opens the same worktree, the work may already
+be complete. The `.claude-prompt-NNNN.md` file is dropped into the worktree for agent context
+but does not indicate whether implementation is pending or done.


### PR DESCRIPTION
## Summary

Documents the pattern of verifying issue implementation status before starting work
in pre-created worktrees, preventing duplicate effort when prior agent sessions
have already completed the implementation.

- Always check `git log --oneline -10` before implementing — committed history shows prior work
- Always check `gh pr list --head <branch>` — an open PR signals work is done
- The `.claude-prompt-NNNN.md` file in a worktree does NOT indicate pending work

## Key Findings

**What Worked**:
- Reading `git log` immediately surfaces prior implementation commits
- `gh pr list --head <branch>` quickly confirms if a PR already exists and links the issue

**What Failed**:
- Relying on `git status` alone: a clean status only means no uncommitted changes, not that no work was done
- Assuming `.claude-prompt-NNNN.md` presence means implementation is pending — it is injected for agent context regardless of implementation state

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Confirm skill activates on "implement issue" triggers in pre-created worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)
