### PR TITLE
feat: add verify-issue-already-implemented skill

### DIFF
--- a/skills/architecture/verify-issue-already-implemented/.claude-plugin/plugin.json
+++ b/skills/architecture/verify-issue-already-implemented/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-issue-already-implemented",
+  "version": "1.0.0",
+  "description": "Verify whether a GitHub issue has already been implemented before starting work. Use when: (1) assigned to implement a GitHub issue, (2) issue prompt file exists in worktree, (3) before writing any code to avoid duplicate work.",
+  "category": "architecture",
+  "date": "2026-03-05",
+  "tags": ["github", "issues", "verification", "idempotency", "git-log", "worktree"]
+}

--- a/skills/architecture/verify-issue-already-implemented/references/notes.md
+++ b/skills/architecture/verify-issue-already-implemented/references/notes.md
@@ -1,0 +1,35 @@
+# Session Notes: verify-issue-already-implemented
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey (Mojo AI research platform)
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3112`
+- **Branch**: `3112-auto-impl`
+- **Issue**: #3112 — Standardize matrix multiplication: Convert `A.__matmul__(B)` to `matmul(A, B)`
+
+## What Happened
+
+1. Received `.claude-prompt-3112.md` asking to implement GitHub issue #3112
+2. Read the issue — it asked to find all `.__matmul__(` method call patterns and convert to `matmul(A, B)` function calls
+3. Used `Grep` to search for `\.__matmul__\(` across all `.mojo` files
+4. Found zero matches
+5. Checked `git log --oneline -10` — commit `86b485a3` already said "refactor(tests): standardize matmul calls to function syntax" with "Closes #3112"
+6. Ran `gh pr list --head 3112-auto-impl` — PR #3214 already existed
+7. Reported: issue already implemented, PR already created, nothing to do
+
+## Key Insight
+
+When working in a worktree named `<issue-number>-auto-impl`, it was created specifically for automated implementation. A prior agent or session may have already committed the work. **Always check git log first** before searching the codebase or writing code.
+
+## Timing
+
+- Time from session start to "already done" conclusion: ~3 tool calls
+- Time saved by not re-implementing: significant (would have found no patterns to fix anyway, but could have caused confusion)
+
+## Related
+
+- Issue: #3112
+- PR: #3214
+- Commit: `86b485a3`
+- Worktree branch convention: `<issue-number>-auto-impl`

--- a/skills/architecture/verify-issue-already-implemented/skills/verify-issue-already-implemented/SKILL.md
+++ b/skills/architecture/verify-issue-already-implemented/skills/verify-issue-already-implemented/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: verify-issue-already-implemented
+description: "Verify whether a GitHub issue has already been implemented before starting work. Use when: assigned to implement a GitHub issue, before writing any code, when working in a worktree that may have prior commits."
+category: architecture
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Name** | verify-issue-already-implemented |
+| **Category** | architecture |
+| **Trigger** | Start of any issue implementation task |
+| **Output** | Decision: implement vs report already done |
+
+## When to Use
+
+- When assigned to implement a GitHub issue via a `.claude-prompt-<N>.md` file
+- When working in a named worktree branch (e.g. `<issue>-auto-impl`)
+- Before searching for code to change or writing any new code
+- When the branch name suggests prior automated work was done on the issue
+
+## Verified Workflow
+
+### Step 1: Check git log for issue reference
+
+```bash
+git log --oneline -20 | grep -i "<issue-number>\|Closes #<issue-number>"
+```
+
+If a commit references the issue number (e.g. `Closes #3112`), the work is already done.
+
+### Step 2: Verify no remaining patterns exist
+
+Search for the specific pattern the issue targets:
+
+```bash
+# Example: for a matmul standardization issue
+grep -r "__matmul__(" --include="*.mojo" tests/ shared/ papers/
+```
+
+If no matches found AND a prior commit exists, the issue is fully implemented.
+
+### Step 3: Check for existing PR
+
+```bash
+gh pr list --head <branch-name>
+```
+
+If a PR already exists and references the issue, report completion — do not create a duplicate PR.
+
+### Step 4: Report status
+
+Post to the GitHub issue if still open:
+
+```bash
+gh issue view <number> --json state -q .state
+gh issue comment <number> --body "Issue already implemented in commit <sha> and PR #<pr>."
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Immediately searching for patterns | Searched codebase for `.__matmul__(` before checking git log | Would have found nothing and been confused | Always check git log first — a prior commit may have already done the work |
+| Assuming worktree is fresh | Assumed `3112-auto-impl` branch had no prior commits | The branch had commit `86b485a3` already closing the issue | Named worktree branches often have auto-impl commits already applied |
+
+## Results & Parameters
+
+### Canonical check sequence
+
+```bash
+# 1. Check recent commits for issue reference
+git log --oneline -20
+
+# 2. Check for existing PR on this branch
+gh pr list --head "$(git branch --show-current)"
+
+# 3. Search for remaining instances of the target pattern
+grep -r "<target-pattern>" --include="*.mojo" .
+
+# 4. If already done: report and exit
+echo "Issue #<N> already implemented. PR exists. No further action needed."
+```
+
+### Decision matrix
+
+| git log has "Closes #N" | Pattern search finds results | PR exists | Action |
+|-------------------------|------------------------------|-----------|--------|
+| Yes | No | Yes | Report done, exit |
+| Yes | No | No | Create PR linking to issue |
+| Yes | Yes | Any | Investigate — partial implementation |
+| No | Yes | No | Implement the issue |
+| No | No | No | Implement the issue (may be unrelated) |


### PR DESCRIPTION
## Summary

Documents the pattern of verifying whether a GitHub issue has already been implemented before starting work, learned from implementing issue #3112 in ProjectOdyssey.

- Always check `git log` for prior commits referencing the issue number before searching the codebase
- Named worktree branches (`<issue>-auto-impl`) frequently have commits already applied by prior automation sessions
- Use `gh pr list --head <branch>` to detect existing PRs before creating duplicates

## Key Findings

**What Worked**:
- `git log --oneline -20` immediately revealed commit `86b485a3` with "Closes #3112"
- `gh pr list --head 3112-auto-impl` confirmed PR #3214 already existed
- Pattern search for `.__matmul__(` found zero matches — confirming completion

**What Failed**:
- Starting with codebase search (Grep) before checking git log — wastes time finding nothing when prior commits already did the work
- Assuming a fresh worktree branch — `*-auto-impl` branches are created specifically for automated commits

## Test Plan

- [x] Plugin validated with `python3 scripts/validate_plugins.py skills/ plugins/` (387/387 pass)
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates on issue implementation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)