### PR TITLE
feat: add fix-mypy-ruff-script-ci skill

### DIFF
--- a/skills/ci-cd/fix-mypy-ruff-script-ci/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-mypy-ruff-script-ci/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-mypy-ruff-script-ci",
+  "version": "1.0.0",
+  "description": "Fix mypy and ruff CI failures in Python scripts caused by unused variables, missing type annotations, and bare f-strings. Use when: (1) mypy reports 'Incompatible return value type' for list with None elements, (2) ruff reports F841 unused variables or F541 f-string without placeholders, (3) pre-commit ruff-format or ruff-check hooks fail on scripts.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["mypy", "ruff", "type-annotations", "python", "ci-cd", "pre-commit"]
+}

--- a/skills/ci-cd/fix-mypy-ruff-script-ci/references/notes.md
+++ b/skills/ci-cd/fix-mypy-ruff-script-ci/references/notes.md
@@ -1,0 +1,58 @@
+# Session Notes: Fix Mypy and Ruff Script CI Failures
+
+## Context
+
+**Issue**: #3140 - Port all skills to ProjectMnemosyne
+**PR**: #3224 - feat(skills): add migration script to port Odyssey2 skills to ProjectMnemosyne
+**Branch**: `3140-auto-impl` in HomericIntelligence/ProjectOdyssey
+
+## What Was Fixed
+
+`scripts/migrate_odyssey_skills.py` had 5 mypy errors and 3 ruff violations that caused 3 CI jobs to fail:
+- `mypy` job
+- `pre-commit` job (ruff-format-python + ruff-check-python hooks)
+- `validate-scripts` job
+
+## Exact Errors
+
+### mypy errors
+
+```
+scripts/migrate_odyssey_skills.py:344: error: Need type annotation for 'pre_workflow'
+scripts/migrate_odyssey_skills.py:345: error: Need type annotation for 'post_workflow_order'
+scripts/migrate_odyssey_skills.py:539: error: Argument 1 to "append" of "list" ...
+scripts/migrate_odyssey_skills.py:549: error: Argument 1 to "append" of "list" ...
+scripts/migrate_odyssey_skills.py:551: error: Incompatible return value type
+  (got "list[tuple[str, Path, None]]", expected "list[tuple[str, Path, Optional[str]]]")
+```
+
+Root cause: `skills = []` was inferred as `list[tuple[str, Path, None]]` because the first `.append()` used literal `None`. mypy's list invariance means this can't be widened to `Optional[str]` without an explicit annotation.
+
+### ruff errors
+
+```
+F841 Local variable `ordered_headers` is assigned to but never used  (line 342)
+F841 Local variable `pre_workflow` is assigned to but never used  (line 344)
+F841 Local variable `post_workflow_order` is assigned to but never used  (line 345)
+F541 f-string without any placeholders  (line 643: print(f"Migration Summary:"))
+```
+
+## Fixes Applied
+
+1. `skills: list[tuple[str, Path, Optional[str]]] = []` — explicit annotation fixes invariance
+2. `workflow_section: Optional[str] = None` etc. — explicit annotations on None-initialized variables
+3. Removed `ordered_headers`, `pre_workflow`, `post_workflow_order` (unused, from earlier refactor)
+4. Changed `print(f"Migration Summary:")` to `print("Migration Summary:")`
+5. Ran `ruff format` to apply automatic line-length fixes
+
+## Key Insight
+
+The `ordered_headers`, `pre_workflow`, `post_workflow_order` variables were dead code left over from a planned but unused "smart reordering" algorithm. The code was refactored to use simpler section-by-section accumulation instead, but the variable declarations were never removed.
+
+## Push Complication
+
+The remote branch `3140-auto-impl` had been force-pushed (different history), requiring:
+```bash
+git pull --rebase origin 3140-auto-impl
+git push origin 3140-auto-impl
+```

--- a/skills/ci-cd/fix-mypy-ruff-script-ci/skills/fix-mypy-ruff-script-ci/SKILL.md
+++ b/skills/ci-cd/fix-mypy-ruff-script-ci/skills/fix-mypy-ruff-script-ci/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: fix-mypy-ruff-script-ci
+description: "Fix mypy and ruff CI failures in Python scripts. Use when CI fails with F841 unused variables, F541 bare f-strings, or mypy list invariance errors."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Skill: Fix Mypy and Ruff Script CI Failures
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Name | fix-mypy-ruff-script-ci |
+| Category | ci-cd |
+| Description | Fix mypy and ruff CI failures in Python scripts caused by unused variables, missing type annotations, and bare f-strings |
+
+## When to Use
+
+- CI `mypy` job fails with "Incompatible return value type" on a list that contains `None` elements
+- CI `mypy` job fails with "Need type annotation for ..." on local variables
+- CI `ruff-check-python` fails with F841 (local variable assigned but never used)
+- CI `ruff-check-python` fails with F541 (f-string without any placeholders)
+- CI `ruff-format-python` fails with "files were modified by this hook"
+- `validate-scripts` job fails citing the same ruff errors
+
+## Verified Workflow
+
+### 1. Get the exact errors from CI logs
+
+```bash
+gh run view --job <job-id> --log | grep -E "error:|F[0-9]+"
+```
+
+### 2. Fix mypy list invariance error
+
+**Pattern**: `list[tuple[str, Path, None]]` is not compatible with `list[tuple[str, Path, Optional[str]]]`
+
+**Root cause**: mypy infers the list type from first `append()` call. If the first append uses `None` (not `Optional[str]`), the list type is locked as `None`, not `Optional[str]`.
+
+**Fix**: Add an explicit type annotation to the variable declaration:
+
+```python
+# Before (mypy error)
+skills = []
+
+# After (mypy passes)
+skills: list[tuple[str, Path, Optional[str]]] = []
+```
+
+### 3. Fix mypy "Need type annotation" for Optional variables
+
+**Pattern**: Variables initialized to `None` that are later assigned `str` values need `Optional[str]` annotations.
+
+```python
+# Before (mypy error)
+workflow_section = None
+failed_section = None
+
+# After (mypy passes)
+workflow_section: Optional[str] = None
+failed_section: Optional[str] = None
+```
+
+### 4. Fix F841 unused variables
+
+**Pattern**: Variables assigned but never read (often leftover from refactoring or dead code).
+
+```python
+# Before (F841: ordered_headers assigned but never used)
+ordered_headers = ["## When to Use", "## Verified Workflow"]
+pre_workflow = []
+post_workflow_order = []
+
+# After: simply remove the unused variables
+```
+
+### 5. Fix F541 f-string without placeholders
+
+```python
+# Before (F541)
+print(f"Migration Summary:")
+
+# After
+print("Migration Summary:")
+```
+
+### 6. Run ruff format to fix style issues
+
+```bash
+pixi run ruff format scripts/<script>.py
+```
+
+### 7. Verify all checks pass locally
+
+```bash
+pixi run ruff check scripts/<script>.py
+pixi run ruff format --check scripts/<script>.py
+pixi run mypy --exclude 'generators/' scripts/
+pixi run pre-commit run --files scripts/<script>.py
+```
+
+### 8. Commit and push
+
+```bash
+git add scripts/<script>.py
+git commit -m "fix(scripts): fix mypy and ruff errors in <script>.py"
+git push origin <branch>
+```
+
+If the remote branch has been force-updated (diverged), pull with rebase first:
+
+```bash
+git pull --rebase origin <branch>
+git push origin <branch>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Direct push | `git push origin <branch>` after rebase | Remote had been force-pushed; local was behind | Always `git pull --rebase origin <branch>` before pushing when collaborating |
+| Fixing only mypy errors | Added `Optional[str]` annotations but left unused variables | Ruff F841 still failed in validate-scripts job | Both mypy and ruff errors must be fixed together |
+
+## Results & Parameters
+
+**Common mypy errors in migration/porting scripts**:
+
+| Error Code | Pattern | Fix |
+|------------|---------|-----|
+| `[return-value]` | `list[T1]` returned where `list[T1 | T2]` expected | Annotate the list: `skills: list[tuple[str, Path, Optional[str]]] = []` |
+| `[annotation-needed]` | `None`-initialized variable later assigned different type | Add `Optional[T]` annotation: `var: Optional[str] = None` |
+
+**Common ruff errors in scripts**:
+
+| Code | Pattern | Fix |
+|------|---------|-----|
+| F841 | `x = [...]` assigned but never used | Remove the variable |
+| F541 | `f"string without {placeholders}"` | Convert to plain string |
+| E501 | Line too long | Let `ruff format` handle it automatically |
+
+**Run order for CI parity**:
+
+```bash
+# Match CI checks exactly
+pixi run ruff check scripts/
+pixi run ruff format --check scripts/
+pixi run mypy --exclude 'generators/' scripts/
+```


### PR DESCRIPTION
## Summary

Documents how to fix mypy list invariance errors and ruff F841/F541 violations in Python migration/porting scripts.

- Explicit type annotation fixes mypy's `list[tuple[str, Path, None]]` vs `list[tuple[str, Path, Optional[str]]]` incompatibility
- `Optional[str]` annotations on `None`-initialized variables resolve "Need type annotation" errors
- Removing dead code from abandoned refactors clears F841 unused variable violations
- Converting bare f-strings to plain strings clears F541

## Key Findings

**What Worked**:
- Adding `skills: list[tuple[str, Path, Optional[str]]] = []` as explicit annotation
- Adding `var: Optional[str] = None` for None-initialized variables
- Removing unused `ordered_headers`, `pre_workflow`, `post_workflow_order` variables (dead code from earlier refactor)

**What Failed**:
- Fixing only mypy errors — ruff F841/F541 still failed `validate-scripts` job
- Direct push without pulling — remote had been force-pushed, needed `git pull --rebase`

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/`
- [x] Verified skill passes: `PASS: fix-mypy-ruff-script-ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)