### PR TITLE
feat: add delete-placeholder-docs skill

### DIFF
--- a/skills/documentation/delete-placeholder-docs/.claude-plugin/plugin.json
+++ b/skills/documentation/delete-placeholder-docs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "delete-placeholder-docs",
+  "version": "1.0.0",
+  "description": "Delete empty placeholder documentation stubs and remove all broken links to them. Use when: (1) docs contain only placeholder text like 'Content here.', (2) a cleanup issue targets stub files, (3) YAGNI principle requires removing premature documentation.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["documentation", "cleanup", "yagni", "placeholder", "broken-links"]
+}

--- a/skills/documentation/delete-placeholder-docs/references/notes.md
+++ b/skills/documentation/delete-placeholder-docs/references/notes.md
@@ -1,0 +1,63 @@
+# Session Notes: delete-placeholder-docs
+
+## Context
+
+- **Date**: 2026-03-05
+- **Issue**: HomericIntelligence/ProjectOdyssey#3142
+- **Branch**: 3142-auto-impl
+- **PR**: HomericIntelligence/ProjectOdyssey#3308
+
+## Objective
+
+Delete 17 (listed as 18 in title, 17 in body) empty placeholder documentation files containing
+only "Content here." text. Update all docs that link to the deleted stubs. Part of a YAGNI
+cleanup pass (PR-B in the improvement plan).
+
+## Files Deleted
+
+**docs/advanced/** (6): custom-layers.md, debugging.md, distributed-training.md, integration.md,
+performance.md, visualization.md
+
+**docs/core/** (8): agent-system.md, configuration.md, mojo-patterns.md, paper-implementation.md,
+project-structure.md, shared-library.md, testing-strategy.md, workflow.md
+
+**docs/dev/** (3): api-reference.md, architecture.md, ci-cd.md
+
+## Files Updated
+
+1. `docs/index.md` - Removed Core Documentation section (8 links), removed 6 stub links from
+   Advanced Topics, removed 3 stub links from Development Guides. Kept:
+   benchmarking.md, troubleshooting.md, release-process.md.
+
+2. `docs/README.md` - Updated directory tree to reflect actual structure, removed 2 broken
+   links from Next Steps section.
+
+3. `docs/glossary.md` - Removed 2 links from See Also section (mojo-patterns, api-reference).
+
+4. `docs/advanced/troubleshooting.md` - Removed 4 plain-text path references from Quick
+   Reference Links section.
+
+5. `docs/getting-started/first_model.md` - Removed 4 stub links from Learn More section,
+   removed 2 stub links from Related Documentation section.
+
+## Key Decisions
+
+- Kept non-stub files linked from the same sections: `benchmarking.md`, `troubleshooting.md`,
+  `release-process.md`, `build.md`
+- Removed entire "Core Documentation" section from index.md (all 8 entries were stubs)
+- Simplified "Advanced Topics" to only substantive files
+- Replaced missing performance/custom-layers links in first_model.md with benchmarking.md
+
+## Environment Issues
+
+- `just` not in PATH - used `pixi run pre-commit run --all-files` instead
+- `mojo-format` pre-commit hook fails due to GLIBC version mismatch on this host machine
+  (not a code issue) - used `SKIP=mojo-format` for verification
+- All other hooks (markdown lint, ruff, yaml, etc.) passed cleanly
+
+## Verification
+
+```bash
+grep -rl "custom-layers\|advanced/performance\|core/mojo-patterns\|..." docs/
+# Returns: No files found
+```

--- a/skills/documentation/delete-placeholder-docs/skills/delete-placeholder-docs/SKILL.md
+++ b/skills/documentation/delete-placeholder-docs/skills/delete-placeholder-docs/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: delete-placeholder-docs
+description: "Delete empty placeholder documentation stubs and remove broken links. Use when: stub files contain only placeholder text, YAGNI cleanup is needed, or broken links must be fixed."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Category | documentation |
+| Complexity | S |
+| Files changed | N stubs deleted + M referencing files updated |
+| Pre-requisite | Confirm all files contain only placeholder text before deleting |
+
+Deletes documentation stub files that contain only placeholder text (e.g. `Content here.`) and
+removes all broken links to the deleted files from other documents. Applies the YAGNI principle:
+documentation should be written alongside feature implementation, not created as empty stubs.
+
+## When to Use
+
+- A GitHub issue asks to delete empty/placeholder documentation files
+- Files contain only placeholder text like "Content here." or similar boilerplate
+- `docs/index.md` or other navigation files link to non-existent or stub content
+- Cleanup pass after a documentation reorganization left orphaned stubs
+
+## Verified Workflow
+
+1. **Identify stub files** - Grep for placeholder text to confirm and find all stubs:
+
+   ```bash
+   grep -rl "Content here\." docs/
+   ```
+
+2. **Find all referencing files** - Search for links to each stub path across all docs:
+
+   ```bash
+   grep -rl "custom-layers\|debugging\.md\|..." docs/
+   ```
+
+3. **Read referencing files** - Read each file that links to stubs to understand context
+   before editing (required by Edit tool).
+
+4. **Delete stub files** - Use a single `rm` command for all stubs at once:
+
+   ```bash
+   rm docs/advanced/stub1.md docs/core/stub2.md docs/dev/stub3.md
+   ```
+
+5. **Update referencing files** - For each file containing broken links:
+   - Remove the entire bullet/line for the deleted file
+   - If removing from a section that becomes empty, remove or simplify the section
+   - Keep links that point to real, substantive files (e.g. `benchmarking.md`, `troubleshooting.md`)
+
+6. **Verify no broken links remain**:
+
+   ```bash
+   grep -rl "deleted-stub-path" docs/
+   # Should return: No files found
+   ```
+
+7. **Run pre-commit** skipping hooks with known environmental failures:
+
+   ```bash
+   SKIP=mojo-format pixi run pre-commit run --all-files
+   ```
+
+8. **Commit, push, create PR** with `Closes #<issue>` in the message.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Deleting files without checking referencing files first | Ran `rm` on all stubs immediately | Left broken links in `docs/README.md`, `docs/glossary.md`, `docs/advanced/troubleshooting.md`, `docs/getting-started/first_model.md` | Always grep for all references before deleting |
+| Running `just pre-commit-all` | Used `just` to invoke pre-commit | `just` not in PATH in this environment | Use `pixi run pre-commit run --all-files` directly |
+| Expecting all pre-commit hooks to pass | Ran full pre-commit suite | `mojo-format` fails due to GLIBC version mismatch (pre-existing env issue, not caused by our changes) | Use `SKIP=mojo-format` when the hook failure is environmental, not code-related |
+
+## Results & Parameters
+
+**Session outcome**: Deleted 17 stub files, updated 5 referencing documents, all relevant
+pre-commit hooks passed (markdown lint, ruff, yaml, trailing whitespace, etc.).
+
+**Files typically referencing stubs**:
+- `docs/index.md` - Main navigation hub (most links)
+- `docs/README.md` - Directory structure tree + Next Steps section
+- `docs/glossary.md` - See Also section
+- `docs/getting-started/first_model.md` - Learn More + Related Documentation sections
+- Topic-specific docs with cross-reference sections
+
+**Key pattern for updating referencing files**: When a section in a nav file (like `index.md`)
+contains only stubs, remove the entire section. When a section contains a mix, remove only
+the stub links and keep substantive ones.
+
+**Commit message format**:
+
+```
+docs: delete N empty placeholder documentation stubs
+
+Remove all documentation files containing only "Content here." as
+placeholder text. Per YAGNI, documentation should be written alongside
+feature implementation, not created as empty stubs beforehand.
+
+Also remove all broken links to the deleted files from:
+- docs/index.md
+- docs/README.md
+- docs/glossary.md
+- docs/advanced/troubleshooting.md
+- docs/getting-started/first_model.md
+
+Closes #NNNN
+```


### PR DESCRIPTION
## Summary

Documents the workflow for deleting empty placeholder documentation stubs and removing
all broken links to deleted files from navigation docs.

- Grep-first approach: find all referencing files before deleting stubs
- Handle environmental pre-commit failures (mojo-format GLIBC mismatch) with SKIP=
- Use `pixi run pre-commit run --all-files` when `just` is not in PATH

## Key Findings

**What Worked**:
- Single `rm` command to delete all stubs at once
- Verify with grep returning "No files found" after cleanup
- Removing entire nav sections when all entries were stubs

**What Failed**:
- Deleting files before checking all referencing docs → left broken links in README, glossary, first_model.md, troubleshooting.md
- Using `just pre-commit-all` → `just` not in PATH
- Running full pre-commit suite → mojo-format fails on this host due to GLIBC version mismatch

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
