### PR TITLE
feat: add fix-security-scan-gaps skill

### DIFF
--- a/skills/ci-cd/fix-security-scan-gaps/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-security-scan-gaps/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-security-scan-gaps",
+  "version": "1.0.0",
+  "description": "Fix common GitHub Actions security scanning gaps: missing PR triggers, silenced Semgrep failures, and Gitleaks working-directory-only scans. Use when: (1) security scans only run on push to main, not PRs, (2) Semgrep has continue-on-error masking failures, (3) Gitleaks uses --no-git missing history secrets.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["security", "gitleaks", "semgrep", "github-actions", "pull-request"]
+}

--- a/skills/ci-cd/fix-security-scan-gaps/references/notes.md
+++ b/skills/ci-cd/fix-security-scan-gaps/references/notes.md
@@ -1,0 +1,70 @@
+# Session Notes: fix-security-scan-gaps
+
+## Context
+
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3143 — [P0-3] Fix security scanning to actually enforce on PRs
+- **PR**: #3315
+- **Branch**: 3143-auto-impl
+- **Date**: 2026-03-05
+
+## Problem Statement
+
+Three gaps made security scanning ineffective as a PR gate:
+
+1. `security-scan.yml` only had `push: branches: [main]` trigger — SAST and dependency
+   scans ran only after merge, not before
+2. Semgrep step had `continue-on-error: true` — any SAST finding would be silently ignored
+   and the job would show green
+3. Gitleaks in `security-pr-scan.yml` used `--no-git` — only scanned working directory files,
+   missing any secrets in git history
+
+## Files Modified
+
+- `.github/workflows/security-scan.yml`: Added `pull_request:` trigger; removed
+  `continue-on-error` from Semgrep step (lines 8 and 100)
+- `.github/workflows/security-pr-scan.yml`: Removed `--no-git` from both Gitleaks
+  invocations (lines 46 and 49 in original)
+
+## Diff Summary
+
+```diff
+# security-scan.yml
++  pull_request:
++
+   push:
+     branches:
+       - main
+
+# security-scan.yml (Semgrep step)
+-      continue-on-error: true   # removed from scan step
+
+# security-pr-scan.yml (both branches of if/else)
+-    ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --no-git --exit-code=1
++    ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
+-    ./gitleaks detect --source=. --verbose --no-git --exit-code=1
++    ./gitleaks detect --source=. --verbose --exit-code=1
+```
+
+## Tricky Part
+
+`continue-on-error: true` appeared on 4 lines in `security-scan.yml`:
+- Line 100: Semgrep scan step — **REMOVED** (this was the bug)
+- Line 109: SARIF upload step — **KEPT** (legitimate, upload failure shouldn't block scan)
+- Line 136: Dependency Review action — **KEPT** (supply-chain-scan job, already gated by `if: github.event_name == 'pull_request'`)
+- Line 149: Checkout in security-report job — **KEPT** (report aggregation, not blocking)
+
+The key insight: only the scan step itself needs to fail hard. Reporting/upload steps
+can legitimately use `continue-on-error`.
+
+## Validation
+
+```bash
+python3 -c "
+import yaml
+for f in ['.github/workflows/security-scan.yml', '.github/workflows/security-pr-scan.yml']:
+    yaml.safe_load(open(f))
+    print(f'OK: {f}')
+"
+# Output: OK for both files
+```

--- a/skills/ci-cd/fix-security-scan-gaps/skills/fix-security-scan-gaps/SKILL.md
+++ b/skills/ci-cd/fix-security-scan-gaps/skills/fix-security-scan-gaps/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: fix-security-scan-gaps
+description: "Fix common GitHub Actions security scanning gaps: missing PR triggers, silenced Semgrep failures, and Gitleaks history blindness. Use when: (1) security scans only run on push to main, (2) Semgrep has continue-on-error masking failures, (3) Gitleaks uses --no-git missing history secrets."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Fix Security Scan Gaps
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Fix three common security scanning gaps in GitHub Actions workflows |
+| Outcome | Operational — applied in ProjectOdyssey PR #3315 (issue #3143) |
+
+Addresses the three most common ways security workflows fail silently or miss issues before they reach main.
+
+## When to Use
+
+- Security scans only trigger on `push: branches: [main]` — not on PRs
+- Semgrep step has `continue-on-error: true` so SAST failures are silently ignored
+- Gitleaks runs with `--no-git` — scans only the working directory, missing secrets in git history
+- Post-audit of a security workflow to verify it actually enforces on PRs
+- Setting up a new security scanning workflow from scratch
+
+## Verified Workflow
+
+### Gap 1: Add PR trigger to security-scan.yml
+
+```yaml
+# BEFORE (only runs after merge to main):
+on:
+  push:
+    branches:
+      - main
+
+# AFTER (runs on all PRs and pushes to main):
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+```
+
+### Gap 2: Remove continue-on-error from Semgrep
+
+```yaml
+# BEFORE (failures silently ignored):
+- name: Run Semgrep
+  uses: returntocorp/semgrep-action@v1
+  with:
+    config: auto
+    generateSarif: true
+  continue-on-error: true
+
+# AFTER (failures block the job and PR):
+- name: Run Semgrep
+  uses: returntocorp/semgrep-action@v1
+  with:
+    config: auto
+    generateSarif: true
+```
+
+Note: `continue-on-error: true` on the **SARIF upload** step after Semgrep is acceptable —
+the upload is a reporting step and should not block the scan result itself.
+
+### Gap 3: Remove --no-git from Gitleaks
+
+```bash
+# BEFORE (scans working directory only — misses git history):
+./gitleaks detect --source=. --verbose --no-git --exit-code=1
+
+# AFTER (git log mode — scans full commit history):
+./gitleaks detect --source=. --verbose --exit-code=1
+```
+
+The default Gitleaks mode (without `--no-git`) uses `git log` to scan the full history.
+This requires `fetch-depth: 0` on the checkout step:
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@...
+  with:
+    fetch-depth: 0  # Full history for comprehensive scanning
+```
+
+### Verification checklist
+
+After applying fixes, verify:
+
+```bash
+# 1. Confirm pull_request trigger is present
+grep -n "pull_request" .github/workflows/security-scan.yml
+
+# 2. Confirm Semgrep step has NO continue-on-error
+grep -A 6 "Run Semgrep" .github/workflows/security-scan.yml | grep "continue-on-error"
+# Should return nothing
+
+# 3. Confirm --no-git is gone from Gitleaks
+grep "no-git" .github/workflows/security-pr-scan.yml
+# Should return nothing
+
+# 4. Validate YAML syntax
+python3 -c "
+import yaml, sys
+for f in ['.github/workflows/security-scan.yml', '.github/workflows/security-pr-scan.yml']:
+    yaml.safe_load(open(f))
+    print(f'OK: {f}')
+"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Remove all continue-on-error | Removed `continue-on-error` from every step in the file | SARIF upload and artifact download steps legitimately use it to prevent reporting failures from blocking scan results | Only remove `continue-on-error` from the scan step itself, not reporting/upload steps |
+| Use `--log-opts` for PR diff only | Considered `--log-opts="HEAD~1..HEAD"` to limit Gitleaks to PR diff | Would miss secrets introduced earlier in the branch history | Default git log mode is safer; scans entire branch reachable history |
+
+## Results & Parameters
+
+Applied to ProjectOdyssey issue #3143, PR #3315:
+
+- Files changed: `.github/workflows/security-scan.yml`, `.github/workflows/security-pr-scan.yml`
+- Lines changed: 6 insertions, 3 deletions
+- YAML validation: passed with Python `yaml.safe_load`
+
+Key pattern: security workflows often have these gaps because they were initially set up
+for reporting only (main branch), then `continue-on-error` was added to avoid blocking
+pipelines during setup, and `--no-git` was added to make Gitleaks faster. All three
+are technically functional but defeat the purpose of pre-merge security enforcement.
+
+## References
+
+- Gitleaks docs: `--no-git` flag disables git log scanning
+- Semgrep Action: `continue-on-error` masks SAST failures from PR status checks
+- GitHub Actions `pull_request` trigger: required for PR blocking checks
+- ProjectOdyssey CLAUDE.md: security scanning policy


### PR DESCRIPTION
## Summary

Documents three common GitHub Actions security scanning gaps and their fixes,
captured from ProjectOdyssey issue #3143.

- Missing `pull_request` trigger causes security scans to run only after merge to main
- `continue-on-error: true` on Semgrep scan step silently ignores SAST failures
- Gitleaks `--no-git` flag scans only the working directory, missing secrets in git history

## Key Findings

**What Worked**:
- Removing `pull_request:` trigger addition is a one-line fix that immediately enforces pre-merge scanning
- Removing `continue-on-error` from the Semgrep step (not the SARIF upload step) blocks failures correctly
- Removing `--no-git` from Gitleaks with `fetch-depth: 0` on checkout enables full history scanning

**What to Watch Out For**:
- `continue-on-error: true` appears on multiple steps — only remove from scan step, not reporting/upload steps
- `--no-git` removal requires `fetch-depth: 0` on checkout (common to already be present for secret scanning)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with security workflow review triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
