### PR TITLE
feat: add consolidate-review-agents skill

### DIFF
--- a/skills/architecture/consolidate-review-agents/.claude-plugin/plugin.json
+++ b/skills/architecture/consolidate-review-agents/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "consolidate-review-agents",
+  "version": "1.0.0",
+  "description": "Merge overlapping review specialist agents into a single general-review-specialist to reduce complexity. Use when: (1) you have many fine-grained review agents with overlapping scopes, (2) a project is in early stages and doesn't need 13+ specialists, (3) you want to reduce agent count while preserving full review coverage.",
+  "category": "architecture",
+  "date": "2026-03-05",
+  "tags": ["agents", "review", "consolidation", "architecture", "complexity-reduction"]
+}

--- a/skills/architecture/consolidate-review-agents/references/notes.md
+++ b/skills/architecture/consolidate-review-agents/references/notes.md
@@ -1,0 +1,80 @@
+# Session Notes: consolidate-review-agents
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Issue**: ProjectOdyssey #3144 — [P1-1] Consolidate review specialist agents (13 → 5)
+- **Branch**: 3144-auto-impl
+- **PR created**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3319
+
+## Objective
+
+Reduce 13 code review specialist agents to 5 by merging 10 overlapping specialists into
+`general-review-specialist.md`. Keep mojo-language, security, test, and orchestrator as-is.
+
+## What Was Merged
+
+10 agents deleted:
+- algorithm-review-specialist.md
+- architecture-review-specialist.md
+- data-engineering-review-specialist.md
+- dependency-review-specialist.md
+- documentation-review-specialist.md
+- implementation-review-specialist.md
+- paper-review-specialist.md
+- performance-review-specialist.md
+- research-review-specialist.md
+- safety-review-specialist.md
+
+## Steps Taken
+
+1. Read all 10 agent files to understand their structure and scope
+2. Read code-review-orchestrator.md and agents/hierarchy.md for reference update targets
+3. Created general-review-specialist.md combining all 10 domains
+4. Deleted 10 merged files via `git rm`
+5. Updated code-review-orchestrator.md: delegates_to, decision matrix, routing table, delegates section
+6. Updated agents/hierarchy.md: Level 3 count, total count, breakdown
+7. Ran `python3 tests/agents/validate_configs.py .claude/agents/` — ALL VALIDATIONS PASSED
+8. Ran `pixi run pre-commit run --all-files` — all hooks passed
+9. Committed and pushed; PR #3319 created with auto-merge enabled
+
+## Key Observations
+
+All 10 merged agents were structurally identical:
+- Same YAML: `tools: Read,Grep,Glob`, `model: sonnet`, `level: 3`, `phase: Cleanup`
+- Identical hooks blocks (block Edit, Write, Bash)
+- Identical output location and feedback format references
+- Each had a 10-item checklist and one example
+
+The only substantive difference between them was their review domain checklist.
+
+## Error Encountered
+
+The `Edit` tool requires the file to have been read using the `Read` tool in the current
+conversation. Reading via Bash (`sed`) does not satisfy this requirement. Solution: always
+use the `Read` tool explicitly even when you've seen content via other means.
+
+## Validation Results
+
+```
+python3 tests/agents/validate_configs.py .claude/agents/
+ALL VALIDATIONS PASSED
+
+pixi run pre-commit run --all-files
+Check for deprecated List[Type](args) syntax.............................Passed
+Ruff Format Python.......................................................Passed
+Ruff Check Python........................................................Passed
+Markdown Lint............................................................Passed
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Check YAML...............................................................Passed
+```
+
+## Metrics
+
+- Files deleted: 10
+- Files created: 1
+- Files updated: 2
+- Net line change: -766 lines
+- Total agent count: 44 → 35
+- Review specialist count: 13 → 5

--- a/skills/architecture/consolidate-review-agents/skills/consolidate-review-agents/SKILL.md
+++ b/skills/architecture/consolidate-review-agents/skills/consolidate-review-agents/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: consolidate-review-agents
+description: "Merge overlapping review specialist agents into a single general-review-specialist. Use when: (1) multiple review agents have overlapping scopes, (2) project complexity doesn't justify 10+ specialists, (3) you want to reduce total agent count while keeping full review coverage."
+category: architecture
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Pattern** | Agent consolidation — many-to-one specialist merge |
+| **When Applicable** | Early-stage projects with premature specialization |
+| **Effort** | ~30 min (read 10 files, write 1, update 2 references) |
+| **Risk** | Low — review coverage preserved, only file count changes |
+| **Result (ProjectOdyssey)** | 13 review specialists → 5, total agents 44 → 35 |
+
+## When to Use
+
+Trigger this skill when:
+
+1. Agent count for a single concern (e.g., code review) has grown to 10+
+2. Most specialists share identical YAML frontmatter (same tools, model, level, phase, hooks)
+3. Specialists cross-reference each other in "What I do NOT review" sections, creating circular scope
+4. The project is still in planning/early implementation phase — premature specialization adds overhead
+5. An orchestrator's `delegates_to` list has more than 5–6 entries for the same concern
+
+## Verified Workflow
+
+### Step 1: Identify candidates for merging
+
+Read all candidate files. Look for:
+- Same `tools`, `model`, `level`, `phase`, and `hooks` in YAML frontmatter
+- Scope definitions that explicitly exclude each other ("→ Implementation Specialist", "→ Algorithm Specialist")
+- Small, focused review checklists (5–10 items each)
+
+Agents to **keep separate** if they have genuinely unique requirements:
+- Mojo-language-specific agents (special syntax knowledge)
+- Security agents (distinct attack-vector expertise)
+- Test agents (coverage metrics, assertions)
+- Orchestrators (coordination role, different tools)
+
+### Step 2: Create `general-review-specialist.md`
+
+Create `.claude/agents/general-review-specialist.md` with:
+
+```yaml
+---
+name: general-review-specialist
+description: "Reviews code for [list all merged dimensions]. Select for any general code review dimension not covered by [remaining specialists]."
+level: 3
+phase: Cleanup
+tools: Read,Grep,Glob
+model: sonnet
+delegates_to: []
+receives_from: [code-review-orchestrator]
+hooks:
+  PreToolUse:
+    - matcher: "Edit"
+      action: "block"
+      reason: "Review specialists are read-only - cannot modify files"
+    - matcher: "Write"
+      action: "block"
+      reason: "Review specialists are read-only - cannot create files"
+    - matcher: "Bash"
+      action: "block"
+      reason: "Review specialists are read-only - cannot run commands"
+---
+```
+
+Body structure:
+- One `## Scope` section with subsections per merged domain
+- Merged review checklists (one per domain)
+- Representative example review per domain (keep 3–4, skip redundant ones)
+- Coordinates With pointing to remaining specialists
+
+### Step 3: Delete the merged files
+
+```bash
+git rm .claude/agents/algorithm-review-specialist.md \
+       .claude/agents/architecture-review-specialist.md \
+       # ... (all 10)
+```
+
+### Step 4: Update the orchestrator
+
+In `code-review-orchestrator.md`, update:
+- `delegates_to` list: replace 10 entries with `general-review-specialist`
+- Delegation decision matrix: merge 10 rows into one catch-all row
+- Routing dimensions table: collapse to 4 rows
+- "Delegates To" section: 13 items → 4 items
+- Body text mentioning "13 specialists" → "4 specialists"
+
+### Step 5: Update hierarchy documentation
+
+In `agents/hierarchy.md`, update:
+- Level 3 specialist count in the ASCII diagram
+- Level 3 agent count in the "Level Summaries" section
+- Agent Count table (Level 3 row + Total row)
+- Level 3 Breakdown bullet list
+
+### Step 6: Validate
+
+```bash
+python3 tests/agents/validate_configs.py .claude/agents/
+pixi run pre-commit run --all-files
+```
+
+All hooks should pass. The mojo GLIBC errors on older Linux systems are pre-existing
+environment issues unrelated to agent file changes.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `Edit` tool without prior `Read` | Tried to edit `code-review-orchestrator.md` directly after reading it via `bash sed` | Tool requires `Read` tool call in conversation history | Always call `Read` tool explicitly before `Edit`, even if you saw file contents via Bash |
+| Single `git rm` with wildcard | `git rm .claude/agents/*-review-specialist.md` excluding some files | Shell glob would also match files to keep (mojo, security, test) | List each file explicitly in `git rm` |
+
+## Results & Parameters
+
+**ProjectOdyssey outcome**:
+
+```
+Before: 13 review specialists (algorithm, architecture, data-engineering,
+        dependency, documentation, implementation, mojo-language, paper,
+        performance, research, safety, security, test)
+
+After: 5 review agents (general, mojo-language, security, test, orchestrator)
+
+Files changed: -10 deleted, +1 created, +2 updated
+Lines changed: -1063 insertions, +297 deletions (net -766 lines)
+Total agents: 44 → 35
+```
+
+**Which specialists to keep separate (decision criteria)**:
+
+| Keep Separate | Reason |
+|---------------|--------|
+| `mojo-language-review-specialist` | Language-specific: SIMD patterns, ownership semantics, v0.26.1+ syntax |
+| `security-review-specialist` | Domain expertise: CVEs, attack vectors, auth flows |
+| `test-review-specialist` | Metrics-driven: coverage thresholds, assertion quality, test isolation |
+| `code-review-orchestrator` | Coordinator role: different tools (`Task`), different level (2 vs 3) |
+
+**Key insight**: When 10 agents all have identical `tools: Read,Grep,Glob`, `model: sonnet`,
+`level: 3`, `phase: Cleanup`, and identical `hooks` blocks, they are structurally identical.
+The only difference is the review checklist — which can live as subsections in one file.


### PR DESCRIPTION
## Summary

- Documents the pattern for merging 10+ overlapping review specialist agents into a single general-review-specialist
- Derived from ProjectOdyssey issue #3144 (13 review specialists → 5, total agents 44 → 35)
- Includes verified workflow, failure modes, and decision criteria for which specialists to keep separate

## Key Findings

**What Worked**:
- Identifying merge candidates by looking for identical YAML frontmatter (tools/model/level/phase/hooks)
- Keeping security, mojo-language, and test specialists separate (genuine domain expertise)
- Updating orchestrator in 4 places: delegates_to list, decision matrix, routing table, delegates section

**What Failed**:
- Edit tool requires Read tool call (not Bash cat/sed) to have been called on the target file first

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with agent consolidation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)