### PR TITLE
feat: add agent-to-skill-conversion skill

### DIFF
--- a/skills/architecture/agent-to-skill-conversion/.claude-plugin/plugin.json
+++ b/skills/architecture/agent-to-skill-conversion/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "agent-to-skill-conversion",
+  "version": "1.0.0",
+  "description": "Convert agent configurations to skills when tasks are fixed/predictable rather than adaptive. Use when: (1) agent performs repeatable automation steps, (2) agent does not require exploration or adaptive decision-making, (3) reducing agent count to simplify hierarchy.",
+  "category": "architecture",
+  "date": "2026-03-05",
+  "tags": ["agents", "skills", "refactoring", "abstraction", "hierarchy"]
+}

--- a/skills/architecture/agent-to-skill-conversion/references/notes.md
+++ b/skills/architecture/agent-to-skill-conversion/references/notes.md
@@ -1,0 +1,77 @@
+# Session Notes: Agent-to-Skill Conversion
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3145 - Convert blog-writer and pr-cleanup agents to skills
+- **Branch**: 3145-auto-impl
+- **PR**: #3320
+
+## Agents Converted
+
+### blog-writer-specialist → blog-writer skill
+
+**Original agent** (`.claude/agents/blog-writer-specialist.md`):
+- Level 3 Specialist, Package phase
+- Workflow: gather commits → extract themes → structure narrative → write content → validate
+- Skills used: `gh-create-pr-linked`
+- Tools: Read, Grep, Glob, Task
+
+**Created skill** (`.claude/skills/blog-writer/SKILL.md`):
+- Category: doc
+- Added: Quick Reference bash commands, Writing Style Guidelines, Markdown Compliance Checklist
+- Added: Error Handling table
+
+### pr-cleanup-specialist → pr-cleanup skill
+
+**Original agent** (`.claude/agents/pr-cleanup-specialist.md`):
+- Level 3 Specialist, Cleanup phase
+- Full pre-merge checklist, squash/rebase operations
+- Coordinated with: Code Review Orchestrator, Implementation Engineer, Test Engineer
+
+**Created skill** (`.claude/skills/pr-cleanup/SKILL.md`):
+- Category: github
+- Preserved: Pre-Merge Checklist, Cleanup Operations, Squash Strategy Example, Feedback Format
+- Added: Error Handling table with specific fixes
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `.claude/agents/blog-writer-specialist.md` | Deleted |
+| `.claude/agents/pr-cleanup-specialist.md` | Deleted |
+| `.claude/skills/blog-writer/SKILL.md` | Created |
+| `.claude/skills/pr-cleanup/SKILL.md` | Created |
+| `.claude/skills/gh-batch-merge-by-labels/SKILL.md` | Removed `agent: pr-cleanup-specialist` frontmatter field |
+| `agents/hierarchy.md` | Updated Level 3 count 24→22, agent count table 44→42, breakdown list |
+| `agents/README.md` | Updated Level 3 count 24→22, total 44→42, removed agent entries |
+
+## References Found via grep
+
+```
+grep -rl "blog-writer-specialist|pr-cleanup-specialist" . --include="*.md"
+```
+
+Results:
+- `.claude/agents/blog-writer-specialist.md` (the source)
+- `.claude/agents/pr-cleanup-specialist.md` (the source)
+- `.claude/skills/gh-batch-merge-by-labels/SKILL.md` (had `agent: pr-cleanup-specialist` in frontmatter)
+- `agents/README.md`
+- `docs/dev/agent-claude4-update-status.md` (tracking doc - left as historical record)
+
+## Environment Notes
+
+- `just` command not available in this environment (not in PATH)
+- `pixi run npx markdownlint-cli2` not available (npx not in pixi env)
+- `mojo-format` pre-commit hook fails due to GLIBC incompatibility (requires 2.32-2.34)
+- All other pre-commit hooks passed including Markdown Lint
+- Correct pre-commit command: `pixi run pre-commit run --all-files`
+
+## Commit
+
+```
+e92e2726 refactor(agents): convert blog-writer and pr-cleanup agents to skills
+```
+
+7 files changed, 314 insertions(+), 264 deletions(-)

--- a/skills/architecture/agent-to-skill-conversion/skills/agent-to-skill-conversion/SKILL.md
+++ b/skills/architecture/agent-to-skill-conversion/skills/agent-to-skill-conversion/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: agent-to-skill-conversion
+description: "Convert agent configurations to skills when tasks are fixed/predictable. Use when: (1) agent performs repeatable automation steps without adaptive reasoning, (2) reducing agent count to simplify hierarchy, (3) moving fixed-step workflows to the right abstraction layer."
+category: architecture
+date: 2026-03-05
+user-invocable: false
+---
+
+# Agent-to-Skill Conversion
+
+Convert Claude Code agent configurations to skills when the task matches the skill pattern
+(fixed steps, automation) rather than the agent pattern (adaptive reasoning, exploration).
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-05 |
+| Objective | Convert blog-writer and pr-cleanup agents to skills (ProjectOdyssey issue #3145) |
+| Outcome | 2 agents removed, 2 skills created, all references updated, PR #3320 created |
+
+## When to Use
+
+- Agent performs fixed, predictable, repeatable steps with no branching logic
+- Agent does not require exploration, discovery, or adaptive decision-making
+- Agent acts as automation wrapper rather than a reasoning entity
+- Goal is to reduce agent count and put functionality at the right abstraction layer
+
+**Trigger phrases**: "convert agent to skill", "agent does fixed steps", "too many agents",
+"agent is just automation", "predictable agent workflow"
+
+**Decision criteria** (all three must apply):
+
+- Fixed, predictable steps
+- Repeatable automation
+- Does NOT require adaptive decision-making
+
+## Verified Workflow
+
+### Phase 1: Identify Candidate Agents
+
+Review agent files and apply criteria:
+
+```bash
+# List all agents
+ls .claude/agents/
+
+# Check agent workflow for fixed vs adaptive steps
+cat .claude/agents/<name>.md
+```
+
+Ask: Does this agent explore/discover, or does it follow a fixed checklist?
+
+### Phase 2: Find an Existing Skill as Format Reference
+
+```bash
+# Find a similar skill for format reference
+ls .claude/skills/
+cat .claude/skills/<similar-skill>/SKILL.md
+```
+
+Key skill format elements:
+
+- YAML frontmatter: `name`, `description`, `mcp_fallback`, `category`
+- `## When to Use` - trigger conditions
+- `## Quick Reference` - bash commands for common operations
+- `## Workflow` - numbered steps
+- `## Error Handling` - table of issues and fixes
+- `## References` - related skills
+
+### Phase 3: Create the Skill
+
+Create `<skill-name>/SKILL.md` under `.claude/skills/`:
+
+```markdown
+---
+name: <skill-name>
+description: <description>. Use when <trigger>.
+mcp_fallback: none
+category: <category>
+---
+
+# <Skill Title>
+
+<Brief overview paragraph.>
+
+## When to Use
+
+- Trigger condition 1
+- Trigger condition 2
+
+## Quick Reference
+
+```bash
+# Key commands
+```
+
+## Workflow
+
+1. **Step 1** - Description
+2. **Step 2** - Description
+...
+
+## Error Handling
+
+| Problem | Solution |
+|---------|----------|
+| Issue 1 | Fix 1 |
+
+## References
+
+- Related skill: `<skill-name>`
+```
+
+### Phase 4: Delete the Agent Files
+
+```bash
+rm .claude/agents/<name>-specialist.md
+```
+
+### Phase 5: Update All References
+
+Find and update every file that references the deleted agents:
+
+```bash
+# Find all references
+grep -rl "<agent-name>" . --include="*.md"
+
+# Common locations to check:
+# - Other skill SKILL.md files (agent: field in frontmatter)
+# - agents/hierarchy.md (agent count table, Level 3 diagram)
+# - agents/README.md (Operational Agents section, Level 3 listing)
+# - docs/dev/ files
+```
+
+**Update agent count in hierarchy.md:**
+
+- Diagram box: `Level 3: Specialists (N agents)` → reduce N by count of removed agents
+- Level 3 summary: `X total (Y implementation/execution specialists + 13 code review specialists)`
+- Agent Count table: Level 3 row and Total row
+- Level 3 Breakdown bullet: remove agent names from list
+- Historical Note: update to reflect conversion rationale
+
+**Update agents/README.md:**
+
+- Level 3 section header count
+- Implementation/Execution Specialists count and bullet list
+- Operational Agents total count
+- Level 3 Component Specialists section
+
+### Phase 6: Commit and PR
+
+```bash
+git add .claude/agents/<deleted>.md .claude/skills/<new>/ \
+        agents/hierarchy.md agents/README.md \
+        .claude/skills/<updated>/SKILL.md
+
+git commit -m "refactor(agents): convert <name> agents to skills
+
+Closes #<issue>"
+
+git push -u origin <branch>
+gh pr create --title "..." --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command directly | `just` not in PATH in this environment | Use `pixi run pre-commit run --all-files` instead |
+| Running `pixi run npx markdownlint-cli2` directly | Called markdownlint outside pre-commit | `npx` not in pixi environment PATH | Markdown linting runs correctly via the pre-commit hook |
+| Expecting mojo-format to pass | Ran pre-commit expecting all hooks to pass | GLIBC version incompatibility on host (requires 2.32-2.34, host has older) | mojo-format failure is environment-specific, not caused by our changes; other hooks still validate |
+| Edit tool after long gap without re-read | Tried to edit a file not recently read | Edit tool requires a Read in current session | Always re-read files before editing if session has been long or file may have been modified |
+
+## Results & Parameters
+
+### Files Changed Pattern
+
+For each agent converted to skill:
+
+| Action | File |
+|--------|------|
+| Create | `.claude/skills/<name>/SKILL.md` |
+| Delete | `.claude/agents/<name>-specialist.md` |
+| Update | `agents/hierarchy.md` (counts, listings) |
+| Update | `agents/README.md` (counts, listings) |
+| Update | Any skill with `agent: <name>` in frontmatter |
+
+### Agent Count Formula
+
+```text
+New total = Old total - number of converted agents
+New Level 3 = Old Level 3 - number of converted agents
+New implementation specialists = Old count - number of converted agents
+```
+
+### Skill Frontmatter Template (ProjectOdyssey format)
+
+```yaml
+---
+name: <kebab-case-name>
+description: <What it does>. Use when <trigger condition>.
+mcp_fallback: none
+category: <doc|github|phase|mojo|agent|quality|testing|review>
+---
+```
+
+### Cross-Reference Search Pattern
+
+```bash
+# Find all references to old agent name
+grep -rl "old-agent-name\|old-agent-specialist" . --include="*.md"
+
+# Check for agent: field in skill frontmatter
+grep -r "^agent:" .claude/skills/ --include="SKILL.md"
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3145, PR #3320 | [notes.md](../references/notes.md) |
+
+## Related Skills
+
+- `agent-validate-config` - Validate agent YAML frontmatter after changes
+- `agent-coverage-check` - Verify agent hierarchy coverage is still complete after removal
+- `agent-hierarchy-diagram` - Regenerate hierarchy diagram after agent count changes


### PR DESCRIPTION
## Summary

Documents the workflow for converting Claude Code agent configurations to skills when
tasks are fixed/predictable rather than requiring adaptive reasoning.

- Captures learnings from ProjectOdyssey issue #3145 (blog-writer + pr-cleanup conversion)
- 3-criteria decision test for agent vs skill classification
- Complete reference update workflow (hierarchy.md, README.md, cross-references)

## Key Findings

**What Worked**:
- `grep -rl` to exhaustively find all cross-references before deleting agents
- Updating counts in 5 places in hierarchy.md: diagram box, level summary, count table, breakdown bullet, historical note
- Running `pixi run pre-commit run --all-files` (not `just pre-commit-all`) for validation
- Creating skill with Quick Reference bash commands + Error Handling table for usability

**What Failed**:
- `just pre-commit-all` → `just` not in PATH in this environment
- `pixi run npx markdownlint-cli2` → `npx` not in pixi env PATH
- `mojo-format` pre-commit hook → GLIBC version incompatibility on host (not caused by changes)
- Edit tool without recent re-read → requires file to have been read in current session

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` (387/387 pass)
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
