### PR TITLE
feat: add merge-duplicate-docs skill

### DIFF
--- a/skills/documentation/merge-duplicate-docs/.claude-plugin/plugin.json
+++ b/skills/documentation/merge-duplicate-docs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "merge-duplicate-docs",
+  "version": "1.0.0",
+  "description": "Merge two overlapping documentation files into one canonical source, preserving unique content and fixing all cross-references. Use when: (1) two markdown files document the same topic creating a DRY violation, (2) one file is a visual/summary reference and the other has detailed specs, (3) you need to consolidate docs and update all links.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["dry", "markdown", "consolidation", "references", "hierarchy"]
+}

--- a/skills/documentation/merge-duplicate-docs/references/notes.md
+++ b/skills/documentation/merge-duplicate-docs/references/notes.md
@@ -1,0 +1,82 @@
+# Session Notes: Merging Duplicate Agent Hierarchy Docs
+
+## Context
+
+- **Issue**: #3147 — [P1-4] Merge overlapping agent hierarchy files
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3147-auto-impl
+- **Date**: 2026-03-05
+
+## Files Involved
+
+- **Canonical (kept)**: `agents/hierarchy.md` — visual diagram + quick reference
+- **Deleted**: `agents/agent-hierarchy.md` — detailed per-agent specifications
+
+## What Each File Had
+
+### agents/hierarchy.md (277 lines before merge)
+- Visual ASCII hierarchy diagram
+- Level summaries (L0–L5) with agents/scope/decisions
+- Mojo-specific considerations
+- Delegation flow (top-down + bottom-up)
+- Agent count table
+- Quick reference (when to use each level)
+- Coordination rules
+- See Also (including broken link to agent-hierarchy.md)
+
+### agents/agent-hierarchy.md (668 lines — deleted)
+- Overview/intro paragraph
+- More detailed hierarchy diagram (text-based tree)
+- Per-agent detailed specs (each agent: scope, responsibilities, inputs, outputs, config file path)
+- Delegation rules (6 formal rules)
+- Agent configuration template (YAML frontmatter + sections)
+- Mapping to organizational models (Traditional, Spotify)
+- Integration with 5-phase workflow table
+- Next steps list
+- References
+
+## Bugs Found in Original hierarchy.md
+
+1. **Broken code block closings**: Code blocks were ending with ` ```text ` instead of ` ``` `
+   - This is a markdown syntax error — closing fences should be plain ` ``` `
+   - Affected: hierarchy diagram, top-down flow, bottom-up flow blocks
+
+2. **Self-referential See Also link**: `hierarchy.md` linked to `agent-hierarchy.md` in its See Also section
+
+## Cross-References Updated (7 files)
+
+| File | Old Reference | New Reference |
+|------|--------------|---------------|
+| `agents/hierarchy.md` | `[agent-hierarchy.md](agent-hierarchy.md)` | removed (self-ref) |
+| `agents/README.md` (line 476) | description of agent-hierarchy.md | updated description |
+| `agents/README.md` (line 503) | `[Complete Agent Hierarchy](agent-hierarchy.md)` | `hierarchy.md` |
+| `agents/docs/workflows.md` | `[Agent Hierarchy](../agent-hierarchy.md)` | `../hierarchy.md` |
+| `agents/docs/quick-start.md` | `[../agent-hierarchy.md](../agent-hierarchy.md)` | `../hierarchy.md` |
+| `agents/docs/5-phase-integration.md` | `[Agent Hierarchy](../agent-hierarchy.md)` | `../hierarchy.md` |
+| `CLAUDE.md` | `agent-hierarchy.md` in project tree | removed (merged into hierarchy.md) |
+| `scripts/agents/README.md` | `[Agent Hierarchy](../../agents/agent-hierarchy.md)` | `../../agents/hierarchy.md` |
+| `tests/agents/mock_agents/README.md` | `[Agent Hierarchy](../../../agents/agent-hierarchy.md)` | `../../../agents/hierarchy.md` |
+
+## Markdownlint Errors After Merge (All Fixed)
+
+Line-length errors from the detailed spec content:
+
+```
+agents/hierarchy.md:98:121   MD013 - "Language Context" line (150 chars)
+agents/hierarchy.md:106:121  MD013 - Another "Language Context" line (140 chars)
+agents/hierarchy.md:108:121  MD013 - Package Phase line (186 chars)
+agents/hierarchy.md:110:121  MD013 - Review Specialties line (186 chars)
+agents/hierarchy.md:216:121  MD013 - Level 3 Breakdown list items (209/185 chars)
+agents/hierarchy.md:216      MD032 - Missing blank line before list
+agents/hierarchy.md:219:121  MD013 - Historical Note line (241 chars)
+```
+
+All fixed by:
+- Wrapping long lines at natural phrase boundaries (semicolons, commas)
+- Adding blank line before the Level 3 breakdown list
+
+## PR Created
+
+- **PR**: #3334 in HomericIntelligence/ProjectOdyssey
+- **Title**: docs(agents): merge agent-hierarchy.md into hierarchy.md
+- **Auto-merge**: enabled with rebase strategy

--- a/skills/documentation/merge-duplicate-docs/skills/merge-duplicate-docs/SKILL.md
+++ b/skills/documentation/merge-duplicate-docs/skills/merge-duplicate-docs/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: merge-duplicate-docs
+description: "Merge two overlapping markdown docs into one canonical source, preserving unique content and fixing all cross-references. Use when: two files cover the same topic (DRY violation), one has visual/summary content and the other has detailed specs, or you need a single authoritative reference."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Goal** | Eliminate duplicate documentation by merging into one canonical file |
+| **Inputs** | Two overlapping markdown files, grep search for cross-references |
+| **Outputs** | Updated canonical file, deleted duplicate, updated references |
+| **Trigger** | DRY violation: two files document the same topic |
+| **Time** | ~15 minutes for typical doc merge |
+
+## When to Use
+
+- Two markdown files both document the same concept (e.g., an agent hierarchy)
+- One file is a visual/diagram/quick-reference and the other has detailed specs
+- A GitHub issue requests merging/consolidating overlapping docs
+- Cross-references between files create circular dependencies
+
+## Verified Workflow
+
+### Step 1: Read Both Files
+
+Read both files in parallel to understand their content and overlap:
+
+```
+Read file-A.md  # e.g., hierarchy.md (visual diagrams, quick reference)
+Read file-B.md  # e.g., agent-hierarchy.md (detailed per-agent specs)
+```
+
+Identify:
+- Shared content (same in both)
+- Unique content in file-A (keep in place)
+- Unique content in file-B (must be merged into file-A)
+
+### Step 2: Find All Cross-References
+
+Search the entire repo for references to the file being deleted:
+
+```bash
+grep -r "agent-hierarchy\.md" --include="*.md" -l
+```
+
+Or use the Grep tool with `output_mode: "content"` to see exact lines.
+
+### Step 3: Fix Broken Syntax in the Canonical File
+
+Before merging, fix any existing issues in the canonical file:
+
+- Fenced code blocks ending with ` ```text ` instead of ` ``` `
+- Overly long lines (>120 chars for markdownlint MD013)
+- Missing blank lines around lists (MD032)
+- Self-referential links in "See Also" sections pointing to the file being deleted
+
+### Step 4: Append Unique Content
+
+Add unique sections from file-B to file-A in a logical structure. For a hierarchy doc, the typical order is:
+
+1. Visual diagram (already in canonical)
+2. Level summaries (already in canonical)
+3. Quick reference (already in canonical)
+4. **Detailed per-agent specs** (unique to detailed file — append as new section)
+5. **Delegation rules** (unique to detailed file — append)
+6. **Config template** (unique to detailed file — append)
+7. **Org model mappings** (unique to detailed file — append)
+8. **Phase workflow table** (unique to detailed file — append)
+9. See Also (update to remove reference to deleted file)
+
+### Step 5: Delete the Duplicate File
+
+```bash
+rm agents/agent-hierarchy.md
+```
+
+### Step 6: Update All Cross-References
+
+For each file found in Step 2, update the link:
+
+```
+old: [Agent Hierarchy](../agent-hierarchy.md)
+new: [Agent Hierarchy](../hierarchy.md)
+```
+
+Also update any prose descriptions:
+- `**agent-hierarchy.md** - Complete detailed hierarchy specification`
+- → `**hierarchy.md** - Visual hierarchy diagram and complete agent specifications`
+
+### Step 7: Run Linting
+
+```bash
+SKIP=mojo-format pixi run pre-commit run markdownlint-cli2 --all-files
+```
+
+Fix any line-length (MD013) or list-spacing (MD032) errors from the merged content.
+Long lines from the detailed file often need wrapping at natural phrase boundaries.
+
+### Step 8: Commit and PR
+
+Stage all modified files explicitly (not `git add -A`):
+
+```bash
+git add canonical-file.md deleted-file.md file1.md file2.md ...
+git commit -m "docs(scope): merge duplicate-file.md into canonical-file.md
+
+Eliminates DRY violation. Closes #ISSUE"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Closing code blocks with ` ```text ` | Original file used ` ```text ` to close fenced blocks (not just open them) | markdownlint treats ` ```text ` as an opening of a new block, not a closing | Always close fenced code blocks with plain ` ``` ` — only opening tags get a language specifier |
+| Adding merged content without checking line lengths | Pasted detailed spec content directly | Lines from the detailed file were 150-241 chars, failing MD013 (120 char limit) | After merging content, always run markdownlint to catch line-length violations from the source file |
+| Keeping self-referential "See Also" link | `hierarchy.md` had a link to `agent-hierarchy.md` in its See Also section | Creates a broken link after deletion | When merging, remove all references to the deleted file from the canonical file itself |
+
+## Results & Parameters
+
+### Reference Update Pattern
+
+Files that commonly reference documentation files and need updating:
+
+- `CLAUDE.md` — project structure tree diagram
+- `agents/README.md` — documentation index and references section
+- `agents/docs/*.md` — cross-links in related docs
+- `scripts/agents/README.md` — see also sections
+- `tests/agents/mock_agents/README.md` — test documentation links
+
+### Markdownlint Common Fixes After Merge
+
+```markdown
+# Long line fix — wrap at natural phrase boundary
+- **Language Context**: Designs Mojo module structures, leverages Mojo features (SIMD, traits, structs);
+  coordinates review across all code dimensions
+
+# List spacing fix — add blank line before list
+**Level 3 Breakdown:**
+
+- Implementation/Execution Specialists: 11 (...)
+- Code Review Specialists: 13 (...)
+```
+
+### Grep Command for Finding References
+
+```bash
+# Find all markdown files referencing the file to be deleted
+grep -rn "old-filename\.md" --include="*.md" .
+
+# Or use ripgrep
+rg "old-filename\.md" --type md -l
+```


### PR DESCRIPTION
## Summary

Documents the workflow for merging two overlapping markdown files into one canonical source,
eliminating DRY violations while preserving all unique content and fixing cross-references.

- Verified 8-step workflow covering: read both files, grep all references, fix syntax bugs,
  append unique content, delete duplicate, update all links, run linting, commit
- Documents 3 common failure patterns (broken code block closings, long line lengths,
  missing blank lines before lists)
- Based on merging `agents/hierarchy.md` + `agents/agent-hierarchy.md` in ProjectOdyssey PR #3334

## Key Findings

**What Worked**:
- Parallel file reads to quickly identify overlap vs unique content
- `grep -rn "filename.md" --include="*.md"` to find all 7 cross-references before deletion
- Running `SKIP=mojo-format pixi run pre-commit run markdownlint-cli2 --all-files` to catch
  line-length and spacing errors from merged content

**What Failed**:
- Original file used ` ```text ` to close fenced code blocks (should be plain ` ``` `)
- Merged content had lines up to 241 characters (MD013 limit is 120) — needed wrapping
- Self-referential "See Also" link pointed to the file being deleted

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` — 387 passed, 0 failed
- [ ] Install plugin and verify skill appears in skill list
- [ ] Check skill triggers on relevant documentation merge tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)