### PR TITLE
feat: add stale-script-cleanup skill

### DIFF
--- a/skills/tooling/stale-script-cleanup/.claude-plugin/plugin.json
+++ b/skills/tooling/stale-script-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "stale-script-cleanup",
+  "version": "1.0.0",
+  "description": "Remove stale one-time fix/migration scripts from a scripts/ directory safely. Use when: (1) scripts/ directory has accumulated one-time fix or migration scripts no longer needed, (2) cleaning up development artifacts before a release, (3) reducing cognitive load for new contributors by removing irrelevant scripts.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["cleanup", "scripts", "maintenance", "git", "refactoring"]
+}

--- a/skills/tooling/stale-script-cleanup/references/notes.md
+++ b/skills/tooling/stale-script-cleanup/references/notes.md
@@ -1,0 +1,101 @@
+# Session Notes: Stale Script Cleanup
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Issue**: HomericIntelligence/ProjectOdyssey#3148
+- **PR**: HomericIntelligence/ProjectOdyssey#3335
+- **Branch**: `3148-auto-impl`
+- **Working directory**: `/home/mvillmow/Odyssey2/.worktrees/issue-3148`
+
+## Objective
+
+Remove 19 one-time fix/migration scripts from `scripts/` directory in ProjectOdyssey
+that were used during development and are no longer needed. Issue title:
+"[P1-5] Remove stale one-time migration and fix scripts (~19 files)"
+
+## Scripts Deleted
+
+```
+scripts/fix_arithmetic_backward.sh
+scripts/fix_code_fences.py
+scripts/fix_docstring_warnings.py
+scripts/fix_floor_divide_edge.sh
+scripts/fix_initializer_signatures.py
+scripts/fix_invalid_links.py
+scripts/fix_list_initialization.py
+scripts/fix_list_patterns.py
+scripts/fix_list_syntax_batch.py
+scripts/fix_markdown_errors.py
+scripts/fix_markdown_lint.py
+scripts/fix_markdown.py
+scripts/fix_remaining_markdown.py
+scripts/fix_syntax_errors.py
+scripts/fix_yaml_colon_parsing.sh
+scripts/create_fix_pr.py
+scripts/create_benchmark_distribution.sh
+scripts/migrate_notes_to_github.py
+scripts/update_agents_claude4.py
+```
+
+## Steps Taken
+
+1. Read `.claude-prompt-3148.md` to understand the task
+2. Listed `scripts/` directory to confirm all 19 files exist
+3. Ran broad grep to check if any file was referenced in:
+   - GitHub Actions workflows (`.yml`/`.yaml`)
+   - Justfile / justfile
+   - Python scripts (`.py`)
+   - Shell scripts (`.sh`)
+   - Markdown files (`.md`)
+4. Found references only in:
+   - The scripts themselves (self-references)
+   - `docs/dev/` blog/notes files (historical)
+   - `scripts/README.md` (documentation section for `fix_markdown.py`)
+5. Deleted all 19 scripts with a single `rm` command
+6. Edited `scripts/README.md` to remove:
+   - The `fix_markdown.py` entry in the directory listing
+   - The full documentation section for `fix_markdown.py`
+7. Ran `pixi run pre-commit run --all-files` — all hooks passed
+8. Committed, pushed, created PR#3335, enabled auto-merge
+
+## Key Observations
+
+### `just` Not Available
+
+The CLAUDE.md recommends `just pre-commit-all` but `just` was not installed on this system.
+`pixi run pre-commit run --all-files` works as a direct substitute.
+
+### Self-references Are Safe to Ignore
+
+When grepping for references, scripts that only appear in their own file body,
+blog posts (`notes/blog/`), or `docs/dev/` notes are safe to delete.
+Only references in active tooling matter.
+
+### scripts/README.md Had TWO Locations
+
+`fix_markdown.py` appeared in:
+1. The directory tree listing (line ~34) — removed
+2. A full documentation section with Usage/Features/Examples — removed
+
+Both needed to be cleaned up for accuracy.
+
+### Commit SHA
+
+`3b74ccc2` — "cleanup(scripts): remove 19 stale one-time fix/migration scripts"
+
+## Pre-commit Hook Results
+
+All hooks passed:
+- Check for deprecated List[Type](args) syntax: Passed
+- Check for shell=True (Security): Passed
+- Ruff Format Python: Passed
+- Ruff Check Python: Passed
+- Validate Test Coverage: Passed
+- Markdown Lint: Passed
+- Strip Notebook Outputs: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check YAML: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed

--- a/skills/tooling/stale-script-cleanup/skills/stale-script-cleanup/SKILL.md
+++ b/skills/tooling/stale-script-cleanup/skills/stale-script-cleanup/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: stale-script-cleanup
+description: "Remove stale one-time fix/migration scripts safely. Use when: scripts/ directory has accumulated one-time scripts no longer needed, cleaning up before releases, or reducing contributor confusion."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Name** | stale-script-cleanup |
+| **Category** | tooling |
+| **Complexity** | S (Simple) |
+| **Risk** | Low — deletions are reversible via git |
+
+Safely identifies and removes one-time fix/migration scripts from a `scripts/` directory
+that have accumulated during development. Ensures nothing is broken before deletion by
+verifying no workflows or build recipes reference the scripts.
+
+## When to Use
+
+- GitHub issue requests removal of ~N stale fix/migration scripts
+- `scripts/` directory has grown cluttered with one-time-use files
+- New contributors are confused by scripts that are no longer relevant
+- Pre-release cleanup to reduce maintenance surface area
+
+## Verified Workflow
+
+### Step 1: Confirm files exist
+
+```bash
+ls scripts/ | sort
+```
+
+### Step 2: Check for references in CI/workflows and build system
+
+Run these checks in parallel — they are independent:
+
+```bash
+# Check GitHub Actions workflows and Justfile
+grep -r "<script-name>" --include="*.yml" --include="*.yaml" --include="justfile" --include="Justfile" -l
+
+# Check broader file types (Python, shell, markdown)
+grep -r "<script-name>" --include="*.py" --include="*.sh" --include="*.md" -l
+```
+
+Key insight: References found only inside the scripts themselves (self-references),
+blog posts, or notes are safe to ignore. Only references in CI workflows, Justfile
+recipes, or active tooling scripts require keeping the file.
+
+### Step 3: Delete confirmed stale scripts
+
+```bash
+rm scripts/fix_foo.py scripts/migrate_bar.sh scripts/create_baz.py
+```
+
+### Step 4: Update documentation
+
+If `scripts/README.md` documents any deleted scripts, remove those sections.
+Look for both the directory listing entry AND any full documentation sections.
+
+```bash
+grep -n "<deleted-script-name>" scripts/README.md
+```
+
+### Step 5: Validate with pre-commit
+
+```bash
+pixi run pre-commit run --all-files
+# OR
+just pre-commit-all
+```
+
+All hooks must pass before committing.
+
+### Step 6: Commit, push, create PR
+
+```bash
+git add scripts/
+git commit -m "cleanup(scripts): remove N stale one-time fix/migration scripts
+
+Closes #<issue-number>"
+
+git push -u origin <branch-name>
+gh pr create --title "cleanup(scripts): remove stale scripts" \
+  --body "Closes #<issue-number>" \
+  --label "cleanup"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command runner | `just` was not in PATH on this system | Fall back to `pixi run pre-commit run --all-files` when `just` is unavailable |
+| Using `$$` for PID-scoped build dir in bash | `MNEMOSYNE_DIR="build/$$/..."` then `echo $MNEMOSYNE_DIR` | `$$` expands to the shell PID at assignment but the variable was empty when echoed in a new shell invocation | Use a fixed path like `build/mnemosyne/ProjectMnemosyne` instead of relying on `$$` across separate Bash tool calls |
+
+## Results & Parameters
+
+### Pre-commit hooks that run
+
+- `mojo format` (Mojo files only — skipped for pure script cleanup)
+- `markdownlint-cli2` — validates README.md edits
+- `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`
+- `ruff-format`, `ruff-check` — for Python files
+- `validate-test-coverage` — ensures no test files are orphaned
+
+### Grep patterns for bulk reference check
+
+```bash
+# Build one grep pattern for all scripts at once
+grep -r "fix_arithmetic_backward\|fix_code_fences\|fix_markdown" \
+  --include="*.yml" --include="*.yaml" --include="justfile" -l
+```
+
+### Commit message format
+
+```text
+cleanup(scripts): remove N stale one-time fix/migration scripts
+
+Brief description of what was deleted and verification done.
+
+Closes #<issue-number>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for safely removing one-time fix/migration scripts from a project's
`scripts/` directory, based on a real cleanup of 19 stale scripts in ProjectOdyssey.

- Safe verification pattern: grep for references in CI workflows AND broader files before deleting
- Key insight: self-references and blog/notes references are safe to ignore
- Handles README.md with multiple locations (directory listing + documentation section)

## Key Findings

**What Worked**:
- Single `rm` command for all 19 files at once
- Grepping for all script names in one pipe-delimited pattern
- `pixi run pre-commit run --all-files` as fallback when `just` unavailable

**What Failed**:
- `just pre-commit-all` → `just` not installed on target system; use pixi fallback
- PID-scoped build dirs with `$$` → don't persist across separate Bash tool calls; use fixed paths

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)