### PR TITLE
feat: add adr-status-deferred-update skill

### DIFF
--- a/skills/documentation/adr-status-deferred-update/.claude-plugin/plugin.json
+++ b/skills/documentation/adr-status-deferred-update/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr-status-deferred-update",
+  "version": "1.0.0",
+  "description": "Update ADR status to Accepted (Deferred) when implementation is bypassed pending language/platform support. Use when: (1) an ADR has Status: Accepted but its implementation is fully or partially bypassed, (2) the bypass is temporary pending a known platform limitation (e.g., global state, stdlib gap), (3) documentation needs to accurately reflect deferred rather than active implementation.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["adr", "status", "deferred", "documentation", "mojo", "global-state"]
+}

--- a/skills/documentation/adr-status-deferred-update/references/notes.md
+++ b/skills/documentation/adr-status-deferred-update/references/notes.md
@@ -1,0 +1,49 @@
+# Session Notes: ADR-003 Status Update
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Issue**: ProjectOdyssey #3151
+- **PR**: ProjectOdyssey #3339
+- **Branch**: `3151-auto-impl`
+
+## Objective
+
+Update `docs/adr/ADR-003-memory-pool-architecture.md` status from `Accepted` to
+`Accepted (Deferred)` to reflect that `pooled_alloc()`/`pooled_free()` bypass the
+memory pool via direct `malloc`/`free`, pending Mojo global variable support.
+
+## File Changed
+
+`docs/adr/ADR-003-memory-pool-architecture.md`
+
+- Line 3: `**Status**: Accepted` → `**Status**: Accepted (Deferred)`
+- Line 301: `- **Status**: Accepted` → `- **Status**: Accepted (Deferred)` (Document Metadata)
+
+## Key Observations
+
+1. ADR had status in two places — the header (line 3) and the Document Metadata section
+   (line ~301). Using `replace_all: true` on Edit updated both in one operation.
+
+2. The ADR body already had a "Current Limitation" section (lines 97-111) that documented
+   the bypass and explained the Mojo global state constraint. Only the status label was wrong.
+
+3. `just` was not available in the worktree shell. `pixi run npx markdownlint-cli2` also
+   failed. The working command was `pixi run pre-commit run markdownlint-cli2 --files <file>`.
+
+4. Markdownlint passed on first try — the change was purely a label update, no formatting impact.
+
+## Implementation
+
+```
+Edit with replace_all=true:
+  old: **Status**: Accepted
+  new: **Status**: Accepted (Deferred)
+```
+
+## Environment
+
+- Shell: bash (worktree environment)
+- Package manager: pixi
+- Linting: pre-commit via pixi (`pixi run pre-commit run markdownlint-cli2`)
+- `just` and `npx` not available in this shell

--- a/skills/documentation/adr-status-deferred-update/skills/adr-status-deferred-update/SKILL.md
+++ b/skills/documentation/adr-status-deferred-update/skills/adr-status-deferred-update/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: adr-status-deferred-update
+description: "Update ADR status to Accepted (Deferred) when implementation is bypassed pending platform support. Use when: ADR is marked Accepted but code explicitly bypasses the design, or a known platform limitation prevents activation."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Category | documentation |
+| Trigger | ADR status says Accepted but implementation uses a bypass (e.g., `# Temporary: Direct malloc`) |
+| Root Cause | Status label was set at design time and not updated when implementation deferred activation |
+| Fix | Change status to `Accepted (Deferred)` in both header and Document Metadata section |
+
+## When to Use
+
+- An ADR has `**Status**: Accepted` but the implementation explicitly bypasses the architecture
+- The bypass comment references a known platform gap (e.g., Mojo global variable support, missing stdlib feature)
+- The underlying design decision is still valid — only the _active status_ is incorrect
+- A PR or issue flags the discrepancy between ADR status and code reality
+
+## Verified Workflow
+
+1. **Read the ADR** to confirm it has both a header status and a Document Metadata status:
+
+   ```text
+   **Status**: Accepted          ← line ~3 (header)
+   ...
+   - **Status**: Accepted        ← line ~301 (Document Metadata section)
+   ```
+
+2. **Use `replace_all: true`** in the Edit tool to update both occurrences in one operation:
+
+   ```
+   old_string: **Status**: Accepted
+   new_string: **Status**: Accepted (Deferred)
+   replace_all: true
+   ```
+
+3. **Verify both locations were updated** by reading the file at the header and tail.
+
+4. **Run markdownlint** to confirm no formatting regressions:
+
+   ```bash
+   pixi run pre-commit run markdownlint-cli2 --files docs/adr/<adr-file>.md
+   ```
+
+   Note: Use `pixi run pre-commit run markdownlint-cli2 --files <file>`, NOT
+   `pixi run npx markdownlint-cli2` (npx may not be available in all environments).
+
+5. **Commit with conventional commit format**:
+
+   ```bash
+   git commit -m "docs(adr): update ADR-NNN status to Accepted (Deferred)"
+   ```
+
+6. **Create PR** linked to the tracking issue and enable auto-merge.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `just pre-commit-all` | Ran `just pre-commit-all` to validate markdown | `just` not available in the worktree shell environment | Use `pixi run pre-commit run markdownlint-cli2 --files <file>` instead |
+| `pixi run npx markdownlint-cli2` | Ran markdownlint via npx | `npx` not available in the pixi environment | Use `pixi run pre-commit run markdownlint-cli2 --files <file>` — pre-commit has the tool |
+| Single Edit without `replace_all` | Edited only the header status field | ADR has two status locations (header + Document Metadata); only one was updated | Use `replace_all: true` to catch all occurrences in one edit |
+
+## Results & Parameters
+
+### Correct Edit Command
+
+```text
+Tool: Edit
+file_path: docs/adr/ADR-NNN-<name>.md
+old_string: **Status**: Accepted
+new_string: **Status**: Accepted (Deferred)
+replace_all: true
+```
+
+### Correct Lint Command
+
+```bash
+# Works in pixi-managed environments (does NOT require npx or just)
+pixi run pre-commit run markdownlint-cli2 --files docs/adr/<adr-file>.md
+```
+
+### Commit Message Pattern
+
+```bash
+git commit -m "docs(adr): update ADR-NNN status to Accepted (Deferred)
+
+<Brief explanation of what the bypass is and why it is deferred>
+
+Closes #<issue-number>"
+```
+
+### When the ADR Already Has a "Current Limitation" Section
+
+If the ADR body already documents the bypass (e.g., has a "Current Limitation" or "Known Limitation"
+section with the bypass code), only the status label needs changing — no body edits required.
+The existing limitation section is sufficient context.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3151, PR #3339 | ADR-003 memory pool bypassed pending Mojo global state support |


### PR DESCRIPTION
## Summary

Documents the workflow for updating ADR status to `Accepted (Deferred)` when
an implementation explicitly bypasses the design pending a known platform limitation.

- `replace_all: true` in Edit catches all status occurrences (header + Document Metadata) in one pass
- Markdownlint works via `pixi run pre-commit run markdownlint-cli2 --files <file>`; `just` and `npx` may not be available in worktree shells
- If the ADR body already has a "Current Limitation" section, only the status label needs changing

## Key Findings

**What Worked**:
- Single `replace_all` Edit updated both status locations atomically
- `pixi run pre-commit run markdownlint-cli2 --files <file>` validated the change without npx or just
- Conventional commit `docs(adr):` prefix passed pre-commit hooks

**What Failed**:
- `just pre-commit-all` — `just` not available in worktree shell environment
- `pixi run npx markdownlint-cli2` — `npx` not available via pixi

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] 387 plugins pass, 0 failures
- [ ] Install plugin and verify skill appears in `/advise` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
