### PR TITLE
feat: add fix-precommit-pass-filenames skill

### DIFF
--- a/skills/ci-cd/fix-precommit-pass-filenames/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-precommit-pass-filenames/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-precommit-pass-filenames",
+  "version": "1.0.0",
+  "description": "Fix pre-commit hooks that use pass_filenames: false when they should use pass_filenames: true, removing hardcoded directory args from entry so pre-commit passes only changed files. Use when: (1) pre-commit hooks always scan entire directories instead of only changed files, (2) hooks are slower than expected on partial changes, (3) ruff/linter hooks have hardcoded directory paths in entry instead of using file filtering.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["pre-commit", "ruff", "pass-filenames", "incremental", "performance"]
+}

--- a/skills/ci-cd/fix-precommit-pass-filenames/references/notes.md
+++ b/skills/ci-cd/fix-precommit-pass-filenames/references/notes.md
@@ -1,0 +1,53 @@
+# Session Notes: fix-precommit-pass-filenames
+
+## Context
+
+- **Issue**: #3154 — Fix ruff pre-commit hooks to use pass_filenames: true
+- **Branch**: 3154-auto-impl
+- **PR**: #3347
+- **Date**: 2026-03-05
+
+## Problem
+
+`.pre-commit-config.yaml` had two ruff hooks with `pass_filenames: false` and hardcoded
+directory args in `entry`. This meant every commit triggered a full scan of `scripts/`,
+`examples/`, `tests/`, and `tools/` regardless of which files actually changed.
+
+## Root Cause
+
+When `pass_filenames: false`, pre-commit calls the entry command with no file arguments.
+The hook then uses its own hardcoded paths. The `files:` pattern only controls which staged
+files trigger the hook — it does not restrict what the hook scans.
+
+With `pass_filenames: true`, pre-commit appends the matching staged files to the entry
+command, enabling true incremental checking.
+
+## Exact Change
+
+File: `.pre-commit-config.yaml`
+
+```diff
+- entry: pixi run ruff format scripts/ examples/ tests/ tools/
++ entry: pixi run ruff format
+- pass_filenames: false
++ pass_filenames: true
+
+- entry: pixi run ruff check --fix scripts/ examples/ tests/ tools/
++ entry: pixi run ruff check --fix
+- pass_filenames: false
++ pass_filenames: true
+```
+
+## Verification
+
+```
+$ pixi run pre-commit run --all-files
+Ruff Format Python.......................................................Passed
+Ruff Check Python........................................................Passed
+```
+
+All other hooks also passed (Mojo Format hook failed due to GLIBC on Debian 10 — pre-existing).
+
+## Time taken
+
+~5 minutes total: read config, make 4-line edit, run verification, commit, push, create PR.

--- a/skills/ci-cd/fix-precommit-pass-filenames/skills/fix-precommit-pass-filenames/SKILL.md
+++ b/skills/ci-cd/fix-precommit-pass-filenames/skills/fix-precommit-pass-filenames/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: fix-precommit-pass-filenames
+description: "Fix pre-commit hooks that use pass_filenames: false when they should use pass_filenames: true, removing hardcoded directory args so pre-commit passes only changed files. Use when: hooks always scan entire directories instead of only changed files, or linter entry commands have hardcoded directory paths."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | fix-precommit-pass-filenames |
+| **Category** | ci-cd |
+| **Complexity** | S (small) |
+| **Language** | YAML |
+| **File** | `.pre-commit-config.yaml` |
+
+## When to Use
+
+- A pre-commit hook uses `pass_filenames: false` but also specifies a `files:` pattern — this combination means the hook always runs on the full directories regardless of what changed
+- Ruff (or similar linter) hooks have hardcoded directory paths in `entry` (e.g., `ruff format scripts/ tests/`) instead of relying on pre-commit's file filtering
+- Hooks are noticeably slow on commits touching a single file
+- Issue/PR description says "use pass_filenames: true and remove hardcoded directories"
+
+## Verified Workflow
+
+1. Read `.pre-commit-config.yaml` to identify affected hooks
+2. For each hook with `pass_filenames: false` and a `files:` pattern:
+   - Change `pass_filenames: false` → `pass_filenames: true`
+   - Remove hardcoded directory args from `entry` (keep only the command and fixed flags)
+   - The `files:` pattern already restricts which files are passed — no other changes needed
+3. Run `pixi run pre-commit run --all-files` to verify all hooks still pass
+4. Commit and push; create PR with `Closes #<issue>`
+
+### Example transformation
+
+Before:
+
+```yaml
+- id: ruff-format-python
+  entry: pixi run ruff format scripts/ examples/ tests/ tools/
+  files: ^(scripts|examples|tests|tools)/.*\.py$
+  pass_filenames: false
+```
+
+After:
+
+```yaml
+- id: ruff-format-python
+  entry: pixi run ruff format
+  files: ^(scripts|examples|tests|tools)/.*\.py$
+  pass_filenames: true
+```
+
+Pre-commit will now call `pixi run ruff format <file1> <file2> ...` with only the changed
+files that match the `files:` pattern.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command runner | `just` not in PATH on this machine | Fall back to `pixi run pre-commit run --all-files` directly |
+| Removing `files:` pattern too | Considered removing `files:` alongside adding `pass_filenames: true` | Not needed — `files:` is still required to restrict hook to Python files | Only remove the hardcoded dirs from `entry`; keep `files:` intact |
+
+## Results & Parameters
+
+### Verified config snippet (ruff hooks)
+
+```yaml
+- id: ruff-format-python
+  name: Ruff Format Python
+  entry: pixi run ruff format
+  language: system
+  files: ^(scripts|examples|tests|tools)/.*\.py$
+  types: [python]
+  pass_filenames: true
+
+- id: ruff-check-python
+  name: Ruff Check Python
+  entry: pixi run ruff check --fix
+  language: system
+  files: ^(scripts|examples|tests|tools)/.*\.py$
+  types: [python]
+  pass_filenames: true
+```
+
+### Verification command
+
+```bash
+pixi run pre-commit run --all-files
+# Expected: Ruff Format Python...Passed, Ruff Check Python...Passed
+```
+
+### Note on GLIBC errors
+
+The `mojo-format` hook may produce GLIBC version errors on older Linux systems (Debian 10).
+These are pre-existing environment limitations unrelated to `pass_filenames` changes and do
+not cause the hook to fail CI (CI runs inside Docker with newer glibc).


### PR DESCRIPTION
## Summary

- Documents how to fix pre-commit hooks using `pass_filenames: false` with hardcoded directory paths
- Pattern: change to `pass_filenames: true` and strip hardcoded dirs from `entry`; keep `files:` pattern intact
- Verified on ProjectOdyssey issue #3154 (ruff hooks)

## Key Findings

**What Worked**:
- 4-line edit: two `pass_filenames: false` → `true`, two `entry` lines stripped of directory args
- `pixi run pre-commit run --all-files` confirms both Ruff hooks pass after change

**What Failed**:
- `just pre-commit-all` not in PATH on Debian 10 — use `pixi run pre-commit run --all-files` directly
- Considered removing `files:` pattern — not needed, it serves a different purpose (triggering condition vs. scanning scope)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [x] Skill placed under `skills/ci-cd/fix-precommit-pass-filenames/`
- [x] `plugin.json` has all required fields (name, version, description, category, date)
- [x] `SKILL.md` has YAML frontmatter, Overview, When to Use, Verified Workflow, Failed Attempts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)