### PR TITLE
feat: add claude-md-doc-consolidation skill

### DIFF
--- a/skills/documentation/claude-md-doc-consolidation/.claude-plugin/plugin.json
+++ b/skills/documentation/claude-md-doc-consolidation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "claude-md-doc-consolidation",
+  "version": "1.0.0",
+  "description": "Trim duplicate documentation sections in CLAUDE.md by replacing verbose content with a summary + link to canonical docs. Use when: (1) CLAUDE.md has sections that duplicate content in docs/, (2) CLAUDE.md is growing too large and consuming excess tokens, (3) consolidating 4+ doc locations to 2.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["claude-md", "documentation", "consolidation", "token-reduction", "dry"]
+}

--- a/skills/documentation/claude-md-doc-consolidation/references/notes.md
+++ b/skills/documentation/claude-md-doc-consolidation/references/notes.md
@@ -1,0 +1,40 @@
+# Session Notes: claude-md-doc-consolidation
+
+## Context
+
+- **Issue**: #3153 — [P2-3] Consolidate testing strategy documentation (4 → 2 locations)
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3153-auto-impl
+- **Date**: 2026-03-05
+
+## Problem
+
+CLAUDE.md (1,786 lines) contained a ~112-line Testing Strategy section that nearly
+duplicated `docs/dev/testing-strategy.md`. This section was loaded into context on
+every Claude Code session, consuming unnecessary tokens.
+
+The issue asked to trim it to a 3-5 line summary + link.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3153.md` to understand the task
+2. Used `Grep` to locate `## Testing Strategy` at line 1236
+3. Read CLAUDE.md lines 1236-1347 (the full section)
+4. Confirmed `docs/dev/testing-strategy.md` exists and is comprehensive
+5. Used `Edit` tool to replace 112 lines with 5-line summary
+6. Ran `pixi run pre-commit run --all-files` — all hooks passed except mojo-format
+7. mojo-format failed due to GLIBC 2.32/2.33/2.34 requirement on older host
+8. Since no .mojo files were changed, used `SKIP=mojo-format git commit ...`
+9. Pushed branch and created PR #3348 with auto-merge enabled
+
+## Key Observations
+
+- `just` is not in PATH on this host — must use `pixi run pre-commit ...` directly
+- mojo binary requires GLIBC 2.32+; this host has an older version
+- SKIP=mojo-format is safe when the commit only changes .md files
+- The Edit tool is the right approach for targeted section replacement
+- Canonical doc was already complete — no content needed to be added
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/3348

--- a/skills/documentation/claude-md-doc-consolidation/skills/claude-md-doc-consolidation/SKILL.md
+++ b/skills/documentation/claude-md-doc-consolidation/skills/claude-md-doc-consolidation/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: claude-md-doc-consolidation
+description: "Trim duplicate documentation sections in CLAUDE.md by replacing verbose content with a summary + link to canonical docs. Use when: CLAUDE.md has sections duplicating docs/ content, file is too large, or consolidating multiple doc locations."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | claude-md-doc-consolidation |
+| **Category** | documentation |
+| **Complexity** | S (Small) |
+| **PR Pattern** | Edit CLAUDE.md → pre-commit (SKIP mojo-format if needed) → commit → PR |
+
+## When to Use
+
+- CLAUDE.md has a section that nearly duplicates content in `docs/dev/` or similar canonical docs
+- CLAUDE.md is growing large (1,500+ lines) and consuming excess tokens on every context load
+- Issue asks to consolidate N doc locations to 2 (CLAUDE.md summary + canonical doc)
+- The canonical doc already exists and is complete
+
+## Verified Workflow
+
+1. **Read the target section** in CLAUDE.md (use `Grep` to find line numbers, then `Read` with offset/limit)
+2. **Verify canonical doc** at `docs/dev/<topic>.md` is complete and covers everything in the CLAUDE.md section
+3. **Replace with Edit tool** — swap the verbose section for the 3-5 line summary format:
+   ```markdown
+   ## <Section Title>
+
+   See [docs/dev/<topic>.md](docs/dev/<topic>.md) for the complete
+   <brief description of what the canonical doc covers>.
+   ```
+4. **Run pre-commit** — `pixi run pre-commit run --all-files`
+   - If `mojo-format` fails due to GLIBC incompatibility on older Linux hosts, use `SKIP=mojo-format git commit ...`
+   - All other hooks (markdownlint, trailing-whitespace, check-yaml, etc.) must pass
+5. **Commit with `SKIP=mojo-format`** if no `.mojo` files were changed:
+   ```bash
+   SKIP=mojo-format git commit -m "docs(claude): trim <section> section to summary + link"
+   ```
+6. **Push and create PR** with `Closes #<issue>` in body, enable auto-merge
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command runner | `just` not in PATH on this host | Use `pixi run pre-commit run --all-files` directly |
+| Full pre-commit without SKIP | Ran all hooks including mojo-format | mojo binary requires GLIBC 2.32-2.34, host has older version | Use `SKIP=mojo-format` when no `.mojo` files were changed |
+
+## Results & Parameters
+
+**Target section size**: ~85-115 lines → 3-5 lines (95%+ reduction)
+
+**Canonical summary template**:
+```markdown
+## <Section Title>
+
+See [docs/dev/<topic>.md](docs/dev/<topic>.md) for the complete
+<tier1 description>, <tier2 description>, and
+<tier3 description>.
+```
+
+**Commit command** (when no `.mojo` files changed):
+```bash
+SKIP=mojo-format git commit -m "$(cat <<'EOF'
+docs(claude): trim <section> section to summary + link
+
+Replaces ~N-line duplicate section in CLAUDE.md with a 3-line summary
+pointing to the canonical docs/dev/<topic>.md.
+
+Reduces CLAUDE.md token consumption on every context load.
+
+Closes #<issue>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Success criteria**:
+- CLAUDE.md section is ≤10 lines
+- Canonical doc is complete and accurate
+- All pre-commit hooks pass (except mojo-format on GLIBC-incompatible hosts)
+- PR linked to issue with auto-merge enabled


### PR DESCRIPTION
## Summary

- Documents the workflow for trimming duplicate documentation sections in CLAUDE.md
- Captures the `SKIP=mojo-format` workaround for GLIBC-incompatible hosts
- Notes that `just` is not available; use `pixi run pre-commit` directly

## Key Findings

**What Worked**:
- `Edit` tool for targeted section replacement (112 lines → 5 lines)
- `SKIP=mojo-format git commit` when only `.md` files changed on older Linux hosts
- Verifying canonical doc completeness before trimming

**What Failed**:
- `just pre-commit-all` — `just` not in PATH on this host
- Running mojo-format hook — GLIBC 2.32/2.33/2.34 required, not available

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 387/387 pass
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with CLAUDE.md consolidation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)