### PR TITLE
feat: add consolidate-ci-matrix skill

### DIFF
--- a/skills/ci-cd/consolidate-ci-matrix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/consolidate-ci-matrix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "consolidate-ci-matrix",
+  "version": "1.0.0",
+  "description": "Consolidate GitHub Actions matrix test groups to reduce job overhead. Use when: (1) CI matrix has too many groups (>20) causing excessive startup overhead, (2) reducing CI wall time without losing test coverage, (3) grouping related test directories that rarely fail independently.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["github-actions", "matrix", "test-groups", "ci-optimization", "mojo"]
+}

--- a/skills/ci-cd/consolidate-ci-matrix/references/notes.md
+++ b/skills/ci-cd/consolidate-ci-matrix/references/notes.md
@@ -1,0 +1,74 @@
+# Session Notes: CI Matrix Consolidation
+
+## Context
+
+- **Issue**: ProjectOdyssey #3156 — Reduce CI test matrix granularity (32 groups → ~15)
+- **Branch**: `3156-auto-impl`
+- **PR**: #3354
+- **Date**: 2026-03-05
+
+## Problem
+
+`comprehensive-tests.yml` had 31 matrix entries + 3 separate non-blocking jobs (Configs,
+Benchmarks, Core Layers). Each GitHub Actions matrix job has ~30-60s startup overhead
+(checkout + pixi setup + just install). With 31 matrix jobs, this was ~15-30min of pure
+overhead per CI run.
+
+Additionally, the CI summary was cluttered with fine-grained groups like "Core DTypes"
+(3 files) that rarely produced unique failure signal.
+
+## Discovery
+
+Carefully read the full matrix (lines 188-289 of comprehensive-tests.yml). Found:
+
+1. **5 redundant entries**: Data Formats, Data Datasets, Data Loaders, Data Transforms,
+   Data Samplers — all covered by the parent "Data" group's `datasets/test_*.mojo`,
+   `formats/test_*.mojo` etc. subdirectory patterns
+2. **8 mergeable pairs/triples**: Related subsystems in the same `tests/shared/core/` path
+   that could be combined
+
+## Consolidation performed
+
+| Original groups | Merged into |
+|----------------|-------------|
+| Core Activations + Core DTypes | Core Activations & Types |
+| Core Initializers + Core NN Modules | Core Neural Network |
+| Core Elementwise + Core ExTensor | Core Operations |
+| Shared Infra + Helpers + Testing Fixtures | Shared Infra & Testing |
+| Top-Level Tests + Debug + Tooling + Fuzz | Misc Tests |
+| Examples + Test Examples | Examples |
+| Data Formats + Data Datasets + Data Loaders + Data Transforms + Data Samplers | REMOVED (redundant) |
+| Autograd + Benchmarking (shared/) | Autograd & Benchmarking |
+
+## Kept separate
+
+- Core Tensors (large, high-signal)
+- Core Gradient (frequently fails independently)
+- Core Utilities (large, distinct from other core groups)
+- Data (already aggregates subdirs)
+- Integration Tests (continue-on-error, segfault-prone)
+- Models (primary test suite)
+- LeNet-5 Examples (different root path)
+- Core Types & Fuzz
+- Benchmark Framework (different root: `benchmarks/` not `tests/`)
+
+## Validation
+
+```bash
+python scripts/validate_test_coverage.py
+# Exit 0 — all test files covered
+```
+
+Pre-commit hooks (excluding mojo-format which fails due to GLIBC 2.32/2.33/2.34
+incompatibility on the dev machine — not related to this change):
+
+```
+SKIP=mojo-format pixi run pre-commit run --all-files
+# All hooks passed
+```
+
+## Final count
+
+- Before: 31 matrix entries
+- After: 16 matrix entries
+- Target: ≤20 (met)

--- a/skills/ci-cd/consolidate-ci-matrix/skills/consolidate-ci-matrix/SKILL.md
+++ b/skills/ci-cd/consolidate-ci-matrix/skills/consolidate-ci-matrix/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: consolidate-ci-matrix
+description: "Consolidate GitHub Actions matrix test groups to reduce job overhead. Use when: (1) CI matrix has >20 groups with ~30-60s startup cost each, (2) grouping related tests that rarely fail independently, (3) reducing CI summary noise while preserving failure signal."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Consolidate CI Test Matrix
+
+Reduce GitHub Actions job count by merging related test groups without losing coverage or failure signal.
+
+## Overview
+
+| Date | Objective | Outcome |
+|------|-----------|---------|
+| 2026-03-05 | Reduce 31-group CI matrix to ~15 for ProjectOdyssey | 31 → 16 groups; all tests covered; validate_test_coverage.py passes |
+
+## When to Use
+
+- (1) CI matrix has >20 groups causing excessive startup overhead (each job = ~30-60s overhead)
+- (2) CI summary is cluttered with fine-grained groups that rarely fail independently
+- (3) Related test directories (e.g. Core Activations + Core DTypes) can share a runner
+- (4) Redundant matrix entries exist (same files covered by multiple patterns)
+
+## Verified Workflow
+
+1. **Read the full matrix** in `.github/workflows/comprehensive-tests.yml` (or equivalent)
+2. **Identify consolidation candidates**:
+   - Groups with overlapping paths (e.g. `tests/shared/data/formats` already covered by `tests/shared/data`)
+   - Groups that test the same subsystem and rarely fail separately
+   - Tiny groups (1-3 test files) that can be appended to a related group's pattern
+3. **Keep separate** any group that:
+   - Frequently fails independently (e.g. gradient math, integration tests)
+   - Has different `path:` root (e.g. `benchmarks/` vs `tests/`)
+   - Has `continue-on-error: true` (already a special case)
+4. **Merge patterns** by combining space-separated file lists in the `pattern:` field
+5. **Remove duplicate entries** — groups whose files are already matched by a broader pattern
+6. **Run validate_test_coverage.py** to confirm no tests were dropped:
+
+   ```bash
+   python scripts/validate_test_coverage.py
+   # Exit 0 = all test files covered
+   ```
+
+7. **Commit and PR**: No Mojo changes needed — YAML-only diff
+
+## Key Decisions
+
+### What to merge
+
+| Merge candidates | Rationale |
+|-----------------|-----------|
+| Core Activations + Core DTypes | Different feature areas but same `path:`, rarely fail together |
+| Core Initializers + Core NN Modules | Same subsystem (layer construction) |
+| Core Elementwise + Core ExTensor | Both test tensor operation primitives |
+| Shared Infra + Testing Fixtures + Helpers | All support test infrastructure, not core logic |
+| Top-Level + Debug + Tooling + Fuzz | Low-frequency failures, heterogeneous but all under `tests/` |
+
+### What NOT to merge
+
+| Keep separate | Reason |
+|--------------|--------|
+| Core Gradient | Numerical gradient math fails independently; clear signal needed |
+| Integration Tests | Already `continue-on-error: true`; segfault-prone |
+| Models | Primary PR-blocking suite; important standalone signal |
+| Data | Already uses subdirectory patterns — don't merge into others |
+| Benchmark Framework | Different root path (`benchmarks/`) than `tests/` |
+
+### Redundant entries to remove
+
+The "Data" group pattern `datasets/test_*.mojo samplers/test_*.mojo ...` already covers
+all data subdirectory tests. Remove separate "Data Formats", "Data Datasets", "Data Loaders",
+"Data Transforms", "Data Samplers" entries entirely.
+
+## Results & Parameters
+
+### Before/After
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Matrix groups | 31 | 16 |
+| Separate non-blocking jobs | 3 | 3 (unchanged) |
+| Test files covered | 100% | 100% |
+| Startup overhead saved | — | ~15 × 45s = ~11min saved |
+
+### Pattern for merging two groups
+
+```yaml
+# Before (2 jobs):
+- name: "Core Activations"
+  path: "tests/shared/core"
+  pattern: "test_activations.mojo test_activation_funcs.mojo"
+- name: "Core DTypes"
+  path: "tests/shared/core"
+  pattern: "test_unsigned.mojo test_dtype_dispatch.mojo"
+
+# After (1 job):
+- name: "Core Activations & Types"
+  path: "tests/shared/core"
+  pattern: "test_activations.mojo test_activation_funcs.mojo test_unsigned.mojo test_dtype_dispatch.mojo"
+```
+
+### Pattern for subdirectory consolidation
+
+```yaml
+# Before (redundant — formats already covered by parent):
+- name: "Data"
+  path: "tests/shared/data"
+  pattern: "test_*.mojo datasets/test_*.mojo formats/test_*.mojo loaders/test_*.mojo"
+- name: "Data Formats"  # REDUNDANT
+  path: "tests/shared/data/formats"
+  pattern: "test_*.mojo"
+
+# After (remove "Data Formats" entry entirely):
+- name: "Data"
+  path: "tests/shared/data"
+  pattern: "test_*.mojo datasets/test_*.mojo formats/test_*.mojo loaders/test_*.mojo"
+```
+
+### Validation command
+
+```bash
+python scripts/validate_test_coverage.py
+# Script parses YAML matrix and checks every test_*.mojo file is covered
+# Exit 0 = success; exit 1 = uncovered tests found
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Merging groups with different `path:` roots | Combined `benchmarks/` and `tests/shared/benchmarking/` into one entry | `just test-group` uses a single `path` prefix; can't glob across two roots | Keep separate matrix entries when root paths differ |
+| Removing all data sub-groups | Deleted Data Formats/Loaders/etc. without checking "Data" group coverage first | Would have dropped tests if "Data" group didn't include subdirectory patterns | Always verify parent group patterns cover subdirs before removing child entries |
+| Setting `path: "tests"` for Autograd tests | Used `tests` as path with `autograd/test_*.mojo` pattern | Correct approach (glob works), but confusing — easier to use specific path | Use specific path when single-subsystem; use parent path only when grouping multiple subsystems |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3156, PR #3354 | Mojo test suite, `just test-group` runner, `validate_test_coverage.py` gate |
+
+## References
+
+- See `validate-workflow` skill for general workflow validation
+- See `github-actions-mojo` skill for Mojo-specific CI setup
+- ProjectOdyssey `scripts/validate_test_coverage.py` — Python script that parses YAML matrix and checks coverage


### PR DESCRIPTION
## Summary

Documents the pattern for consolidating GitHub Actions matrix test groups to reduce per-PR CI overhead.

- Captures the 31 → 16 group reduction from ProjectOdyssey issue #3156
- Documents which groups to merge vs. keep separate and why
- Provides copy-paste patterns for merging and removing redundant entries

## Key Findings

**What Worked**:
- Merging groups with the same `path:` root by concatenating `pattern:` values
- Removing redundant child-path entries (e.g. `tests/shared/data/formats`) when a parent entry already covers them via subdirectory glob patterns
- Using `validate_test_coverage.py` as an automated gate to confirm 100% coverage after consolidation

**What Failed**:
- Attempting to merge groups with different root paths (`benchmarks/` vs `tests/`) into a single entry — `just test-group` uses a single path prefix, so each distinct root needs its own entry
- Removing data sub-groups without first verifying the parent "Data" entry's patterns actually covered them

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` (passed)
- [x] All required sections present (YAML frontmatter, Overview, When to Use, Verified Workflow, Failed Attempts table, Results & Parameters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)