### PR TITLE
feat: add small-doc-edit-workflow skill

### DIFF
--- a/skills/documentation/small-doc-edit-workflow/.claude-plugin/plugin.json
+++ b/skills/documentation/small-doc-edit-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "small-doc-edit-workflow",
+  "version": "1.0.0",
+  "description": "Workflow for implementing small, well-specified documentation edits: read file, apply targeted Edit, verify with pre-commit, commit and create PR. Use when: (1) issue specifies exact line/location for a doc change, (2) adding a note or clarification to an existing markdown file, (3) change is a single insert with no structural refactoring.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["documentation", "markdown", "pull-request", "pre-commit", "worktree"]
+}

--- a/skills/documentation/small-doc-edit-workflow/references/notes.md
+++ b/skills/documentation/small-doc-edit-workflow/references/notes.md
@@ -1,0 +1,34 @@
+# Session Notes: small-doc-edit-workflow
+
+## Context
+
+- **Issue**: #3160 — [Bonus] Add output destination note to docs/ANALYSIS_PROMPT.md
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3160-auto-impl (worktree at /home/mvillmow/Odyssey2/.worktrees/issue-3160)
+- **Date**: 2026-03-05
+
+## Objective
+
+Add a single markdown note after line 4 of `docs/ANALYSIS_PROMPT.md` clarifying that
+analysis output should be conversation text only, not committed to the repo.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3160.md` to parse the issue requirements
+2. Read `docs/ANALYSIS_PROMPT.md` to confirm insertion point (after line 4)
+3. Applied Edit with `old_string` anchoring on the line before the `---` separator
+4. Ran `pixi run pre-commit run --all-files` — all hooks passed (GLIBC warnings for mojo are non-fatal)
+5. Committed: `docs(analysis-prompt): add output destination note`
+6. Pushed branch, created PR #3362, enabled auto-merge
+
+## Environment Notes
+
+- `just` is not on PATH in this environment — use `pixi run pre-commit` directly
+- GLIBC version errors from mojo format hook are non-fatal (library incompatibility with host OS)
+- pre-commit hooks: mojo format, markdownlint-cli2, trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, mixed-line-ending
+
+## Result
+
+- PR #3362 created and auto-merge enabled
+- All pre-commit hooks passed
+- Change: 3 lines added to docs/ANALYSIS_PROMPT.md

--- a/skills/documentation/small-doc-edit-workflow/skills/small-doc-edit-workflow/SKILL.md
+++ b/skills/documentation/small-doc-edit-workflow/skills/small-doc-edit-workflow/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: small-doc-edit-workflow
+description: "Workflow for implementing small, well-specified documentation edits in a worktree. Use when: (1) issue specifies exact insert location, (2) change is adding a note/clarification to markdown, (3) single targeted Edit with pre-commit verification."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | documentation |
+| **Complexity** | S (small) |
+| **Typical runtime** | < 5 minutes |
+| **Key tools** | Read, Edit, Bash (pre-commit), git, gh |
+
+## When to Use
+
+- Issue specifies exact line number or anchor text for the insertion point
+- Change is a single block of markdown to insert (note, warning, clarification)
+- No structural refactoring required — pure additive change
+- File is an existing markdown doc (`.md`)
+
+## Verified Workflow
+
+1. **Read the prompt file** — parse issue title, deliverable, and exact insertion point
+2. **Read the target file** — confirm current content and line numbers
+3. **Apply Edit** — use `old_string` anchored to the line just before and after the insertion point
+4. **Run pre-commit** — `pixi run pre-commit run --all-files` to verify markdownlint and other hooks
+5. **Commit** — stage only the modified file; use conventional commit format with `Closes #<issue>`
+6. **Push and create PR** — `git push -u origin <branch>` then `gh pr create`
+7. **Enable auto-merge** — `gh pr merge --auto --rebase <pr-number>`
+
+### Key Edit Pattern
+
+Use surrounding context to anchor the insertion uniquely:
+
+```python
+# old_string: the line before + newline
+old_string = "Paste it into a new Claude Code session at the root of ProjectOdyssey.\n\n---"
+
+# new_string: original line + new content + rest
+new_string = """Paste it into a new Claude Code session at the root of ProjectOdyssey.
+
+**Output**: Present the analysis as conversation text only. Do not create files or commit
+the analysis to the repository.
+
+---"""
+```
+
+### Pre-commit Caveat
+
+The `mojo format` hook may print GLIBC version errors (library incompatibility with the host OS)
+but still exits 0 — this is non-fatal. The markdown lint and Python hooks run normally.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` as the command runner | `just` not on PATH in this environment | Fall back to `pixi run pre-commit run --all-files` directly |
+| Using `replace_all: false` without sufficient context | Tried a short old_string that could match multiple locations | Edit tool requires unique old_string | Always include the line before AND after the insertion point |
+
+## Results & Parameters
+
+### Commit message format
+
+```text
+docs(<scope>): <what was added>
+
+<One sentence why>
+
+Closes #<issue-number>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### PR body format
+
+```markdown
+## Summary
+
+- Added `**Output**` note to `docs/ANALYSIS_PROMPT.md` after line 4
+
+## Changes
+
+- `docs/ANALYSIS_PROMPT.md`: Added note after instruction line
+
+## Verification
+
+- [x] `pixi run pre-commit run --all-files` passes (markdownlint, trailing-whitespace, etc.)
+
+Closes #<issue-number>
+```
+
+### Auto-merge command
+
+```bash
+gh pr merge --auto --rebase <pr-number>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for implementing small, well-specified documentation edits in a worktree context.

- Covers the Read → Edit → pre-commit → commit → PR pattern for single-insert doc changes
- Captures environment quirks: `just` not on PATH, GLIBC mojo format errors being non-fatal
- Provides copy-paste commit and PR body templates

## Key Findings

**What Worked**:
- Using `pixi run pre-commit run --all-files` directly when `just` is unavailable
- Anchoring Edit `old_string` on the line before AND after the insertion point for uniqueness
- `gh pr merge --auto --rebase <pr-number>` for hands-off merge after CI passes

**What Failed**:
- `just pre-commit-all` → `just` not on PATH in this environment
- Short `old_string` without surrounding context → Edit uniqueness failure

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — PASSED (388/388)
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)