### PR TITLE
feat: add claude-md-token-trimming skill

### DIFF
--- a/skills/documentation/claude-md-token-trimming/.claude-plugin/plugin.json
+++ b/skills/documentation/claude-md-token-trimming/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "claude-md-token-trimming",
+  "version": "1.0.0",
+  "description": "Trim CLAUDE.md token consumption by moving verbose sections to .claude/shared/ files with summary links. Use when: (1) CLAUDE.md exceeds 1200+ lines and is consuming too many context tokens, (2) sections have detailed examples that duplicate content in dedicated docs, (3) reducing context overhead while preserving all critical information.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["claude-md", "token-optimization", "context-reduction", "documentation", "refactoring"]
+}

--- a/skills/documentation/claude-md-token-trimming/references/notes.md
+++ b/skills/documentation/claude-md-token-trimming/references/notes.md
@@ -1,0 +1,78 @@
+# Session Notes: CLAUDE.md Token Trimming (Issue #3158)
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Issue**: #3158 — [P3-4] Trim CLAUDE.md length to reduce token consumption
+- **Branch**: `3158-auto-impl`
+- **PR**: #3363
+- **Repo**: HomericIntelligence/ProjectOdyssey
+
+## Objective
+
+Reduce CLAUDE.md from 1,786 lines to ≤1,400 lines (target was ≤1,200 lines success criterion)
+without losing critical information.
+
+## Approach
+
+1. Read all section headings with line numbers via `grep -n "^##\|^###"``
+2. Classified each section: keep-full / trim-examples / move-and-link
+3. Created two new `.claude/shared/` files for moved content
+4. Edited CLAUDE.md with targeted `Edit` tool calls (no full rewrites)
+5. Ran pre-commit to verify markdown linting
+
+## Files Changed
+
+- **Modified**: `CLAUDE.md` (1786 → 1199 lines, -587 lines)
+- **Created**: `.claude/shared/output-style-guidelines.md`
+- **Created**: `.claude/shared/tool-use-optimization.md`
+
+## Environment Gotchas
+
+### Working Directory Confusion
+
+The task ran with cwd at `.worktrees/issue-3158/` but the shell cwd reset on each Bash call.
+Initial edits went to `/home/mvillmow/Odyssey2/CLAUDE.md` (main repo) rather than the worktree.
+Had to copy files manually after noticing `git status` showed no changes in the worktree.
+
+**Fix**: Always check `git status` after edits to confirm you're editing the right copy.
+
+### pre-commit not in PATH
+
+`just` and `just pre-commit-all` were not available. Resolution:
+- Found pre-commit at `/home/mvillmow/Odyssey2/.pixi/envs/default/bin/pre-commit`
+- Called directly: `SKIP=mojo-format /path/to/pre-commit run --all-files`
+
+### mojo-format GLIBC Failure
+
+The `mojo-format` pre-commit hook fails with GLIBC version errors on this host.
+This is a pre-existing infrastructure issue — not caused by documentation changes.
+Use `SKIP=mojo-format` when running pre-commit for markdown-only changes.
+
+## What Worked Well
+
+- Targeted `Edit` tool calls to replace specific sections without reading/writing the full file
+- Parallel section reads to plan all changes before executing
+- Creating `.claude/shared/` files first, then editing CLAUDE.md to replace sections with links
+- Preserving decision trees and tables (high information density) while removing example code blocks
+
+## Sections to Always Preserve
+
+These sections should never be trimmed from CLAUDE.md:
+
+1. `## ⚠️ CRITICAL RULES` — Contains PR workflow enforcement
+2. `## Git Workflow / ### Development Workflow` — Has concrete `gh pr create` command patterns
+3. `### Pre-Commit Hook Policy - STRICT ENFORCEMENT` — Has enforcement language
+4. `### Mojo Development Guidelines / Critical Patterns` — Compact constructor/mutation table
+5. `### Common Commands / Justfile Build System` — Command reference needed in every session
+
+## Sections Safe to Move to .claude/shared/
+
+These are pure reference/example content not needed inline:
+
+1. Output Style Guidelines (code-block examples)
+2. Tool Use Optimization (parallel calls, bash patterns)
+3. Agentic Loop Patterns (exploration→planning→execution)
+4. Testing Strategy (comprehensive detail in docs/dev/)
+5. Extended Thinking examples (illustrative only)
+6. Hooks YAML examples (illustrative only)

--- a/skills/documentation/claude-md-token-trimming/skills/claude-md-token-trimming/SKILL.md
+++ b/skills/documentation/claude-md-token-trimming/skills/claude-md-token-trimming/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: claude-md-token-trimming
+description: "Trim CLAUDE.md token consumption by moving verbose sections to .claude/shared/ files with summary links. Use when: CLAUDE.md exceeds 1200+ lines, sections have detailed examples duplicating dedicated docs, or reducing context overhead is needed."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Goal** | Reduce CLAUDE.md line count without losing critical information |
+| **Input** | Bloated CLAUDE.md with verbose example-heavy sections |
+| **Output** | Trimmed CLAUDE.md (≤1400 lines) + new `.claude/shared/*.md` files |
+| **Result** | 33% token reduction (1786 → 1199 lines) in one session |
+
+## When to Use
+
+Trigger this skill when:
+
+1. CLAUDE.md grows beyond ~1200 lines (loaded on every Claude Code interaction)
+2. Sections contain long code-block examples that explain concepts (not rules)
+3. Content duplicates or elaborates on dedicated docs in `.claude/shared/` or `docs/dev/`
+4. Token overhead is visibly slowing context utilization
+
+Do NOT trim:
+
+- CRITICAL RULES sections (PR workflow, branch protection, never-push-to-main)
+- Decision trees used in every interaction
+- Quick reference tables (e.g., Thinking Budget, Hook Types)
+- Any section prefixed with `⚠️` or containing enforcement language
+
+## Verified Workflow
+
+### 1. Audit sections by category
+
+Read CLAUDE.md headings with line numbers to categorize each section:
+
+```bash
+grep -n "^##\|^###\|^####" CLAUDE.md
+```
+
+Classify each section as:
+- **Keep full**: Critical rules, decision trees, quick-ref tables
+- **Trim examples**: Keep bullets/tables, remove code-block examples
+- **Move + link**: Pure reference content that belongs in `.claude/shared/`
+
+### 2. For move + link sections
+
+Create `.claude/shared/<section-name>.md` with full content, then replace
+the CLAUDE.md section with a 2-5 line summary + link:
+
+```markdown
+### Output Style Guidelines
+
+Use repo-relative file paths with line numbers for code references. Structure PR/issue comments with
+`## Summary`, `## Changes Made`, `## Files Modified`, `## Verification` sections.
+
+See [Output Style Guidelines](.claude/shared/output-style-guidelines.md) for complete examples.
+```
+
+### 3. For trim-examples sections
+
+Remove markdown code-block examples that illustrate points already stated in bullet
+form. Keep:
+- Bullet lists of when/when-not
+- Tables (budget, hook types, tool selection)
+- Decision trees (text-art `├─` style)
+
+Remove:
+- ` ```markdown ` code blocks showing "GOOD" vs "BAD" examples
+- ` ```yaml ` examples for hooks/config
+- ` ```python ` examples for tool calls
+- Prose "Example — When to Use X" blocks
+
+### 4. Verify line count and linting
+
+```bash
+wc -l CLAUDE.md  # Must be ≤1400
+SKIP=mojo-format pre-commit run --all-files  # Markdown Lint must pass
+```
+
+Note: `mojo-format` fails on this system due to GLIBC version mismatch — skip it.
+The hook failure is pre-existing and unrelated to markdown changes.
+
+### 5. Files to create for this project
+
+| New File | Content Moved From |
+|----------|-------------------|
+| `.claude/shared/output-style-guidelines.md` | Output Style Guidelines section (~148 lines) |
+| `.claude/shared/tool-use-optimization.md` | Tool Use Optimization + Agentic Loop Patterns (~219 lines) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` directly | Tried `just --list` and `just pre-commit-all` | `just` not in PATH in this shell environment | Use `pre-commit` directly from `.pixi/envs/default/bin/pre-commit` |
+| Running `pixi run just pre-commit-all` | Pixi doesn't expose `just` as a run target | `just: command not found` inside pixi env | Run pre-commit directly, not via just |
+| Running `pixi run markdownlint-cli2` | Tried to lint markdown directly | `markdownlint-cli2: command not found` as pixi task | Use `pre-commit run --all-files` which invokes it correctly |
+| Editing main repo instead of worktree | Made all CLAUDE.md edits to `/home/mvillmow/Odyssey2/CLAUDE.md` | Worktree at `.worktrees/issue-3158/` tracks a different branch | Must `cp` changes from main repo to worktree, or edit worktree directly |
+
+## Results & Parameters
+
+### Line count reduction achieved
+
+| Metric | Before | After | Savings |
+|--------|--------|-------|---------|
+| CLAUDE.md total lines | 1,786 | 1,199 | 587 lines (33%) |
+| Output Style Guidelines | ~148 lines | 4 lines + link | ~144 lines |
+| Tool Use Optimization | ~103 lines | 4 lines + link | ~99 lines |
+| Agentic Loop Patterns | ~116 lines | 5 lines + link | ~111 lines |
+| Extended Thinking examples | ~25 lines | 0 lines | ~25 lines |
+| Agent Skills examples | ~37 lines | ~3 lines | ~34 lines |
+| Hooks YAML examples | ~42 lines | 0 lines | ~42 lines |
+| Cross-References + Further Reading | ~17 lines | 0 lines | ~17 lines |
+| Testing Strategy | ~113 lines | 5 lines + link | ~108 lines |
+| Skill Delegation Patterns | ~45 lines | 4 lines | ~41 lines |
+
+### Pre-commit invocation (workaround for GLIBC environment)
+
+```bash
+# Works — skips mojo-format which fails due to GLIBC version mismatch
+SKIP=mojo-format /path/to/.pixi/envs/default/bin/pre-commit run --all-files
+```
+
+### Key preservation rules
+
+Always keep in CLAUDE.md (never move to shared):
+- `## ⚠️ CRITICAL RULES` section in full
+- Git workflow with concrete `gh pr create` examples
+- Commit message format with HEREDOC example
+- `### Mojo Development Guidelines` (Critical Patterns table)
+- All `### Pre-Commit Hook Policy - STRICT ENFORCEMENT` content


### PR DESCRIPTION
## Summary

Documents how to trim CLAUDE.md token consumption by moving verbose reference sections to
`.claude/shared/` files and replacing them with concise summaries + links.

- Achieved 33% line reduction (1,786 → 1,199 lines) without losing critical information
- Identified which sections are safe to move vs. must stay in CLAUDE.md
- Documented pre-commit workarounds for GLIBC mismatch environments

## Key Findings

**What Worked**:
- Moving Output Style Guidelines + Tool Use Optimization + Agentic Loop Patterns to `.claude/shared/`
- Removing code-block "GOOD/BAD" examples from sections that state the rule in bullets
- Keeping all decision trees, quick-ref tables, and enforcement-language sections in full

**What Failed**:
- `just pre-commit-all` not available — use pre-commit binary directly from `.pixi/envs/default/bin/`
- `mojo-format` hook fails due to GLIBC version mismatch — use `SKIP=mojo-format`
- Editing main repo CLAUDE.md instead of worktree copy — always verify `git status` after edits

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
