### PR TITLE
feat: add mypy-precommit-hook-pixi skill

### DIFF
--- a/skills/ci-cd/mypy-precommit-hook-pixi/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mypy-precommit-hook-pixi/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mypy-precommit-hook-pixi",
+  "version": "1.0.0",
+  "description": "Add mypy type checking as a pre-commit hook in pixi-managed projects. Use when: (1) adding mypy enforcement to pre-commit, (2) scripts use X|Y union syntax that mypy rejects without --python-version 3.10, (3) mirrors-mypy isolated env is missing types-PyYAML stubs.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["mypy", "pre-commit", "type-checking", "pixi", "python", "mirrors-mypy", "types-PyYAML"]
+}

--- a/skills/ci-cd/mypy-precommit-hook-pixi/references/notes.md
+++ b/skills/ci-cd/mypy-precommit-hook-pixi/references/notes.md
@@ -1,0 +1,86 @@
+# Session Notes: mypy-precommit-hook-pixi
+
+## Context
+
+- **Project**: ProjectOdyssey (Mojo-based AI research platform)
+- **Issue**: #3159 — [P3-5] Add mypy to pre-commit hooks for Python type checking
+- **PR**: #3364
+- **Date**: 2026-03-05
+- **Branch**: 3159-auto-impl
+
+## Issue Spec
+
+The issue asked for:
+1. Add mypy hook to `.pre-commit-config.yaml` (provided exact YAML in issue)
+2. Run mypy on existing scripts and fix any errors
+3. Add `mypy` to `pixi.toml` dev dependencies if not already present
+4. Verify `just pre-commit-all` passes
+
+## What Was Already in Place
+
+- `mypy = ">=1.19.1,<2"` already in `pixi.toml` — no change needed
+- `types-PyYAML = ">=6.0"` already in `pixi.toml` — but NOT sufficient for mirrors-mypy hook
+
+## Errors Encountered
+
+### Error 1: Module found twice
+```
+scripts/generators/templates.py: error: Source file found twice under different
+module names: "generators.templates" and "scripts.generators.templates"
+```
+**Fix**: Add `--explicit-package-bases` flag.
+
+### Error 2: X | Y union syntax
+```
+scripts/generators/generate_training_script.py:301: error: X | Y syntax for
+unions requires Python 3.10  [syntax]
+        batch_size: int | None = None,
+```
+6 errors across 3 files. **Fix**: Add `--python-version 3.10`.
+
+### Error 3: var-annotated (after fixing above)
+```
+scripts/generators/templates.py:66: error: Need type annotation for "missing"
+(hint: "missing: List[<type>] = ...")  [var-annotated]
+        missing = []
+scripts/validation.py:91: error: Need type annotation for "missing"
+```
+**Fix**: Annotate as `missing: list[str] = []` in both files.
+
+### Error 4: import-untyped (in mirrors-mypy hook)
+```
+scripts/validate_test_coverage.py:25: error: Library stubs not installed for "yaml"
+scripts/agents/tests/conftest.py:14: error: Library stubs not installed for "yaml"
+scripts/agents/agent_utils.py:25: error: Library stubs not installed for "yaml"
+scripts/agents/check_frontmatter.py:29: error: Library stubs not installed for "yaml"
+```
+Even though `types-PyYAML` is in pixi.toml, the `mirrors-mypy` hook runs in its own
+isolated virtualenv. **Fix**: Add `additional_dependencies: [types-PyYAML]` to the hook config.
+
+## Files Changed
+
+- `.pre-commit-config.yaml` — added mypy hook (9 lines)
+- `scripts/generators/templates.py:66` — `missing: list[str] = []`
+- `scripts/validation.py:91` — `missing: list[str] = []`
+
+## Final Working Config
+
+```yaml
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.8.0
+  hooks:
+    - id: mypy
+      files: ^scripts/.*\.py$
+      args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+      additional_dependencies: [types-PyYAML]
+```
+
+## Verification
+
+```bash
+pixi run pre-commit run mypy --all-files
+# mypy...Passed
+
+pixi run pre-commit run --all-files
+# All hooks Passed
+```

--- a/skills/ci-cd/mypy-precommit-hook-pixi/skills/mypy-precommit-hook-pixi/SKILL.md
+++ b/skills/ci-cd/mypy-precommit-hook-pixi/skills/mypy-precommit-hook-pixi/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: mypy-precommit-hook-pixi
+description: "Add mypy type checking as a pre-commit hook in a pixi-managed project. Use when: (1) adding mypy enforcement to pre-commit, (2) scripts have X|Y union syntax errors with default mypy version, (3) types-PyYAML stubs missing in mirrors-mypy isolated env."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Skill: Add mypy Pre-Commit Hook (pixi projects)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-05 |
+| **Objective** | Add `mypy` pre-commit hook to enforce Python type checking on `scripts/*.py` |
+| **Outcome** | All hooks passing; `pixi run pre-commit run --all-files` green |
+| **Issue** | ProjectOdyssey #3159 |
+
+## When to Use
+
+Use this skill when:
+
+- A pixi-managed project has Python scripts with type hints but no mypy enforcement in pre-commit
+- You need to add `mirrors-mypy` as a pre-commit hook and want it to pass out-of-the-box
+- Scripts use `X | Y` union syntax (Python 3.10+) that mypy rejects with default `--python-version`
+- The `mirrors-mypy` hook fails with "Library stubs not installed for yaml" (missing `types-PyYAML`)
+- A `missing = []` list variable causes `var-annotated` errors from mypy
+
+**Trigger phrases:**
+
+- "Add mypy to pre-commit"
+- "mypy hook failing with import-untyped"
+- "X | Y syntax for unions requires Python 3.10"
+- "Library stubs not installed for yaml"
+
+## Verified Workflow
+
+### Step 1: Verify mypy is in pixi.toml
+
+```bash
+grep "mypy" pixi.toml
+grep "types-PyYAML" pixi.toml
+```
+
+If missing, add to `[dependencies]`:
+
+```toml
+mypy = ">=1.8.0,<2"
+types-PyYAML = ">=6.0"
+```
+
+### Step 2: Run mypy locally to find errors before hooking
+
+```bash
+pixi run mypy scripts/ --ignore-missing-imports --no-strict-optional --explicit-package-bases
+```
+
+**Common errors to fix first:**
+
+- `X | Y syntax for unions requires Python 3.10` — add `--python-version 3.10` or use `Optional[X]`
+- `Need type annotation for "missing"` — annotate as `missing: list[str] = []`
+- Module found twice under different names — add `--explicit-package-bases`
+
+Verify clean with:
+
+```bash
+pixi run mypy scripts/ --ignore-missing-imports --no-strict-optional --explicit-package-bases --python-version 3.10
+# Expected: Success: no issues found in N source files
+```
+
+### Step 3: Add hook to .pre-commit-config.yaml
+
+```yaml
+# Python type checking
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.8.0
+  hooks:
+    - id: mypy
+      files: ^scripts/.*\.py$
+      args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+      additional_dependencies: [types-PyYAML]
+```
+
+**Key points:**
+- `additional_dependencies: [types-PyYAML]` — mirrors-mypy runs in an isolated venv; stubs must be declared here
+- `--explicit-package-bases` — prevents "Source file found twice under different module names" when `scripts/` has subdirectories
+- `--python-version "3.10"` — enables `X | Y` union syntax used in modern Python; pixi provides Python 3.14 but mypy defaults to an older version
+- `files: ^scripts/.*\.py$` — scope to the target directory only
+
+### Step 4: Verify the hook passes
+
+```bash
+pixi run pre-commit run mypy --all-files
+# Expected: mypy...Passed
+
+pixi run pre-commit run --all-files
+# Expected: all hooks Passed
+```
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| `rev` | `v1.8.0` |
+| `--python-version` | `3.10` |
+| `additional_dependencies` | `[types-PyYAML]` |
+| `--ignore-missing-imports` | Required — third-party libs without stubs |
+| `--no-strict-optional` | Required — avoids noise on existing codebase |
+| `--explicit-package-bases` | Required — scripts/ has subdirectories with no `__init__.py` |
+| Files checked | 78 source files |
+| PR | HomericIntelligence/ProjectOdyssey#3364 |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run mypy without `--explicit-package-bases` | `pixi run mypy scripts/` | "Source file found twice under different module names" for `scripts/generators/templates.py` | scripts/ has subdirectories without `__init__.py`; always use `--explicit-package-bases` |
+| Run mypy without `--python-version 3.10` | Default mypy python version | 6 errors: "X \| Y syntax for unions requires Python 3.10" | mypy defaults to a version < 3.10 even when runtime Python is 3.14; must explicitly set `--python-version 3.10` |
+| Add mirrors-mypy hook without `additional_dependencies` | Standard hook config from issue spec | "Library stubs not installed for yaml" in 4 files | `mirrors-mypy` creates an isolated venv; stubs installed in pixi env are NOT available — must declare via `additional_dependencies` |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3364, issue #3159 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to add `mirrors-mypy` as a pre-commit hook in pixi-managed projects,
capturing three non-obvious failure modes encountered during ProjectOdyssey #3159.

## Key Findings

**What Worked**:
- `additional_dependencies: [types-PyYAML]` in hook config supplies stubs to mirrors-mypy's isolated venv
- `--python-version 3.10` enables X|Y union syntax even on Python 3.14 runtime
- `--explicit-package-bases` fixes "file found twice" errors from scripts/ subdirectories

**What Failed**:
- Default hook config (from issue spec) → "Library stubs not installed for yaml" (4 files)
- No `--explicit-package-bases` → "Source file found twice under different module names"
- No `--python-version 3.10` → 6 syntax errors across 3 files

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] All 3 required files created in correct structure
- [x] YAML frontmatter, Failed Attempts table, and all required sections present

🤖 Generated with [Claude Code](https://claude.com/claude-code)