### PR TITLE
feat: add pr-review-fix-no-op-detection skill

### DIFF
--- a/skills/ci-cd/pr-review-fix-no-op-detection/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-review-fix-no-op-detection/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-review-fix-no-op-detection",
+  "version": "1.0.0",
+  "description": "Detect when a PR review-fix plan requires no code changes and verify the fix commit exists on the remote before declaring the task complete. Use when: (1) a .claude-review-fix-*.md plan file says 'no fixes needed', (2) CI shows stale failures after a fix commit, (3) verifying whether a pre-commit or format fix was actually pushed.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["pr-review", "ci", "pre-commit", "no-op", "fix-detection", "stale-ci"]
+}

--- a/skills/ci-cd/pr-review-fix-no-op-detection/references/notes.md
+++ b/skills/ci-cd/pr-review-fix-no-op-detection/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: PR Review Fix No-Op Detection
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3187 (MobileNetV1 backward pass placeholder)
+- **PR**: #3189 (branch: `3084-auto-impl`)
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3187`
+
+## What Happened
+
+A `.claude-review-fix-3187.md` file was found in the worktree with a fix plan for PR #3189.
+The plan concluded:
+- Pre-commit CI failure: Already fixed by commit `1be9b841` (mojo format reformatting)
+- link-check CI failure: Pre-existing infrastructure issue, not caused by this PR
+- 5 failing test groups: Pre-existing, unrelated to PR changes
+
+The task said "implement all fixes from the plan above" but the plan itself said "no fixes are needed."
+
+## Investigation Steps
+
+1. Read `.claude-review-fix-3187.md` — plan says fix commit `1be9b841` already exists
+2. `git log --oneline -10` in worktree — showed worktree is on `3187-auto-impl` at `origin/main`
+3. `gh pr view 3189` — confirmed PR is on branch `3084-auto-impl`, not current worktree branch
+4. `gh pr checks 3189` — showed `pre-commit: fail`, `link-check: fail` (stale from pre-fix run)
+5. `gh run list --branch 3084-auto-impl` — ALL runs showed original commit message, none showed fix commit
+6. `git log --oneline origin/3084-auto-impl -10` — fix commit `1be9b841` NOT present on remote
+7. `git -C /home/mvillmow/Odyssey2 log --oneline origin/3084-auto-impl...3084-auto-impl` — fix commit was local-only in main repo
+
+## Root Cause
+
+The fix commit `1be9b841` existed in the local `3084-auto-impl` branch in the main repo clone,
+but had NOT been pushed to `origin/3084-auto-impl`. The plan said "the script will push" —
+meaning a separate automation was expected to handle the push. Since the task instructions also
+said "do NOT push", the correct action was to confirm this state and do nothing else.
+
+## Pre-Existing link-check Failure
+
+The link-check fails on root-relative paths in `CLAUDE.md` like `/.claude/shared/pr-workflow.md`.
+These are internal repo paths that lychee interprets as HTTP URLs. The fix was already applied
+in commit `3a5c1dad fix(ci): exclude root-relative links from lychee link check` on main, but
+the PR branch (`3084-auto-impl`) predated that fix and its CI was run before the branch was
+rebased to include it.
+
+## Key Lesson
+
+When a review-fix plan says "already fixed" or "no action needed", always verify:
+1. Does the fix commit exist on the REMOTE branch? (`git log origin/<branch>...<branch>`)
+2. Are CI run timestamps stale? (`gh run list --branch <branch> --limit 5`)
+3. Is the plan's push expectation handled by automation or manual action?

--- a/skills/ci-cd/pr-review-fix-no-op-detection/skills/pr-review-fix-no-op-detection/SKILL.md
+++ b/skills/ci-cd/pr-review-fix-no-op-detection/skills/pr-review-fix-no-op-detection/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pr-review-fix-no-op-detection
+description: "Detect when a PR review-fix plan requires no code changes and verify the fix commit is pushed. Use when: fix plan says no action needed, CI shows stale failures after a fix commit, or verifying whether a format fix was pushed."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | pr-review-fix-no-op-detection |
+| **Category** | ci-cd |
+| **Trigger** | `.claude-review-fix-*.md` plan file with "no fixes needed" conclusion |
+| **Outcome** | Confirm fix commit exists on remote; identify if CI re-run is the only action needed |
+
+## When to Use
+
+- A `.claude-review-fix-<issue>.md` plan file concludes "no fixes are needed" or "already fixed"
+- CI shows failures that appear stale (run against an older commit than the fix)
+- The fix commit hash is mentioned in the plan but you need to confirm it is on the remote branch
+- Pre-commit or mojo-format failures were fixed locally but CI hasn't re-run yet
+
+## Verified Workflow
+
+1. **Read the fix plan** to extract:
+   - The fix commit hash (e.g. `1be9b841`)
+   - The PR number and branch name
+   - Whether failures are claimed to be pre-existing
+
+2. **Check local vs. remote branch divergence:**
+   ```bash
+   git log --oneline origin/<branch>...<branch> 2>/dev/null
+   ```
+   - If the fix commit appears here, it exists locally but NOT on remote
+   - If empty, local and remote are in sync
+
+3. **Check CI run timestamps vs. fix commit timestamp:**
+   ```bash
+   gh run list --branch <branch> --limit 5
+   ```
+   - All runs showing the original commit message = stale; fix not yet triggered CI
+
+4. **Check remote branch HEAD:**
+   ```bash
+   gh pr view <pr-number> --json headRefOid,headRefName
+   ```
+   - Compare `headRefOid` to `git log --oneline origin/<branch> -1`
+
+5. **Confirm pre-existing failures on main:**
+   ```bash
+   gh run list --branch main --workflow "<workflow-name>" --limit 3
+   ```
+   - If main also shows the same failures, they are pre-existing
+
+6. **Conclusion**: If fix commit is local-only, the only action needed is to push the branch. The plan's "no code changes needed" is correct — only a `git push` is required to trigger CI re-run.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assumed fix was pushed because plan said "already fixed" | Checked CI status without verifying remote branch | CI showed stale failures from pre-fix run; fix commit was local-only | Always verify `git log origin/<branch>` vs local to confirm push state |
+| Declared task complete after reading plan | Did not check `gh run list` timestamps vs. fix commit date | Would have left CI in failing state with unresolved appearance | Cross-check CI run commit message against the fix commit message |
+| Checked PR head commit via `gh pr view` | Compared `headRefOid` to local fix commit hash | The PR head was the pre-fix commit; fix was not yet reflected on remote | `headRefOid` from `gh pr view` reflects what GitHub knows, not local state |
+
+## Results & Parameters
+
+### Key Commands (Copy-Paste)
+
+```bash
+# 1. Find fix commit hash from plan file
+grep -E "commit|fix commit|[0-9a-f]{8}" .claude-review-fix-*.md | head -5
+
+# 2. Check if fix commit is on remote
+BRANCH=$(git branch --show-current)
+git log --oneline origin/${BRANCH}...${BRANCH}
+
+# 3. Confirm CI runs are against old commit (stale)
+gh run list --branch ${BRANCH} --limit 5
+
+# 4. Confirm failures are pre-existing on main
+gh run list --branch main --workflow "Pre-commit Checks" --limit 3
+
+# 5. Trigger CI re-run (if authorized to push)
+git push origin ${BRANCH}
+```
+
+### Diagnosis Matrix
+
+| Local has fix commit | Remote has fix commit | CI shows failures | Action |
+|---------------------|----------------------|-------------------|--------|
+| Yes | No | Yes (stale) | Push branch to trigger CI re-run |
+| Yes | Yes | Yes (stale) | Re-run CI workflow manually via `gh workflow run` |
+| Yes | Yes | No | Done - CI is passing |
+| No | No | Yes | Fix commit missing; implement the actual fix |
+
+### Stale CI Identification
+
+CI runs are stale when:
+- `gh run list --branch <branch>` shows ALL runs with the same (pre-fix) commit message
+- The fix commit date is newer than the latest CI run date
+- `gh pr view --json headRefOid` shows the pre-fix commit hash


### PR DESCRIPTION
## Summary

Documents how to detect when a PR review-fix plan requires no code changes
and verify the fix commit exists on the remote before declaring the task complete.

- Fix plans saying "no action needed" may still have unpushed fix commits
- CI failures can appear stale when the fix commit was never pushed to remote
- Simple git commands reveal local-only commits vs. remote branch state

## Key Findings

**What Worked**:
- `git log --oneline origin/<branch>...<branch>` reveals fix commits that are local-only
- `gh run list --branch <branch>` commit messages confirm whether CI ran against the fix
- `gh pr view --json headRefOid` shows what GitHub currently knows as the PR head

**What Failed**:
- Assuming "already fixed" in plan = pushed to remote → fix commit was local-only
- Trusting stale CI results as current state → CI had not re-run after fix commit

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with review-fix plan triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
