### PR TITLE
feat: add pr-review-fix-stale-branch skill

### DIFF
--- a/skills/ci-cd/pr-review-fix-stale-branch/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-review-fix-stale-branch/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-review-fix-stale-branch",
+  "version": "1.0.0",
+  "description": "Fix CI failures on a PR when the remote branch was rebased/force-pushed and the fix commit was lost. Use when: (1) pre-commit CI check fails on a PR that previously had a fix applied, (2) local branch diverges from remote with lost commits after rebase, (3) mojo format line-length violations appear in CI but not locally.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["pr", "rebase", "mojo-format", "ci-failure", "stale-branch", "force-push"]
+}

--- a/skills/ci-cd/pr-review-fix-stale-branch/references/notes.md
+++ b/skills/ci-cd/pr-review-fix-stale-branch/references/notes.md
@@ -1,0 +1,54 @@
+# Session Notes: PR Review Fix - Stale Branch After Rebase
+
+## Session Context
+
+- **Date**: 2026-03-06
+- **Project**: ProjectOdyssey (Mojo ML platform)
+- **PR**: #3189 (branch: `3084-auto-impl`)
+- **Issue**: #3181
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3181`
+
+## Objective
+
+Apply review feedback fixes for PR #3189 as described in `.claude-review-fix-3181.md`.
+
+## What Happened
+
+### Initial Plan Was Wrong
+
+The `.claude-review-fix-3181.md` file said:
+> "No fixes are required. The PR is correct as written."
+> "These are pre-existing infrastructure issues... This PR's changes have zero relation to these failures."
+
+But CI was still showing `pre-commit` as FAILED.
+
+### Root Cause Discovery
+
+1. Checked `gh pr view 3189 --json statusCheckRollup` → found `pre-commit` FAILURE
+2. Ran `gh run view 22748980306 --log-failed` → found mojo format line-length errors
+3. Checked `gh pr view 3189 --json headRefName` → PR branch is `3084-auto-impl`, NOT `3181-auto-impl`
+4. Ran `git fetch origin 3084-auto-impl` → showed `(forced update)` — branch was rebased
+5. Created worktree for `3084-auto-impl` → local had fix commit `1be9b841`
+6. But `git log origin/3084-auto-impl` → remote tip was `099c43cc` without the fix
+7. Ran `git show origin/3084-auto-impl:examples/googlenet-cifar10/train.mojo | grep STATUS` → confirmed long lines still present on remote
+
+### Fix Applied
+
+Reset local worktree to `origin/3084-auto-impl`, then manually applied mojo format splits to 3 files:
+
+- `examples/googlenet-cifar10/train.mojo` (line 436: 93 chars → split)
+- `examples/mobilenetv1-cifar10/train.mojo` (line 215: 94 chars → split)
+- `examples/resnet18-cifar10/train.mojo` (line 313: 91 chars → split)
+
+### Pre-existing failures correctly NOT fixed
+
+- `link-check`: Root-relative links in CLAUDE.md — fails on main too (confirmed via `gh run list --branch main`)
+- 5 test groups (Core Tensors, Initializers, DTypes, Benchmarking, Examples): Runtime crashes in `libKGENCompilerRTShared.so` — unrelated to PR changes
+
+## Key Learnings
+
+1. **Review fix plans can be stale** — always check actual CI status even when plan says "no fixes needed"
+2. **The PR branch ≠ the worktree branch** — always run `gh pr view <n> --json headRefName` first
+3. **`(forced update)` in git fetch = fix commits may have been lost** — always verify remote state
+4. **mojo format enforces 88-char limit** — split long print strings with implicit string concatenation
+5. **`git show origin/<branch>:<file>`** is the fastest way to verify remote file state without checkout

--- a/skills/ci-cd/pr-review-fix-stale-branch/skills/pr-review-fix-stale-branch/SKILL.md
+++ b/skills/ci-cd/pr-review-fix-stale-branch/skills/pr-review-fix-stale-branch/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pr-review-fix-stale-branch
+description: "Fix CI failures when a PR's remote branch was rebased and lost a fix commit. Use when: pre-commit CI fails but fix was already applied locally, local and remote branches have diverged after force-push, mojo format violations appear in CI but not in local files."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | pr-review-fix-stale-branch |
+| **Category** | ci-cd |
+| **Trigger** | PR pre-commit CI fails; local branch has fix but remote doesn't |
+| **Root Cause** | Remote branch force-pushed/rebased, dropping the fix commit |
+| **Resolution** | Reset local to remote, re-apply fix, commit, push |
+
+## When to Use
+
+- A `.claude-review-fix-<issue>.md` plan says "no fixes needed" but CI still fails pre-commit
+- `git log main..<branch>` shows a fix commit locally but CI shows the unfixed code
+- `git fetch` output shows `(forced update)` for the PR branch
+- `gh run view <run-id> --log-failed` reveals `mojo format` line-length violations in files
+  the PR touched (but differently worded than expected)
+- Local worktree and remote branch have diverged with incompatible histories
+
+## Verified Workflow
+
+### Step 1: Read the review fix plan
+
+```bash
+cat .claude-review-fix-<issue>.md
+```
+
+Note: "no fixes needed" plans may be outdated if CI is still failing.
+
+### Step 2: Identify actual CI failures
+
+```bash
+gh pr view <pr-number> --json statusCheckRollup | python3 -c "
+import json,sys
+for c in json.load(sys.stdin)['statusCheckRollup']:
+    if c.get('conclusion') == 'FAILURE':
+        print(c['name'], c['detailsUrl'])
+"
+```
+
+Then fetch the actual failure log:
+
+```bash
+gh run view <run-id> --log-failed 2>&1 | grep -E "ERROR|error|FAIL" | head -40
+```
+
+### Step 3: Determine if failures are pre-existing vs PR-caused
+
+```bash
+# Check if the same CI check fails on main
+gh run list --branch main --workflow "<workflow-name>" --limit 3 \
+  --json conclusion,databaseId,createdAt | python3 -c "
+import json,sys; [print(r['databaseId'], r['conclusion'], r['createdAt']) for r in json.load(sys.stdin)]
+"
+```
+
+Pre-existing = same failure on main = no fix needed for those checks.
+PR-caused = passes on main but fails on PR = must fix.
+
+### Step 4: Identify the PR branch and create/reset worktree
+
+```bash
+# Find the actual PR branch (may differ from your current worktree branch)
+gh pr view <pr-number> --json headRefName
+
+# Fetch the remote branch
+git fetch origin <head-branch>
+
+# Create a worktree for it (or reset existing)
+git worktree add .worktrees/issue-<n> <head-branch>
+
+# If worktree already exists but is diverged, reset to remote
+cd .worktrees/issue-<n>
+git reset --hard origin/<head-branch>
+```
+
+### Step 5: Verify the remote still has the unfixed code
+
+```bash
+git show origin/<head-branch>:<path/to/file.mojo> | grep -n "long line pattern"
+```
+
+Confirm the line is still too long (>88 chars for mojo format).
+
+### Step 6: Apply the fix
+
+For mojo format line-length violations, split long `print()` strings:
+
+```mojo
+# Before (>88 chars):
+print("STATUS: Very long string that exceeds the 88 char limit set by mojo format.")
+
+# After (mojo format style):
+print(
+    "STATUS: Very long string that exceeds the 88 char"
+    " limit set by mojo format."
+)
+```
+
+### Step 7: Commit (do NOT push — the calling script pushes)
+
+```bash
+git add <files>
+git commit -m "fix: Address review feedback for PR #<pr-number>
+
+<Brief description of what was fixed>.
+
+Closes #<issue>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the review plan | Plan said "no fixes needed" so stopped | CI was still failing pre-commit due to mojo format violations | Always verify actual CI status even when plan says no fixes needed |
+| Work in current worktree | Tried to fix files in `issue-3181` worktree | Wrong branch — PR was on `3084-auto-impl`, not `3181-auto-impl` | Always confirm the PR's `headRefName` before editing files |
+| Apply fix to local branch as-is | Local `3084-auto-impl` had fix commit but was diverged from remote | Remote was force-pushed and had 13 newer commits; local fix was on old history | Must reset local to remote before re-applying fix |
+| Assume fix commit exists on remote | Saw fix commit locally (`1be9b841`) and assumed it was pushed | `git fetch` showed `(forced update)` — remote had dropped the commit | Check remote state explicitly with `git show origin/<branch>:<file>` |
+
+## Results & Parameters
+
+**Key metrics**:
+
+- Files fixed: 3 Mojo files with `print()` strings >88 chars
+- CI check fixed: `pre-commit` (mojo format)
+- Pre-existing failures (not fixed, correctly identified): `link-check`, 5 test groups
+
+**mojo format line length rule**: 88 characters (configured in `pyproject.toml` or `mojo.toml`)
+
+**Identifying the right branch**:
+
+```bash
+gh pr view <number> --json headRefName,baseRefName
+```
+
+**Checking if a fix commit survived a rebase**:
+
+```bash
+# Local has it:
+git log --oneline main..<branch> | grep "fix"
+
+# Remote may not:
+git log --oneline origin/main..origin/<branch> | grep "fix"
+```
+
+If local has it but remote doesn't: the commit was dropped in a force-push.
+Always reset local to remote before applying fixes to avoid working on stale history.


### PR DESCRIPTION
## Summary

Documents how to diagnose and fix CI failures when a PR branch was force-pushed/rebased
and a previously-applied fix commit was lost from the remote.

- Root cause: `git fetch` shows `(forced update)` — remote dropped the fix commit
- Symptoms: pre-commit CI fails on mojo format violations; local branch has fix but remote doesn't
- Fix: reset local to remote, re-apply formatting, commit

## Key Findings

**What Worked**:
- `gh pr view <n> --json headRefName` to confirm actual PR branch (may differ from worktree)
- `git show origin/<branch>:<file>` to verify remote file state without checkout
- `git reset --hard origin/<branch>` to sync local to remote before re-applying fix
- mojo format split pattern for long print() strings (implicit string concatenation)

**What Failed**:
- Trusting the review fix plan blindly → plan said "no fixes needed" but CI was still failing
- Assuming fix commit was on remote because it existed locally → `(forced update)` dropped it
- Working in current worktree branch → was on wrong branch (3181 vs 3084)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
