### PR TITLE
feat: add cherry-pick-fix-diverged-pr skill

### DIFF
--- a/skills/ci-cd/cherry-pick-fix-diverged-pr/.claude-plugin/plugin.json
+++ b/skills/ci-cd/cherry-pick-fix-diverged-pr/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "cherry-pick-fix-diverged-pr",
+  "version": "1.0.0",
+  "description": "Apply a local fix commit to a remote PR branch when histories have diverged (same-content commits with different SHAs). Use when: (1) a fix exists locally but can't be fast-forward pushed to the PR branch, (2) git rebase created duplicate commits with different SHAs on local vs remote, (3) review fix plan says 'no changes needed' but CI still fails because the fix was never pushed.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["cherry-pick", "diverged-branch", "pr-fix", "mojo-format", "rebase"]
+}

--- a/skills/ci-cd/cherry-pick-fix-diverged-pr/references/notes.md
+++ b/skills/ci-cd/cherry-pick-fix-diverged-pr/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes: cherry-pick-fix-diverged-pr
+
+## Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **PR**: #3189 (branch `3084-auto-impl`, issue #3184)
+- **Worktree**: `.worktrees/issue-3184` on branch `3184-auto-impl`
+
+## The Problem
+
+A `.claude-review-fix-3184.md` plan was provided that said:
+
+> "No code fixes required. The branch tip (1be9b841) already has the correct mojo-formatted output."
+
+CI was failing `pre-commit` (mojo format) on commit `099c43cc` — the PR branch tip on remote.
+
+## Investigation
+
+1. `gh pr view 3189 --json headRefOid` showed remote tip: `099c43cc`
+2. Local fix commit `1be9b841` existed in the main repo on branch history
+3. `git diff 14a9de24 099c43cc` showed **no diff** — identical file content
+4. Both `14a9de24` (local parent) and `099c43cc` (remote tip) had the same changes but different SHAs
+5. `git merge-base 14a9de24 099c43cc` → `597f77fa` (common ancestor, neither of them)
+
+## Root Cause
+
+A rebase had created two parallel "versions" of the docs commit with different SHAs.
+The mojo-format fix `1be9b841` was on top of the local `14a9de24`, not on top of
+the remote `099c43cc`. Pushing `1be9b841` directly to `origin/3084-auto-impl` failed
+with "non-fast-forward" because the remote had 1 more commit (`099c43cc`) that wasn't
+an ancestor of `1be9b841`.
+
+## What Confirmed Divergence
+
+```bash
+git show 099c43cc:examples/googlenet-cifar10/train.mojo | awk '{if(length>88) print NR, length}'
+# Line 436: 103 chars — confirmed unfixed on remote
+```
+
+## Solution
+
+```bash
+git checkout -b 3084-auto-impl-fix origin/3084-auto-impl
+git cherry-pick 1be9b841
+git push origin 3084-auto-impl-fix:3084-auto-impl
+git checkout main && git branch -d 3084-auto-impl-fix
+```
+
+Result: CI triggered on new commit `ed716348` with mojo-format fix applied.
+
+## Line Length Check Pattern
+
+```bash
+git show <remote-sha>:<path> | awk '{if(length>88) print NR, length, $0}' | head
+```
+
+Used to confirm remote branch still had the >88-char lines even after review plan
+claimed the fix was in place.

--- a/skills/ci-cd/cherry-pick-fix-diverged-pr/skills/cherry-pick-fix-diverged-pr/SKILL.md
+++ b/skills/ci-cd/cherry-pick-fix-diverged-pr/skills/cherry-pick-fix-diverged-pr/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: cherry-pick-fix-diverged-pr
+description: "Apply a local fix commit to a remote PR branch when histories have diverged (same-content commits with different SHAs). Use when: fix exists locally but can't fast-forward push to PR branch due to diverged history from rebase."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | cherry-pick-fix-diverged-pr |
+| **Category** | ci-cd |
+| **Trigger** | Fix commit exists locally but `git push` is rejected as non-fast-forward |
+| **Root Cause** | Local and remote branch have diverged: same file content, different commit SHAs (caused by rebase) |
+| **Resolution** | Create temp branch from remote PR branch, cherry-pick the fix commit, push to PR branch, clean up |
+
+## When to Use
+
+- `git push origin <fix-commit>:refs/heads/<pr-branch>` fails with "non-fast-forward"
+- `git diff <local-parent> <remote-tip> -- <files>` shows no diff (identical content, different SHAs)
+- `git merge-base <local-commit> <remote-commit>` points to the same ancestor — confirming diverged parallel histories
+- A review fix plan says "branch already has the fix" but the fix is on a local branch with a different parent than the remote PR branch
+- Re-triggering CI via `gh run rerun` still fails because the fix commit was never pushed to the remote
+
+## Verified Workflow
+
+### Step 1: Identify the divergence
+
+```bash
+# Get the PR's actual remote branch
+gh pr view <pr-number> --json headRefName,headRefOid
+
+# Find your local fix commit
+git log --oneline <local-branch> -5
+
+# Compare parents: same content, different SHAs?
+git diff <local-parent-sha> <remote-tip-sha> -- <path/to/file>
+# If no diff: diverged history — cherry-pick is needed
+```
+
+### Step 2: Verify the fix commit content
+
+```bash
+git show <fix-commit-sha> --stat
+# Confirm it only touches the files you intend to fix
+```
+
+### Step 3: Create a temp branch from the remote PR branch
+
+```bash
+git fetch origin <pr-branch>
+git checkout -b <pr-branch>-fix origin/<pr-branch>
+# This puts you exactly at the remote PR branch tip
+```
+
+### Step 4: Cherry-pick the fix
+
+```bash
+git cherry-pick <fix-commit-sha>
+# Verify it applied cleanly
+git log --oneline -3
+```
+
+### Step 5: Push to the PR branch (fast-forward)
+
+```bash
+git push origin <pr-branch>-fix:<pr-branch>
+# This is a fast-forward push — no force required
+```
+
+### Step 6: Clean up the temp branch
+
+```bash
+git checkout main
+git branch -d <pr-branch>-fix
+```
+
+### Step 7: Verify CI is triggered on the new commit
+
+```bash
+gh pr view <pr-number> --json headRefOid,statusCheckRollup | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print('HEAD:', d['headRefOid'][:12]); [print(c['name'], c['conclusion'] or c['status']) for c in d['statusCheckRollup'][:5]]"
+# Confirm HEAD SHA matches your pushed commit and checks are queued/running
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Re-trigger CI via `gh run rerun` | Re-ran the failing CI run on the old commit | CI ran against the unfixed commit SHA — still failed mojo format | Re-triggering doesn't help if the fix was never pushed to the remote branch |
+| Direct push fix commit to PR branch | `git push origin <fix-sha>:refs/heads/<pr-branch>` | Rejected as non-fast-forward — local fix had a different parent SHA than the remote tip | When histories diverge (same content, different SHAs), a direct push always fails |
+| Trust "no changes needed" in review plan | Plan said fix was on the branch already | Plan was generated against a local branch with diverged history; remote never had the fix | Always verify the fix is on `origin/<pr-branch>` not just locally |
+| Check if contents are identical | Ran `git diff <local-parent> <remote-tip>` | No diff — but that confirmed diverged histories, not that fix was pushed | Same content + different SHAs = diverged history; cherry-pick onto remote tip is the fix |
+
+## Results & Parameters
+
+**Key pattern — detecting diverged histories**:
+
+```bash
+# Both show the same diff as their parent — content is identical:
+git show <local-sha>  # shows same changes as...
+git show <remote-sha>  # ...this remote commit
+
+# But they can't be merged without cherry-pick:
+git merge-base <local-sha> <remote-sha>
+# => their common ancestor is NEITHER of them
+```
+
+**When `git diff` shows no difference but push is rejected**:
+
+This is the signature of a rebase that created two parallel "versions" of the same commit
+with different SHAs. The local branch's commit history is not a superset of the remote's —
+it's a parallel branch that happened to produce the same files.
+
+**Cherry-pick is safe here because**:
+
+- The fix commit is small and isolated (only touches the files you care about)
+- The cherry-pick is a clean fast-forward onto the remote tip
+- No force-push needed — no risk of overwriting others' work
+
+**mojo format line length**: 88 chars. Check with:
+
+```bash
+git show <remote-tip>:<path/to/file> | awk '{if(length>88) print NR, length, $0}' | head -10
+```


### PR DESCRIPTION
## Summary

Documents how to apply a local fix commit to a remote PR branch when their histories
have diverged (same file content but different commit SHAs, caused by rebase).

- The root cause is two parallel "versions" of a commit created by rebase
- Pushing the fix directly always fails with "non-fast-forward"
- Solution: temp branch from remote tip + cherry-pick + fast-forward push

## Key Findings

**What Worked**:
- `git checkout -b <branch>-fix origin/<pr-branch>` + cherry-pick + push is a clean, no-force-push solution
- `git diff <local-parent> <remote-tip>` returning no diff is the diagnostic signature of this problem
- Verifying line length on the remote file (`awk '{if(length>88) print NR, length}'`) confirms the fix is missing remotely

**What Failed**:
- `gh run rerun <run-id>` — re-triggers CI on the same unfixed SHA, doesn't help
- `git push origin <fix-sha>:refs/heads/<pr-branch>` — rejected as non-fast-forward when histories diverge
- Trusting review plan's "no changes needed" — plan was generated from local state, not remote state

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
