### PR TITLE
feat: add mojo-unsafepointer-bitcast-fix skill

### DIFF
--- a/skills/ci-cd/mojo-unsafepointer-bitcast-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mojo-unsafepointer-bitcast-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-unsafepointer-bitcast-fix",
+  "version": "1.0.0",
+  "description": "Fix Mojo compile error: UnsafePointer.address_of() is not a valid API; use UnsafePointer[T](to=val).bitcast[U]()[] instead. Use when: (1) CI fails with 'value has no attribute address_of', (2) converting float values to bit representation for hashing, (3) mojo format line-length failures on raise Error() calls.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["mojo", "unsafepointer", "bitcast", "compile-error", "hash", "mojo-format"]
+}

--- a/skills/ci-cd/mojo-unsafepointer-bitcast-fix/references/notes.md
+++ b/skills/ci-cd/mojo-unsafepointer-bitcast-fix/references/notes.md
@@ -1,0 +1,76 @@
+# Session Notes — mojo-unsafepointer-bitcast-fix
+
+## Context
+
+- **Issue**: #3164 (ProjectOdyssey)
+- **PR**: #3373
+- **Branch**: `3164-auto-impl`
+- **Date**: 2026-03-05
+
+## Problem
+
+Two CI failures blocked merge of PR #3373:
+
+1. **Compile error** (`Mojo Package Compilation` job, workflow run `22738204367`):
+   ```
+   shared/core/extensor.mojo:2672:42: error:
+   'UnsafePointer[?, ?, address_space=?]' value has no attribute 'address_of'
+   ```
+
+2. **Formatting failure** (`pre-commit` job, workflow run `22738204224`):
+   Two `raise Error(...)` lines in `tests/shared/core/test_utility.mojo` exceeded
+   line-length limit. Lines were 81 and 86 characters.
+
+## Prior Commit That Didn't Fix It
+
+Commit `b6cbd428` had message "fix(extensor): use bitcast for exact float bit representation
+in __hash__" but inspection of `git show HEAD:shared/core/extensor.mojo` confirmed the
+broken code was still present. The commit message described the intent, not what was done.
+
+**Lesson**: Always check `git diff` or `git show` to verify a commit actually changed code,
+not just the commit message.
+
+## Fix Applied
+
+### extensor.mojo (line ~2671-2672)
+
+Before:
+```mojo
+var local_val = val  # local copy required before UnsafePointer.address_of
+var int_bits = (UnsafePointer.address_of(local_val)).bitcast[UInt64][]
+```
+
+After:
+```mojo
+var int_bits = UnsafePointer[Float64](to=val).bitcast[UInt64]()[]
+```
+
+The `local_val` intermediate was removed — `UnsafePointer[T](to=val)` takes the address
+of the existing `val` variable directly.
+
+### test_utility.mojo (lines 397-398 and 422-423)
+
+Before:
+```mojo
+raise Error("Tensors with different values should have different hashes")
+raise Error("Distinct small values should have different hashes with bitcast")
+```
+
+After:
+```mojo
+raise Error(
+    "Tensors with different values should have different hashes"
+)
+raise Error(
+    "Distinct small values should have different hashes with bitcast"
+)
+```
+
+## Environment Constraint
+
+The `mojo` binary in the local pixi environment requires GLIBC 2.32/2.33/2.34 which are
+not available on this host (Linux 5.10, Debian Buster-era libc). The `mojo-format`
+pre-commit hook therefore always fails locally with a GLIBC version error. CI runs in
+Docker where this is satisfied.
+
+Workaround: `SKIP=mojo-format git commit -m "..."` is acceptable with documented reason.

--- a/skills/ci-cd/mojo-unsafepointer-bitcast-fix/skills/mojo-unsafepointer-bitcast-fix/SKILL.md
+++ b/skills/ci-cd/mojo-unsafepointer-bitcast-fix/skills/mojo-unsafepointer-bitcast-fix/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: mojo-unsafepointer-bitcast-fix
+description: "Fix Mojo compile error where UnsafePointer.address_of() is used but is not a valid API. Use when: CI fails with 'value has no attribute address_of', implementing float-to-bits conversion for hashing, or fixing mojo format line-length violations on raise Error() calls."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Category | ci-cd |
+| Trigger | `UnsafePointer.address_of` compile error in Mojo |
+| Scope | Single file edit — `extensor.mojo` or similar |
+| Related | `mojo format` line-length pre-commit failures |
+
+## When to Use
+
+- CI `Mojo Package Compilation` job fails with:
+  `error: 'UnsafePointer[?, ?, address_space=?]' value has no attribute 'address_of'`
+- Code needs to read the IEEE 754 bit representation of a float (e.g. for `__hash__`)
+- Pre-commit `mojo format` fails because `raise Error("...")` lines exceed line-length limit
+- A prior commit claimed to fix the issue but the code was not actually changed
+
+## Verified Workflow
+
+1. **Identify the broken line** — typically in a `__hash__` implementation:
+
+   ```mojo
+   # BROKEN — UnsafePointer has no .address_of() method
+   var local_val = val
+   var int_bits = (UnsafePointer.address_of(local_val)).bitcast[UInt64][]
+   ```
+
+2. **Apply the correct Mojo v0.26.1+ idiom**:
+
+   ```mojo
+   # CORRECT — UnsafePointer[T](to=val) takes address of val, then bitcast
+   var int_bits = UnsafePointer[Float64](to=val).bitcast[UInt64]()[]
+   ```
+
+   The `local_val` intermediate variable is not needed; `to=val` takes the address of the
+   existing variable directly.
+
+3. **Wrap long `raise Error(...)` lines** for `mojo format` compliance (>80 chars fails):
+
+   ```mojo
+   # BEFORE (too long)
+   raise Error("Distinct small values should have different hashes with bitcast")
+
+   # AFTER
+   raise Error(
+       "Distinct small values should have different hashes with bitcast"
+   )
+   ```
+
+4. **Commit with `SKIP=mojo-format`** if local `mojo` binary is unavailable (GLIBC mismatch):
+
+   ```bash
+   SKIP=mojo-format git commit -m "fix: correct UnsafePointer bitcast in __hash__"
+   ```
+
+   This is safe because `mojo format` will run correctly in CI (Docker environment).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Prior commit `b6cbd428` | Commit message said "use bitcast for exact float bit representation" | Code was NOT actually changed — `UnsafePointer.address_of` remained | Always verify the diff, not just the commit message |
+| `UnsafePointer.address_of(local_val).bitcast[UInt64][]` | Static method call on type | `address_of` is not a method on `UnsafePointer` type in Mojo v0.26.1 | Use constructor `UnsafePointer[T](to=val)` to take address |
+| Running `mojo format --check` locally | Tried to verify formatting pre-commit | `mojo` binary requires GLIBC 2.32+ not available on host | Use `SKIP=mojo-format` locally; CI Docker has correct GLIBC |
+
+## Results & Parameters
+
+### Correct UnsafePointer bitcast pattern (Mojo v0.26.1+)
+
+```mojo
+# Take address of a local Float64 variable and read as UInt64 bits
+var int_bits = UnsafePointer[Float64](to=val).bitcast[UInt64]()[]
+```
+
+- `UnsafePointer[Float64](to=val)` — constructor that takes the address of `val`
+- `.bitcast[UInt64]()` — reinterpret the pointer as `UnsafePointer[UInt64]`
+- `[]` — dereference to get the `UInt64` value
+
+### mojo format line-length threshold
+
+Lines over ~80 characters in `raise Error(...)` calls will be reformatted by `mojo format`.
+Wrap proactively to avoid pre-commit failures:
+
+```mojo
+raise Error(
+    "Your error message here that would otherwise exceed the limit"
+)
+```
+
+### SKIP environment variable for broken hooks
+
+```bash
+# Skip only the mojo-format hook (document reason in commit/PR)
+SKIP=mojo-format git commit -m "..."
+```


### PR DESCRIPTION
## Summary

Documents the fix for Mojo compile error when using `UnsafePointer.address_of()` (not a valid API).

- `UnsafePointer.address_of(val)` does not exist in Mojo v0.26.1+
- Correct idiom: `UnsafePointer[Float64](to=val).bitcast[UInt64]()[]`
- Also covers `mojo format` line-length violations on `raise Error(...)` calls

## Key Findings

**What Worked**:
- `UnsafePointer[T](to=val)` constructor takes address of local variable directly
- `SKIP=mojo-format` commit bypass is acceptable when mojo binary has GLIBC mismatch

**What Failed**:
- `UnsafePointer.address_of(local_val).bitcast[UInt64][]` → attribute does not exist
- Prior commit with fix in message but not in code → always verify `git diff`/`git show`
- Running `mojo format --check` locally → GLIBC 2.32+ required, not available on host

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
