### PR TITLE
feat: add pre-commit-ruff-pass-filenames-fix skill

### DIFF
--- a/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pre-commit-ruff-pass-filenames-fix",
+  "version": "1.0.0",
+  "description": "Fix pre-commit ruff hooks to use pass_filenames: true and remove hardcoded directory args, enabling per-file linting instead of whole-directory scans. Use when: (1) ruff pre-commit hooks run on all files instead of only staged files, (2) ruff hooks have hardcoded directory args in entry field, (3) pre-commit ruff hooks ignore file scope.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["pre-commit", "ruff", "linting", "pass_filenames", "hooks"]
+}

--- a/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/references/notes.md
+++ b/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/references/notes.md
@@ -1,0 +1,57 @@
+# Session Notes: pre-commit-ruff-pass-filenames-fix
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: `3154-auto-impl`
+- **PR**: #3347
+- **Issue**: #3154
+
+## Objective
+
+Address review feedback for PR #3347, which fixed pre-commit ruff hooks to use
+`pass_filenames: true` and removed hardcoded directory arguments from the `entry` fields
+of `ruff-format-python` and `ruff-check-python` hooks in `.pre-commit-config.yaml`.
+
+## What Was Found
+
+The review fix plan (`.claude-review-fix-3154.md`) stated:
+
+> The PR is **correctly implemented** — `.pre-commit-config.yaml` already has
+> `pass_filenames: true` and hardcoded directory args removed from both ruff hooks (lines 41-53).
+
+Verified with `git status`: the working tree was clean. No code changes were needed.
+
+## CI Failures Observed (Pre-Existing)
+
+Four CI jobs failed on PR #3347:
+
+1. **Core Initializers** — GitHub 404 HTML response (no `.mojo` files at `tests/core/initializers/`)
+2. **Core Types** — `mojo: error: execution crashed` in `test_mxfp4_block.mojo`, `test_nvfp4_block.mojo`
+3. **Helpers** — `mojo: error: execution crashed` in `test_fixtures.mojo`, `test_utils.mojo`
+4. **Data Samplers** — `mojo: error: execution crashed` in `test_random.mojo`, `test_weighted.mojo`
+
+These failures were confirmed to also occur on the `main` branch (CI run `22748872310`),
+proving they are pre-existing infrastructure-level flaky failures unrelated to the ruff hook change.
+
+## Key Takeaways
+
+1. **Always read the plan file first** — The `.claude-review-fix-*.md` plan clearly stated no
+   fixes were needed. Reading it saved time that would have been wasted on unnecessary changes.
+
+2. **Verify state before acting** — `git status` immediately confirmed the working tree was clean,
+   corroborating the plan's conclusion.
+
+3. **Flaky Mojo crashes are a known issue** — `mojo: error: execution crashed` is an intermittent
+   runtime crash in ProjectOdyssey's CI infrastructure, not a code bug. Always compare against
+   `main` branch CI history before concluding a PR introduced a failure.
+
+4. **The correct fix for `pass_filenames`** — Remove hardcoded directory paths from `entry`
+   AND add `pass_filenames: true`. Both are needed; either alone is insufficient.
+
+## Final State
+
+- PR #3347 ready to merge as-is
+- No commits made (nothing to commit)
+- Pre-commit CI check passed on the PR

--- a/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/skills/pre-commit-ruff-pass-filenames-fix/SKILL.md
+++ b/skills/ci-cd/pre-commit-ruff-pass-filenames-fix/skills/pre-commit-ruff-pass-filenames-fix/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pre-commit-ruff-pass-filenames-fix
+description: "Fix pre-commit ruff hooks to use pass_filenames: true and remove hardcoded directory args. Use when: ruff hooks scan all files instead of only staged files, or entry field has hardcoded directory paths."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# Pre-Commit Ruff pass_filenames Fix
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Fix ruff pre-commit hooks that ignore file scope due to missing `pass_filenames: true` |
+| Issue | PR #3347, Issue #3154 in ProjectOdyssey |
+| Outcome | Verified complete — hooks already correctly configured |
+
+## When to Use
+
+- `ruff-format-python` or `ruff-check-python` hooks scan the whole project on every commit
+- The `entry` field in `.pre-commit-config.yaml` contains hardcoded directory paths (e.g. `ruff check .` or `ruff check scripts/`)
+- CI pre-commit check fails because ruff runs on unrelated files
+- You need ruff to only lint/format the files actually staged for commit
+
+## Root Cause
+
+Pre-commit passes staged filenames to hooks only when `pass_filenames: true` is set. Without it
+(default is `true` for most hooks, but `false` for some custom configs), ruff receives no filenames
+and either scans the working directory or uses its own default discovery. Hardcoded directory args
+in `entry` compound the problem by always scanning that directory regardless of what was staged.
+
+## Verified Workflow
+
+1. **Locate hooks** — open `.pre-commit-config.yaml` and find `ruff-format-python` and `ruff-check-python` hook blocks
+
+2. **Verify `pass_filenames`** — both hooks must have:
+
+   ```yaml
+   pass_filenames: true
+   ```
+
+3. **Remove hardcoded dirs from `entry`** — the `entry` field must NOT contain directory arguments:
+
+   ```yaml
+   # WRONG - hardcoded dir bypasses staged-file scope
+   entry: ruff check scripts/
+
+   # CORRECT - no hardcoded path; pre-commit passes staged files
+   entry: ruff check
+   ```
+
+4. **Full correct hook block example**:
+
+   ```yaml
+   - id: ruff-check-python
+     name: ruff-check-python
+     language: system
+     entry: ruff check
+     types: [python]
+     pass_filenames: true
+
+   - id: ruff-format-python
+     name: ruff-format-python
+     language: system
+     entry: ruff format
+     types: [python]
+     pass_filenames: true
+   ```
+
+5. **Verify locally**:
+
+   ```bash
+   just pre-commit-all
+   ```
+
+6. **Distinguish PR failures from pre-existing flaky CI** — after confirming hook config is correct,
+   check if CI test failures are pre-existing:
+
+   ```bash
+   # View CI run failures on the PR
+   gh pr checks <pr-number>
+
+   # Compare with main branch CI history
+   gh run list --branch main --limit 10
+   gh run view <run-id> --log-failed
+   ```
+
+   Mojo runtime crashes (`mojo: error: execution crashed`) are a known intermittent infrastructure
+   issue in ProjectOdyssey and are NOT caused by pre-commit hook changes.
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Hook IDs | `ruff-format-python`, `ruff-check-python` |
+| Config file | `.pre-commit-config.yaml` |
+| Required field | `pass_filenames: true` |
+| Entry format | `ruff check` / `ruff format` (no directory args) |
+| Local verify command | `just pre-commit-all` |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assuming changes were needed | Loaded review plan expecting to make code edits | The PR was already correctly implemented before the session started | Always verify current state with `git status` and `grep` before making any changes |
+| Treating all CI failures as PR-related | Initially considered fixing flaky test failures | Failures were `mojo: error: execution crashed` — a pre-existing infra issue confirmed on `main` branch | Check `main` branch CI history to distinguish pre-existing flaky failures from PR-introduced regressions |


### PR DESCRIPTION
## Summary

Documents the fix pattern for pre-commit ruff hooks that scan all files instead of only staged files.

- `pass_filenames: true` must be set on both `ruff-check-python` and `ruff-format-python` hooks
- Hardcoded directory args in `entry` (e.g. `ruff check scripts/`) must be removed
- Includes guidance for distinguishing PR-introduced CI failures from pre-existing flaky Mojo runtime crashes

## Key Findings

**What Worked**:
- Setting `pass_filenames: true` on both ruff hooks ensures only staged files are linted
- Removing hardcoded directory paths from `entry` prevents full-project scans on every commit
- Comparing CI failures against `main` branch history reliably identifies pre-existing flaky failures

**What Failed**:
- Assuming code changes were needed without reading the review plan first → wasted preparation time
- Treating all CI failures as PR-related → Mojo `execution crashed` errors are pre-existing infra flakiness, not regressions

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with pre-commit ruff hook triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
