### PR TITLE
feat: add no-op-review-fix skill

### DIFF
--- a/skills/documentation/no-op-review-fix/.claude-plugin/plugin.json
+++ b/skills/documentation/no-op-review-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-op-review-fix",
+  "version": "1.0.0",
+  "description": "Handle review fix plans that require no changes. Use when: (1) a .claude-review-fix-*.md plan states no fixes are required, (2) a PR is already correct and CI failures are pre-existing, (3) verifying clean git state before reporting back.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["review", "pr", "no-op", "verification", "git"]
+}

--- a/skills/documentation/no-op-review-fix/references/notes.md
+++ b/skills/documentation/no-op-review-fix/references/notes.md
@@ -1,0 +1,40 @@
+# Session Notes: no-op-review-fix
+
+## Date
+2026-03-05
+
+## Repository
+HomericIntelligence/Odyssey2 (worktree: issue-3150)
+
+## Issue / PR
+- Issue: #3150
+- PR: #3338
+- Branch: `3150-auto-impl`
+
+## Objective
+Implement fixes described in `.claude-review-fix-3150.md` for PR #3338.
+
+## What the Fix Plan Said
+The plan explicitly stated:
+- "No fixes required. The PR correctly implements the issue deliverable."
+- ADR-009 row added at `docs/adr/README.md:27` ✅
+- Format matches existing entries ✅
+- CI failures (Core Elementwise, Core Tensors) are pre-existing, not introduced by this PR
+
+## Steps Taken
+1. Read `.claude-review-fix-3150.md` — found plan conclusion was "no fixes required"
+2. Ran `git status` — branch was clean, only untracked file was the review instructions itself
+3. Ran `git log --oneline -5` — confirmed correct commit `db9af4d2` was already on branch
+4. Reported back that no action was needed
+
+## Key Insight
+When a review fix automation script provides a `.claude-review-fix-*.md` plan that concludes "no fixes required," the correct response is:
+- Verify git state is clean
+- Do NOT create empty commits
+- Do NOT push (script handles pushing)
+- Report back clearly that the PR is already correct
+
+## Pre-existing CI Failures
+- Core Elementwise test group: failing on `main` before this PR
+- Core Tensors test group: failing on `main` before this PR
+- These are tracked separately and are not related to documentation changes

--- a/skills/documentation/no-op-review-fix/skills/no-op-review-fix/SKILL.md
+++ b/skills/documentation/no-op-review-fix/skills/no-op-review-fix/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: no-op-review-fix
+description: "Handle review fix plans that require no changes. Use when: a review fix plan explicitly states no fixes are needed, CI failures are pre-existing and unrelated to the PR, or you need to verify clean git state before confirming a PR is ready."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Name | no-op-review-fix |
+| Category | documentation |
+| Trigger | `.claude-review-fix-*.md` plan with "no fixes required" conclusion |
+| Output | Git status confirmation, no commit |
+
+## When to Use
+
+- A `.claude-review-fix-*.md` review plan explicitly says "No fixes required" or "PR is ready to merge as-is"
+- CI failures listed in the plan are confirmed pre-existing (exist on `main` before this PR)
+- The PR only modifies documentation files that cannot cause test failures
+- You need to verify the branch is clean before reporting back to the automation script
+
+## Verified Workflow
+
+1. **Read the fix plan** — load `.claude-review-fix-*.md` to understand the conclusion
+2. **Check for "no fixes required"** — if the plan explicitly states this, do not make changes
+3. **Run `git status`** — confirm no uncommitted changes exist (only the review instructions file should be untracked)
+4. **Run `git log --oneline -5`** — confirm the correct commit is already on the branch
+5. **Report back** — explain that the PR is correct as-is and no commit is needed
+6. **Do NOT create an empty commit** — the script only needs a push if there are actual changes
+
+```bash
+# Verification commands used
+git status
+git log --oneline -5
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Creating empty commit | Considered committing `.claude-review-fix-*.md` or a dummy change | Would add noise to git history with no value | Only commit when there are real implementation changes |
+| Running full test suite | Considered running `pixi run python -m pytest tests/ -v` | Tests unrelated to a docs-only PR; CI failures were pre-existing | Skip test runs for documentation-only PRs when fix plan confirms no changes needed |
+| Pushing unchanged branch | Considered pushing origin even with no new commits | Script handles pushing; no-op push would be redundant | Trust the automation script's push step; only commit if there are changes |
+
+## Results & Parameters
+
+**Session context**: PR #3338 for issue #3150 — added ADR-009 to `docs/adr/README.md` index.
+
+**Fix plan conclusion**: "No fixes required. The PR correctly implements the issue deliverable."
+
+**Pre-existing CI failures**: Core Elementwise and Core Tensors test groups — both existed on `main` before this PR and are unrelated to a documentation-only change.
+
+**Git state after verification**:
+
+```text
+On branch 3150-auto-impl
+Your branch is up to date with 'origin/3150-auto-impl'.
+
+Untracked files:
+  .claude-review-fix-3150.md   ← review instructions only, not committed
+
+nothing added to commit but untracked files present
+```
+
+**Key rule**: When a review fix plan explicitly states no fixes are required, verify git status is clean and report — do not create empty commits or unnecessary pushes.


### PR DESCRIPTION
## Summary

Documents the pattern for handling review fix plans that require no changes.

- Verify git status is clean when a fix plan says "no fixes required"
- Do not create empty commits or unnecessary pushes
- Pre-existing CI failures on `main` are not blockers for documentation-only PRs

## Key Findings

**What Worked**:
- Reading the fix plan conclusion first before taking any action
- Running `git status` + `git log` to confirm clean state
- Reporting back clearly that the PR was already correct

**What Failed**:
- Creating empty commits (adds noise to git history with no value)
- Running the full test suite for a docs-only PR when failures are pre-existing
- Considering a no-op push (script handles pushing; no-op push is redundant)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
