### PR TITLE
feat: add pr-review-no-action-determination skill

### DIFF
--- a/skills/ci-cd/pr-review-no-action-determination/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-review-no-action-determination/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-review-no-action-determination",
+  "version": "1.0.0",
+  "description": "Determine when a PR requires no fixes by distinguishing pre-existing CI failures from PR-introduced regressions. Use when: (1) CI jobs fail on a PR but the PR changes are unrelated to failing tests, (2) link-check or runtime-crash CI failures appear on a PR touching only documentation or config, (3) you need to confirm a PR is merge-ready despite red CI checks.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["pr-review", "ci-failures", "pre-existing", "no-action", "merge-ready"]
+}

--- a/skills/ci-cd/pr-review-no-action-determination/references/notes.md
+++ b/skills/ci-cd/pr-review-no-action-determination/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes: PR Review No-Action Determination
+
+## Session Context
+
+- **Date**: 2026-03-05
+- **Repository**: HomericIntelligence/Odyssey2
+- **Issue**: #3146 (consolidate implementation engineer tiers from 4 to 2)
+- **PR**: #3327
+- **Branch**: 3146-auto-impl
+
+## What Happened
+
+A review fix file (`.claude-review-fix-3146.md`) was loaded that described a plan
+for PR #3327. The plan had analyzed CI failures and concluded no fixes were needed.
+
+The task was to "implement all fixes from the plan" — but the plan's fix list was empty
+because all CI failures were pre-existing infrastructure issues:
+
+1. **link-check FAILURE** — lychee tool cannot resolve root-relative paths (e.g.
+   `/.claude/shared/pr-workflow.md`) without `--root-dir` config. This fails on
+   `main` branch too, confirming it predates the PR.
+
+2. **Autograd test FAILURE** — three Mojo test files crash with
+   `mojo: error: execution crashed`. This is a pre-existing Mojo runtime instability
+   also visible on `main` CI runs.
+
+## PR Changes (Confirmed Correct)
+
+- `implementation-engineer.md` — consolidated 3 generalist tiers into 1 agent
+- `senior-implementation-engineer.md` — deleted
+- `junior-implementation-engineer.md` — deleted
+- `implementation-specialist.md` — kept, `delegates_to` updated
+- `agents/hierarchy.md` — updated to 2-tier structure, 42 agents
+
+## Key Insight
+
+The correct response to "implement all fixes" when the fix plan says "no fixes required"
+is to report that no action is needed — not to invent work or attempt to fix
+pre-existing infrastructure issues that are out of scope.
+
+## Evidence Pattern
+
+The distinguishing signal: agent configuration changes cannot cause:
+- Mojo runtime execution crashes (different subsystem entirely)
+- Link-checker infrastructure failures (tool configuration, not file content)
+
+Cross-checking on `main` is the definitive confirmation step.

--- a/skills/ci-cd/pr-review-no-action-determination/skills/pr-review-no-action-determination/SKILL.md
+++ b/skills/ci-cd/pr-review-no-action-determination/skills/pr-review-no-action-determination/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: pr-review-no-action-determination
+description: "Determine when a PR requires no fixes by distinguishing pre-existing CI failures from PR-introduced regressions. Use when: PR has red CI but changes are unrelated to failing jobs."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | pr-review-no-action-determination |
+| **Category** | ci-cd |
+| **Trigger** | PR has CI failures but changes appear unrelated |
+| **Outcome** | Confirmed no-action determination with evidence |
+
+## When to Use
+
+- A PR shows red CI checks but only modifies documentation, configuration, or agent files
+- `link-check` fails on a PR that did not add new broken links
+- Runtime crash tests fail on a PR that does not touch the crashing code
+- You need to verify a PR is merge-ready despite failing CI jobs
+- A review plan states "no fixes required" and you need to confirm correctness
+
+## Verified Workflow
+
+1. **Identify failing CI jobs** — read the review plan or check `gh run list --branch <branch>` to enumerate failures.
+
+2. **Classify each failure** — for each failing job, determine if it could plausibly be caused by the PR's diff:
+   - Agent/config-only changes cannot cause Mojo runtime crashes
+   - Documentation-only changes cannot cause test execution failures
+   - Link-check failures from `CLAUDE.md` root-relative paths predate any PR
+
+3. **Cross-check on main** — confirm failures are pre-existing by checking main branch CI:
+
+   ```bash
+   gh run list --branch main --workflow "<failing-workflow-name>" --limit 3
+   gh run view <main-run-id> --log-failed | grep -E "(FAILED|error)"
+   ```
+
+4. **Confirm PR diff scope** — verify the PR only touches the expected files:
+
+   ```bash
+   gh pr diff <pr-number> --name-only
+   ```
+
+5. **Declare no-action** — if all failures are pre-existing and unrelated to the PR diff, the PR is ready to merge as-is. Document findings:
+
+   ```bash
+   gh issue comment <issue-number> --body "CI failures confirmed pre-existing. PR ready to merge."
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Applying fixes for link-check failures | Attempted to update links in new files to pass lychee link-check | The checker fails on root-relative paths in CLAUDE.md and other pre-existing files regardless of what the PR adds — the tool lacks `--root-dir` configuration | link-check failures are infrastructure-level; fixing individual file links does not resolve the CI job |
+| Treating all red CI as blocking | Assumed every CI failure required a code fix | Autograd test crashes are Mojo runtime instability unrelated to agent config changes; fixing them is out of scope for a config PR | Scope discipline: only fix regressions introduced by the PR, not pre-existing repo-wide issues |
+
+## Results & Parameters
+
+### Confirming pre-existing link-check failure
+
+```bash
+# Check if link-check fails on main (confirms pre-existing)
+gh run list --branch main --workflow "Check Markdown Links" --limit 3 --json status,conclusion,databaseId
+
+# View failure details
+gh run view <run-id> --log-failed | grep -E "ERROR|404|not found"
+```
+
+### Confirming pre-existing test crashes
+
+```bash
+# Check if the same test group crashes on main
+gh run list --branch main --workflow "Comprehensive Tests" --limit 3
+gh run view <run-id> --log-failed | grep "execution crashed"
+```
+
+### Final determination output
+
+When both checks confirm pre-existing failures, document:
+
+```
+## CI Failure Analysis
+
+| Job | Status | Caused by this PR? | Evidence |
+|-----|--------|--------------------|----------|
+| link-check | FAIL | No | Fails on main (run #XXXXX) — lychee lacks --root-dir |
+| Autograd tests | FAIL | No | Fails on main (run #XXXXX) — Mojo runtime crash |
+
+**Conclusion**: PR is merge-ready. No fixes required.
+```


### PR DESCRIPTION
## Summary

Documents how to determine when a PR requires no fixes by distinguishing pre-existing CI failures from PR-introduced regressions.

- Captures the pattern of cross-checking CI failures on `main` to confirm they are pre-existing
- Documents that agent/config-only PRs cannot cause Mojo runtime crashes or link-checker failures
- Provides copy-paste `gh` commands for the evidence-gathering workflow

## Key Findings

**What Worked**:
- Checking `gh run list --branch main --workflow "<name>"` to confirm failures predate the PR
- Scoping the PR diff with `gh pr diff --name-only` to confirm no overlap with failing jobs
- Declaring no-action with documented evidence rather than inventing fixes

**What Failed**:
- Attempting to fix individual file links to resolve link-check failures (tool lacks `--root-dir`, so root-relative links in CLAUDE.md fail regardless)
- Treating all red CI as blocking when failures are in unrelated subsystems (Mojo runtime vs. agent config)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "PR has red CI but changes are config-only" trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)