### PR TITLE
feat: add preexisting-ci-failure-triage skill

### DIFF
--- a/skills/ci-cd/preexisting-ci-failure-triage/.claude-plugin/plugin.json
+++ b/skills/ci-cd/preexisting-ci-failure-triage/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "preexisting-ci-failure-triage",
+  "version": "1.0.0",
+  "description": "Triage CI failures to determine if they are pre-existing on main branch vs caused by PR changes. Use when: (1) CI fails on a PR that only changes non-code files, (2) determining whether to block merge on CI failures, (3) reviewing PRs with runtime crashes unrelated to changed files.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["ci", "triage", "pre-existing", "pr-review", "mojo", "test-failures"]
+}

--- a/skills/ci-cd/preexisting-ci-failure-triage/references/notes.md
+++ b/skills/ci-cd/preexisting-ci-failure-triage/references/notes.md
@@ -1,0 +1,36 @@
+# Session Notes: Pre-existing CI Failure Triage
+
+## Context
+
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3145 — convert blog-writer and pr-cleanup agents to skills
+- **PR**: #3320
+- **Branch**: `3145-auto-impl`
+- **Date**: 2026-03-05
+
+## What Happened
+
+PR #3320 converted two specialist agent markdown files into skill files:
+- Deleted: `.claude/agents/blog-writer-specialist.md`, `.claude/agents/pr-cleanup-specialist.md`
+- Created: `.claude/skills/blog-writer/SKILL.md`, `.claude/skills/pr-cleanup/SKILL.md`
+- Updated: `agents/README.md`, `agents/hierarchy.md` (agent count references)
+
+CI showed failures in:
+1. `Core DTypes` — `tests/shared/core/test_dtype_dispatch.mojo` crashed with `mojo: error: execution crashed`
+2. `Data Loaders` — `tests/shared/data/loaders/test_batch_loader.mojo` crashed
+3. `Data Samplers` — data samplers test crashed
+4. `link-check` — root-relative link errors in `docs/adr/README.md` and `notebooks/README.md`
+
+## Key Determination
+
+All failures were pre-existing on `main`. The PR only changed markdown files in `.claude/` and `agents/` — no `.mojo` files were touched, so Mojo runtime crashes are physically impossible to be caused by this PR.
+
+Verified by checking `gh run list --branch main --workflow comprehensive-tests.yml` showing the same test groups failing before this PR was opened.
+
+## Outcome
+
+No fixes needed. PR merged as-is. The review plan (`.claude-review-fix-3145.md`) correctly identified this and instructed no action.
+
+## Lesson
+
+The most important first step when reviewing any PR with CI failures is `git diff main...HEAD --name-only` — if the changed files cannot possibly affect the failing tests, check main branch CI history before spending any time on fixes.

--- a/skills/ci-cd/preexisting-ci-failure-triage/skills/preexisting-ci-failure-triage/SKILL.md
+++ b/skills/ci-cd/preexisting-ci-failure-triage/skills/preexisting-ci-failure-triage/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: preexisting-ci-failure-triage
+description: "Triage CI failures to determine if they are pre-existing on main branch vs caused by PR changes. Use when: CI fails on a PR with only doc/config changes, determining whether to block merge, or reviewing Mojo runtime crashes unrelated to changed files."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Name** | preexisting-ci-failure-triage |
+| **Category** | ci-cd |
+| **Trigger** | CI fails on a PR; need to determine if failures are caused by the PR or pre-existing |
+| **Outcome** | Clear determination: block merge or proceed; no wasted fix attempts |
+
+## When to Use
+
+- CI test groups fail with `mojo: error: execution crashed` on a PR that only changed `.claude/`, `agents/`, or other non-code files
+- `link-check` or linting CI fails on files the PR did not touch
+- A PR review plan needs to confirm whether CI failures block merge
+- You want to verify a PR is safe to merge despite red CI
+
+## Verified Workflow
+
+1. **Identify changed files** — what did this PR actually modify?
+
+   ```bash
+   git diff main...HEAD --name-only
+   ```
+
+2. **Classify changed files** — can they cause the failing tests?
+
+   - `.claude/agents/*.md`, `.claude/skills/*.md`, `agents/*.md` → documentation only, cannot cause Mojo runtime crashes
+   - `.mojo`, `.🔥`, `shared/`, `tests/` → can cause test failures
+
+3. **Check main branch CI history** — are the same failures present on main?
+
+   ```bash
+   gh run list --branch main --workflow comprehensive-tests.yml --limit 5
+   gh run list --branch main --workflow link-check.yml --limit 5
+   ```
+
+4. **Compare failure signatures** — do the failing test names match between PR and main?
+
+   - Same test groups failing (e.g., `Core DTypes`, `Data Loaders`, `Data Samplers`) → pre-existing
+   - New test groups failing that correspond to changed files → PR-caused
+
+5. **Decision**:
+
+   - All failures are pre-existing AND PR only changes non-code files → **proceed with merge**
+   - Any failure corresponds to changed code → **block merge, fix required**
+
+6. **Document findings** — post to PR or issue:
+
+   ```bash
+   gh issue comment <number> --body "All CI failures are pre-existing on main (confirmed via gh run list). PR only modifies documentation files. Safe to merge."
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Fixing Mojo runtime crashes in PR | Attempted to diagnose `mojo: error: execution crashed` in test files | The PR changed zero `.mojo` files — Mojo crashes cannot be caused by markdown changes | Always check `git diff main...HEAD --name-only` before attempting any CI fix |
+| Treating link-check as PR-caused | Assumed `link-check` failure was introduced by new markdown files | The failing links were in `docs/adr/README.md` and `notebooks/README.md`, neither touched by PR | Cross-reference failing file paths against PR diff before investigating |
+| Running tests to verify | Considered running `pixi run python -m pytest tests/` to confirm | The test failures are Mojo runtime crashes, not Python tests; running them locally would not help without reproducing the exact CI environment | Match the test runner to the failing workflow type |
+
+## Results & Parameters
+
+### Key Commands
+
+```bash
+# Step 1: What did the PR change?
+git diff main...HEAD --name-only
+
+# Step 2: Check main CI history for same failures
+gh run list --branch main --workflow comprehensive-tests.yml --limit 5
+gh run list --branch main --workflow link-check.yml --limit 5
+
+# Step 3: View a specific run to compare failing jobs
+gh run view <run-id> --log-failed
+
+# Step 4: Check if pre-commit passes (the one CI check that IS affected by doc changes)
+just pre-commit-all
+```
+
+### Decision Matrix
+
+| Changed files | Failing CI | Action |
+|---------------|-----------|--------|
+| Only `.claude/`, `agents/`, docs | Mojo runtime crashes | Pre-existing — proceed |
+| Only `.claude/`, `agents/`, docs | `link-check` on untouched files | Pre-existing — proceed |
+| Only `.claude/`, `agents/`, docs | `pre-commit` / `test-agents` | PR-caused — fix required |
+| Any `.mojo` / `shared/` / `tests/` | Any test failure | Investigate — may be PR-caused |
+
+### Success Criteria for "Safe to Merge"
+
+- [ ] `git diff main...HEAD --name-only` shows only documentation/config files
+- [ ] Failing test groups match failures visible on recent `main` CI runs
+- [ ] `pre-commit` CI check passes (the check that validates changed files)
+- [ ] `test-agents` CI check passes (if agent configs were modified)


### PR DESCRIPTION
## Summary

Documents the pattern for triaging CI failures on PRs to determine if they are pre-existing on `main` vs caused by the PR.

- Identifies the key diagnostic: `git diff main...HEAD --name-only` to classify changed files
- Provides a decision matrix for common scenarios (doc-only PRs with Mojo crashes, link-check failures)
- Captures the lesson that Mojo runtime crashes cannot be caused by markdown-only changes

## Key Findings

**What Worked**:
- Checking `gh run list --branch main` to confirm failures existed before the PR
- Classifying changed files by type (`.mojo` vs docs) to scope impact
- Using `pre-commit` and `test-agents` CI as the only checks actually affected by doc/config PRs

**What Failed**:
- Attempting to diagnose Mojo runtime crashes for a PR that changed zero `.mojo` files
- Treating `link-check` failures as PR-caused without checking if the failing files were in the PR diff

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with CI triage triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
