### PR TITLE
feat: add mkdocs-nav-cleanup skill

### DIFF
--- a/skills/ci-cd/mkdocs-nav-cleanup/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mkdocs-nav-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mkdocs-nav-cleanup",
+  "version": "1.0.0",
+  "description": "Fix MkDocs build failures caused by nav entries referencing deleted documentation files. Use when: (1) CI 'Deploy Documentation' job fails after deleting doc stubs, (2) mkdocs build --strict reports missing files, (3) PR deletes placeholder docs but mkdocs.yml nav still references them.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["mkdocs", "documentation", "nav", "broken-links", "ci-fix"]
+}

--- a/skills/ci-cd/mkdocs-nav-cleanup/references/notes.md
+++ b/skills/ci-cd/mkdocs-nav-cleanup/references/notes.md
@@ -1,0 +1,48 @@
+# Session Notes: mkdocs-nav-cleanup
+
+## Context
+
+- **Date**: 2026-03-05
+- **PR**: #3308 (issue #3142), branch `3142-auto-impl`
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Task**: Fix CI failures after deleting 17 empty placeholder documentation stubs
+
+## What Was Done
+
+The PR deleted 17 placeholder `.md` files across `docs/core/`, `docs/advanced/`, and `docs/dev/`.
+CI "Deploy Documentation" failed because `mkdocs.yml` still listed all 17 files in its `nav` section.
+Additionally, `docs/advanced/benchmarking.md:666` had a relative link `[SIMD Integration Guide](integration.md)`
+pointing to the deleted `docs/advanced/integration.md`.
+
+### Files Changed
+
+- `mkdocs.yml`: Removed Core section (8 nav entries), 6 Advanced entries, 3 Development entries
+- `docs/advanced/benchmarking.md`: Removed broken relative link at line 666
+
+### Files NOT Changed (pre-existing failures)
+
+- `CLAUDE.md`, `docs/adr/ADR-005-...`, `docs/adr/README.md`, `notebooks/README.md`:
+  20 root-relative path errors in `link-check` workflow — pre-existing on main, out of scope.
+
+## Commands Used
+
+```bash
+# Verify no remaining references
+grep -r "core/project-structure|core/workflow|..." docs/ mkdocs.yml
+
+# Pre-commit on changed files only
+pre-commit run --files mkdocs.yml docs/advanced/benchmarking.md
+
+# Commit
+git add mkdocs.yml docs/advanced/benchmarking.md
+git commit -m "fix: Address review feedback for PR #3308\n\nCloses #3142"
+```
+
+## Key Insight
+
+When a PR deletes placeholder docs, there are always two separate concerns:
+1. `mkdocs.yml` nav entries (always need updating)
+2. Cross-references in remaining docs (grep to find, then remove/update)
+
+A third concern — pre-existing link-check failures from root-relative paths — looks related
+but is not caused by the PR and should not be fixed in the same PR.

--- a/skills/ci-cd/mkdocs-nav-cleanup/skills/mkdocs-nav-cleanup/SKILL.md
+++ b/skills/ci-cd/mkdocs-nav-cleanup/skills/mkdocs-nav-cleanup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: mkdocs-nav-cleanup
+description: "Fix MkDocs build failures caused by nav entries referencing deleted documentation files. Use when: (1) CI 'Deploy Documentation' job fails after deleting doc stubs, (2) mkdocs build --strict reports missing files, (3) PR deletes placeholder docs but mkdocs.yml nav still references them."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mkdocs-nav-cleanup |
+| **Category** | ci-cd |
+| **Trigger** | CI Deploy Documentation failure after deleting placeholder doc stubs |
+| **Scope** | mkdocs.yml nav section + any cross-links in remaining docs |
+
+## When to Use
+
+- A PR deletes placeholder/stub documentation files and CI "Deploy Documentation" fails
+- `mkdocs build --strict` reports "Documentation file 'X.md' specified in nav is not found"
+- A remaining markdown file contains a relative link to a now-deleted file
+- Pre-existing link-check failures (root-relative paths) are conflated with PR-caused failures — need to distinguish which CI failures are in-scope
+
+## Verified Workflow
+
+1. **Identify deleted files** — check the PR diff for removed `.md` files
+2. **Audit mkdocs.yml nav** — find all nav entries referencing the deleted files
+3. **Audit remaining docs for cross-links** — grep for relative links pointing to deleted files:
+   ```bash
+   grep -r "deleted-file-name" docs/ mkdocs.yml
+   ```
+4. **Remove nav entries** from `mkdocs.yml` — delete the entries (and their parent section if now empty)
+5. **Remove broken relative links** from remaining docs — remove or update bullet points referencing deleted files
+6. **Verify no remaining references**:
+   ```bash
+   grep -r "deleted-file1\|deleted-file2" docs/ mkdocs.yml
+   ```
+7. **Run pre-commit on changed files**:
+   ```bash
+   pre-commit run --files mkdocs.yml docs/path/to/changed.md
+   ```
+8. **Commit** with message format `fix: Address review feedback for PR #<N>`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Removing entire section blocks at once | Used Edit to replace multi-line nav blocks covering Core + Advanced + Development | Initially included Release Process (a surviving file) in the removal | Always check which files in a nav section still exist before removing the whole block — keep entries for surviving files |
+| Treating link-check failures as in-scope | Considered fixing 20 root-relative path errors in CLAUDE.md, docs/adr/, notebooks/README.md | These were pre-existing on main, unrelated to the PR | Verify pre-existing CI failures with `gh run list --branch main --workflow "Check Markdown Links"` before scoping fixes |
+
+## Results & Parameters
+
+**What was fixed (PR #3308, issue #3142):**
+
+- `mkdocs.yml`: Removed `Core` section (8 entries), 6 `Advanced` entries, 3 `Development` entries — all referencing deleted placeholder stubs
+- `docs/advanced/benchmarking.md:666`: Removed `[SIMD Integration Guide](integration.md)` bullet — relative link to deleted stub
+
+**Verification command:**
+
+```bash
+grep -r "core/project-structure\|core/workflow\|core/shared-library\|core/testing-strategy\|core/agent-system\|core/mojo-patterns\|core/configuration\|core/paper-implementation\|advanced/performance\|advanced/custom-layers\|advanced/visualization\|advanced/integration\|advanced/distributed-training\|advanced/debugging\|dev/architecture\|dev/ci-cd\|dev/api-reference" docs/ mkdocs.yml
+```
+
+Expected output: empty (no matches).
+
+**Key distinction — two independent CI failure types:**
+
+1. **In-scope**: `build-docs` fails because nav references deleted files → fix mkdocs.yml and cross-links
+2. **Out-of-scope (pre-existing)**: `link-check` fails on root-relative paths (e.g. `/.claude/shared/`) → do not fix in this PR; confirm with `gh run list --branch main --workflow "..."` that it was already failing before the PR


### PR DESCRIPTION
## Summary

Documents how to fix CI Deploy Documentation failures caused by `mkdocs.yml` nav entries referencing deleted placeholder documentation files.

- Covers both `mkdocs.yml` nav cleanup and broken relative link removal from remaining docs
- Documents how to distinguish in-scope build failures from pre-existing link-check failures
- Derived from PR #3308 fix in ProjectOdyssey (issue #3142)

## Key Findings

**What Worked**:
- Grepping for deleted file names across `docs/` and `mkdocs.yml` to find all references
- Running `pre-commit run --files <changed-files>` on only the modified files for fast validation
- Confirming pre-existing failures via `gh run list --branch main --workflow "..."` before scoping

**What Failed**:
- Removing entire nav sections without checking for surviving files → had to keep `Release Process` entry under `Development`
- Treating pre-existing `link-check` failures (root-relative paths) as in-scope → they were on `main` before the PR

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with mkdocs CI failure triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
