### PR TITLE
feat: add fix-stale-agent-crossrefs skill

### DIFF
--- a/skills/documentation/fix-stale-agent-crossrefs/.claude-plugin/plugin.json
+++ b/skills/documentation/fix-stale-agent-crossrefs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-stale-agent-crossrefs",
+  "version": "1.0.0",
+  "description": "Fix stale cross-references in agent config files after specialist consolidation. Use when: (1) agent specialists are deleted/consolidated and remaining configs still link to the deleted files, (2) PR review identifies broken internal links in .claude/agents/*.md files.",
+  "category": "documentation",
+  "date": "2026-03-05",
+  "tags": ["agents", "cross-references", "consolidation", "markdown", "review-feedback"]
+}

--- a/skills/documentation/fix-stale-agent-crossrefs/references/notes.md
+++ b/skills/documentation/fix-stale-agent-crossrefs/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: Fix Stale Agent Cross-References
+
+## Context
+
+- **PR**: #3319
+- **Issue**: #3144
+- **Branch**: `3144-auto-impl`
+- **Date**: 2026-03-05
+
+## What Was Done
+
+PR #3319 consolidated 13 review specialists into 5. The consolidation correctly deleted the
+specialist files but left stale `Coordinates With` links in 4 remaining agent configs.
+
+### Files Fixed
+
+1. `.claude/agents/mojo-language-review-specialist.md:131-132`
+   - Deleted: `performance-review-specialist.md`, `safety-review-specialist.md`
+   - Replaced with: `general-review-specialist.md`
+
+2. `.claude/agents/numerical-stability-specialist.md:117-118`
+   - Deleted: `algorithm-review-specialist.md`, `performance-review-specialist.md`
+   - Replaced with: `general-review-specialist.md`
+
+3. `.claude/agents/security-review-specialist.md:93`
+   - Deleted: `dependency-review-specialist.md`
+   - Replaced with: `general-review-specialist.md`
+
+4. `.claude/agents/test-review-specialist.md:95-96`
+   - Deleted: `algorithm-review-specialist.md`, `implementation-review-specialist.md`
+   - Replaced with: `general-review-specialist.md`
+
+## Environment Issues Encountered
+
+- `just` not installed: use `pre-commit run --all-files` directly
+- GLIBC too old for `mojo` binary (requires GLIBC 2.32+, host has older): mojo-format hook
+  fails on all files but is pre-existing and unrelated to `.md` changes
+- `npx` / `markdownlint-cli2` not in PATH outside pixi env: rely on pre-commit hook
+
+## Line Length Issue
+
+First attempt at merging two lines used a long description (127 chars). Fixed by shortening:
+
+- Too long: "Suggests numerical/gradient tests and notes untested code paths" (line 127 chars)
+- Fixed: "Coordinates on tests and untested code paths" (line 109 chars)
+
+## Validation Results
+
+- `validate_configs.py`: 35/35 PASS, 0 errors (60 pre-existing warnings)
+- pre-commit (on commit): all hooks passed for `.md` files
+- mojo-format: skipped automatically (no `.mojo` files staged)

--- a/skills/documentation/fix-stale-agent-crossrefs/skills/fix-stale-agent-crossrefs/SKILL.md
+++ b/skills/documentation/fix-stale-agent-crossrefs/skills/fix-stale-agent-crossrefs/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: fix-stale-agent-crossrefs
+description: "Fix stale cross-references in agent configs after specialist consolidation. Use when: agent files are deleted during consolidation and remaining configs still reference them."
+category: documentation
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | PR review finds stale links in `.claude/agents/*.md` after consolidation |
+| **Scope** | `.claude/agents/` directory |
+| **Output** | Updated `Coordinates With` sections pointing to replacement agents |
+| **Validation** | `python3 tests/agents/validate_configs.py .claude/agents/` + pre-commit markdownlint |
+
+## When to Use
+
+- After consolidating multiple review specialists into fewer (e.g., 13 → 5 agents)
+- When PR review feedback identifies `Coordinates With` entries pointing to deleted files
+- When `validate_configs.py` passes but internal markdown links are stale
+
+## Verified Workflow
+
+1. **Identify stale links** from PR review feedback or grep:
+
+   ```bash
+   grep -r "deleted-specialist-name" .claude/agents/
+   ```
+
+2. **Read each flagged file** around the `Coordinates With` section to confirm exact text.
+
+3. **Apply parallel edits** — all four files can be updated simultaneously since they are
+   independent:
+
+   - Replace `[Deleted Specialist](./deleted-specialist.md)` with
+     `[General Review Specialist](./general-review-specialist.md)`
+   - Merge the description from both deleted lines into one concise line
+   - Keep line length under 120 characters (markdownlint MD013)
+
+4. **Validate** agent configs pass:
+
+   ```bash
+   python3 tests/agents/validate_configs.py .claude/agents/
+   ```
+
+5. **Run pre-commit** on affected files (markdownlint will catch line-length violations):
+
+   ```bash
+   pre-commit run --files .claude/agents/mojo-language-review-specialist.md \
+     .claude/agents/numerical-stability-specialist.md \
+     .claude/agents/security-review-specialist.md \
+     .claude/agents/test-review-specialist.md
+   ```
+
+6. **Commit** with the format specified in the review plan file.
+
+## Results & Parameters
+
+### Line Length Rule
+
+Markdownlint MD013 enforces 120-character max. When merging two bullet points into one,
+always count characters before committing:
+
+```text
+- [General Review Specialist](./general-review-specialist.md) - <description>
+ ^--- count from here to end must be <= 120
+```
+
+If over limit, shorten the description (e.g., "Coordinates on tests and untested code paths"
+instead of "Suggests numerical/gradient tests and notes untested code paths").
+
+### Mojo Format Hook
+
+The `mojo-format` pre-commit hook will fail on hosts with GLIBC < 2.32 (Debian Buster).
+This is a pre-existing environmental issue — skip it with `SKIP=mojo-format` or ignore
+when only `.md` files changed. The commit hook runs only on staged filetypes, so committing
+`.md`-only changes naturally skips mojo-format.
+
+### Validation Output
+
+`validate_configs.py` reports warnings (missing recommended sections) but these are
+pre-existing and not caused by cross-reference fixes. Zero errors = passing.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Merging two lines into continuation indent | `- [General...] - Suggests...\n  untested code paths` | Markdownlint may reject indented continuation in list items | Prefer shortening the description to a single line under 120 chars |
+| Running `just pre-commit-all` | `just: command not found` | `just` not installed on this host | Fall back to `pre-commit run --all-files` directly |
+| Running `npx markdownlint-cli2` directly | `npx: command not found` | Node.js not in PATH outside pixi env | Use `pixi run npx markdownlint-cli2` or rely on pre-commit hook |
+| `pixi run markdownlint-cli2` | `markdownlint-cli2: command not found` | pixi task not registered under that name | Rely on pre-commit hook for linting instead |
+


### PR DESCRIPTION
## Summary

Documents the workflow for fixing stale `Coordinates With` cross-references
in agent config files after specialist consolidation.

- Read all flagged agent files in parallel, apply edits simultaneously
- Merge deleted references into one line pointing to the replacement agent
- Keep merged lines under 120 chars (markdownlint MD013)

## Key Findings

**What Worked**:
- Parallel reads + parallel edits for 4 independent files
- Shortening merged description instead of line-continuing in list items
- Relying on pre-commit hook for markdownlint rather than running it directly

**What Failed**:
- `just pre-commit-all` → `just: command not found` on this host
- `npx markdownlint-cli2` → `npx: command not found` outside pixi env
- `pixi run markdownlint-cli2` → task not registered
- First merged line was 127 chars (over 120 limit) — fixed by shortening description

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)