### PR TITLE
feat: add diverged-branch-cherry-pick-fix skill

### DIFF
--- a/skills/ci-cd/diverged-branch-cherry-pick-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/diverged-branch-cherry-pick-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "diverged-branch-cherry-pick-fix",
+  "version": "1.0.0",
+  "description": "Fix a diverged feature branch by resetting to remote and cherry-picking specific fix commits. Use when: (1) local and remote branches have diverged and cannot be fast-forward pushed, (2) a fix commit exists locally but the remote has additional commits not present locally, (3) git push fails due to non-fast-forward rejection on a feature branch.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["git", "cherry-pick", "diverged-branch", "feature-branch", "pr-fix"]
+}

--- a/skills/ci-cd/diverged-branch-cherry-pick-fix/references/notes.md
+++ b/skills/ci-cd/diverged-branch-cherry-pick-fix/references/notes.md
@@ -1,0 +1,95 @@
+# Session Notes: Diverged Branch Cherry-Pick Fix
+
+## Context
+
+- **Project**: ProjectOdyssey
+- **Branch**: `3088-auto-impl`
+- **PR**: #3197 (issue #3088)
+- **Date**: 2026-03-05
+
+## Objective
+
+Push a BF16 test-skip fix commit to a feature branch PR that was failing CI. The CI failure
+was `test_dtypes_bfloat16()` returning `Element 0 = 0.0, expected 1.0` because
+`ExTensor._set_float64/_get_float64` does not correctly round-trip bfloat16 values.
+
+## What the Fix Plan Said
+
+The fix plan (`-claude-review-fix-3088.md`) stated:
+
+> The local branch is 2 commits ahead of remote. Run `git push origin 3088-auto-impl`.
+
+## What Was Actually True
+
+```
+git log --oneline origin/3088-auto-impl..HEAD
+0353c9b0 fix(tests): skip bfloat16 special values test until float64 path fixed
+3d522e5e cleanup(training): document BF16 native support, remove stale alias comments
+
+git log --oneline HEAD..origin/3088-auto-impl | wc -l
+13
+```
+
+The remote had **13 commits** not present locally. The branches had genuinely diverged from
+a shared ancestor at `597f77fa`. The fix plan was written against an outdated snapshot.
+
+## Diagnosis Steps
+
+1. Ran `git log --oneline -6` and `git status` — saw "diverged, 2 and 13 different commits"
+2. Ran `git log --oneline origin/3088-auto-impl | head -20` — confirmed 13 remote-only commits
+3. Ran `git merge-base HEAD origin/3088-auto-impl` — found common ancestor `597f77fa`
+4. Checked remote file: `git show origin/3088-auto-impl:tests/shared/testing/test_special_values.mojo`
+   — confirmed remote still had the broken BF16 test with real assertions
+5. Checked local fix: `git show 0353c9b0 --stat` — only 1 file changed, 11 insertions/6 deletions
+6. Checked diff of local cleanup commit to understand overlap with remote's equivalent commit
+
+## Solution
+
+```bash
+git reset --hard origin/3088-auto-impl   # absorb 13 remote commits
+git cherry-pick 0353c9b0                  # apply BF16 fix on top
+```
+
+Cherry-pick applied with zero conflicts. Result: local branch 1 commit ahead of remote.
+
+## Key Fix
+
+`tests/shared/testing/test_special_values.mojo` — `test_dtypes_bfloat16()` body:
+
+**Before (remote/broken)**:
+```mojo
+fn test_dtypes_bfloat16() raises:
+    """Test special values work with bfloat16.
+    Uses native DType.bfloat16 available in current Mojo.
+    Note: DType.bfloat16 is not supported on Apple Silicon hardware.
+    """
+    var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
+    assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
+    verify_special_value_invariants(tensor, 1.0)
+```
+
+**After (fixed)**:
+```mojo
+fn test_dtypes_bfloat16() raises:
+    """Test special values work with bfloat16.
+
+    DType.bfloat16 is available in Mojo, but ExTensor's _set_float64/_get_float64
+    path does not correctly round-trip values through bfloat16 storage, so this
+    test is skipped until the ExTensor float64 read/write path supports bfloat16.
+
+    Note: DType.bfloat16 is also not supported on Apple Silicon hardware.
+
+    TODO: Enable when ExTensor._set_float64/_get_float64 correctly handle bfloat16.
+        var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
+        assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
+        verify_special_value_invariants(tensor, 1.0)
+    """
+    pass
+```
+
+## Lessons
+
+1. Fix plans can be stale — always re-diagnose the actual git state before acting
+2. Check `HEAD..origin/<branch>` not just `origin/<branch>..HEAD` to see full divergence
+3. When local has a targeted single-file fix, reset + cherry-pick is cleaner than merge
+4. Cherry-picks of small, focused commits rarely conflict even on diverged branches

--- a/skills/ci-cd/diverged-branch-cherry-pick-fix/skills/diverged-branch-cherry-pick-fix/SKILL.md
+++ b/skills/ci-cd/diverged-branch-cherry-pick-fix/skills/diverged-branch-cherry-pick-fix/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: diverged-branch-cherry-pick-fix
+description: "Fix a diverged feature branch by resetting to remote and cherry-picking specific fix commits. Use when: local branch has diverged from remote, fix commits exist locally but remote has additional commits."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+# diverged-branch-cherry-pick-fix
+
+Workflow for recovering when a local feature branch has diverged from its remote counterpart
+and you need to apply a specific fix commit on top of the updated remote state.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-05 |
+| Objective | Apply a local fix commit onto a remote branch that has diverged |
+| Outcome | Success |
+| Project | ProjectOdyssey |
+| Context | PR #3197 (issue #3088) — BF16 test skip fix |
+
+## When to Use
+
+- `git push` fails with "non-fast-forward" on a feature branch
+- `git status` shows "Your branch and 'origin/<branch>' have diverged"
+- A fix commit exists locally but the remote has accumulated additional commits
+- A fix plan assumed the remote was behind, but it actually has more commits than local
+- You need to land a minimal targeted fix (one file) on top of an updated remote state
+
+## Verified Workflow
+
+### Step 1: Diagnose the divergence
+
+```bash
+# Check local vs remote state
+git log --oneline -6
+git status
+
+# Show commits unique to local (ahead of remote)
+git log --oneline origin/<branch>..HEAD
+
+# Show commits unique to remote (behind locally)
+git log --oneline HEAD..origin/<branch>
+
+# Find common ancestor
+git merge-base HEAD origin/<branch>
+```
+
+### Step 2: Understand what each side changed
+
+```bash
+# See what the remote-only commits changed in the target file
+git show origin/<branch>:path/to/file.ext | grep -n "relevant pattern"
+
+# See what the local fix commit changes
+git show <fix-commit-sha> --stat
+git diff <merge-base>..<fix-commit-sha> -- path/to/file.ext
+```
+
+### Step 3: Reset local to remote tip
+
+Only do this after confirming your fix applies cleanly on top of the remote state.
+
+```bash
+git reset --hard origin/<branch>
+```
+
+### Step 4: Cherry-pick the fix commit
+
+```bash
+git cherry-pick <fix-commit-sha>
+```
+
+If conflicts arise, resolve them manually, then `git cherry-pick --continue`.
+
+### Step 5: Verify
+
+```bash
+# Should show exactly 1 commit ahead
+git status
+
+# Confirm fix is present
+git show HEAD --stat
+sed -n '<start>,<end>p' path/to/fixed/file.ext
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Direct push after local commits | Assumed local was ahead of remote | Branches had diverged; remote had 13 additional commits not present locally | Always check `HEAD..origin/<branch>` not just `origin/<branch>..HEAD` before pushing |
+| Treating fix plan at face value | Fix plan said "2 commits ahead, just push" | Plan was written before remote accumulated additional commits | Verify actual remote state with `git log --oneline HEAD..origin/<branch>` before acting |
+| Keeping local commits and merging | Would merge unrelated cleanup commit with remote's version of same | Remote already had an equivalent cleanup commit; merge would create duplicate | Use cherry-pick of the minimal fix only, not the full local commit stack |
+
+## Results & Parameters
+
+The fix involved only 1 file changed (test file BF16 test body replaced with `pass` + docstring).
+Cherry-pick applied with zero conflicts because the remote's version of the file differed only
+in the same function body that the fix commit modifies.
+
+Key diagnostic commands:
+
+```bash
+# Full divergence diagnosis
+git log --oneline origin/<branch>..HEAD       # local-only commits
+git log --oneline HEAD..origin/<branch>       # remote-only commits
+git merge-base HEAD origin/<branch>           # common ancestor SHA
+
+# Safe reset + cherry-pick
+git reset --hard origin/<branch>              # absorb all remote commits
+git cherry-pick <fix-sha>                     # apply only the targeted fix
+
+# Verify result
+git log --oneline -3                          # should show fix as single HEAD commit
+git status                                    # should show "ahead by 1 commit"
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3197, issue #3088 — BF16 test skip | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the workflow for fixing a diverged feature branch by resetting to the remote tip
and cherry-picking a targeted fix commit, rather than attempting a push that would fail.

- Handles the case where a fix plan is stale and the remote has accumulated additional commits
- Uses `reset --hard` + `cherry-pick` for clean, conflict-free application of minimal fixes
- Covers bidirectional divergence diagnosis (`HEAD..origin/<branch>` and `origin/<branch>..HEAD`)

## Key Findings

**What Worked**:
- `git reset --hard origin/<branch>` to absorb all remote commits cleanly
- `git cherry-pick <sha>` to apply the targeted 1-file fix with zero conflicts
- Checking both directions of divergence before deciding on a strategy

**What Failed**:
- Following the fix plan literally (it said "just push", but remote had 13 extra commits)
- Assuming `git status` "ahead by 2" meant local was strictly ahead (it was a diverged state)
- Checking only `origin/<branch>..HEAD` and missing the remote-only commits

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Confirm skill appears under `ci-cd` category
- [ ] Verify SKILL.md frontmatter and Failed Attempts table render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
