### PR TITLE
feat: add no-op-review-fix-detection skill

### DIFF
--- a/skills/tooling/no-op-review-fix-detection/.claude-plugin/plugin.json
+++ b/skills/tooling/no-op-review-fix-detection/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-op-review-fix-detection",
+  "version": "1.0.0",
+  "description": "Recognize when a review-fix plan requires zero implementation changes. Use when: (1) a .claude-review-fix-*.md plan says 'No fixes required', (2) verifying a worktree already contains the correct committed state, (3) avoiding unnecessary commits on already-clean branches.",
+  "category": "tooling",
+  "date": "2026-03-05",
+  "tags": ["review", "pr", "no-op", "worktree", "ci"]
+}

--- a/skills/tooling/no-op-review-fix-detection/references/notes.md
+++ b/skills/tooling/no-op-review-fix-detection/references/notes.md
@@ -1,0 +1,37 @@
+# Session Notes: no-op-review-fix-detection
+
+## Context
+
+- **Repository**: HomericIntelligence/Odyssey2
+- **Branch**: 3083-auto-impl
+- **Worktree**: /home/mvillmow/Odyssey2/.worktrees/issue-3083
+- **Date**: 2026-03-05
+
+## Task
+
+The session was invoked with a `.claude-review-fix-3083.md` file instructing the agent to
+"implement all fixes from the plan." The plan itself stated:
+
+> "No problems found. The PR is ready to merge."
+> "No fixes required."
+
+## What Happened
+
+1. Read the plan file — identified it as a no-op plan
+2. Verified `git status` — no uncommitted changes, only the untracked plan file
+3. Verified `git log` — the expected commit (`3fea321a cleanup(logging): remove unimplemented
+   RotatingFileHandler placeholder`) was present at HEAD
+4. Reported to user: no action needed
+
+## Key Insight
+
+The `.claude-review-fix-*.md` wrapper always says "Implement all fixes from the plan above."
+This is a generic template. The actual plan body determines whether any work is needed.
+Agents must read the plan body, not just the wrapper instructions.
+
+## PR Context
+
+- **Issue**: #3083 (remove dead RotatingFileHandler test)
+- **PR**: #3182
+- **Change**: Removed no-op `test_rotating_file_handler()` function and its `main()` call
+- **CI**: All 32 test groups passed, pre-commit clean

--- a/skills/tooling/no-op-review-fix-detection/skills/no-op-review-fix-detection/SKILL.md
+++ b/skills/tooling/no-op-review-fix-detection/skills/no-op-review-fix-detection/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: no-op-review-fix-detection
+description: "Recognize when a review-fix plan requires zero implementation changes and verify the worktree is already correct. Use when: a .claude-review-fix-*.md plan explicitly states no fixes are required."
+category: tooling
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | no-op-review-fix-detection |
+| **Category** | tooling |
+| **Trigger** | `.claude-review-fix-*.md` plan with "No fixes required" conclusion |
+| **Outcome** | Confirm worktree is already in correct state; avoid phantom commits |
+
+## When to Use
+
+- A `.claude-review-fix-*.md` plan is provided and its "Fix Order" section says "No fixes required"
+- A PR review summary concludes "The PR is ready to merge as-is"
+- You need to verify the committed state matches the plan before the external script pushes
+- You want to avoid creating an empty or unnecessary commit on an already-clean branch
+
+## Verified Workflow
+
+1. **Read the plan file** — look for the "Problems Found" and "Fix Order" sections
+2. **Confirm no-op** — if both sections say none/no fixes, skip all implementation steps
+3. **Check git status** — run `git status && git log --oneline -5` to verify the expected commit is present
+4. **Confirm and report** — tell the user the fix is already committed and no action is needed
+5. **Do NOT create an empty commit** — the script that calls this agent handles pushing
+
+### Key Commands
+
+```bash
+# Verify worktree state
+git status && git log --oneline -5
+
+# Confirm the target change is in history
+git log --oneline --grep="<expected commit keyword>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Blindly following "implement all fixes" instruction | Started looking for code to change despite the plan saying no fixes needed | The task wrapper says "implement all fixes" even when the plan says there are none — the wrapper is generic | Always read the plan body first; the wrapper instruction is a template, not a guarantee of work |
+| Creating a commit anyway to satisfy the script | Considered making a trivial no-op commit | Would pollute history and could confuse CI or rebase operations | An empty/no-op commit is worse than no commit; trust the plan |
+
+## Results & Parameters
+
+### Plan File Pattern
+
+```
+## Problems Found
+None. The PR:
+- <reason 1>
+- <reason 2>
+
+## Fix Order
+No fixes required.
+```
+
+When this pattern is present, the correct action is:
+
+1. Verify `git status` shows no modified tracked files
+2. Verify the expected commit appears in `git log --oneline -5`
+3. Report to user: "No action needed — fix already committed"
+4. Do NOT push (the calling script handles that)
+
+### Worktree State Verification
+
+```bash
+git status           # Should show: "nothing to commit" or only untracked files
+git log --oneline -5  # Should show the expected change at HEAD or recently
+```


### PR DESCRIPTION
## Summary

Documents how to correctly handle `.claude-review-fix-*.md` plan files that conclude no implementation changes are required.

- Prevents phantom commits on already-clean branches
- Captures the insight that the wrapper instruction is a generic template — the plan body is authoritative
- Provides a verified workflow for confirming worktree state before the calling script pushes

## Key Findings

**What Worked**:
- Reading the plan body (Problems Found + Fix Order sections) before taking any action
- Running `git status && git log --oneline -5` to confirm the expected commit was already present
- Reporting to the user that no action was needed rather than creating an empty commit

**What Failed**:
- Blindly following "implement all fixes" wrapper instruction → plan said no fixes needed
- Considering a no-op commit to satisfy the script → would pollute history unnecessarily

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
