### PR TITLE
feat: add retrigger-flaky-ci skill

### DIFF
--- a/skills/ci-cd/retrigger-flaky-ci/.claude-plugin/plugin.json
+++ b/skills/ci-cd/retrigger-flaky-ci/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "retrigger-flaky-ci",
+  "version": "1.0.0",
+  "description": "Diagnose and re-trigger pre-existing flaky CI failures on pull requests without code changes. Use when: (1) CI fails on a PR that only has cosmetic/doc changes, (2) failure is in tests not touched by the PR, (3) Mojo runtime crashes (SIGABRT, execution crashed) appear in CI logs.",
+  "category": "ci-cd",
+  "date": "2026-03-05",
+  "tags": ["flaky-tests", "ci", "mojo", "github-actions", "retrigger"]
+}

--- a/skills/ci-cd/retrigger-flaky-ci/references/notes.md
+++ b/skills/ci-cd/retrigger-flaky-ci/references/notes.md
@@ -1,0 +1,46 @@
+# Session Notes: retrigger-flaky-ci
+
+## Context
+
+- **PR**: #3189 (issue #3187, branch `3187-auto-impl`)
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Date**: 2026-03-05
+- **PR Changes**: Cosmetic only — `print()` string replacements in 3 example training scripts + README updates
+
+## Problem
+
+CI run `22749573506` had 4 failing jobs:
+- Core Gradient
+- Core Layers
+- Test Report
+- link-check
+
+The "Core Gradient" job crashed with `execution crashed` in:
+- `test_backward_linear.mojo`
+- `test_backward_conv_pool.mojo`
+- `test_backward_losses.mojo`
+- `test_gradient_checking_basic.mojo`
+
+None of these files appear in `gh pr diff 3189 --name-only`. The PR only touches files under `examples/`.
+
+## Investigation
+
+1. Read `.claude-review-fix-3187.md` — fix plan confirmed: pre-existing flaky test, no code changes needed
+2. Ran `gh pr checks 3189` to confirm failure details and get run ID `22749573506`
+3. The crash signature (`SIGABRT in libKGENCompilerRTShared.so`) is a known Mojo runtime intermittent failure
+4. Main branch's latest successful CI run (`22751133381`) showed "Core Gradient success"
+
+## Resolution
+
+```bash
+gh run rerun 22749573506 --failed
+```
+
+Ran without errors. No commits needed — no files were modified.
+
+## Key Lessons
+
+- Always cross-reference failing test files with `gh pr diff <pr> --name-only` before attempting fixes
+- Mojo runtime crashes (SIGABRT, `execution crashed`) are often intermittent, not logic bugs
+- `gh run rerun <id> --failed` is the correct tool — re-runs only failed jobs, not the whole workflow
+- The fix plan review workflow (`-review-fix-*.md`) correctly identified this as a no-op fix

--- a/skills/ci-cd/retrigger-flaky-ci/skills/retrigger-flaky-ci/SKILL.md
+++ b/skills/ci-cd/retrigger-flaky-ci/skills/retrigger-flaky-ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: retrigger-flaky-ci
+description: "Diagnose and re-trigger pre-existing flaky CI failures on PRs without code changes. Use when: CI fails on a PR with only cosmetic/doc changes, the failure is in test files not touched by the PR, or Mojo runtime crashes (SIGABRT, execution crashed) appear in CI logs."
+category: ci-cd
+date: 2026-03-05
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | retrigger-flaky-ci |
+| **Category** | ci-cd |
+| **Trigger** | Pre-existing flaky CI failure on a PR with unrelated changes |
+| **Resolution** | Verify flakiness, then re-trigger failed jobs |
+| **Key Tool** | `gh run rerun <run-id> --failed` |
+
+## When to Use
+
+1. CI fails on a PR that only modifies cosmetic files (print strings, READMEs, comments)
+2. The failing test files are not in `gh pr diff <pr> --name-only`
+3. Mojo runtime crashes appear: `execution crashed`, `SIGABRT`, `libKGENCompilerRTShared.so`
+4. The same CI job passes on the latest successful `main` run (confirming flakiness)
+
+## Verified Workflow
+
+1. **Identify the failing run ID** from `gh pr checks <pr-number>`
+2. **Confirm the failure is unrelated** — check that failing test files are NOT in the PR diff:
+   ```bash
+   gh pr diff <pr-number> --name-only
+   gh pr checks <pr-number>
+   ```
+3. **Verify it passes on main** — find a recent successful main CI run and confirm the job passes there
+4. **Re-trigger failed jobs only**:
+   ```bash
+   gh run rerun <run-id> --failed
+   ```
+5. **Confirm resolution** — watch for the jobs to go green on the next run
+
+## Results & Parameters
+
+```bash
+# Step 1: Get PR check status and run ID
+gh pr checks 3189 --watch=false
+
+# Step 2: Verify PR diff does NOT contain failing test files
+gh pr diff 3189 --name-only
+# Expected: only examples/ and README files, no test_backward_*.mojo
+
+# Step 3: Re-trigger only failed jobs (not the whole workflow)
+gh run rerun 22749573506 --failed
+
+# Step 4: Monitor re-run
+gh run watch 22749573506
+```
+
+**Mojo Flaky Test Signature** (pre-existing, not PR-caused):
+- Job name: "Core Gradient"
+- Files: `test_backward_linear.mojo`, `test_backward_conv_pool.mojo`, `test_backward_losses.mojo`, `test_gradient_checking_basic.mojo`
+- Error: `execution crashed` / `SIGABRT in libKGENCompilerRTShared.so`
+- Pattern: Intermittent — passes on main's latest successful run
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Making code changes | Considered modifying test files to fix the crash | Not needed — crash is a pre-existing Mojo runtime flake, not introduced by PR | Always verify whether failing tests are in the PR diff before attempting fixes |
+| Full workflow rerun | Could have re-run the entire workflow | Wastes CI minutes re-running passing jobs | Use `--failed` flag to re-trigger only the failed jobs |


### PR DESCRIPTION
## Summary

Documents the pattern for diagnosing and re-triggering pre-existing flaky CI failures on PRs that have no related code changes.

- Mojo runtime crashes (SIGABRT in `libKGENCompilerRTShared.so`) are intermittent and not caused by PR changes
- Cross-referencing failing test files with `gh pr diff --name-only` is the key diagnostic step
- `gh run rerun <id> --failed` re-triggers only failed jobs rather than the entire workflow

## Key Findings

**What Worked**:
- `gh run rerun <run-id> --failed` to re-trigger only failed CI jobs
- Comparing failing test files against `gh pr diff <pr> --name-only` to confirm unrelatedness
- Checking main branch's latest successful run to confirm the failure is intermittent

**What Failed**:
- Attempting code changes first → Not needed; crash was pre-existing Mojo runtime flake
- Full workflow rerun → Wastes CI minutes re-running already-passing jobs; use `--failed` flag

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
