### PR TITLE
feat: add mojo-trait-conformance-fix skill

### DIFF
--- a/skills/debugging/mojo-trait-conformance-fix/.claude-plugin/plugin.json
+++ b/skills/debugging/mojo-trait-conformance-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-trait-conformance-fix",
+  "version": "1.0.0",
+  "description": "Fix Mojo struct missing trait declaration causing compile-time 'does not conform to trait' errors. Use when: (1) a struct implements trait methods (e.g. __hash__, __eq__) but is not listed in the struct trait list, (2) CI fails with 'argument type X does not conform to trait Y', (3) hash() or other trait-dispatched functions fail on a struct that has the implementation.",
+  "category": "debugging",
+  "date": "2026-03-06",
+  "tags": ["mojo", "traits", "hashable", "compile-error", "struct", "extensor"]
+}

--- a/skills/debugging/mojo-trait-conformance-fix/references/notes.md
+++ b/skills/debugging/mojo-trait-conformance-fix/references/notes.md
@@ -1,0 +1,55 @@
+# Session Notes: mojo-trait-conformance-fix
+
+## Session Context
+
+- **Date**: 2026-03-06
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: `3164-auto-impl`
+- **PR**: #3373
+- **Issue**: #3164
+
+## Problem
+
+CI failure in `Core Utilities` test group:
+
+```text
+tests/shared/core/test_utility.mojo:383
+error: no matching function in call to 'hash'
+note: argument type 'ExTensor' does not conform to trait 'Hashable'
+```
+
+`ExTensor` had `__hash__` implemented (using `bitcast` for exact float bit representation) but
+`Hashable` was not listed in its struct declaration at `shared/core/extensor.mojo:46`.
+
+## Fix
+
+Single-line change:
+
+```mojo
+# Before (line 46)
+struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+
+# After (line 46)
+struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized, Hashable):
+```
+
+## Environment Constraints
+
+- Host OS: Debian with GLIBC 2.31
+- Mojo requires GLIBC 2.32, 2.33, 2.34
+- Result: `mojo` binary cannot run locally — all test verification must go through CI
+- Pre-commit `mojo-format` hook fails for same reason
+- Workaround: `SKIP=mojo-format git commit ...`
+- CI uses Docker image with correct GLIBC — formatting and tests pass there
+
+## Integration Tests Note
+
+The `Integration Tests` CI failure (4 tests crashing with `mojo: error: execution crashed`)
+was identified as pre-existing and unrelated to this PR — those files were not modified by
+the PR and also crash on `main`.
+
+## Key Insight
+
+In Mojo, implementing a trait's methods is necessary but not sufficient. The trait must also
+be explicitly declared in the struct's conformance list. This is different from some languages
+where duck typing or implicit interface satisfaction applies.

--- a/skills/debugging/mojo-trait-conformance-fix/skills/mojo-trait-conformance-fix/SKILL.md
+++ b/skills/debugging/mojo-trait-conformance-fix/skills/mojo-trait-conformance-fix/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: mojo-trait-conformance-fix
+description: "Fix Mojo struct missing trait declaration causing compile-time 'does not conform to trait' errors. Use when: a struct has trait method implementations but is missing the trait in its declaration list."
+category: debugging
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo struct implements trait methods (e.g. `__hash__`) but is not declared as conforming to the trait |
+| **Symptom** | CI fails: `argument type 'X' does not conform to trait 'Hashable'` / `no matching function in call to 'hash'` |
+| **Fix** | Add the missing trait to the struct declaration: `struct Foo(Existing, NewTrait):` |
+| **Scope** | One-line change to the struct header |
+| **Verification** | CI (local Mojo may be unavailable due to GLIBC version mismatch) |
+
+## When to Use
+
+- A Mojo struct has `__hash__`, `__eq__`, `__lt__`, or other trait methods implemented but the trait (`Hashable`, `Comparable`, etc.) is missing from `struct Foo(...):`
+- CI reports: `argument type 'ExTensor' does not conform to trait 'Hashable'`
+- A new test calls `hash(obj)` and the build fails even though `__hash__` is defined on the struct
+- PR adds trait method implementations without updating the struct declaration
+
+## Verified Workflow
+
+1. **Identify the struct and missing trait** from CI error:
+
+   ```text
+   error: no matching function in call to 'hash'
+   argument type 'ExTensor' does not conform to trait 'Hashable'
+   ```
+
+2. **Read the struct declaration** in the relevant `.mojo` file (e.g. `shared/core/extensor.mojo:46`).
+
+3. **Add the missing trait** to the parenthesized list:
+
+   ```mojo
+   # Before
+   struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+
+   # After
+   struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized, Hashable):
+   ```
+
+4. **Commit** with the pre-commit hook. If `mojo-format` fails due to GLIBC version mismatch on the host (local Mojo cannot run), skip only that hook:
+
+   ```bash
+   SKIP=mojo-format git commit -m "fix: add Hashable trait declaration to ExTensor"
+   ```
+
+5. **Push and verify CI** — the Docker-based CI environment has the correct GLIBC version and will run `mojo format` and the tests.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `pixi run mojo test` locally | Attempted to verify fix with local Mojo test runner | GLIBC version mismatch: host has 2.31, Mojo requires 2.32+ | Local Mojo is not runnable on this host; rely on CI for test verification |
+| Running `git commit` without SKIP | Pre-commit hook `mojo-format` invokes `mojo` binary which fails with GLIBC error | Same GLIBC constraint prevents formatter from running | Use `SKIP=mojo-format` when Mojo cannot run locally; CI enforces formatting |
+
+## Results & Parameters
+
+**Fix applied**: `shared/core/extensor.mojo:46`
+
+```mojo
+# One-line fix
+struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized, Hashable):
+```
+
+**Commit command (with hook workaround)**:
+
+```bash
+SKIP=mojo-format git commit -m "fix: add Hashable trait declaration to ExTensor
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+**Root cause pattern**: When implementing a trait method in Mojo, the trait must also appear in the struct's parenthesized conformance list. Implementing `__hash__` alone is not sufficient — `Hashable` must be declared explicitly. This is a common oversight when adding new trait methods to existing structs.
+
+**Trait conformance list location**: Always the first line of the struct definition, in parentheses after the struct name.


### PR DESCRIPTION
## Summary

Documents the pattern for fixing Mojo structs that implement trait methods but are missing the trait declaration in their struct header.

- Single-line fix: add missing trait (e.g. `Hashable`) to struct conformance list
- Covers GLIBC-constrained environments where `mojo` cannot run locally
- Distinguishes pre-existing CI failures from PR-introduced regressions

## Key Findings

**What Worked**:
- Adding `Hashable` to `struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized, Hashable):` resolved the compile error
- `SKIP=mojo-format git commit` bypasses the mojo-format pre-commit hook when Mojo binary is unavailable locally

**What Failed**:
- Running `pixi run mojo test` locally → GLIBC 2.31 host, Mojo requires 2.32+ → must rely on CI
- Running `git commit` without `SKIP=mojo-format` → same GLIBC issue causes hook failure

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation when encountering Mojo trait conformance errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
