### PR TITLE
feat: add verify-before-fix skill

### DIFF
--- a/skills/documentation/verify-before-fix/.claude-plugin/plugin.json
+++ b/skills/documentation/verify-before-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-before-fix",
+  "version": "1.0.0",
+  "description": "Verify PR state before implementing review fixes to avoid unnecessary changes. Use when: (1) a review fix script is generated but the PR may already be correct, (2) pre-existing CI failures are present that may not be caused by the PR, (3) a documentation-only PR has unrelated test failures blocking merge.",
+  "category": "documentation",
+  "date": "2026-03-06",
+  "tags": ["pr-review", "verification", "ci-failures", "documentation", "no-op"]
+}

--- a/skills/documentation/verify-before-fix/references/notes.md
+++ b/skills/documentation/verify-before-fix/references/notes.md
@@ -1,0 +1,44 @@
+# Session Notes: verify-before-fix
+
+## Context
+
+- **Date**: 2026-03-06
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3153-auto-impl
+- **PR**: #3348
+- **Issue**: #3153
+
+## Objective
+
+Address review feedback for PR #3348. A `.claude-review-fix-3153.md` file was provided
+with a fix plan. The task was to implement the fixes, run tests, and commit.
+
+## What Happened
+
+1. Read `.claude-review-fix-3153.md` — the fix plan concluded "No fixes required"
+2. Verified CLAUDE.md Testing Strategy section: 3 lines (well under the 10-line budget)
+3. Verified `docs/dev/testing-strategy.md` exists (9785 bytes)
+4. Noted 3 CI failures (Core Initializers, Core NN Modules, Core Tensors) were pre-existing
+5. Concluded: nothing to commit
+
+## Key Insight
+
+A documentation-only PR (only `.md` files changed) cannot cause Mojo test failures.
+When CI shows unrelated test failures on such a PR, they are pre-existing and should be
+tracked in a separate issue — not used to block merge.
+
+## Fix Plan Conclusion (verbatim)
+
+> "No fixes required. The PR is ready to merge."
+> "The 3 CI test failures should be investigated in a separate issue — they are not caused
+> by this PR and should not block its merge."
+
+## Files Verified
+
+- `CLAUDE.md` lines 1236-1240: Testing Strategy section (3 lines + heading + blank)
+- `docs/dev/testing-strategy.md`: exists, 9785 bytes
+
+## Lesson
+
+When a review fix script says "no fixes required", verify the success criteria independently
+then stop. Do not create a no-op commit just to satisfy the script's commit step.

--- a/skills/documentation/verify-before-fix/skills/verify-before-fix/SKILL.md
+++ b/skills/documentation/verify-before-fix/skills/verify-before-fix/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: verify-before-fix
+description: "Verify PR state before implementing review fixes to avoid unnecessary changes. Use when: a fix plan is provided but the PR may already be correct, CI failures are present that may be pre-existing, or a docs-only PR has unrelated test failures."
+category: documentation
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | verify-before-fix |
+| **Category** | documentation |
+| **Complexity** | Low |
+| **Risk** | Low — read-only verification |
+
+Confirms whether a PR already satisfies its success criteria before applying fixes.
+Prevents wasted effort and accidental regressions from implementing unnecessary changes.
+
+## When to Use
+
+- A `.claude-review-fix-<number>.md` plan says "no fixes required" — confirm before skipping
+- CI shows failing tests on a documentation-only PR
+- Pre-existing CI failures may be unrelated to the PR's diff
+- Review feedback has already been addressed in a previous commit
+
+## Verified Workflow
+
+1. **Read the fix plan** — check if it says "no fixes required"
+2. **Verify success criteria** directly in the working directory:
+   - Check the actual file contents match what was requested
+   - Confirm referenced canonical docs exist
+3. **Attribute CI failures** — determine if failures predate the PR change:
+   - A docs-only diff (`.md` files only) cannot cause Mojo test failures
+   - Compare failing tests against the PR diff to rule out causation
+4. **Conclude**: if all criteria are met and failures are pre-existing, no commit is needed
+
+### Example Verification Commands
+
+```bash
+# Verify a CLAUDE.md section is within line budget
+grep -n "## Testing Strategy" CLAUDE.md
+# Then count lines in that section
+
+# Confirm canonical doc exists
+ls -la docs/dev/testing-strategy.md
+
+# Check PR diff scope (docs only = cannot break tests)
+git diff main...HEAD --name-only
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Implementing fixes when plan says none needed | Following fix script template literally without reading the conclusion | Would create an empty or no-op commit | Always read the fix plan conclusion before taking action |
+| Treating all CI failures as blockers | Blocking merge on 3 failing test groups for a docs-only PR | Failures were pre-existing and unrelated to the diff | Attribute failures to the diff — docs changes cannot break Mojo tests |
+| Running full test suite to verify no-op | Running `pytest` to confirm nothing changed | Time wasted; result was already known from the diff | A documentation-only diff has a deterministic blast radius |
+
+## Results & Parameters
+
+**Session context**: PR #3348 (issue #3153) — trimmed `CLAUDE.md` Testing Strategy section
+
+**Success criteria verified**:
+
+```bash
+# 1. Section is <= 10 lines (was 3 lines after trim)
+grep -A5 "## Testing Strategy" CLAUDE.md
+
+# 2. Canonical doc exists
+ls -la docs/dev/testing-strategy.md
+
+# 3. Markdown linting passes
+just pre-commit-all
+```
+
+**Key conclusion pattern**:
+
+> "The diff is exactly what the issue requested. The failing CI tests are pre-existing and
+> unrelated to a documentation-only change. No fixes required."
+
+**When to escalate**: If the fix plan identifies real problems (broken links, missing files,
+wrong content), implement those. Only skip implementation when the plan explicitly concludes
+"no fixes required" AND independent verification confirms the success criteria are met.


### PR DESCRIPTION
## Summary

Documents the pattern of verifying PR state before implementing review fixes to avoid unnecessary changes.

- Verify success criteria independently before concluding no action is needed
- Docs-only diffs cannot cause test failures — pre-existing CI failures should not block merge
- A fix plan conclusion of "no fixes required" still needs independent verification

## Key Findings

**What Worked**:
- Reading the fix plan conclusion first to determine if any action is needed
- Checking actual file state (grep for section, ls for referenced docs) rather than assumptions
- Attributing CI failures by diff scope (docs-only = cannot break Mojo tests)

**What Failed**:
- Following fix script template literally without reading the conclusion would create a no-op commit
- Treating unrelated CI test failures as blockers for a documentation-only PR
- Running full test suites to verify a no-op when the diff already proves the blast radius

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
