### PR TITLE
feat: add pre-commit-hook-pass-filenames skill

### DIFF
--- a/skills/ci-cd/pre-commit-hook-pass-filenames/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pre-commit-hook-pass-filenames/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pre-commit-hook-pass-filenames",
+  "version": "1.0.0",
+  "description": "Fix pre-commit hooks running on hardcoded directories instead of staged files by setting pass_filenames: true. Use when: (1) ruff/linter pre-commit hooks ignore staged files and run on entire directories, (2) hook entry point has hardcoded paths that override filename passing, (3) PR review requests pass_filenames fix for formatter/linter hooks.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["pre-commit", "ruff", "pass_filenames", "hooks", "linting", "formatting"]
+}

--- a/skills/ci-cd/pre-commit-hook-pass-filenames/references/notes.md
+++ b/skills/ci-cd/pre-commit-hook-pass-filenames/references/notes.md
@@ -1,0 +1,55 @@
+# Session Notes: pre-commit-hook-pass-filenames
+
+## Session Context
+
+- **Date**: 2026-03-06
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3154-auto-impl
+- **PR**: #3347
+- **Issue**: #3154
+
+## What Was Done
+
+The session started with a `.claude-review-fix-3154.md` review plan that described:
+- Fix already committed as `26669e4f fix(pre-commit): use pass_filenames: true for ruff hooks`
+- 3 failing CI tests (`Core Types`, `Data Samplers`, `Helpers`) are pre-existing and unrelated
+- No fixes needed
+
+### Steps Taken
+
+1. Read `.claude-review-fix-3154.md` — plan said implementation complete
+2. Ran `git log --oneline -5` — confirmed `26669e4f` was already committed
+3. Ran `pixi run python -m pytest tests/ -v` — failed with `ModuleNotFoundError: No module named 'scripts.dashboard'` (pre-existing, unrelated)
+4. Ran `pixi run pre-commit run --all-files` — all hooks passed including ruff
+5. No new commits needed
+
+## The Actual Fix (already in commit 26669e4f)
+
+Changed `.pre-commit-config.yaml` ruff hooks from:
+
+```yaml
+- id: ruff-format-python
+  entry: pixi run ruff format src/ scripts/
+  pass_filenames: false
+```
+
+To:
+
+```yaml
+- id: ruff-format-python
+  entry: pixi run ruff format
+  pass_filenames: true
+```
+
+Same pattern applied to `ruff-check-python`.
+
+## Environment Details
+
+- Mojo: incompatible GLIBC (pre-existing, environment-level issue, not related to PR)
+- Python tests: `scripts.dashboard` module missing (pre-existing)
+- Pre-commit: all hooks passed
+
+## Key Observation
+
+When a review fix plan says "no fixes required" and lists what was already done, trust it after
+verifying with `git log`. Do not start implementing changes before checking the current state.

--- a/skills/ci-cd/pre-commit-hook-pass-filenames/skills/pre-commit-hook-pass-filenames/SKILL.md
+++ b/skills/ci-cd/pre-commit-hook-pass-filenames/skills/pre-commit-hook-pass-filenames/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: pre-commit-hook-pass-filenames
+description: "Fix pre-commit hooks running on hardcoded directories instead of staged files by setting pass_filenames: true. Use when: ruff/linter hooks ignore staged files, hook entry has hardcoded paths, or PR review requests pass_filenames fix."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+# Pre-commit Hook pass_filenames Fix
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-06 |
+| **Issue** | #3154 - ruff pre-commit hooks running on hardcoded dirs instead of staged files |
+| **Objective** | Fix ruff-format-python and ruff-check-python hooks to pass filenames correctly |
+| **Outcome** | Success - Removed hardcoded dirs from `entry`, set `pass_filenames: true` |
+
+## When to Use
+
+Use this skill when:
+
+- Pre-commit ruff (or other linter) hooks run on hardcoded directories instead of staged files
+- Hook `entry` field contains hardcoded paths like `pixi run ruff format src/ scripts/`
+- PR review feedback requests `pass_filenames: true` fix for formatter/linter hooks
+- Hooks pass on all files but miss newly staged files not in hardcoded directories
+- Review plan states the fix is already committed — verify before making changes
+
+## Verified Workflow
+
+### 1. Verify Current State Before Making Changes
+
+Always read the review plan and check git log first:
+
+```bash
+# Check if fix is already committed
+git log --oneline -5
+
+# Check current hook configuration
+cat .pre-commit-config.yaml
+```
+
+**Key Finding**: Review fix plans may describe a completed fix. Check `git log` before touching anything.
+
+### 2. Identify the Problem Pattern
+
+The broken pattern has hardcoded directories in `entry` and `pass_filenames: false` (or absent):
+
+```yaml
+# BROKEN - hardcoded dirs, filenames not passed
+- id: ruff-format-python
+  name: Ruff Format Python
+  entry: pixi run ruff format src/ scripts/
+  language: system
+  types: [python]
+  pass_filenames: false
+```
+
+### 3. Apply the Fix
+
+Remove hardcoded directories from `entry`, set `pass_filenames: true`:
+
+```yaml
+# FIXED - no hardcoded dirs, filenames passed by pre-commit
+- id: ruff-format-python
+  name: Ruff Format Python
+  entry: pixi run ruff format
+  language: system
+  types: [python]
+  pass_filenames: true
+
+- id: ruff-check-python
+  name: Ruff Check Python
+  entry: pixi run ruff check --fix
+  language: system
+  types: [python]
+  pass_filenames: true
+```
+
+### 4. Verify Hooks Pass
+
+```bash
+pixi run pre-commit run --all-files
+```
+
+Expected output:
+
+```
+Ruff Format Python.......................................................Passed
+Ruff Check Python........................................................Passed
+```
+
+### 5. Commit
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "fix(pre-commit): use pass_filenames: true for ruff hooks
+
+Closes #<issue-number>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests first | Ran `pixi run python -m pytest tests/ -v` | `ModuleNotFoundError: No module named 'scripts.dashboard'` — pre-existing unrelated failure | Pre-existing test failures are not blockers; verify they are unrelated before spending time on them |
+| Assuming changes needed | Started planning edits to `.pre-commit-config.yaml` | Fix was already committed in `26669e4f` | Always check `git log` before implementing fixes from a review plan |
+
+## Results & Parameters
+
+### Working Hook Configuration
+
+```yaml
+# .pre-commit-config.yaml
+- repo: local
+  hooks:
+    - id: ruff-format-python
+      name: Ruff Format Python
+      entry: pixi run ruff format
+      language: system
+      types: [python]
+      pass_filenames: true
+
+    - id: ruff-check-python
+      name: Ruff Check Python
+      entry: pixi run ruff check --fix
+      language: system
+      types: [python]
+      pass_filenames: true
+```
+
+### Verification Command
+
+```bash
+pixi run pre-commit run --all-files 2>&1 | grep -E "(Ruff|Passed|Failed)"
+```
+
+### Pre-existing CI Failures
+
+If CI shows unrelated test failures (e.g., Mojo GLIBC errors, missing Python modules), confirm they
+predate the PR by checking git history:
+
+```bash
+git log --oneline --all | head -20
+# If failures exist before your branch diverged, they are not your responsibility
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3347, Issue #3154 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the fix pattern for pre-commit ruff hooks that run on hardcoded directories
instead of staged files, solved by setting `pass_filenames: true` and removing hardcoded
paths from the hook `entry`.

- Root cause: `entry: pixi run ruff format src/ scripts/` with `pass_filenames: false` ignores staged files
- Fix: Remove hardcoded dirs, set `pass_filenames: true`
- Key insight: Always verify `git log` before implementing — fix may already be committed

## Key Findings

**What Worked**:
- Reading the review plan carefully before making any changes
- Checking `git log` to confirm fix was already committed (`26669e4f`)
- Running `pixi run pre-commit run --all-files` to confirm hooks pass

**What Failed**:
- `pixi run python -m pytest tests/ -v` → pre-existing `ModuleNotFoundError: No module named 'scripts.dashboard'` (unrelated to PR)
- Mojo binary: pre-existing GLIBC incompatibility in local environment (unrelated)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates on pre-commit hook pass_filenames queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
