### PR TITLE
feat: add docs-only-pr-preexisting-ci-failures skill

### DIFF
--- a/skills/documentation/docs-only-pr-preexisting-ci-failures/.claude-plugin/plugin.json
+++ b/skills/documentation/docs-only-pr-preexisting-ci-failures/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs-only-pr-preexisting-ci-failures",
+  "version": "1.0.0",
+  "description": "Verify and close a review-fix task when a docs-only PR has no actual code changes needed and CI failures are pre-existing. Use when: (1) a review-fix plan concludes no changes are required, (2) CI failures exist but are unrelated to the PR diff, (3) a docs-only PR needs final pre-commit verification before merge.",
+  "category": "documentation",
+  "date": "2026-03-06",
+  "tags": ["pr-review", "ci-failures", "docs-only", "no-op", "pre-commit", "adr"]
+}

--- a/skills/documentation/docs-only-pr-preexisting-ci-failures/references/notes.md
+++ b/skills/documentation/docs-only-pr-preexisting-ci-failures/references/notes.md
@@ -1,0 +1,46 @@
+# Session Notes: docs-only-pr-preexisting-ci-failures
+
+## Date
+2026-03-06
+
+## Context
+
+Working in worktree `/home/mvillmow/Odyssey2/.worktrees/issue-3150` on branch `3150-auto-impl`.
+
+The task was to implement fixes described in `.claude-review-fix-3150.md` for PR #3338 (issue #3150).
+
+## What the PR Does
+
+PR #3338 adds a single row to the ADR index table in `docs/adr/README.md`:
+
+```
+| [ADR-009](ADR-009-heap-corruption-workaround.md) | Heap Corruption Workaround for Mojo Runtime Bug | Accepted | 2025-12-30 |
+```
+
+This is a documentation-only change. No code files were modified.
+
+## Review Fix Plan Summary
+
+The `.claude-review-fix-3150.md` file stated:
+- "No problems found with this PR's changes."
+- The CI failures (`Core Elementwise`, `Core Tensors`) are pre-existing issues unrelated to the diff.
+- Suggested verification: run `just pre-commit-all` and `head -20 docs/adr/ADR-009-...`
+
+## Steps Taken
+
+1. Read the review fix plan — determined no code changes needed.
+2. Checked `git status` — branch clean, only untracked `.claude-review-fix-3150.md`.
+3. Confirmed the ADR-009 entry was committed in `db9af4d2`.
+4. Ran `pixi run pre-commit run --all-files` — all hooks passed.
+   - GLIBC errors appeared for `mojo format` but it still reported `Passed`.
+5. Confirmed no commit needed.
+
+## Environment Notes
+
+- `just` is not in PATH on the local host — must use `pixi run pre-commit` directly.
+- `mojo` binary requires GLIBC 2.32/2.33/2.34 which is not available (host has 2.31).
+  This causes stderr noise but does not affect hook pass/fail status.
+
+## Outcome
+
+No changes made. PR #3338 is ready to merge as-is.

--- a/skills/documentation/docs-only-pr-preexisting-ci-failures/skills/docs-only-pr-preexisting-ci-failures/SKILL.md
+++ b/skills/documentation/docs-only-pr-preexisting-ci-failures/skills/docs-only-pr-preexisting-ci-failures/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: docs-only-pr-preexisting-ci-failures
+description: "Verify and close a review-fix task when a docs-only PR has no actual code changes needed and CI failures are pre-existing. Use when: a review-fix plan concludes no changes are required, CI failures are unrelated to the PR diff, or a docs-only PR needs final pre-commit verification before merge."
+category: documentation
+date: 2026-03-06
+user-invocable: false
+---
+
+# Skill: docs-only-pr-preexisting-ci-failures
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-06 |
+| Objective | Verify a docs-only PR (ADR index update) is complete and no fixes are needed despite CI failures |
+| Outcome | Success — pre-commit passes, no code changes needed, PR ready to merge |
+| Category | documentation |
+
+## When to Use
+
+Use this skill when:
+
+- A `.claude-review-fix-<number>.md` plan states "No problems found" or "No fixes needed"
+- A PR modifies only documentation files (e.g., `docs/adr/README.md`) and CI test failures are in
+  unrelated test groups (e.g., `Core Elementwise`, `Core Tensors`)
+- You need to confirm a docs-only PR is merge-ready without making code changes
+- CI reports failing test groups but the PR diff cannot possibly affect those tests
+
+## Verified Workflow
+
+### 1. Read the review fix plan
+
+```bash
+cat .claude-review-fix-<PR>.md
+```
+
+Look for:
+- "No problems found" or "No fixes needed" — if present, no code changes are needed
+- List of CI failures — verify they are in test groups unrelated to the changed files
+- Verification commands suggested in the plan
+
+### 2. Verify current git state
+
+```bash
+git status
+git log --oneline -5
+```
+
+Confirm the feature branch is clean (no uncommitted changes) and the relevant commit exists
+(e.g., the ADR index entry was already committed in a prior commit).
+
+### 3. Verify the change is correct
+
+For ADR index PRs, confirm the entry exists in `docs/adr/README.md`:
+
+```bash
+grep "ADR-00N" docs/adr/README.md
+```
+
+Also confirm the ADR file itself exists and the metadata matches:
+
+```bash
+head -20 docs/adr/ADR-00N-<name>.md
+```
+
+### 4. Run pre-commit to confirm hooks pass
+
+```bash
+pixi run pre-commit run --all-files 2>&1 | tail -20
+```
+
+Expected output: all hooks show `Passed`. The `mojo format` hook may emit GLIBC errors
+(environment incompatibility on the local host) but still reports `Passed` at the end —
+this is a known pre-existing environment issue, not a failure of the PR.
+
+### 5. Confirm no commit is needed
+
+If git status shows only the untracked `.claude-review-fix-<PR>.md` file and no modified files,
+there is nothing to commit. The task is complete.
+
+Do NOT commit the `.claude-review-fix-*.md` file — it is a task instruction artifact, not
+part of the implementation.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | No alternative approaches needed | Plan was clear: no changes required | When a review-fix plan says "no fixes needed," trust it and just verify + close |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| PR | #3338 |
+| Issue | #3150 |
+| Branch | `3150-auto-impl` |
+| Files changed by PR | `docs/adr/README.md` only |
+| Pre-commit result | All hooks passed |
+| CI failures | `Core Elementwise`, `Core Tensors` — pre-existing, unrelated to diff |
+| Commit needed | None |
+| GLIBC errors | Present during pre-commit (env issue) but hooks still pass |
+
+## Key Insights
+
+1. **Trust the review-fix plan**: When `.claude-review-fix-<N>.md` says "No problems found,"
+   the job is to verify, not to find something to fix. Read the plan carefully before
+   touching anything.
+
+2. **Docs-only PRs cannot cause test failures**: If a PR only changes markdown files in
+   `docs/adr/`, any failing test groups are definitionally pre-existing. No investigation
+   of the test failures is needed — just confirm the diff is documentation-only.
+
+3. **GLIBC errors in pre-commit are environment noise**: On the worktree host, `mojo format`
+   emits GLIBC version errors but still reports `Passed`. These are not hook failures.
+   Look at the final per-hook status lines, not the stderr noise.
+
+4. **Do not commit task artifacts**: The `.claude-review-fix-*.md` file is a task instruction
+   file placed by automation. It should never be staged or committed.
+
+5. **Untracked files in git status are normal**: After a no-op review fix, `git status` shows
+   only the untracked `.claude-review-fix-*.md` file. This is the expected clean state.


### PR DESCRIPTION
## Summary

Documents the pattern for handling review-fix tasks where a docs-only PR has no actual code changes needed and CI test failures are pre-existing and unrelated to the PR diff.

- Covers how to read and trust a "no fixes needed" review-fix plan
- Documents the GLIBC pre-commit noise pattern on older hosts
- Captures the rule: do not commit task artifact files

## Key Findings

**What Worked**:
- Reading the review-fix plan carefully before touching anything
- Running `pixi run pre-commit run --all-files` directly (since `just` was not in PATH)
- Checking `git status` to confirm branch is clean before concluding no work is needed

**What Failed**:
- N/A — the task was straightforward once the review-fix plan was read correctly

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with docs-only PR review triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
