### PR TITLE
feat: add fix-markdown-fenced-code-blocks skill

### DIFF
--- a/skills/documentation/fix-markdown-fenced-code-blocks/.claude-plugin/plugin.json
+++ b/skills/documentation/fix-markdown-fenced-code-blocks/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-markdown-fenced-code-blocks",
+  "version": "1.0.0",
+  "description": "Fix malformed fenced code block closings and markdownlint violations (MD013, MD032, MD040) in markdown files. Use when: (1) markdownlint reports closing fences with language tags (e.g. ```text used as closing fence), (2) line-length violations on documentation lines, (3) lists missing surrounding blank lines in PR review feedback.",
+  "category": "documentation",
+  "date": "2026-03-06",
+  "tags": ["markdown", "markdownlint", "code-fences", "line-length", "md013", "md032", "md040", "pr-review"]
+}

--- a/skills/documentation/fix-markdown-fenced-code-blocks/references/notes.md
+++ b/skills/documentation/fix-markdown-fenced-code-blocks/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes: fix-markdown-fenced-code-blocks
+
+## Context
+
+- **Repo**: HomericIntelligence/Odyssey2
+- **PR**: #3327
+- **Issue**: #3146
+- **Branch**: 3146-auto-impl
+- **Date**: 2026-03-06
+
+## Objective
+
+Address PR review feedback: `agents/hierarchy.md` had 3 fenced code blocks closed with ` ```text `
+(language tag on closing fence) instead of plain ` ``` `. The review plan identified lines 68, 183, 199.
+
+## Steps Taken
+
+1. Read `.claude-review-fix-3146.md` for fix plan
+2. Read `agents/hierarchy.md` around flagged lines to confirm the pattern
+3. Used `Edit` tool to fix all 3 closing fences (```text → ```)
+4. Ran `pixi run pre-commit run markdownlint-cli2 --all-files`
+5. Discovered additional violations NOT in the review plan:
+   - MD013 on lines 96, 104, 106, 214, 215, 217 (>120 chars)
+   - MD032 on line 214 (list not preceded by blank line)
+6. Fixed all secondary violations with additional `Edit` calls
+7. Re-ran markdownlint — Passed
+8. Committed with conventional commit message
+
+## Tool Invocation Learnings
+
+- `pixi run npx markdownlint-cli2` → fails (npx not in env)
+- `pixi run markdownlint-cli2` → fails (not a direct pixi task)
+- `just pre-commit-all` → fails (just not on PATH in this shell)
+- `pixi run pre-commit run markdownlint-cli2 --all-files` → WORKS
+- `pixi run pre-commit run markdownlint-cli2 --files <path>` → WORKS for single file
+
+## Key Insight
+
+The review plan only identified the 3 closing fence issues. Running linting after the fix revealed
+additional MD013/MD032 violations on the same file. Always re-run linting after implementing a fix
+plan — the plan may be incomplete.
+
+## Mojo Format Note
+
+`mojo-format` pre-commit hook always fails in this environment due to GLIBC incompatibility
+(GLIBC_2.32/2.33/2.34 not found). This is a pre-existing environment issue, not related to the PR
+changes. It can be safely ignored when the only changed files are `.md` files.

--- a/skills/documentation/fix-markdown-fenced-code-blocks/skills/fix-markdown-fenced-code-blocks/SKILL.md
+++ b/skills/documentation/fix-markdown-fenced-code-blocks/skills/fix-markdown-fenced-code-blocks/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: fix-markdown-fenced-code-blocks
+description: "Fix malformed fenced code block closings and markdownlint violations in markdown files. Use when: closing fences have language tags, line-length violations in docs, or lists lack surrounding blank lines."
+category: documentation
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Trigger** | markdownlint CI failure or PR review feedback citing MD013/MD032/MD040 |
+| **Primary Fix** | Edit closing fences from ` ```lang ` to ` ``` ` |
+| **Secondary Fixes** | Wrap long lines, add blank lines around lists |
+| **Verification** | `pixi run pre-commit run markdownlint-cli2 --all-files` |
+
+## When to Use
+
+- markdownlint reports MD040 (missing language on fenced code block) or MD031 on a closing fence line
+- A closing fence has a language tag, e.g. ` ```text ` used as a closing ` ``` `
+- MD013 line-length violations on descriptive bullet points in agent/hierarchy docs
+- MD032 (blanks-around-lists) violations after a bold heading line
+
+## Verified Workflow
+
+1. **Identify violations** — run pre-commit or read CI output to get file:line references
+2. **Read context** — `Read` the file around each flagged line to confirm the pattern
+3. **Fix closing fences** — use `Edit` to change ` ```text ` → ` ``` ` on closing fence lines only
+4. **Fix line-length** — wrap long bullet lines by inserting a newline+indent continuation:
+   ```markdown
+   - **Key**: Short intro text that fits,
+     continuation on next line at 2-space indent
+   ```
+5. **Fix MD032** — add a blank line after the preceding paragraph/heading before the list
+6. **Verify** — run `pixi run pre-commit run markdownlint-cli2 --all-files` and confirm Passed
+7. **Commit** — stage only the markdown file, commit with conventional message
+
+## Results & Parameters
+
+### Environment
+
+```bash
+# Verify markdown linting (no npx needed — pixi wraps it)
+pixi run pre-commit run markdownlint-cli2 --all-files
+
+# Check a single file
+pixi run pre-commit run markdownlint-cli2 --files agents/hierarchy.md
+```
+
+### markdownlint Rule Reference
+
+| Rule | Name | Fix |
+|------|------|-----|
+| MD013 | line-length (max 120) | Wrap at natural clause boundary, indent continuation 2 spaces |
+| MD031 | blanks-around-fences | Ensure blank line before and after fenced block |
+| MD032 | blanks-around-lists | Add blank line before first list item after paragraph/heading |
+| MD040 | fenced-code-language | Opening fences need language; closing fences must be plain ` ``` ` |
+
+### Key Pattern: Malformed Closing Fence
+
+Wrong (closing fence with language tag — triggers MD040/MD031):
+
+```text
+    └──────────────────────────────────────┘
+```text
+```
+
+Correct:
+
+```text
+    └──────────────────────────────────────┘
+```
+```
+
+### Key Pattern: Line Wrap for MD013
+
+Wrong (>120 chars):
+
+```markdown
+- **Language Context**: Designs Mojo module structures, leverages Mojo features (SIMD, traits, structs); coordinates review across all code dimensions
+```
+
+Correct:
+
+```markdown
+- **Language Context**: Designs Mojo module structures, leverages Mojo features (SIMD, traits, structs);
+  coordinates review across all code dimensions
+```
+
+### Key Pattern: MD032 Blank Line Before List
+
+Wrong:
+
+```markdown
+**Level 3 Breakdown:**
+- Item one with detail
+- Item two with detail
+```
+
+Correct:
+
+```markdown
+**Level 3 Breakdown:**
+
+- Item one with detail
+- Item two with detail
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `pixi run npx markdownlint-cli2` | Called npx directly through pixi | `npx: command not found` — npx not in pixi env | Use `pixi run pre-commit run markdownlint-cli2` instead |
+| `pixi run markdownlint-cli2` | Called markdownlint-cli2 as a direct pixi task | `markdownlint-cli2: command not found` | markdownlint is invoked via pre-commit hook, not as standalone pixi task |
+| `just pre-commit-all` | Used just command runner | `just: command not found` in this environment | Use `pixi run pre-commit run ...` directly |
+| Fix only the 3 fence closings | Assumed fix plan was complete | Linting also caught MD013/MD032 violations not listed in the review plan | Always re-run linting after initial fixes to catch secondary violations |


### PR DESCRIPTION
## Summary

Documents how to fix malformed fenced code block closings and markdownlint violations in markdown files, captured from fixing PR #3327 in HomericIntelligence/Odyssey2.

- Fix closing fences that incorrectly use a language tag (e.g. ` ```text ` as a closing fence)
- Fix MD013 line-length violations by wrapping at clause boundaries
- Fix MD032 by adding blank lines before lists

## Key Findings

**What Worked**:
- `pixi run pre-commit run markdownlint-cli2 --all-files` is the correct invocation (not `npx` or `just`)
- Wrapping long bullet points with 2-space indent continuation satisfies MD013
- Adding a blank line between a bold heading and its list satisfies MD032

**What Failed**:
- `pixi run npx markdownlint-cli2` → `npx: command not found`
- `pixi run markdownlint-cli2` → `markdownlint-cli2: command not found`
- `just pre-commit-all` → `just: command not found`
- Implementing only the 3 fence fixes from the review plan → secondary MD013/MD032 violations remained

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with markdownlint-related triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
