### PR TITLE
feat: add stale-agent-count-fix skill

### DIFF
--- a/skills/documentation/stale-agent-count-fix/.claude-plugin/plugin.json
+++ b/skills/documentation/stale-agent-count-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "stale-agent-count-fix",
+  "version": "1.0.0",
+  "description": "Fix stale agent count references in documentation after agents are deleted or converted to skills. Use when: (1) agent files are removed or converted and doc counts are out of sync, (2) CLAUDE.md or hierarchy docs still reference old agent totals, (3) tracking docs list files that no longer exist.",
+  "category": "documentation",
+  "date": "2026-03-06",
+  "tags": ["agents", "documentation", "count", "stale-refs", "cleanup"]
+}

--- a/skills/documentation/stale-agent-count-fix/references/notes.md
+++ b/skills/documentation/stale-agent-count-fix/references/notes.md
@@ -1,0 +1,56 @@
+# Session Notes: Stale Agent Count Fix
+
+## Session Context
+
+- **Date**: 2026-03-06
+- **PR**: #3320 (issue #3145)
+- **Branch**: `3145-auto-impl`
+- **Repo**: HomericIntelligence/ProjectOdyssey
+
+## What Was Done
+
+Two agents (`pr-cleanup-specialist` and `blog-writer-specialist`) were previously converted to
+skills (removed from `.claude/agents/`, added to `.claude/skills/`). This reduced the agent
+count from 44 to 42. However, `CLAUDE.md` still referenced "44 agents" in two places, and
+`docs/dev/agent-claude4-update-status.md` still listed the deleted agents as files to update.
+
+### Fix 1: CLAUDE.md
+
+- Line 84: `- [Agent Configurations](/.claude/agents/) - 44 agents` → `42 agents`
+- Line 98: `- All 44 agents with roles and responsibilities` → `42 agents`
+
+### Fix 2: docs/dev/agent-claude4-update-status.md
+
+Lines 95-96 listed:
+```
+- `.claude/agents/pr-cleanup-specialist.md`
+- `.claude/agents/blog-writer-specialist.md`
+```
+
+Changed to strikethrough annotations:
+```
+- `.claude/agents/code-review-orchestrator.md`
+  - ~~`.claude/agents/pr-cleanup-specialist.md`~~ — converted to skill
+  - ~~`.claude/agents/blog-writer-specialist.md`~~ — converted to skill
+```
+
+## Environment Notes
+
+- `just` command runner not available in PATH — use `pre-commit run --all-files` directly
+- `mojo-format` pre-commit hook fails due to GLIBC version incompatibility (host lacks GLIBC 2.32+)
+  - This is pre-existing and not caused by doc changes
+  - All other hooks (markdownlint, trailing-whitespace, end-of-file-fixer, YAML) pass
+- Agent validation: `python3 tests/agents/validate_configs.py .claude/agents/` → ALL VALIDATIONS PASSED (42 agents)
+
+## Commit
+
+```
+fix: Address review feedback for PR #3320
+
+Update stale "44 agents" references in CLAUDE.md to "42 agents"
+following deletion of pr-cleanup-specialist and blog-writer-specialist
+agents (converted to skills). Also annotate agent-claude4-update-status.md
+to reflect this conversion.
+
+Closes #3145
+```

--- a/skills/documentation/stale-agent-count-fix/skills/stale-agent-count-fix/SKILL.md
+++ b/skills/documentation/stale-agent-count-fix/skills/stale-agent-count-fix/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: stale-agent-count-fix
+description: "Fix stale agent count references in documentation after agents are deleted or converted to skills. Use when: agent files are removed/converted and doc counts are out of sync."
+category: documentation
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | stale-agent-count-fix |
+| **Category** | documentation |
+| **Context** | ML Odyssey / ProjectOdyssey agent system |
+| **Trigger** | Agents deleted or converted to skills, leaving stale count references |
+| **Outcome** | All agent count references updated and tracking docs annotated |
+
+## When to Use
+
+- After deleting agent `.md` files from `.claude/agents/`
+- After converting agents to skills (agent files removed, skill files added)
+- When `CLAUDE.md` references an agent count that doesn't match `ls .claude/agents/*.md | wc -l`
+- When tracking docs (e.g. `docs/dev/agent-claude4-update-status.md`) still list files that no longer exist
+
+## Verified Workflow
+
+1. **Verify actual agent count**:
+
+   ```bash
+   ls .claude/agents/*.md | wc -l
+   # Note the actual count
+   ```
+
+2. **Find all stale count references**:
+
+   ```bash
+   grep -rn "<old-count> agents" CLAUDE.md agents/hierarchy.md agents/README.md
+   ```
+
+3. **Update CLAUDE.md** — typically two locations:
+   - Quick Links section: `- [Agent Configurations](/.claude/agents/) - N agents`
+   - Agent Hierarchy section: `- All N agents with roles and responsibilities`
+
+   Use the `Edit` tool with exact string replacement (not sed/awk).
+
+4. **Update tracking docs** — annotate deleted entries rather than removing them outright:
+
+   ```markdown
+   - ~~`.claude/agents/deleted-agent.md`~~ — converted to skill
+   ```
+
+   This preserves history while making the status clear.
+
+5. **Verify no stale refs remain**:
+
+   ```bash
+   grep -n "<old-count> agents" CLAUDE.md
+   # Expected: no output
+   ```
+
+6. **Run pre-commit on changed files** (skip mojo-format if GLIBC incompatible):
+
+   ```bash
+   pre-commit run --all-files
+   # mojo-format may fail due to GLIBC version mismatch — this is pre-existing, not caused by doc changes
+   # All other hooks (markdownlint, trailing-whitespace, end-of-file-fixer, check-yaml) must pass
+   ```
+
+7. **Run agent validation**:
+
+   ```bash
+   python3 tests/agents/validate_configs.py .claude/agents/
+   # Expected: ALL VALIDATIONS PASSED
+   ```
+
+8. **Commit**:
+
+   ```bash
+   git add CLAUDE.md docs/dev/agent-claude4-update-status.md
+   git commit -m "fix: update stale agent count references (N → M agents)"
+   ```
+
+## Key Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Files to check | `CLAUDE.md`, `agents/hierarchy.md`, `agents/README.md`, `docs/dev/*.md` |
+| Count verification | `ls .claude/agents/*.md \| wc -l` |
+| Validation command | `python3 tests/agents/validate_configs.py .claude/agents/` |
+| Edit tool | Use `Edit` (exact string), not `sed` |
+| Tracking doc style | Strikethrough + annotation, not deletion |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Files to check | `CLAUDE.md`, `agents/hierarchy.md`, `agents/README.md`, `docs/dev/*.md` |
+| Count verification | `ls .claude/agents/*.md \| wc -l` |
+| Validation command | `python3 tests/agents/validate_configs.py .claude/agents/` |
+| Edit tool | Use `Edit` (exact string), not `sed` |
+| Tracking doc style | Strikethrough + annotation, not deletion |
+| Pre-commit runner | `pre-commit run --all-files` (not `just pre-commit-all`) |
+| Expected validation result | `ALL VALIDATIONS PASSED` |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `just pre-commit-all` | Used `just` command runner for pre-commit | `just` not in PATH in this environment | Use `pre-commit run --all-files` directly |
+| Expecting mojo-format to pass | Ran full pre-commit suite | `mojo` binary requires GLIBC 2.32-2.34, host only has older version | This is a pre-existing env limitation; only non-Mojo hooks matter for doc-only changes |
+| Deleting tracking doc entries outright | Removing lines 95-96 from status doc | Would lose historical context of what was converted | Use strikethrough annotation instead: `~~file~~` — converted to skill |


### PR DESCRIPTION
## Summary

Documents the workflow for fixing stale agent count references in `CLAUDE.md` and
tracking docs after agents are deleted or converted to skills.

- Grep-based discovery of all stale count references across CLAUDE.md and agent docs
- Use strikethrough annotations in tracking docs rather than outright deletion
- Handle pre-existing mojo-format GLIBC failures that are unrelated to doc-only changes

## Key Findings

**What Worked**:
- `Edit` tool with exact string replacement is reliable for count updates
- `grep -n "N agents" CLAUDE.md` quickly finds all stale references
- Annotating deleted entries as `~~file~~` — converted to skill preserves history
- `pre-commit run --all-files` works directly when `just` is not in PATH

**What Failed**:
- `just pre-commit-all` → `just` not in PATH in this environment
- `mojo-format` hook → crashes on hosts without GLIBC 2.32+ (pre-existing, not caused by changes)
- Deleting tracking doc entries outright → loses conversion history

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
