### PR TITLE
feat: add pr-preexisting-failure-triage skill

### DIFF
--- a/skills/ci-cd/pr-preexisting-failure-triage/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-preexisting-failure-triage/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-preexisting-failure-triage",
+  "version": "1.0.0",
+  "description": "Distinguish pre-existing CI failures from regressions introduced by a PR, then verify the PR is ready to merge. Use when: (1) a PR has CI failures and you need to determine if they are blockers, (2) a review plan states 'no fixes needed' but tasks still require verification, (3) confirming PR correctness before enabling auto-merge.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["ci", "pr-review", "triage", "preexisting-failures", "merge-readiness"]
+}

--- a/skills/ci-cd/pr-preexisting-failure-triage/references/notes.md
+++ b/skills/ci-cd/pr-preexisting-failure-triage/references/notes.md
@@ -1,0 +1,55 @@
+# Session Notes: PR Pre-existing Failure Triage
+
+## Session Context
+
+- **Date**: 2026-03-06
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3143 (enforce security scanning on PRs and fix scan gaps)
+- **PR**: #3315 (fix(ci): enforce security scanning on PRs and fix scan gaps)
+- **Branch**: `3143-auto-impl`
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3143`
+
+## Objective
+
+A `.claude-review-fix-3143.md` review plan was left in the worktree. The task was to implement
+any fixes from the plan, run tests, and commit. The plan stated "no fixes required."
+
+## What Happened
+
+1. Read `.claude-review-fix-3143.md` — plan said all 3 deliverables were already implemented,
+   PR was correct, no changes needed.
+
+2. Ran `git status` — branch was clean. Only untracked file was `.claude-review-fix-3143.md`
+   itself (the review plan artifact).
+
+3. Ran `gh pr view 3315 --json state,title,statusCheckRollup` — confirmed:
+   - Most CI checks: SUCCESS (Security Scanning, Build Validation, Pre-commit, Docker)
+   - Two failures: `Data Datasets` and `Shared Infra` (Comprehensive Tests workflow)
+   - One consequential failure: `Test Report` (fails when any test group fails)
+
+4. Cross-referenced PR diff vs failing test groups:
+   - PR only changed `.github/workflows/security-scan.yml` and `.github/workflows/security-pr-scan.yml`
+   - `Data Datasets` tests are in `tests/data/datasets/` — no overlap with workflow changes
+   - `Shared Infra` tests are in `tests/shared/infra/` — no overlap with workflow changes
+   - Conclusion: Both failures are pre-existing, unrelated to this PR
+
+5. Reported: PR is ready to merge, no commit needed, pre-existing failures are not blockers.
+
+## Key Learnings
+
+- When a review plan says "no fixes required", the first action should be `git status` —
+  if clean, the plan is confirmed and there is nothing to commit.
+- Pre-existing CI failures can be identified by checking if the failing test group's files
+  overlap with the PR's diff. Zero overlap = pre-existing.
+- The `.claude-review-fix-*.md` review plan file is a working artifact, never a commit target.
+- `gh pr view --json statusCheckRollup` provides complete CI state without needing to re-run tests.
+- A `Test Report` failure is often consequential — it fails because other groups failed, not
+  independently. Always look at individual check names, not just the summary.
+
+## PR Deliverables Verified
+
+1. `pull_request:` trigger in `security-scan.yml:8` — present
+2. `continue-on-error: true` removed from Semgrep scan step — removed (remains only on SARIF
+   upload step at line 109, which is intentional)
+3. `--no-git` flag removed from both Gitleaks invocations in `security-pr-scan.yml` — removed
+   (lines 47, 50)

--- a/skills/ci-cd/pr-preexisting-failure-triage/skills/pr-preexisting-failure-triage/SKILL.md
+++ b/skills/ci-cd/pr-preexisting-failure-triage/skills/pr-preexisting-failure-triage/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: pr-preexisting-failure-triage
+description: "Distinguish pre-existing CI failures from regressions introduced by a PR, then verify merge readiness. Use when: a PR has CI failures that may not be caused by the PR's own changes."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Determine whether CI failures on a PR are pre-existing (safe to ignore) or regressions (must fix) |
+| **Input** | PR number, review plan file (`.claude-review-fix-*.md`) |
+| **Output** | Triage assessment: which failures are blockers vs pre-existing noise |
+| **Trigger** | Review plan says "no fixes needed" but CI shows failures |
+
+## When to Use
+
+- A `.claude-review-fix-*.md` plan states "no fixes required" and "PR is ready to merge"
+- CI shows some checks as FAILURE but the PR only touches unrelated files (e.g., workflow YAML vs test code)
+- You need to confirm whether failing test groups are affected by the PR's diff before enabling auto-merge
+- Determining if `git status` is clean (nothing to commit) matches the plan's assertion that no changes are needed
+
+## Verified Workflow
+
+### Step 1: Read the review plan
+
+Read `.claude-review-fix-<issue>.md` to extract:
+- Which deliverables are claimed to be implemented
+- Which CI failures are claimed to be pre-existing
+- What files were changed
+
+### Step 2: Check git status
+
+```bash
+git status
+git diff HEAD
+```
+
+If the branch is clean (no staged/unstaged changes, no untracked implementation files), the plan's
+assertion that "no changes are needed" is confirmed. Only the review plan file itself should be
+untracked.
+
+### Step 3: Check PR CI status
+
+```bash
+gh pr view <PR_NUMBER> --json state,title,statusCheckRollup
+```
+
+For each FAILURE check:
+- Note which test group failed (e.g., `Data Datasets`, `Shared Infra`)
+- Identify what files the PR touches (`gh pr diff --name-only`)
+- Determine if the failing test group's files overlap with PR changes
+
+### Step 4: Classify each failure
+
+| Failure | PR touches those files? | Classification |
+|---------|------------------------|----------------|
+| `Data Datasets` FAIL | No (PR only changed `.github/workflows/`) | Pre-existing |
+| `Shared Infra` FAIL | No | Pre-existing |
+| `sast-scan` PASS | Yes (workflow files) | Correctly passing |
+
+### Step 5: Confirm no commit needed
+
+If git status is clean and the plan says no changes are needed, there is nothing to commit.
+The review plan file (`.claude-review-fix-*.md`) itself should NOT be committed — it is a
+working artifact, not an implementation file.
+
+### Step 6: Report outcome
+
+Document findings:
+- PR is correctly implemented (all issue deliverables verified)
+- Pre-existing failures listed by name with justification
+- PR is ready to merge once auto-merge is enabled or approvals received
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Committing review plan file | Treated `.claude-review-fix-*.md` as an implementation artifact to commit | File is a working artifact for the agent, not a deliverable | Only commit actual code/config changes, never the review plan file |
+| Looking for additional changes | Searched for uncommitted fixes matching the plan's deliverables | The plan correctly stated all changes were already pushed; branch was clean | When plan says "no fixes required", verify git status first before assuming work remains |
+| Retrying tests locally | Attempted to rerun failing CI groups locally to confirm pre-existing status | Unnecessary — PR CI history and test group vs diff analysis is sufficient | Use `gh pr view --json statusCheckRollup` + diff analysis to classify failures without running tests |
+
+## Results & Parameters
+
+### Command to check PR CI status
+
+```bash
+gh pr view <PR_NUMBER> --json state,title,statusCheckRollup | \
+  python3 -c "import json,sys; checks=json.load(sys.stdin)['statusCheckRollup']; \
+  [print(c['conclusion'], c['name']) for c in checks]"
+```
+
+### Command to list files changed by PR
+
+```bash
+gh pr diff <PR_NUMBER> --name-only
+```
+
+### Classification heuristic
+
+If the failing test group's directory (e.g., `tests/shared/infra/`, `tests/data/datasets/`) has
+**zero overlap** with the PR's changed files, the failure is pre-existing and not a blocker for
+merging.
+
+### Key signals that plan is complete and no commit is needed
+
+1. `git status` shows only the `.claude-review-fix-*.md` as untracked — no modified files
+2. `git diff HEAD` is empty
+3. Branch is up-to-date with `origin/<branch>`
+4. All issue deliverables are verifiable directly in existing committed files


### PR DESCRIPTION
## Summary

Documents how to triage CI failures on a PR to distinguish pre-existing failures
from regressions introduced by the PR itself.

- Verified workflow: check git status, analyze CI via `gh pr view --json statusCheckRollup`, cross-reference failing test paths vs PR diff
- Key insight: zero path overlap between failing test group and PR diff = pre-existing failure, not a blocker
- Covers the pattern where a review plan says "no fixes needed" but tasks still require verification before closing

## Key Findings

**What Worked**:
- `gh pr view <PR> --json statusCheckRollup` gives complete CI state without re-running tests
- Cross-referencing failing test group directory paths vs `gh pr diff --name-only` is a reliable classification heuristic
- Checking `git status` immediately confirms when a "no fixes needed" plan is accurate

**What Failed**:
- Treating `.claude-review-fix-*.md` as a commit target → it's a working artifact, not a deliverable
- Attempting to re-run failing CI locally to confirm pre-existing status → unnecessary overhead, diff analysis is sufficient
- Assuming uncommitted work exists when plan says "no fixes required" → check git status first

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with CI triage triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)