### PR TITLE
feat: add mojo-format-line-length-fix skill

### DIFF
--- a/skills/ci-cd/mojo-format-line-length-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mojo-format-line-length-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-format-line-length-fix",
+  "version": "1.0.0",
+  "description": "Fix mojo-format pre-commit CI failures caused by lines exceeding the line length limit. Use when: (1) pre-commit CI fails with mojo-format modifying a file, (2) a print() or other statement in .mojo files exceeds the line length limit, (3) you need to wrap long string literals across multiple lines in Mojo code.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["mojo", "mojo-format", "line-length", "pre-commit", "ci", "formatting"]
+}

--- a/skills/ci-cd/mojo-format-line-length-fix/references/notes.md
+++ b/skills/ci-cd/mojo-format-line-length-fix/references/notes.md
@@ -1,0 +1,53 @@
+# Session Notes: mojo-format line length fix
+
+## Context
+
+- **Issue**: #3088 (PR #3197 — remove stale BF16 alias comments)
+- **Branch**: `3088-auto-impl`
+- **Working dir**: `/home/mvillmow/Odyssey2/.worktrees/issue-3088`
+
+## Problem
+
+PR #3197 had two CI failures:
+
+1. **pre-commit failure**: `mojo-format` reformatted line 471 of
+   `tests/shared/testing/test_special_values.mojo` — a `print(...)` call
+   exceeding the line length limit. The formatted version was not committed.
+
+2. **Core NN Modules failure**: Runtime crash (`execution crashed` in
+   `libKGENCompilerRTShared.so`) — confirmed pre-existing/transient, unrelated
+   to this PR's changes.
+
+## Fix Applied
+
+File: `tests/shared/testing/test_special_values.mojo:471`
+
+Before:
+```mojo
+print("✓ test_dtypes_bfloat16 (skipped - bfloat16 float64 read/write not yet supported)")
+```
+
+After:
+```mojo
+print(
+    "✓ test_dtypes_bfloat16 (skipped - bfloat16 float64 read/write not yet"
+    " supported)"
+)
+```
+
+## Verification
+
+- Could not run `pixi run mojo format` locally — GLIBC version mismatch
+  (system has GLIBC 2.31, mojo requires 2.32/2.33/2.34)
+- Applied the known mojo-format output style manually
+- Pre-commit hooks ran in git commit and `Mojo Format` hook **Passed**
+- Commit succeeded: `ae8739bf`
+
+## Key Insight
+
+When mojo-format can't run locally (GLIBC mismatch), you can still fix
+line-length issues by applying the multi-line form manually — mojo-format
+is deterministic, so if you match its output style, the hook passes.
+
+Adjacent string literals in Mojo concatenate without `+`. Continuation
+strings start with a leading space when the split is mid-sentence.

--- a/skills/ci-cd/mojo-format-line-length-fix/skills/mojo-format-line-length-fix/SKILL.md
+++ b/skills/ci-cd/mojo-format-line-length-fix/skills/mojo-format-line-length-fix/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: mojo-format-line-length-fix
+description: "Fix mojo-format pre-commit CI failures caused by lines exceeding the line length limit. Use when: pre-commit CI fails because mojo-format reformatted a file, a print() or string literal in .mojo exceeds the line length limit."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | pre-commit CI fails with `mojo-format` modifying a .mojo file |
+| **Root cause** | A line (often a `print()` call with a long string) exceeds mojo-format's line length limit |
+| **Fix** | Wrap the long line into multi-line form that mojo-format accepts |
+| **Verification** | Run `pixi run mojo format <file> && git diff` — no diff means correctly formatted |
+
+## When to Use
+
+- CI pre-commit job fails showing `mojo-format` modified a file
+- `print("...long string...")` exceeds line length in a `.mojo` file
+- Any single-line statement in Mojo that mojo-format would rewrite
+
+## Verified Workflow
+
+1. **Identify the offending line** from the CI failure log — look for which file `mojo-format` modified.
+
+2. **Read the file** at the reported line number to see the long line.
+
+3. **Apply the multi-line form** that mojo-format produces for `print()`:
+
+   ```mojo
+   # Before (too long):
+   print("some very long message that exceeds the line length limit and causes mojo-format to reformat it")
+
+   # After (mojo-format style):
+   print(
+       "some very long message that exceeds the line"
+       " length limit and causes mojo-format to reformat it"
+   )
+   ```
+
+   Key rules:
+   - Opening `print(` on its own line
+   - String split at a natural word boundary, continuation starts with a space: `" continuation"`
+   - Closing `)` on its own line, indented to match the `print`
+
+4. **Commit** — pre-commit hooks will run `mojo-format` again and it should pass with no modifications.
+
+5. **Cannot run mojo-format locally?** (e.g., GLIBC version mismatch on older Linux)
+   - Apply the multi-line form manually as above
+   - The pre-commit hook in CI will confirm correctness
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run `pixi run mojo format` locally | Ran the formatter on the local machine to verify formatting | GLIBC version too old (`GLIBC_2.32`/`2.33`/`2.34` not found) — mojo binary requires newer glibc | Mojo requires a modern Linux (Ubuntu 22.04+). On older systems, apply multi-line form manually using the known mojo-format output style |
+
+## Results & Parameters
+
+**Working multi-line print pattern** (copy-paste template):
+
+```mojo
+print(
+    "first part of the message up to ~80 chars"
+    " continuation of the message"
+)
+```
+
+**String continuation rule**: adjacent string literals in Mojo are concatenated — no `+` operator needed. The continuation string must start with a space if the split point is mid-word-boundary.
+
+**Verification command** (when mojo is available):
+
+```bash
+pixi run mojo format <file> && git diff
+# Expected: no output from git diff (file already correctly formatted)
+```
+
+**Commit message pattern used**:
+
+```
+fix: Address review feedback for PR #<number>
+
+Wrap long print() call in <file> to pass mojo-format
+line length check (pre-commit CI failure).
+
+Closes #<issue>
+```


### PR DESCRIPTION
## Summary

Documents how to fix mojo-format pre-commit CI failures caused by lines exceeding the line length limit in Mojo source files.

- Identifies the multi-line `print()` wrapping pattern that mojo-format produces
- Documents that adjacent string literals concatenate without `+` in Mojo
- Covers the GLIBC version mismatch workaround (apply multi-line form manually)

## Key Findings

**What Worked**:
- Wrapping long `print()` calls into mojo-format's multi-line style manually passes the pre-commit hook
- Pre-commit CI confirms correctness even when local `mojo` binary can't run due to GLIBC mismatch

**What Failed**:
- Running `pixi run mojo format` locally on older Linux (GLIBC 2.31) — binary requires GLIBC 2.32/2.33/2.34

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — PASSED (388/388)
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with mojo-format CI failure triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)