### PR TITLE
feat: add pr-rebase-stale-plan-fix skill

### DIFF
--- a/skills/ci-cd/pr-rebase-stale-plan-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-rebase-stale-plan-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-rebase-stale-plan-fix",
+  "version": "1.0.0",
+  "description": "Rebase a diverged PR onto main when the automated fix plan has stale state information, resolving comment-only merge conflicts. Use when: (1) automated fix plan claims branch commit is already in main but PR is still open, (2) comment-only Mojo changes cause merge conflicts on rebase, (3) PR needs force-push + auto-merge after resolving stale plan assessment.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["rebase", "merge-conflict", "stale-plan", "auto-merge", "mojo", "comments"]
+}

--- a/skills/ci-cd/pr-rebase-stale-plan-fix/references/notes.md
+++ b/skills/ci-cd/pr-rebase-stale-plan-fix/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes: PR Rebase with Stale Fix Plan
+
+## Date
+2026-03-06
+
+## Repository
+ProjectOdyssey — worktree `/home/mvillmow/Odyssey2/.worktrees/issue-3073`
+
+## PR
+- PR #3286, issue #3073
+- Branch: `3073-auto-impl`
+- Title: "chore(cleanup): link workaround NOTEs to tracking issues"
+- Change: 6 files, comment-only (`# NOTE:` -> `# NOTE(#NNNN):`)
+
+## Fix Plan Assessment (from `.claude-review-fix-3073.md`)
+The automated fix plan stated:
+> "The PR's commit `1d3afd6b` is already present in the `main` branch history"
+
+**This was incorrect.** When verified:
+```
+git log --oneline origin/main | grep 1d3afd6b
+# → (no output — commit NOT in main)
+
+git log --oneline origin/main..HEAD
+# → 1d3afd6b chore(cleanup): link workaround NOTEs to tracking issues (#3073)
+# Confirmed: commit only on branch, not in main
+```
+
+The plan was generated at an earlier point in time when the repo state was different, or based on a misread of `git log --all` vs `git log origin/main`.
+
+## Conflict Details
+File: `shared/training/trainer_interface.mojo`, line ~391
+
+Both the PR branch and main had independently updated the same comment:
+- PR: changed `# NOTE:` to `# NOTE(#3076):`
+- Main: updated comment wording to be more detailed (added "Tracked in #3076 (parent: #3059)")
+
+Resolution: Combined both — PR's `NOTE(#3076):` tag + main's more detailed body text.
+
+## Commands Run (in order)
+```bash
+git log --oneline origin/main | head -10
+gh pr view 3286 --json state,title,mergedAt,headRefName
+git log --oneline origin/3073-auto-impl | head -5
+git log --oneline origin/main | grep "1d3afd6b"
+git log --all --oneline | grep "1d3afd6b"
+git log --oneline origin/main..HEAD | head -10
+git fetch origin && git rebase origin/main
+# → CONFLICT in shared/training/trainer_interface.mojo
+grep -n "<<<\|>>>\|===" shared/training/trainer_interface.mojo
+# Read file, resolved conflict manually
+git add shared/training/trainer_interface.mojo && git rebase --continue
+git push --force-with-lease origin 3073-auto-impl
+gh pr merge 3286 --auto --rebase
+gh pr view 3286 --json state,autoMergeRequest,url
+```
+
+## Key Takeaway
+Automated fix plans contain snapshots of repo state at generation time. Always independently verify git state before acting — especially claims about what's already in main.

--- a/skills/ci-cd/pr-rebase-stale-plan-fix/skills/pr-rebase-stale-plan-fix/SKILL.md
+++ b/skills/ci-cd/pr-rebase-stale-plan-fix/skills/pr-rebase-stale-plan-fix/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: pr-rebase-stale-plan-fix
+description: "Rebase a diverged PR onto main when the automated fix plan has stale state information, resolving comment-only merge conflicts. Use when: automated fix plan claims branch is merged but PR is still open, comment-only changes conflict on rebase, or PR needs force-push + auto-merge after stale assessment."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+# Skill: PR Rebase with Stale Fix Plan Assessment
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Date** | 2026-03-06 |
+| **Objective** | Rebase PR #3286 (issue #3073) onto main and enable auto-merge after automated fix plan contained stale state information |
+| **Outcome** | Successfully rebased, resolved 1 comment-only conflict, force-pushed, auto-merge enabled |
+| **Context** | ProjectOdyssey PR making comment-only changes (`# NOTE:` -> `# NOTE(#NNNN):`) was behind main by ~15 commits. Automated fix plan incorrectly stated the branch commit was already merged to main. |
+
+## When to Use
+
+Use this skill when:
+
+- An automated fix plan (`.claude-review-fix-*.md`) claims the PR's changes are already in `main` but the PR is still open
+- A PR with comment-only or cosmetic changes is blocked by a merge conflict on rebase
+- You need to verify the actual state of a branch vs what a stale plan claims
+- A PR needs to be rebased, force-pushed, and auto-merge enabled
+
+**Key Indicators**:
+
+- Fix plan says "commit `XXXXXXXX` is already in `main` history" but `git log --oneline origin/main | grep XXXXXXXX` returns nothing
+- `git log --oneline origin/main..HEAD` shows the PR's commit is still only on the branch
+- `git rebase origin/main` produces conflicts in files only touched by comments
+
+## Verified Workflow
+
+### 1. Verify Actual State (Don't Trust Stale Plans)
+
+Always verify the actual git state before acting on automated fix plans:
+
+```bash
+# Check if the PR commit is actually in main
+git log --oneline origin/main | grep <short-sha>
+
+# Compare branch vs main
+git log --oneline origin/main..HEAD   # commits in branch not in main
+git log --oneline HEAD..origin/main   # commits in main not in branch
+
+# Check PR state
+gh pr view <PR_NUMBER> --json state,mergedAt,headRefName
+```
+
+If the plan says "already merged" but `origin/main..HEAD` shows the commit, the plan is stale — proceed with rebase.
+
+### 2. Rebase onto Latest Main
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+If conflicts occur, check the conflict markers:
+
+```bash
+grep -n "<<<\|>>>\|===" <conflicted-file>
+```
+
+### 3. Resolve Comment-Only Conflicts
+
+For comment-only conflicts (e.g., two branches updated the same comment differently), determine intent:
+
+- **PR's goal**: The PR is adding `# NOTE(#NNNN):` format to issue-reference NOTE tags
+- **Main's version**: May have updated the comment text with more detail
+- **Resolution**: Combine — use the PR's `# NOTE(#NNNN):` format with main's more precise wording
+
+Example conflict:
+```
+<<<<<<< HEAD
+        # NOTE: Python data loader integration blocked by Track 4.
+        # Tracked in #3076 (parent: #3059). Placeholder tensors used until Track 4 is ready.
+=======
+        # NOTE(#3076): Python data loader integration blocked by Track 4.
+        # For now, we create placeholder tensors until Track 4 infrastructure is ready.
+>>>>>>> 1d3afd6b (chore(cleanup): link workaround NOTEs to tracking issues)
+```
+
+Resolution: Take PR's `NOTE(#3076):` format + main's more detailed tracking text:
+```mojo
+        # NOTE(#3076): Python data loader integration blocked by Track 4.
+        # Tracked in #3076 (parent: #3059). Placeholder tensors used until Track 4 is ready.
+```
+
+Then continue rebase:
+```bash
+git add <resolved-file>
+git rebase --continue
+```
+
+### 4. Force-Push and Enable Auto-Merge
+
+```bash
+# Safe force-push (will fail if remote has new commits you haven't seen)
+git push --force-with-lease origin <branch-name>
+
+# Enable auto-merge with rebase strategy
+gh pr merge <PR_NUMBER> --auto --rebase
+
+# Verify auto-merge is set
+gh pr view <PR_NUMBER> --json state,autoMergeRequest
+```
+
+Expected output confirms `autoMergeRequest.mergeMethod == "REBASE"`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trusting fix plan's "already merged" claim | Plan said commit `1d3afd6b` was in main; plan said close PR or re-target | `git log origin/main \| grep 1d3afd6b` returned nothing — commit was only on the branch | Always verify git state independently; automated plans can have stale snapshots |
+| Assuming no conflicts for comment-only changes | Expected `git rebase origin/main` to succeed cleanly | Main had also updated the same comment in `trainer_interface.mojo` between branch creation and rebase | Comment-only PRs can still conflict if main updated the same comments independently |
+
+## Results & Parameters
+
+**Rebase command**:
+```bash
+git fetch origin && git rebase origin/main
+```
+
+**Conflict resolution strategy for NOTE tag format conflicts**:
+- Keep PR's `# NOTE(#NNNN):` format (the PR's stated goal)
+- Keep main's comment body text if it's more detailed/accurate
+
+**Force-push command** (safe):
+```bash
+git push --force-with-lease origin <branch>
+```
+
+**Auto-merge command**:
+```bash
+gh pr merge <PR_NUMBER> --auto --rebase
+```
+
+**Verification that auto-merge is set**:
+```bash
+gh pr view <PR_NUMBER> --json state,autoMergeRequest | jq '.autoMergeRequest.mergeMethod'
+# Expected: "REBASE"
+```


### PR DESCRIPTION
## Summary

Documents workflow for rebasing PRs when an automated fix plan contains stale state information about whether a branch's commits are already in main.

- Covers how to verify actual git state vs stale plan claims
- Explains comment-only conflict resolution strategy
- Provides force-push + auto-merge commands

## Key Findings

**What Worked**:
- `git log --oneline origin/main..HEAD` to verify actual branch state (two-dot, not three-dot)
- `git push --force-with-lease` for safe force-push after rebase
- Combining PR's format goal (`# NOTE(#NNNN):`) with main's updated comment body text for conflict resolution

**What Failed**:
- Trusting fix plan's claim that commit was already in main — plan had stale snapshot; `git log origin/main | grep <sha>` returned nothing
- Assuming comment-only changes would rebase cleanly — main had independently updated the same comment lines

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
