### PR TITLE
feat: add pr-review-ci-flake-analysis skill

### DIFF
--- a/skills/ci-cd/pr-review-ci-flake-analysis/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-review-ci-flake-analysis/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-review-ci-flake-analysis",
+  "version": "1.0.0",
+  "description": "Analyze CI failures on a PR to distinguish pre-existing flakes from regression. Use when: (1) a review-fix plan says 'no code changes needed', (2) CI shows execution crashes unrelated to PR changes, (3) validating that a cleanup/deletion PR is safe to merge despite CI failures.",
+  "category": "ci-cd",
+  "date": "2026-03-06",
+  "tags": ["ci", "flaky-tests", "pr-review", "mojo", "heap-corruption", "adr-009"]
+}

--- a/skills/ci-cd/pr-review-ci-flake-analysis/references/notes.md
+++ b/skills/ci-cd/pr-review-ci-flake-analysis/references/notes.md
@@ -1,0 +1,45 @@
+# Session Notes: PR Review CI Flake Analysis
+
+**Date**: 2026-03-06
+**Session**: Review fix for PR #3250, issue #3059
+
+## Context
+
+- Worktree: `/home/mvillmow/Odyssey2/.worktrees/issue-3059` on branch `3059-auto-impl`
+- PR #3250 is on branch `3060-auto-impl` (child of issue #3059)
+- The worktree was 21 commits behind `origin/main`
+- Review-fix plan file: `.claude-review-fix-3059.md`
+
+## What the PR Does
+
+Deletes `shared/training/schedulers.mojo` — a deprecated stub containing only a docstring
+directing users to the `schedulers/` directory. The actual implementations live in
+`shared/training/schedulers/__init__.mojo` and subfiles.
+
+## What the CI Failure Was
+
+"Core Gradient" test group in Comprehensive Tests failed with `execution crashed` in:
+- `test_backward_linear.mojo`
+- `test_backward_conv_pool.mojo`
+- `test_backward_losses.mojo`
+- `test_gradient_checking_basic.mojo`
+- `test_gradient_checking_dtype.mojo`
+- `test_gradient_validation.mojo`
+
+Root cause: Mojo 0.26.1 heap corruption (ADR-009), not related to scheduler deletion.
+
+## Key Verification Steps
+
+1. Read `.claude-review-fix-3059.md` — plan said "no code fixes required"
+2. Ran grep for imports of deleted file — got 16 hits, but the file still exists on this branch
+3. Read `schedulers.mojo` — confirmed it is only a deprecated docstring stub
+4. Checked git status — branch 21 commits behind, no staged changes
+5. Identified the CI failure type as ADR-009 heap corruption flake
+6. Re-triggered CI: `gh run rerun 22748975736 --failed`
+7. Did not create any commits (no changes to commit)
+
+## Key Insight
+
+The worktree for the parent tracking issue (#3059) is used as the workspace for the
+review-fix automation, even though the PR is on a child issue branch (#3060). The
+review-fix plan correctly identifies this — no code is needed in the worktree.

--- a/skills/ci-cd/pr-review-ci-flake-analysis/skills/pr-review-ci-flake-analysis/SKILL.md
+++ b/skills/ci-cd/pr-review-ci-flake-analysis/skills/pr-review-ci-flake-analysis/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: pr-review-ci-flake-analysis
+description: "Analyze CI failures on a PR to distinguish pre-existing flakes from regression. Use when: reviewing a PR whose only CI failures are execution crashes unrelated to the changed files, or when a review-fix plan concludes no code changes are needed."
+category: ci-cd
+date: 2026-03-06
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | pr-review-ci-flake-analysis |
+| **Category** | ci-cd |
+| **Trigger** | Review-fix plan says "no code changes required" or CI fails with `execution crashed` |
+| **Outcome** | Confirm PR safety, re-trigger CI, no unnecessary commits made |
+
+## When to Use
+
+- A `.claude-review-fix-<issue>.md` plan concludes the PR change is correct and safe
+- CI failure type is `execution crashed` (Mojo heap corruption / ADR-009 flake)
+- The failing test files have no logical connection to the files changed in the PR
+- You need to distinguish a pre-existing CI flake from a regression introduced by the PR
+
+## Verified Workflow
+
+1. **Read the review-fix plan** — check if it explicitly states "no code changes required"
+2. **Verify the safety claim** — grep for imports of the deleted/changed file across the codebase:
+   ```bash
+   grep -r "from shared.training.schedulers import\|from shared.training import schedulers" \
+     --include="*.mojo" <worktree>/
+   ```
+3. **Understand the git state** — check branch status, note if it is behind main
+4. **Inspect CI failure type** — `execution crashed` = ADR-009 heap corruption flake, not a regression
+5. **Re-trigger failed CI** (if a run ID is provided in the plan):
+   ```bash
+   gh run rerun <run-id> --failed
+   ```
+6. **Do NOT commit** — no changes were made; the working tree only has the untracked review file
+
+## Key Patterns Learned
+
+### Worktree vs PR Branch Mismatch
+
+The review-fix file is dropped into the worktree for the **parent tracking issue** (e.g. `3059-auto-impl`),
+but the actual PR is on a **child issue branch** (e.g. `3060-auto-impl`). This is expected — do not
+try to reconcile the branch names or create extra commits.
+
+### Grep Can Be Misleading
+
+When verifying "no imports of deleted file", grep may return hits **because the file still exists on
+this branch** (the branch is behind main). This is normal — it means the deletion has not yet landed
+on this worktree. Confirm by checking `git status` and `git log`.
+
+### ADR-009: Mojo 0.26.1 Heap Corruption
+
+CI test groups named "Core Gradient" fail intermittently with:
+```
+error: execution crashed
+libKGENCompilerRTShared.so (segfault)
+```
+This is a **runtime-level crash**, not caused by application code changes. It is documented in
+ADR-009 and partially addressed by file-splitting in commit `8a78d3aa`. Re-running CI often passes.
+
+### The "Gradient Checking Tests" Workflow vs "Core Gradient" Group
+
+The separately-named "Gradient Checking Tests" **workflow** (which runs gradient-specific validation)
+can pass even when the "Core Gradient" **test group** in Comprehensive Tests fails. These are
+different CI targets — one passing does not imply the other will.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assuming grep hits = real imports | Ran grep for scheduler imports, got 16 files | The file `schedulers.mojo` still exists on this branch (21 commits behind main) | Always check `git log` and branch position before interpreting grep results |
+| Treating all CI failures as actionable | Initial reaction was to investigate the "Core Gradient" failures | They are ADR-009 heap corruption flakes with no connection to the PR change | Read the failure type (`execution crashed`) and cross-reference with ADR-009 before investigating |
+
+## Results & Parameters
+
+```bash
+# Re-trigger only failed jobs (copy run ID from the review-fix plan)
+gh run rerun <run-id> --failed
+
+# Verify no real imports of a deleted file (adjust pattern for your file)
+grep -r "from shared\.training\.schedulers import\|from shared\.training import schedulers" \
+  --include="*.mojo" <worktree>/
+
+# Check branch position relative to main
+git status  # shows "behind 'origin/main' by N commits"
+git log --oneline -5
+```


### PR DESCRIPTION
## Summary

Documents how to handle PR review-fix plans that conclude no code changes are needed,
specifically when CI failures are pre-existing Mojo 0.26.1 heap corruption flakes (ADR-009).

- Distinguishes `execution crashed` CI failures (ADR-009 flake) from actual regressions
- Documents the worktree/branch mismatch pattern (parent issue worktree hosts child PR review)
- Explains why grep hits for a deleted file may be false positives on a behind-main branch

## Key Findings

**What Worked**:
- Reading the review-fix plan first to check if it explicitly says "no code changes required"
- Cross-referencing CI failure type (`execution crashed`) with ADR-009 documentation
- Re-triggering only failed CI jobs with `gh run rerun <id> --failed`

**What Failed**:
- Assuming grep hits = real imports without checking branch position relative to main
- Treating `execution crashed` as an actionable regression before checking ADR-009

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant CI failure triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)