### PR TITLE
feat: add mass-pr-rebase-conflict-resolution skill

### DIFF
--- a/skills/ci-cd/mass-pr-rebase-conflict-resolution/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mass-pr-rebase-conflict-resolution/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mass-pr-rebase-conflict-resolution",
+  "version": "1.0.0",
+  "description": "Rebase multiple DIRTY/CONFLICTING PRs against main, resolve merge conflicts, and fix pre-commit CI failures. Use when: (1) many PRs show DIRTY/CONFLICTING merge state after main advances, (2) pre-commit format failures need manual fixes because mojo format can't run locally, (3) the same files (e.g. extensor.mojo) conflict across many PRs with diverging implementations.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["rebase", "conflict-resolution", "pull-requests", "mojo", "pre-commit", "ci-failures"]
+}

--- a/skills/ci-cd/mass-pr-rebase-conflict-resolution/references/notes.md
+++ b/skills/ci-cd/mass-pr-rebase-conflict-resolution/references/notes.md
@@ -1,0 +1,117 @@
+# Session Notes: Mass PR Rebase & Conflict Resolution
+
+**Date**: 2026-03-07
+**Repository**: HomericIntelligence/ProjectOdyssey
+**Session duration**: ~90 minutes
+
+## Context
+
+21 open PRs all had auto-merge enabled. After main advanced with several merges,
+16 PRs became DIRTY/CONFLICTING. Additionally:
+- 3 PRs had pre-commit format failures (mojo format reformats)
+- 3 PRs had ADR-009 heap crash failures (not real test failures)
+- 1 PR was waiting on Test Report (auto-merged during session)
+
+## PR Inventory at Session Start
+
+| Status | Count | PRs |
+|--------|-------|-----|
+| DIRTY | 16 | #3161, #3169, #3264, #3269, #3286, #3288, #3319, #3320, #3335, #3340, #3363, #3372, #3373, #3641, #3643 |
+| BLOCKED (format) | 3 | #3177, #3385, #3386 |
+| BLOCKED (ADR-009) | 3 | #3177, #3224, #3385 |
+| Pending Test Report | 1 | #3354 (merged during session) |
+
+## Key Technical Challenge: extensor.mojo
+
+The main conflict source was `shared/core/extensor.mojo`. Multiple PRs were adding
+new methods to ExTensor:
+
+- PR #3161 (2722-auto-impl): `__int__`, `__float__`, `__hash__() -> UInt`, `contiguous()`
+- PR #3232 (3077-auto-impl): Added `Hashable` to struct traits, fix hash test
+- PR #3372 (3163-auto-impl): Activated `__hash__` tests
+- PR #3373 (3164-auto-impl): Fixed `__hash__` to use `Hasher` protocol
+
+The correct final state of `extensor.mojo`:
+```mojo
+struct ExTensor(
+    Copyable, Hashable, ImplicitlyCopyable, Movable, Representable, Sized, Stringable
+):
+
+    fn __int__(self) raises -> Int: ...
+    fn __float__(self) raises -> Float64: ...
+    fn __str__(self) -> String: ...   # Already on main from earlier PR
+    fn __repr__(self) -> String: ...  # Already on main from earlier PR
+    fn __hash__[H: Hasher](self, mut hasher: H):  # Correct Hashable API
+        hasher.write(...)
+    fn contiguous(self) raises -> ExTensor: ...
+```
+
+## Conflict Resolution Decisions
+
+### 2722-auto-impl (PR #3161)
+- HEAD: had `__str__`/`__repr__` from earlier merged PR
+- Branch: added `__int__`, `__float__`, old `__hash__() -> UInt`, `contiguous()`
+- **Decision**: Manual merge — kept HEAD's `__str__`/`__repr__`, added branch's new methods
+- `__hash__` kept as old API for this PR since the Hasher-protocol fix comes in later PRs
+
+### 3077-auto-impl (PR #3232)
+- Branch had `Hashable` in struct traits, fixing test to use `hash()`
+- HEAD was missing `Hashable` trait
+- **Decision**: Manual — added `Hashable` to trait list alphabetically
+- Also fixed: branch used old `__hash__() -> UInt` in one commit, then correct Hasher API in later commit
+- For intermediate commits: kept HEAD to avoid duplicate `__hash__` methods
+
+### 3163-auto-impl (PR #3372) and 3164-auto-impl (PR #3373)
+- Multiple commits, each adding different versions of `__hash__`
+- **Decision**: For each conflict, kept HEAD's `__str__`/`__repr__` and added the branch's
+  `__hash__[H: Hasher](self, mut hasher: H)` with `hasher.write()` implementation
+
+## Pre-commit Format Fix Process
+
+Since `mojo format` can't run locally (GLIBC_2.32+ required, machine has older GLIBC):
+
+1. Read CI failure job ID from `gh pr checks`
+2. Fetch exact diff from GitHub API: `gh api repos/.../actions/jobs/<id>/logs`
+3. Apply the diff manually via Edit tool
+
+**Diffs found:**
+- PR #3177: `create_val_loader` docstring (88+ chars) → closing `"""` on own line
+- PR #3385: `assert_value_at(t, 2, 7.0, 1e-6, "__setitem__ ...")` → wrapped
+- PR #3386: `assert_false(a.is_contiguous(), "msg")` + `assert_true(c.is_contiguous(), "msg")` → wrapped
+
+## Commands Used
+
+```bash
+# Check all PR statuses
+gh pr list --json number,title,mergeStateStatus,headRefName --limit 50 | python3 ...
+
+# Get pre-commit diff from CI
+gh api repos/HomericIntelligence/ProjectOdyssey/actions/jobs/<ID>/logs 2>&1 | grep -A 30 "All changes made by hooks"
+
+# Per-PR rebase
+git checkout -b temp-<branch> origin/<branch>
+git rebase origin/main
+# ... resolve conflicts ...
+git push --force-with-lease origin temp-<branch>:<branch>
+git checkout main && git branch -D temp-<branch>
+
+# Batch binary conflict resolution
+git status --short | grep "^UU\|^AA" | awk '{print $2}' | while read f; do
+  git checkout --theirs "$f" && git add "$f"
+done
+
+# Verify no conflict markers
+grep -c "<<<<<<\|>>>>>>" <file>
+
+# Cleanup
+git remote prune origin
+git worktree prune
+```
+
+## Outcome
+
+- 16 branches rebased and pushed
+- 3 format fixes committed
+- 1 PR merged during session (PR #3354)
+- All 20 remaining PRs have fresh CI running
+- Local state: only `main` branch, no worktrees

--- a/skills/ci-cd/mass-pr-rebase-conflict-resolution/skills/mass-pr-rebase-conflict-resolution/SKILL.md
+++ b/skills/ci-cd/mass-pr-rebase-conflict-resolution/skills/mass-pr-rebase-conflict-resolution/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: mass-pr-rebase-conflict-resolution
+description: "Rebase multiple DIRTY/CONFLICTING PRs against main, resolve merge conflicts, and fix pre-commit format CI failures without local mojo format. Use when: (1) many PRs show DIRTY merge state after main advances, (2) mojo format fails in CI but can't run locally due to GLIBC incompatibility, (3) same files conflict across many PRs."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | Multiple PRs in DIRTY/CONFLICTING merge state |
+| **Complexity** | High — requires reading CI diffs and manually applying format fixes |
+| **Time** | ~2-3 minutes per PR (20 PRs = ~1 hour) |
+| **Risk** | Medium — force-with-lease pushes, no data loss if done correctly |
+
+## When to Use
+
+- `gh pr list --json mergeStateStatus` shows many PRs with `DIRTY` status
+- CI pre-commit hook fails with `reformatted <file>.mojo` but `mojo format` can't run locally
+- A core file (like `extensor.mojo`) is being modified by many concurrent PRs with diverging method implementations
+- You need to batch-rebase 10+ PRs and each one conflicts with main
+
+## Verified Workflow
+
+### Step 0: Triage PRs by status
+
+```bash
+gh pr list --json number,title,mergeStateStatus,headRefName --limit 50 | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+for pr in sorted(prs, key=lambda x: x['number']):
+    print(f\"PR #{pr['number']:4d} [{pr['mergeStateStatus']:12s}] {pr['headRefName']}\")
+"
+```
+
+Categories:
+- `DIRTY` → needs rebase
+- `BLOCKED` → CI failing (check which checks, may be format-only)
+- `UNKNOWN` → CI pending or passing, let auto-merge handle it
+
+### Step 1: Fix pre-commit format failures without local mojo format
+
+When `mojo format` can't run locally (GLIBC incompatibility), read the exact diff from CI logs:
+
+```bash
+# Get the workflow run ID from gh pr checks
+gh pr checks <PR_NUMBER> 2>&1 | grep "pre-commit"
+
+# Get the exact diff from CI logs
+gh api repos/<ORG>/<REPO>/actions/jobs/<JOB_ID>/logs 2>&1 | grep -A 30 "All changes made by hooks"
+```
+
+The diff shows exactly what `mojo format` would change. Apply manually with Edit tool.
+
+**Common format patterns needing fixes:**
+- Long docstring on one line → closing `"""` must be on its own line
+- Long `assert_*` calls → wrap with trailing argument on next line + `)` on line after
+- `assert_false(a.is_contiguous(), "msg")` over 88 chars → multiline
+
+### Step 2: Distinguish ADR-009 heap crashes from real test failures
+
+```bash
+gh api repos/<ORG>/<REPO>/actions/jobs/<JOB_ID>/logs 2>&1 | grep -E "FAILED|crashed"
+```
+
+If output shows `mojo: error: execution crashed`, it is ADR-009 — NOT a real failure. Re-run:
+
+```bash
+gh run rerun <RUN_ID> --failed
+```
+
+Real failures show actual assertion errors or compilation errors, not "execution crashed".
+
+### Step 3: Rebase DIRTY branches — use temp branch pattern
+
+```bash
+git fetch origin <branch>
+git checkout -b temp-<branch> origin/<branch>
+git rebase origin/main
+# ... resolve conflicts ...
+git push --force-with-lease origin temp-<branch>:<branch>
+git checkout main
+git branch -D temp-<branch>
+```
+
+**Critical**: Use `--force-with-lease` not `--force`. This aborts if remote has changed.
+
+### Step 4: Conflict resolution strategy for core files
+
+When a central file (e.g. `extensor.mojo`) is modified by many PRs:
+
+**Strategy A — Take theirs** (for cleanup PRs, docs PRs, test-only PRs):
+```bash
+git checkout --theirs <file>
+git add <file>
+```
+
+**Strategy B — Keep ours** (when HEAD already has the feature the branch adds):
+```bash
+git checkout --ours <file>
+git add <file>
+```
+
+**Strategy C — Manual merge** (when both sides add distinct new content):
+
+Example: HEAD has `__str__`/`__repr__`, branch adds `__hash__[H: Hasher]`:
+1. Keep HEAD's `__str__` and `__repr__` implementations intact
+2. Add the branch's new methods (`__hash__`, `__int__`, `__float__`, `contiguous()`) after `__repr__`
+3. Verify no duplicate method definitions: `grep -n "fn __hash__" extensor.mojo`
+4. Confirm zero conflict markers: `grep -c "<<<<<<\|>>>>>>" extensor.mojo`
+
+### Step 5: Handle the Mojo Hashable trait correctly
+
+When resolving `__hash__` conflicts, the CORRECT signature (Mojo v0.26.1+) is:
+
+```mojo
+fn __hash__[H: Hasher](self, mut hasher: H):
+    hasher.write(value1)
+    hasher.write(value2)
+```
+
+**WRONG** signatures to discard during conflict resolution:
+- `fn __hash__(self) -> UInt:` — old API, not `Hashable` trait compliant
+- `fn __hash__[H: Hasher](self, inout hasher: H):` — `inout` is deprecated, use `mut`
+- `hasher.update(...)` — wrong method name, use `hasher.write(...)`
+
+### Step 6: Struct trait declarations with multiple traits
+
+When two branches both add traits to a struct:
+- HEAD: `struct ExTensor(Copyable, Representable, Sized, Stringable)`
+- Branch: `struct ExTensor(Copyable, Hashable, Sized)`
+
+**Merge**: combine alphabetically on wrapped lines:
+```mojo
+struct ExTensor(
+    Copyable, Hashable, ImplicitlyCopyable, Movable, Representable, Sized, Stringable
+):
+```
+
+### Step 7: Handle binary pyc conflicts
+
+For `tests/**/__pycache__/*.pyc` conflicts, always take theirs:
+```bash
+git status --short | grep "^UU\|^AA" | awk '{print $2}' | while read f; do
+  git checkout --theirs "$f" && git add "$f"
+done
+```
+
+### Step 8: Prune and verify
+
+```bash
+git remote prune origin
+git worktree prune
+git branch  # Should show only main
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `pixi run mojo format` locally | Tried to format files to fix pre-commit | GLIBC_2.32/2.33/2.34 not found on dev machine | Read CI logs instead; the diff shows exact changes needed |
+| `gh run rerun` on still-running workflow | Tried to rerun ADR-009 crashes before new push | "run cannot be rerun; This workflow is already running" | Pushing a new commit triggers fresh CI automatically — no manual rerun needed |
+| Using `--ours` for extensor.mojo when branch adds new methods | Kept HEAD version thinking it already had everything | HEAD was missing `__hash__[H: Hasher]` — the correct trait impl | Always check what new content the branch adds; don't blindly use `--ours` |
+| `git checkout --theirs extensor.mojo` for all hash-related PRs | Took branch version to get `__hash__` | Branch had old `fn __hash__(self) -> UInt` or `inout hasher` — both wrong | Manually merge: keep HEAD's `__str__`/`__repr__`, add branch's hash body but fix to correct API |
+| Adding `Hashable` to struct without `Representable` | Took branch struct declaration that dropped `Representable` | Struct missing `Representable` breaks `__repr__` trait satisfaction | Always merge trait lists from both sides; check what traits HEAD has that branch dropped |
+| Using `gh run rerun` for PR #3224 before checking if new CI started | Tried to rerun the ADR-009 crash run | Got "run cannot be rerun" — new CI was already triggered by our rebase push | Check if new workflow runs are already in progress before rerunning old ones |
+
+## Results & Parameters
+
+### PR volume successfully handled
+
+```
+16 DIRTY branches rebased in ~60 minutes
+3 format fixes applied manually from CI diffs
+1 PR merged automatically (PR #3354, Test Report was pending)
+0 real test failures — all were ADR-009 heap crashes
+```
+
+### Conflict frequency by file
+
+```
+extensor.mojo     — 9 PRs conflicting (highest — core struct)
+agents/hierarchy.md — 4 PRs conflicting
+CLAUDE.md         — 2 PRs conflicting
+test_conv.mojo    — 3 PRs conflicting
+test_utility.mojo — 4 PRs conflicting
+__pycache__/*.pyc — 1 PR (always take --theirs)
+```
+
+### Format fix patterns (copy-paste)
+
+```python
+# Docstring closing quote on its own line (>88 chars)
+# BEFORE:
+"""Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10."""
+# AFTER:
+"""Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10.
+"""
+
+# Long assert call wrapping
+# BEFORE:
+assert_false(a.is_contiguous(), "Column-major tensor should not be contiguous")
+# AFTER:
+assert_false(
+    a.is_contiguous(), "Column-major tensor should not be contiguous"
+)
+```
+
+### Decision tree for extensor.mojo conflicts
+
+```
+Is the conflict in __str__ or __repr__?
+├── YES → Keep HEAD (HEAD always has these from earlier merged PR)
+└── NO
+
+Is the conflict adding __hash__[H: Hasher](self, mut hasher: H)?
+├── YES → Keep/add this version (correct Hashable trait API)
+└── NO
+
+Is the conflict adding fn __hash__(self) -> UInt?
+├── YES → DISCARD — this is the old wrong API
+└── NO
+
+Is the conflict adding __int__, __float__, contiguous()?
+└── YES → Add from branch if not already in HEAD
+```
+
+### Verification after each rebase
+
+```bash
+# Zero conflict markers
+grep -c "<<<<<<\|>>>>>>" <file> || echo "0 — clean"
+
+# No duplicate methods
+grep -n "fn __hash__\|fn __str__\|fn __repr__" shared/core/extensor.mojo
+
+# Push succeeded
+git push --force-with-lease origin temp-<branch>:<branch>
+```


### PR DESCRIPTION
## Summary

Documents how to rebase 16+ DIRTY/CONFLICTING PRs against main in bulk, resolve
complex merge conflicts in core files (especially `extensor.mojo`), and fix
pre-commit format failures without local mojo format access.

- Verified on 21 open PRs in ProjectOdyssey, 16 of which were DIRTY
- All rebases completed without data loss using `--force-with-lease`
- 3 format fixes applied manually from CI diffs (GLIBC prevents local mojo format)

## Key Findings

**What Worked**:
- Reading exact format diffs from `gh api .../actions/jobs/<ID>/logs` instead of running mojo format
- Using `temp-<branch>` local branches for safe rebase + force-with-lease push
- Batch binary conflict resolution: `git status --short | grep "^UU\|^AA" | awk '{print $2}' | while read f; do git checkout --theirs "$f" && git add "$f"; done`
- Manual merge for `extensor.mojo`: keep HEAD's `__str__`/`__repr__`, add branch's correct `__hash__[H: Hasher](self, mut hasher: H)`

**What Failed**:
- `pixi run mojo format` locally → GLIBC_2.32/2.33/2.34 not found; read CI logs instead
- `gh run rerun` on ADR-009 crashes when new push already triggered CI → "workflow already running"
- `git checkout --ours extensor.mojo` blindly → missed new methods the branch was adding
- `git checkout --theirs extensor.mojo` blindly → got old `__hash__() -> UInt` wrong API

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers activate for "DIRTY PRs" and "pre-commit format failure"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
