### PR TITLE
feat(skills): Add bulk-test-type-annotation skill

### DIFF
--- a/skills/bulk-test-type-annotation/.claude-plugin/plugin.json
+++ b/skills/bulk-test-type-annotation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bulk-test-type-annotation",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: Annotating hundreds of unannotated test functions in a test directory to satisfy mypy disallow_untyped_defs. Use when: (1) removing a [[tool.mypy.overrides]] suppress block for a test directory, (2) adding -> None to test methods in bulk, (3) adding typing.Any to pytest fixture parameters, (4) fixing cascade errors from inner helper functions that return values.",
+  "category": "testing",
+  "date": "2026-03-06",
+  "tags": ["mypy", "type-annotations", "pytest", "testing", "bulk", "no-untyped-def", "typing.Any"]
+}

--- a/skills/bulk-test-type-annotation/references/notes.md
+++ b/skills/bulk-test-type-annotation/references/notes.md
@@ -1,0 +1,87 @@
+# bulk-test-type-annotation — Session Notes
+
+## Context
+
+ProjectScylla issue #1379: The `tests/unit/` directory had a mypy override suppressing
+`no-untyped-def` for ~635 unannotated test functions. This was a known gap from the
+incremental mypy adoption in #687. The B023 fix in #1356 had demonstrated that typed
+annotations in tests can catch real bugs.
+
+## Scope
+
+- **62 files** modified in `tests/unit/`
+- **590 functions** received `-> None` annotations in Phase 1
+- **725 `: Any` annotations** added to pytest fixture parameters and inner helpers in Phase 2+
+- **489 cascade errors** resolved after initial annotation pass
+
+## Error Breakdown (after removing override)
+
+```
+489 errors in 41 files
+- [return-value]: 82 — inner helper functions annotated -> None that return values
+- [func-returns-value]: 21 — functions declared -> None called as if returning value
+- [no-any-return]: 6 — fixture functions returning dataframes declared -> None
+- [name-defined]: 11 — Any not imported (import placed inside docstring)
+- [misc]: 2 — generator fixtures needing Generator return type
+- [assignment]: 3 — mock assignments incompatible with -> None annotation
+```
+
+## Script Approach
+
+Three Python scripts were used iteratively:
+
+1. **annotate_tests.py** — Phase 1: regex-based single-line and multi-line def detection,
+   adds `-> None` to test_*, setUp, tearDown, setup_method functions
+
+2. **fix_mypy_annotations.py** — Phase 2-3: runs mypy, groups errors by file/line,
+   dispatches fixes by error type (return-type, untyped-args, missing-annotation)
+
+3. **fix_return_types.py** — Phase 4: specifically targets `[return-value]` errors,
+   finds `-> None` on the def line and replaces with `-> Any`
+
+Plus manual fixes for:
+- `from typing import Any` injected into module docstrings (2 files)
+- `from typing import Any` placed before `from __future__ import annotations` (5 files)
+- Duplicate `) -> None:` closing line in multi-line defs (2 files)
+- `from typing import Any, Generator` placed before docstring (1 file)
+
+## Iteration Count
+
+- Phase 1 (annotate_tests.py): 1 run, fixed 590
+- Phase 2 (fix_mypy_annotations.py): 1 iteration, fixed 489 errors
+- Phase 3 (fix_return_types.py): 1 pass, fixed 82 return-value errors; stalled at 49 remaining
+- Manual fixes: ~15 individual edits for import placement and syntax errors
+- ruff --fix: 1 run, fixed 7 import-ordering errors
+
+## Key Files
+
+- `pyproject.toml`: Removed `[[tool.mypy.overrides]]` block (lines 133-137 before change)
+- `tests/unit/analysis/conftest.py`: Fixture functions returning `pd.DataFrame` annotated `-> Any`
+- `tests/unit/e2e/test_tier_state_machine.py`: `Any` import added after `from __future__`
+- `tests/unit/e2e/test_scheduler.py`: Generator fixture fixed `-> Generator[Any, None, None]`
+
+## Commands Used
+
+```bash
+# Check mypy error count
+pixi run mypy tests/unit/ 2>&1 | grep "error:" | wc -l
+
+# Run iterative fixer
+python3 /tmp/fix_mypy_annotations.py
+
+# Fix ruff ordering
+pixi run ruff check tests/unit/ --fix
+
+# Final verification
+pixi run mypy tests/unit/ 2>&1 | tail -3
+pixi run python -m pytest tests/unit/ -q --no-cov
+pre-commit run --all-files
+```
+
+## Timing
+
+- Phase 1 script: ~5 seconds
+- Phase 2-4 scripts (iterative, running mypy each pass): ~5 minutes
+- Manual fixes: ~10 minutes
+- Full test suite validation: ~5 minutes
+- Total: ~20 minutes end-to-end

--- a/skills/bulk-test-type-annotation/skills/bulk-test-type-annotation/SKILL.md
+++ b/skills/bulk-test-type-annotation/skills/bulk-test-type-annotation/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: bulk-test-type-annotation
+description: "TRIGGER CONDITIONS: Annotating hundreds of unannotated test functions in tests/unit/ to satisfy mypy disallow_untyped_defs. Use when removing a [[tool.mypy.overrides]] suppress block for a test directory, adding -> None to test methods, and adding typing.Any to pytest fixture parameters in bulk."
+user-invocable: false
+category: testing
+date: 2026-03-06
+---
+
+# bulk-test-type-annotation
+
+How to annotate hundreds of test functions in a test suite to satisfy mypy's `disallow_untyped_defs`, remove a mypy override block, and avoid the cascade of secondary errors that follow the first pass.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-06 |
+| Objective | Add type annotations to ~635 unannotated test functions in `tests/unit/`, remove `[[tool.mypy.overrides]]` suppress block |
+| Outcome | Success — zero mypy errors across 200 source files, 4455 unit tests pass |
+| Issue | HomericIntelligence/ProjectScylla#1379 |
+| PR | HomericIntelligence/ProjectScylla#1453 |
+
+## When to Use
+
+- A `[[tool.mypy.overrides]]` block with `disable_error_code = ["no-untyped-def"]` exists for a test directory
+- You need to add `-> None` to hundreds of test methods in bulk
+- Pytest fixture parameters need `typing.Any` annotations
+- Inner helper functions inside tests lack return type annotations
+- You want mypy to enforce full type coverage on the test suite
+
+## Verified Workflow
+
+### Phase 1: Annotate test function return types
+
+Use an AST-guided script that matches `def test_*`, `def setUp`, `def tearDown`, `def setup_method`, etc. and appends `-> None:` when no return annotation exists:
+
+```python
+import re
+from pathlib import Path
+
+# Single-line def: ends with ):
+func_match = re.match(
+    r'^( *)(def (?:test_\w+|setUp|tearDown|setup_method|teardown_method|setup_class|teardown_class|setUpClass|tearDownClass)\s*\(.*\))(\s*):$',
+    stripped
+)
+if func_match and '->' not in func_match.group(2):
+    new_line = f"{func_match.group(1)}{func_match.group(2)} -> None:\n"
+```
+
+Run on entire `<test-dir>/`:
+```bash
+python3 annotate_tests.py   # adds -> None to ~590 functions
+```
+
+### Phase 2: Check actual mypy errors (don't guess)
+
+```bash
+<package-manager> run mypy <test-dir>/
+```
+
+Remove the override from `pyproject.toml` **before** running mypy so you see the real error count. Expect 3 error categories:
+
+1. `[no-untyped-def]` — arguments still unannotated (fixture params, inner helpers)
+2. `[return-value]` — `-> None` added to functions that actually return values
+3. `[no-any-return]` / `[func-returns-value]` — fixture functions returning dataframes annotated `-> None`
+
+### Phase 3: Fix argument annotations with `Any`
+
+Replace unannotated parameters with `Any` (not `object` — `object` causes cascade errors):
+
+```python
+# In parameter parser: replace untyped params with : Any
+new_parts.append(f'{leading}{name}: Any{rest}')
+```
+
+**Critical**: Add `from typing import Any` to each file **after** the module docstring and **after** any `from __future__ import annotations` line. Getting this order wrong causes syntax errors or E402.
+
+### Phase 4: Fix return-value cascade
+
+Inner functions annotated `-> None` that actually return values need `-> Any`:
+
+```python
+# Search backwards from error line for ) -> None:
+re.sub(r'\) -> None:(\s*)$', r') -> Any:\1', line)
+```
+
+### Phase 5: Fix generator fixtures
+
+Generator fixtures (`yield`-based) need `Generator[Any, None, None]`:
+
+```python
+def my_fixture() -> Generator[Any, None, None]:
+    yield value
+```
+
+### Phase 6: Run pre-commit and fix import ordering
+
+Ruff will flag E402 if `from typing import Any` lands before other imports or inside docstrings. Auto-fix:
+
+```bash
+<package-manager> run ruff check <test-dir>/ --fix
+```
+
+### Phase 7: Remove the override and verify
+
+```toml
+# Remove from pyproject.toml:
+# [[tool.mypy.overrides]]
+# module = "tests.unit.*"
+# disable_error_code = ["no-untyped-def"]
+```
+
+```bash
+<package-manager> run mypy <test-dir>/
+# Expected: Success: no issues found in N source files
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| Used `object` as the annotation type for all fixture parameters | `object` is too restrictive — `"object" has no attribute "readouterr"`, `Unsupported left operand type for / ("object")` cascade errors throughout | Always use `Any` for pytest fixture parameters, not `object` |
+| Single-pass script: add `-> None` to all functions at once | Functions that return values (inner helpers, mock callbacks) got `[return-value]` errors — `-> None` is wrong for them | Run mypy after phase 1 to identify which functions need `-> Any` vs `-> None` |
+| Inserting `from typing import Any` at line 0 of file | Placed import before module docstring; caused E402 when `from __future__ import annotations` came later | Insert after docstring closes AND after any `from __future__` line |
+| Regex to insert import `from __future__` on docstring-first files | Pattern matched inside docstring body, inserting `from typing import Any` into the middle of the docstring | Check that insertion point is after the closing `"""` |
+| Multi-line def collection using paren counting | Some defs had `) -> None:` on the last line already; script added a second `) -> None:` producing unmatched `)` syntax errors | Before modifying the closing line, check it doesn't already contain `-> None` |
+| Using `generator` fixture `-> None` annotation | mypy `[misc]`: generator return type must be `Generator` or subtype | Detect `yield` in function body, annotate as `Generator[Any, None, None]` |
+
+## Results & Parameters
+
+**Files changed**: 62 test files
+**Annotations added**: ~590 `-> None` + ~725 `: Any` parameter annotations
+**mypy errors resolved**: 489 cascade errors after initial pass
+**Test count unchanged**: 4455 unit tests pass
+
+Key pyproject.toml change:
+```toml
+# BEFORE (suppress override):
+[[tool.mypy.overrides]]
+module = "tests.unit.*"
+disable_error_code = ["no-untyped-def"]
+
+# AFTER (removed entirely — mypy now enforces full coverage):
+# (block deleted)
+```
+
+Key annotation patterns:
+```python
+# Test method (no params beyond self/fixtures):
+def test_something(self) -> None:
+
+# Test with pytest fixtures — use Any:
+def test_with_fixture(self, my_fixture: Any, tmp_path: Any) -> None:
+
+# Inner mock/helper that returns a value:
+def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
+    return 1
+
+# Generator fixture:
+def my_fixture() -> Generator[Any, None, None]:
+    yield create_thing()
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #1453, issue #1379 — ~635 unannotated functions in tests/unit/ | [notes.md](../../references/notes.md) |
+
+## References
+
+- Related skills: `flaky-test-patch-isolation`, `script-test-coverage-pattern`
+- mypy docs: `disallow_untyped_defs`, `[[tool.mypy.overrides]]`


### PR DESCRIPTION
## Summary

New skill capturing the workflow for annotating hundreds of unannotated test functions to satisfy mypy `disallow_untyped_defs` and remove a `[[tool.mypy.overrides]]` suppress block.

## Key Findings

- Use `typing.Any` (not `object`) for pytest fixture parameters — `object` causes cascade type errors
- Add `-> None` in Phase 1, then run mypy to identify functions that actually return values (need `-> Any`)
- `from typing import Any` must go **after** module docstring and **after** `from __future__ import annotations`
- Multi-line def closing lines may already have `-> None` — avoid duplicating it
- Generator fixtures need `Generator[Any, None, None]` return type

## Validated On

ProjectScylla PR #1453 (issue #1379): 62 files, ~590 `-> None` annotations, ~725 `: Any` parameter annotations, 4455 tests pass, zero mypy errors.

## Files Added

- `skills/bulk-test-type-annotation/skills/bulk-test-type-annotation/SKILL.md`
- `skills/bulk-test-type-annotation/.claude-plugin/plugin.json`
- `skills/bulk-test-type-annotation/references/notes.md`