### PR TITLE
docs(skills): update precommit-schema-validation with _SCHEMA_MAP extension pattern

### DIFF
--- a/skills/precommit-schema-validation/SKILL.md
+++ b/skills/precommit-schema-validation/SKILL.md
@@ -1,117 +1,54 @@
 ---
 name: precommit-schema-validation
-description: "TRIGGER CONDITIONS: Adding a pre-commit hook that validates YAML config files against JSON schemas at commit time. Use when you have schemas/ JSON schemas and config/ YAML files and want to catch schema violations before they reach CI."
+description: "TRIGGER CONDITIONS: Adding a pre-commit hook that validates YAML config files against JSON schemas at commit time. Use when you have schemas/ JSON schemas and config/ YAML files and want to catch schema violations before CI. Also use when extending an existing _SCHEMA_MAP to cover an additional config directory (e.g. adding config/tiers/ alongside config/models/)."
 user-invocable: false
 category: ci-cd
-date: 2026-03-05
+date: 2026-03-07
 ---
 
 # precommit-schema-validation
 
-How to add a pre-commit hook that validates YAML config files against JSON schemas, surfacing
-violations at commit time rather than in CI or at runtime.
+How to add or extend a pre-commit hook that validates YAML config files against JSON schemas,
+surfacing violations at commit time rather than in CI or at runtime.
 
 ## Overview
 
 | Item | Details |
 |------|---------|
-| Date | 2026-03-05 |
-| Objective | Add `scripts/validate_config_schemas.py` + `validate-config-schemas` pre-commit hook |
-| Outcome | Success — PR HomericIntelligence/ProjectScylla#1439 |
-| Issue | HomericIntelligence/ProjectScylla#1382 |
+| Date | 2026-03-05 (updated 2026-03-07) |
+| Objective | Add/extend `scripts/validate_config_schemas.py` + `validate-config-schemas` pre-commit hook |
+| Outcome | Success — PR HomericIntelligence/ProjectScylla#1439 (initial), #1464 (extend to config/tiers/) |
+| Issues | HomericIntelligence/ProjectScylla#1382, #1441 |
 
 ## When to Use
 
 - Adding schema validation to a pre-commit pipeline where schemas already exist in `schemas/`
 - When you want commit-time (not just runtime) validation for YAML configs
 - When multiple config directories each have a different schema (dispatch by path pattern)
+- **Extending an existing `_SCHEMA_MAP`** to cover a new config directory (e.g. production configs
+  alongside test fixtures that share the same schema)
 - Follow-up to wiring schemas into a config loader (see `wire-schema-validation` skill)
 
 ## Verified Workflow
 
-### 1. Create the validation script
+### 1. Create (or extend) the validation script
+
+The core pattern is an ordered `_SCHEMA_MAP` list of `(regex_pattern, schema_path)` pairs:
 
 ```python
-#!/usr/bin/env python3
-"""Validate config files against their JSON schemas as a pre-commit gate."""
-
-import argparse
-import json
-import re
-import sys
-from pathlib import Path
-
-import jsonschema
-import yaml
-
-_REPO_ROOT = Path(__file__).parent.parent
-
-# Map path patterns → schema files (relative to repo root)
 _SCHEMA_MAP: list[tuple[re.Pattern[str], Path]] = [
     (re.compile(r"^config/defaults\.yaml$"), Path("schemas/defaults.schema.json")),
     (re.compile(r"^config/models/.+\.yaml$"), Path("schemas/model.schema.json")),
+    # Production tier configs — same schema as test fixtures
+    (re.compile(r"^config/tiers/.+\.yaml$"), Path("schemas/tier.schema.json")),
     (re.compile(r"^tests/fixtures/config/tiers/.+\.yaml$"), Path("schemas/tier.schema.json")),
 ]
-
-
-def resolve_schema(file_path: Path, repo_root: Path) -> Path | None:
-    """Return schema path for file_path, or None if no match."""
-    try:
-        rel = file_path.resolve().relative_to(repo_root.resolve())
-    except ValueError:
-        rel = Path(str(file_path))
-    rel_str = rel.as_posix()
-    for pattern, schema_rel in _SCHEMA_MAP:
-        if pattern.match(rel_str):
-            return repo_root / schema_rel
-    return None
-
-
-def validate_file(file_path: Path, schema: dict[str, object]) -> list[str]:
-    """Validate a YAML file against schema; returns list of error strings."""
-    try:
-        with open(file_path) as fh:
-            content = yaml.safe_load(fh)
-    except (OSError, yaml.YAMLError) as exc:
-        return [f"Could not read/parse YAML: {exc}"]
-    errors: list[str] = []
-    validator = jsonschema.Draft7Validator(schema)
-    for error in sorted(validator.iter_errors(content), key=lambda e: list(e.path)):
-        path = ".".join(str(p) for p in error.absolute_path) or "<root>"
-        errors.append(f"  [{path}] {error.message}")
-    return errors
-
-
-def check_files(files: list[Path], repo_root: Path, verbose: bool = False) -> int:
-    """Validate each file; return 0 (all valid) or 1 (any failure)."""
-    if not files:
-        return 0
-    schema_cache: dict[Path, dict[str, object]] = {}
-    any_failure = False
-    for file_path in files:
-        schema_path = resolve_schema(file_path, repo_root)
-        if schema_path is None:
-            print(f"WARNING: No schema mapping for {file_path} — skipping", file=sys.stderr)
-            continue
-        if schema_path not in schema_cache:
-            try:
-                schema_cache[schema_path] = json.loads(schema_path.read_text())
-            except (OSError, json.JSONDecodeError) as exc:
-                print(f"ERROR: Could not load schema {schema_path}: {exc}", file=sys.stderr)
-                any_failure = True
-                continue
-        errors = validate_file(file_path, schema_cache[schema_path])
-        if errors:
-            print(f"FAIL: {file_path}", file=sys.stderr)
-            for error in errors:
-                print(error, file=sys.stderr)
-            any_failure = True
-        elif verbose:
-            print(f"PASS: {file_path}")
-    return 1 if any_failure else 0
 ```
 
-### 2. Register the hook in `.pre-commit-config.yaml`
+**Key**: Order matters only if two patterns can match the same path (they don't here). Multiple
+paths can map to the same schema file.
+
+### 2. Register (or extend) the hook in `.pre-commit-config.yaml`
 
 Use `pass_filenames: true` so pre-commit passes only the changed files:
 
@@ -119,12 +56,13 @@ Use `pass_filenames: true` so pre-commit passes only the changed files:
 - id: validate-config-schemas
   name: Validate Config Files Against JSON Schemas
   description: >-
-    Validates config/defaults.yaml, config/models/*.yaml, and
-    tests/fixtures/config/tiers/*.yaml against their JSON schemas in schemas/
+    Validates config/defaults.yaml, config/models/*.yaml,
+    config/tiers/*.yaml, and tests/fixtures/config/tiers/*.yaml
+    against their JSON schemas in schemas/
   entry: pixi run python scripts/validate_config_schemas.py
   language: system
   files: >-
-    ^(config/defaults\.yaml|config/models/.+\.yaml|
+    ^(config/defaults\.yaml|config/models/.+\.yaml|config/tiers/.+\.yaml|
     tests/fixtures/config/tiers/.+\.yaml)$
   pass_filenames: true
 ```
@@ -139,7 +77,7 @@ rather than stopping at the first. This is critical for useful pre-commit feedba
 
 ### 4. Cache loaded schemas
 
-If multiple files share the same schema (e.g., all `config/models/*.yaml` use `model.schema.json`),
+If multiple files share the same schema (e.g., all `config/tiers/*.yaml` use `tier.schema.json`),
 load the schema once and reuse via a `dict[Path, dict]` cache:
 
 ```python
@@ -153,27 +91,47 @@ if schema_path not in schema_cache:
 Files that don't match any schema pattern should produce a WARNING to stderr but return exit code 0.
 This makes the hook future-safe when new file types are staged alongside existing ones.
 
-### 6. Write comprehensive unit tests
+### 6. Write tests that skip gracefully when directories are absent
+
+For production config directories that may not exist yet, use `pytest.skip`:
+
+```python
+def test_production_tier_configs_validate(self) -> None:
+    tiers_dir = _REPO_ROOT / "config" / "tiers"
+    if not tiers_dir.exists():
+        pytest.skip("config/tiers/ directory not present")
+    ...
+```
+
+This pattern works for `resolve_schema` unit tests too — the function accepts hypothetical paths,
+so `_REPO_ROOT / "config" / "tiers" / "t0.yaml"` resolves correctly even without the directory.
+
+### 7. Write comprehensive unit tests
 
 Test all three public functions (`resolve_schema`, `validate_file`, `check_files`) plus
-integration tests against real config files:
+integration tests against real config files. When adding a new pattern, add:
+
+- A dedicated `test_<new_pattern>_matches` unit test in `TestResolveSchema`
+- A new parametrize entry in `test_all_supported_patterns_match`
+- An integration test `test_<new_dir>_configs_validate` in `TestMainIntegration`
 
 ```python
 class TestResolveSchema:
-    def test_defaults_yaml_matches(self) -> None: ...
-    def test_model_yaml_matches(self) -> None: ...
-    def test_tier_fixture_yaml_matches(self) -> None: ...
-    def test_unknown_path_returns_none(self) -> None: ...
+    def test_production_tier_yaml_matches(self) -> None:
+        path = _REPO_ROOT / "config" / "tiers" / "t0.yaml"
+        result = resolve_schema(path, _REPO_ROOT)
+        assert result is not None
+        assert result.name == "tier.schema.json"
 
-class TestValidateFile:
-    def test_valid_yaml_returns_no_errors(self, tmp_path: Path) -> None: ...
-    def test_missing_required_field_returns_error(self, tmp_path: Path) -> None: ...
-    def test_multiple_errors_all_returned(self, tmp_path: Path) -> None: ...
-
-class TestMainIntegration:
-    def test_defaults_yaml_validates(self) -> None: ...     # uses real schemas/
-    def test_model_configs_validate(self) -> None: ...       # uses real config/models/
-    def test_tier_fixture_configs_validate(self) -> None: ... # uses real fixtures
+    @pytest.mark.parametrize("rel_path", [
+        "config/defaults.yaml",
+        "config/models/claude-sonnet.yaml",
+        "config/tiers/t0.yaml",
+        "tests/fixtures/config/tiers/t1.yaml",
+    ])
+    def test_all_supported_patterns_match(self, rel_path: str) -> None:
+        path = _REPO_ROOT / rel_path
+        assert resolve_schema(path, _REPO_ROOT) is not None
 ```
 
 ## Failed Attempts
@@ -188,11 +146,12 @@ class TestMainIntegration:
 - `jsonschema` version: `>=4.0,<5` (already in `pixi.toml` for ProjectScylla)
 - Validator: `jsonschema.Draft7Validator` (matches `"$schema": "http://json-schema.org/draft-07/schema#"` in existing schema files)
 - Unknown-path behavior: `WARNING:` to stderr, exit 0 (not a failure)
-- Test count: 26 unit tests across 4 test classes
-- Hook trigger: `pass_filenames: true` with regex covering all three config directories
+- Test count: 29 unit tests across 4 test classes (28 pass, 1 skips when `config/tiers/` absent)
+- Hook trigger: `pass_filenames: true` with regex covering all four config directories
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectScylla | PR #1439, issue #1382 | Follows wire-schema-validation (#1380/#1424) which wired the same schemas into the config loader |
+| ProjectScylla | PR #1439, issue #1382 | Initial creation of hook (3 schema map entries) |
+| ProjectScylla | PR #1464, issue #1441 | Extended to `config/tiers/*.yaml` (4th `_SCHEMA_MAP` entry) |

--- a/skills/precommit-schema-validation/plugin.json
+++ b/skills/precommit-schema-validation/plugin.json
@@ -1,12 +1,19 @@
 {
   "name": "precommit-schema-validation",
-  "version": "1.0.0",
-  "description": "Add a pre-commit hook that validates YAML config files against JSON schemas at commit time. Use when schemas/ JSON schemas already exist and you want to catch violations before CI. Covers multi-directory dispatch, Draft7Validator.iter_errors() for full reporting, and pass_filenames: true pattern.",
+  "version": "1.1.0",
+  "description": "Add or extend a pre-commit hook that validates YAML config files against JSON schemas at commit time. Use when schemas/ JSON schemas already exist and you want to catch violations before CI. Covers multi-directory dispatch via _SCHEMA_MAP, Draft7Validator.iter_errors() for full reporting, pass_filenames: true pattern, and extending an existing map with new config directories.",
   "category": "ci-cd",
   "created": "2026-03-05",
-  "tags": ["pre-commit", "jsonschema", "yaml", "validation", "config", "hooks"],
+  "updated": "2026-03-07",
+  "tags": ["pre-commit", "jsonschema", "yaml", "validation", "config", "hooks", "schema-map"],
   "project": "ProjectScylla",
-  "issue": "HomericIntelligence/ProjectScylla#1382",
-  "pr": "HomericIntelligence/ProjectScylla#1439",
+  "issues": [
+    "HomericIntelligence/ProjectScylla#1382",
+    "HomericIntelligence/ProjectScylla#1441"
+  ],
+  "prs": [
+    "HomericIntelligence/ProjectScylla#1439",
+    "HomericIntelligence/ProjectScylla#1464"
+  ],
   "outcome": "success"
 }


### PR DESCRIPTION
## Summary

- Updates `skills/precommit-schema-validation/SKILL.md` with learnings from ProjectScylla#1441
- Adds new pattern: extending an existing `_SCHEMA_MAP` with a new config directory that shares an existing schema
- Documents `pytest.skip` pattern for integration tests when a config directory doesn't exist yet
- Adds step 6 and 7 to Verified Workflow covering graceful skip and test extension patterns
- Bumps `plugin.json` to v1.1.0, tracks both issues and PRs

## Test plan

- [x] Updated SKILL.md covers both initial creation and incremental extension use cases
- [x] Failed Attempts table preserved from v1.0.0
- [x] Verified On table updated with PR #1464 entry

From ProjectScylla#1441 / PR HomericIntelligence/ProjectScylla#1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)