### PR TITLE
feat: add repo-audit-count-reconciliation skill

### DIFF
--- a/skills/tooling/repo-audit-count-reconciliation/.claude-plugin/plugin.json
+++ b/skills/tooling/repo-audit-count-reconciliation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "repo-audit-count-reconciliation",
+  "version": "1.0.0",
+  "description": "Reconcile count mismatches across documentation files after a repository audit by counting actual on-disk files and updating all references to match. Use when: (1) agent/skill/workflow counts differ between docs, (2) audit reveals stale documentation claiming non-existent files, (3) README or CLAUDE.md counts drift from actual filesystem state.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["audit", "documentation", "reconciliation", "count-mismatch", "agents", "skills"]
+}

--- a/skills/tooling/repo-audit-count-reconciliation/references/notes.md
+++ b/skills/tooling/repo-audit-count-reconciliation/references/notes.md
@@ -1,0 +1,74 @@
+# Session Notes: Repository Audit Count Reconciliation
+
+**Date**: 2026-03-07
+**Project**: HomericIntelligence/ProjectOdyssey
+**Session type**: Comprehensive repository audit + priority fix implementation
+
+## Objective
+
+Apply top 5 priority fixes from a comprehensive repository audit of ProjectOdyssey
+(~197,500 lines Mojo, 489 files, grade B overall). Priority 1 was reconciling count
+mismatches across documentation — agents (3 different numbers), skills (3 different numbers).
+
+## Audit Findings
+
+| Entity | CLAUDE.md | hierarchy.md | agents/README.md | Actual (disk) |
+|--------|-----------|--------------|------------------|---------------|
+| Agents | 42 | 37 | 42 | 31 |
+| Skills | 82 | — | — | 58 |
+
+Three different numbers for agents across three files. Skills claimed "82 total" but 58
+actual skill definitions exist.
+
+## Investigation Steps
+
+1. `ls .claude/agents/ | wc -l` → 32 (but includes `templates/` dir)
+2. `ls .claude/agents/*.md | xargs -I{} basename {} .md | sort` → 31 agent files listed
+3. `ls .claude/skills/ | wc -l` → 61 (includes SKILL_FORMAT_TEMPLATE.md + tier-1/ + tier-2/)
+4. 61 - 1 (template) - 2 (tier dirs) = 58 actual skills
+5. Cross-checked README.md agent list against disk → found 12 MISSING entries
+
+## Missing Agents (existed in docs, not on disk)
+
+These were likely removed in a consolidation effort but the README was not updated:
+
+- implementation-review-specialist
+- documentation-review-specialist
+- safety-review-specialist
+- performance-review-specialist
+- algorithm-review-specialist
+- architecture-review-specialist
+- data-engineering-review-specialist
+- paper-review-specialist
+- research-review-specialist
+- dependency-review-specialist
+- senior-implementation-engineer
+- junior-implementation-engineer
+
+## Files Updated
+
+1. `CLAUDE.md` — 3 changes: "42 agents"→"31", "All 42"→"All 31", "82 total"→"58 total", "82+"→"58"
+2. `agents/README.md` — total "42"→"31", level 3 "(22 agents)"→"(13 agents)", removed 12 non-existent stubs,
+   level 4 "(6 agents)"→"(5 agents)" (removed senior-implementation-engineer),
+   level 5 "(3 agents)"→"(2 agents)" (removed junior-implementation-engineer)
+3. `agents/hierarchy.md` — table row L3: 17→13, L4: 6→5, L5: 3→2, total: 37→31, breakdown updated
+4. `docs/dev/skills-architecture.md` — "35+"→"58"
+
+## Key Lesson
+
+Never trust any single doc for entity counts. Always count on disk first:
+
+```bash
+ls .claude/agents/*.md | wc -l    # agents
+ls .claude/skills/ | grep -v "\.md\|^tier-" | wc -l  # skills
+```
+
+Then search ALL docs for claims and update each one.
+
+## Other Fixes in Same PR
+
+The PR also included:
+1. Dockerfile layer caching (dep manifests before `pixi install`, source after)
+2. Security CI: removed `continue-on-error` from Semgrep SAST and dependency review
+
+PR: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3659

--- a/skills/tooling/repo-audit-count-reconciliation/skills/repo-audit-count-reconciliation/SKILL.md
+++ b/skills/tooling/repo-audit-count-reconciliation/skills/repo-audit-count-reconciliation/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: repo-audit-count-reconciliation
+description: "Reconcile count mismatches across documentation files after a repository audit. Use when: counts in CLAUDE.md/README/hierarchy docs differ, audit reveals stale agent or skill counts, or on-disk file counts don't match any documented number."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | Count mismatch found during audit (agents, skills, workflows, architectures) |
+| **Output** | Updated documentation with accurate, consistent counts |
+| **Scope** | All docs claiming counts of file-backed entities |
+| **Risk** | Low — documentation only, no code changes |
+
+## When to Use
+
+- An audit scorecard finds 3+ different numbers for the same entity across docs
+- `ls .claude/agents/*.md | wc -l` doesn't match any documented agent count
+- CLAUDE.md, hierarchy.md, and README.md all disagree on agent/skill counts
+- Documentation lists agents/skills that don't exist as files on disk
+
+## Verified Workflow
+
+### Step 1: Count actual on-disk files
+
+```bash
+# Count actual agent files (exclude templates/ directory)
+ls .claude/agents/*.md | wc -l
+
+# Count actual skill definitions (exclude template file and tier dirs)
+ls .claude/skills/ | grep -v "\.md\|^tier-" | wc -l
+
+# Count CI workflows
+ls .github/workflows/*.yml | wc -l
+```
+
+### Step 2: List stale references in documentation
+
+```bash
+# Find all agent count claims
+grep -rn "42 agents\|37 agents\|31 agents\|agents total" \
+  CLAUDE.md agents/ docs/ 2>/dev/null
+
+# Find all skill count claims
+grep -rn "82 total\|58 total\|35+\|82+" \
+  CLAUDE.md docs/ 2>/dev/null
+
+# Find all workflow count claims
+grep -rn "23 workflow\|workflows" CLAUDE.md docs/ 2>/dev/null
+```
+
+### Step 3: Verify listed entities exist on disk
+
+For agents specifically, check README lists against actual files:
+
+```bash
+# Extract agent names from README
+grep '`.*\.md`' agents/README.md | sed "s/.*\`\(.*\)\.md\`.*/\1/" > /tmp/readme_agents.txt
+
+# Check each one exists
+while read name; do
+  if [ ! -f ".claude/agents/$name.md" ]; then
+    echo "MISSING: $name"
+  fi
+done < /tmp/readme_agents.txt
+```
+
+### Step 4: Update all count references
+
+Edit each file found in Step 2, replacing stale counts with the verified number.
+Key files to update for agent counts:
+
+- `CLAUDE.md` — may have 2+ references
+- `agents/README.md` — total + per-level counts
+- `agents/hierarchy.md` — count table + level breakdown
+
+For skill counts:
+
+- `CLAUDE.md` — "N total" in skill delegation section
+- `docs/dev/skills-architecture.md` — executive summary line
+
+### Step 5: Fix stale entity listings
+
+When README.md lists non-existent files (e.g. removed agents), update the list:
+
+- Remove entries for files that don't exist
+- Update per-level subtotals to match
+- Update the total
+
+### Step 6: Commit and PR
+
+```bash
+git checkout -b audit-fixes-count-reconciliation
+git add CLAUDE.md agents/README.md agents/hierarchy.md docs/dev/skills-architecture.md
+git commit -m "fix(audit): reconcile agent/skill counts to match on-disk state
+
+- Agents: N→M (actual .md files on disk)
+- Skills: N→M (actual skill definitions)
+- Removed N non-existent agent stubs from README"
+git push -u origin audit-fixes-count-reconciliation
+gh pr create --title "fix(audit): reconcile counts" --body "Closes #..."
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust CLAUDE.md count | Used "42 agents" from CLAUDE.md as ground truth | CLAUDE.md had 42, hierarchy had 37, disk had 31 — all wrong | Always count with `ls *.md \| wc -l` first |
+| Count `ls .claude/agents/` | `ls` of directory returns 32 (includes `templates/` dir) | `templates/` is a directory, not an agent file | Use `ls .claude/agents/*.md` to get only .md files |
+| Fix only CLAUDE.md | Updated CLAUDE.md count but not hierarchy.md or agents/README.md | Three docs still disagreed | Search ALL docs for count claims before committing |
+| Use README level subtotals | Added up README per-level counts expecting to get disk total | README listed 12 agents that no longer exist as files | Verify each listed agent exists before trusting subtotals |
+
+## Results & Parameters
+
+### Session: 2026-03-07 ProjectOdyssey audit
+
+**Before reconciliation:**
+
+| Doc | Claimed Count |
+|-----|--------------|
+| `CLAUDE.md` | 42 agents, 82 skills |
+| `agents/hierarchy.md` | 37 agents |
+| `agents/README.md` | 42 agents (with 12 non-existent entries) |
+| `docs/dev/skills-architecture.md` | 35+ skills |
+
+**After reconciliation:**
+
+| Entity | On-Disk Count | All Docs Now Say |
+|--------|--------------|-----------------|
+| Agents | 31 `.md` files | 31 |
+| Skills | 58 entries | 58 |
+
+**Non-existent agents removed from README:**
+
+- `implementation-review-specialist`
+- `documentation-review-specialist`
+- `safety-review-specialist`
+- `performance-review-specialist`
+- `algorithm-review-specialist`
+- `architecture-review-specialist`
+- `data-engineering-review-specialist`
+- `paper-review-specialist`
+- `research-review-specialist`
+- `dependency-review-specialist`
+- `senior-implementation-engineer`
+- `junior-implementation-engineer`


### PR DESCRIPTION
## Summary

Documents how to reconcile count mismatches across documentation files after a repository
audit, when on-disk file counts don't match any documented number.

- Verified workflow for counting actual agent/skill/workflow files on disk
- Shell commands for finding all stale count claims across docs
- Method for detecting non-existent entries listed in README

## Key Findings

**What Worked**:
- `ls .claude/agents/*.md | wc -l` gives authoritative agent count (excludes `templates/` dir)
- Searching all docs before committing catches all references: grep across CLAUDE.md, agents/, docs/
- Fixing per-level subtotals in README after removing non-existent entries

**What Failed**:
- Trusting any single doc: CLAUDE.md had 42, hierarchy.md had 37, disk had 31
- `ls .claude/agents/ | wc -l` returns 32 (includes `templates/` subdirectory)
- Fixing only CLAUDE.md while hierarchy.md and README still had stale numbers

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with audit-related triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
