### PR TITLE
feat: add batch-norm-sum-squared-loss-test skill

### DIFF
--- a/skills/testing/batch-norm-sum-squared-loss-test/.claude-plugin/plugin.json
+++ b/skills/testing/batch-norm-sum-squared-loss-test/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "batch-norm-sum-squared-loss-test",
+  "version": "1.0.0",
+  "description": "Replace trivial batch norm gradient test with sum(output^2) loss for real backward pass validation. Use when: (1) batch_norm2d_backward gradient test uses a non-loss-derived grad_output, (2) upgrading from non-uniform ad-hoc grad_output to a principled loss function, (3) gradient check uses arbitrary weights instead of a closed-form derivative.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["batch-norm", "gradient-checking", "sum-squared-loss", "mojo", "backward-pass"]
+}

--- a/skills/testing/batch-norm-sum-squared-loss-test/references/notes.md
+++ b/skills/testing/batch-norm-sum-squared-loss-test/references/notes.md
@@ -1,0 +1,38 @@
+# Session Notes: batch-norm-sum-squared-loss-test
+
+## Issue
+
+GitHub issue #3171: "Add meaningful batch_norm2d_backward gradient test with non-zero loss"
+
+Follow-up from #2724 (original batch norm backward investigation).
+
+## Context
+
+The existing test `test_batch_norm2d_backward_gradient_input` on `main` was already using a
+non-uniform alternating `grad_output` pattern (a prior fix from `batch-norm-gradient-test-fix`
+skill). However, the issue plan specifically called for the `sum(output^2)` approach as a more
+principled loss function with a known closed-form derivative.
+
+## Files Changed
+
+- `tests/shared/core/test_normalization.mojo`:
+  - Line 28: Added `full_like` to extensor import
+  - Lines 280-378: Rewrote `test_batch_norm2d_backward_gradient_input` body to use sum(output^2) loss
+
+## PR
+
+- Branch: `3171-auto-impl`
+- PR: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3662
+
+## Key Decision
+
+The issue plan required `sum(output^2)` specifically (not just any non-trivial loss) because:
+1. It has a mathematically clean derivative: `dL/dY = 2 * output`
+2. Both the analytical `grad_output` and the `forward_for_grad` loss are exactly consistent
+3. It documents WHY the test is correct, not just that it happens to work
+
+## Mojo Notes
+
+- `full_like(tensor, scalar_value)` creates a same-shape tensor filled with the scalar
+- The function exists in `shared/core/extensor.mojo` but was not in the test file's imports
+- Pre-commit hooks include `mojo format` — all changes passed automatically

--- a/skills/testing/batch-norm-sum-squared-loss-test/skills/batch-norm-sum-squared-loss-test/SKILL.md
+++ b/skills/testing/batch-norm-sum-squared-loss-test/skills/batch-norm-sum-squared-loss-test/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: batch-norm-sum-squared-loss-test
+description: "Replace trivial batch norm gradient test with sum(output^2) loss for real backward pass validation. Use when: upgrading ad-hoc grad_output to a principled closed-form loss derivative."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Problem | Gradient test uses ad-hoc non-uniform `grad_output` not derived from a real loss function |
+| Root Cause | Non-uniform weights work but lack a closed-form derivative to verify correctness |
+| Fix | Use `L = sum(output^2)` → `grad_output = 2 * output` + matching `forward_for_grad` |
+| Applies To | Any normalization layer backward gradient check using gradient checker scaffolding |
+
+## When to Use
+
+1. A gradient check test constructs `grad_output` as arbitrary values (e.g. alternating pattern) rather than deriving it from a loss function
+2. An issue requests "meaningful" or "non-trivial" gradient test using `sum(output^2)` loss
+3. Upgrading from the `batch-norm-gradient-test-fix` approach (non-uniform weights) to a principled loss-based approach
+4. You want the numerical and analytical gradients to be consistent via a well-defined loss with known closed-form derivative
+
+## Why sum(output^2)?
+
+- **Non-zero guarantee**: `dL/dY = 2 * output` is non-zero as long as the normalized output is non-zero (true when `gamma != 1` or `beta != 0`)
+- **Closed-form derivative**: The upstream gradient is exactly `2 * output`, making the consistency check mathematically verifiable
+- **Avoids cancellation**: Unlike `sum(output)` which gives `dL/dY = ones` (leading to zero gradient for zero-mean normalized outputs), squaring breaks the cancellation
+
+## Contrast with Non-Uniform grad_output Approach
+
+| Approach | grad_output | forward_for_grad loss | Principled? |
+|----------|-------------|----------------------|-------------|
+| Old (uniform) | `ones_like(output)` | `sum(output)` | Yes, but trivially zero |
+| Interim (non-uniform) | Alternating `[0.5, -0.3, ...]` | `sum(output * grad_output)` | Works, but ad-hoc |
+| Preferred (sum-squared) | `2 * output` | `sum(output^2)` | Yes, clean loss function |
+
+## Verified Workflow
+
+### 1. Import full_like
+
+```mojo
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like, full_like
+```
+
+### 2. Compute grad_output from loss derivative
+
+```mojo
+# Forward pass
+var result6 = batch_norm2d(
+    x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+)
+var output = result6[0]
+
+# Upstream gradient for loss L = sum(output^2): dL/dY = 2 * output
+var two = full_like(output, 2.0)
+var grad_output = multiply(two, output)
+```
+
+### 3. Update forward_for_grad closure to use sum(out^2)
+
+```mojo
+fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    var result_nested = batch_norm2d(
+        inp, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+    )
+    var out = result_nested[0]
+    # Loss: sum(output^2) — matches analytical grad_output = 2 * output
+    var squared = multiply(out, out)
+    var result = squared
+    while result.dim() > 0:
+        result = reduce_sum(result, axis=0, keepdims=False)
+    return result
+```
+
+### 4. Run gradient check with appropriate tolerance
+
+```mojo
+assert_gradients_close(
+    grad_input,
+    numerical_grad,
+    rtol=2e-2,   # 2% tolerance — appropriate for batch norm compound FP errors
+    atol=1e-4,
+    message="Batch norm gradient w.r.t. input (sum(output^2) loss)",
+)
+```
+
+## Results & Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Loss function | `sum(output^2)` | Non-zero derivative for non-trivially normalized outputs |
+| Analytical grad | `2 * output` | Closed-form derivative of sum(output^2) |
+| Numerical epsilon | `1e-3` | Central finite differences, appropriate for float32 |
+| rtol | `2e-2` | Batch norm has compound FP errors across normalize/scale/shift |
+| atol | `1e-4` | Absolute floor for near-zero gradient elements |
+| Input shape | `[2, 2, 2, 2]` | Small for O(n^2) gradient check cost |
+| gamma | `[1.5, 2.0]` | Non-unit to ensure non-zero normalized outputs |
+
+## Key Consistency Requirement
+
+Both `grad_output` passed to `batch_norm2d_backward` AND the loss computed in `forward_for_grad`
+must be derived from the **same** loss function. If they differ, the numerical and analytical
+gradients will not agree even if both are correct.
+
+| | Must use |
+|---|---|
+| `grad_output` | `2 * output` (derivative of sum(output^2)) |
+| `forward_for_grad` return | `sum(out * out)` reduced to scalar |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Uniform `ones_like` grad_output | `grad_output = ones_like(output)`, `forward_for_grad = sum(output)` | Zero-mean batch norm gives dL/dx = 0 analytically; both gradients collapse to ~0, test trivially passes | `sum(output)` loss is pathological for zero-mean normalized layers |
+| Non-uniform alternating pattern | `grad_output[i] = (i%4)*0.25 - 0.3`, `forward_for_grad = sum(output * grad_output)` | Works correctly but `grad_output` is ad-hoc, not derived from a loss — harder to explain and verify | Use a real loss function with a known derivative instead |
+| `full_like` not imported | Used `full_like` without adding it to the import line | Mojo compilation error: `full_like` undefined | Add `full_like` to extensor import before using it |


### PR DESCRIPTION
## Summary

Documents how to upgrade a batch norm backward gradient test from an ad-hoc `grad_output` to a principled `sum(output^2)` loss function with a closed-form derivative.

- Uses `L = sum(output^2)` → `dL/dY = 2 * output` for a mathematically grounded gradient check
- Ensures `grad_output` and `forward_for_grad` use the same loss (critical for consistency)
- Complements the existing `batch-norm-gradient-test-fix` skill (which solved the zero-gradient problem with non-uniform weights)

## Key Findings

**What Worked**:
- `var two = full_like(output, 2.0); var grad_output = multiply(two, output)` for the analytical upstream gradient
- `var squared = multiply(out, out)` followed by reduction to scalar in `forward_for_grad`
- Tolerance `rtol=2e-2, atol=1e-4` appropriate for batch norm's compound float32 errors

**What Failed**:
- Uniform `grad_output = ones_like(output)` → analytical gradient collapses to zero (zero-mean cancellation)
- Non-uniform alternating pattern → works but not derived from a real loss; harder to verify correctness
- Using `full_like` without importing it → Mojo compilation error

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with batch norm gradient test triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
