### PR TITLE
feat: add workflow-deduplication-pixi-composite-action skill

### DIFF
--- a/skills/ci-cd/workflow-deduplication-pixi-composite-action/.claude-plugin/plugin.json
+++ b/skills/ci-cd/workflow-deduplication-pixi-composite-action/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "workflow-deduplication-pixi-composite-action",
+  "version": "1.0.0",
+  "description": "Deduplicate repeated Pixi setup blocks across GitHub Actions workflows using a composite action. Use when: (1) multiple workflows repeat the same setup-pixi block, (2) consolidating CI workflows to reduce maintenance burden, (3) migrating from inline prefix-dev/setup-pixi to a centralized composite action.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["github-actions", "composite-action", "pixi", "deduplication", "ci-consolidation"]
+}

--- a/skills/ci-cd/workflow-deduplication-pixi-composite-action/references/notes.md
+++ b/skills/ci-cd/workflow-deduplication-pixi-composite-action/references/notes.md
@@ -1,0 +1,68 @@
+# Session Notes: CI Workflow Deduplication (Issue #3149)
+
+## Context
+
+- Repository: HomericIntelligence/ProjectOdyssey
+- Issue: #3149 - Consolidate CI workflows (26 -> ~15)
+- Branch: 3149-auto-impl
+- PR: #3663
+
+## What Was Done
+
+### Starting state
+
+- 24 workflows (23 yml + README.md)
+- 9 workflows had inline `prefix-dev/setup-pixi@v0.9.4` setup blocks
+- Composite actions `setup-pixi` and `pr-comment` already existed but underused
+- `dependency-audit.yml` was a standalone weekly audit workflow
+
+### Changes Made
+
+1. Replaced inline Pixi setup in 9 workflows with `./.github/actions/setup-pixi`
+2. Merged `dependency-audit.yml` jobs into `security.yml` with event guards
+3. Deleted `dependency-audit.yml`
+4. Added `schedule`, push path filters, and `issues: write` to `security.yml`
+
+### Final state
+
+- 22 workflows (21 yml + README.md)
+- Zero inline `prefix-dev/setup-pixi` references
+- Pre-commit: all hooks passed
+
+## Key Discoveries
+
+- The Edit tool fails with "File has not been read yet" even if the file was read
+  in a prior tool-use response. Must read AND edit in the same response.
+- Using `rm` with semicolons/newlines in a single Bash call caused shell to
+  interpret echo text as filenames, deleting workflow files accidentally.
+- `git restore .github/workflows/` after accidental deletion wiped all uncommitted
+  edits (restored from HEAD). Had to redo all changes with a Python bulk-replace script.
+- Python bulk replacement (`content.replace(old, new)`) is more reliable than
+  multiple Edit tool calls for this pattern.
+
+## Bulk Replacement Script Used
+
+```python
+OLD = "      - name: Set up Pixi\n        uses: prefix-dev/setup-pixi@v0.9.4\n        with:\n          pixi-version: latest\n          cache: true"
+NEW = "      - name: Set up Pixi\n        uses: ./.github/actions/setup-pixi"
+
+files = [
+    ".github/workflows/mojo-version-check.yml",
+    ".github/workflows/pre-commit.yml",
+    ".github/workflows/test-data-utilities.yml",
+    ".github/workflows/test-gradients.yml",
+    ".github/workflows/script-validation.yml",
+    ".github/workflows/type-check.yml",
+    ".github/workflows/paper-validation.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/dependency-audit.yml",
+]
+
+for f in files:
+    content = open(f).read()
+    count = content.count(OLD)
+    if count > 0:
+        content = content.replace(OLD, NEW)
+        open(f, 'w').write(content)
+        print(f"Updated {count}x: {f}")
+```

--- a/skills/ci-cd/workflow-deduplication-pixi-composite-action/skills/workflow-deduplication-pixi-composite-action/SKILL.md
+++ b/skills/ci-cd/workflow-deduplication-pixi-composite-action/skills/workflow-deduplication-pixi-composite-action/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: workflow-deduplication-pixi-composite-action
+description: "Deduplicate repeated Pixi setup blocks across GitHub Actions workflows using a composite action. Use when: consolidating CI workflows, replacing inline prefix-dev/setup-pixi with a shared composite action, or merging security/audit workflows."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Issue | Replace repeated `prefix-dev/setup-pixi@v0.9.4` blocks in 9+ workflows |
+| Solution | Composite action at `.github/actions/setup-pixi/action.yml` |
+| Result | Eliminated all inline Pixi setup; merged 2 workflows into 1 |
+| Pre-commit | All hooks passed after changes |
+
+## When to Use
+
+- Multiple GitHub Actions workflows contain identical `prefix-dev/setup-pixi@v0.9.4` blocks
+- CI workflow count is high (>20) and maintenance burden is growing
+- Separate security scan + dependency audit workflows can be merged with event guards
+- A `setup-pixi` composite action already exists but not all workflows use it
+
+## Verified Workflow
+
+### 1. Audit existing workflows for inline Pixi setup
+
+```bash
+grep -rl "prefix-dev/setup-pixi" .github/workflows/
+```
+
+### 2. Check if composite action already exists
+
+```bash
+ls .github/actions/setup-pixi/action.yml
+```
+
+### 3. Replace inline blocks with composite action (bulk Python script)
+
+The replacement pattern is exact — match all 5 lines together:
+
+```python
+OLD = "      - name: Set up Pixi\n        uses: prefix-dev/setup-pixi@v0.9.4\n        with:\n          pixi-version: latest\n          cache: true"
+NEW = "      - name: Set up Pixi\n        uses: ./.github/actions/setup-pixi"
+
+for f in workflow_files:
+    content = open(f).read()
+    count = content.count(OLD)
+    if count > 0:
+        content = content.replace(OLD, new)
+        open(f, 'w').write(content)
+```
+
+### 4. Merge scheduled audit workflow into security workflow
+
+Add `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` guards to
+audit jobs and append them to `security.yml`. Update triggers:
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - 'pixi.toml'
+      - 'requirements.txt'
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write  # add for audit issue creation
+```
+
+Then delete the standalone `dependency-audit.yml`.
+
+### 5. Verify no inline setups remain
+
+```bash
+grep -rl "prefix-dev/setup-pixi" .github/workflows/
+# Must return empty
+```
+
+### 6. Run pre-commit to validate YAML
+
+```bash
+pixi run pre-commit run --all-files
+# Check YAML hook will catch malformed workflow files
+```
+
+### 7. Stage and commit only the workflow files
+
+```bash
+git add .github/workflows/ .github/actions/
+git commit -m "ci(workflows): replace inline pixi setup with composite action"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Parallel Edit tool calls | Used Edit tool on 6 files simultaneously | 3 files failed with "File has not been read yet" error despite being read earlier in session | Edit tool requires each file to be read in the current tool-use response, not earlier in the conversation |
+| `rm` with multiple args in single Bash call | Ran `rm file1 && echo msg && rm file2 && ls` | Shell parsed the echo arguments as filenames and deleted all .yml files in the directory | Never mix `rm` with unquoted multiline strings in Bash tool — use separate commands |
+| `git restore .github/workflows/` after accidental deletion | Tried to recover deleted files | `git restore` restored original (unmodified) files from HEAD, wiping all in-session edits | `git restore` is destructive to uncommitted changes; use a Python script to re-apply all edits at once |
+| Multiple parallel Edit calls without prior reads | Attempted batch edits on files read in previous turn | Fails with "File has not been read yet" — Edit tool tracks reads per-response | Read files and edit them in the same response, or use Bash/Python scripts for bulk edits |
+
+## Results & Parameters
+
+### Composite action structure
+
+`.github/actions/setup-pixi/action.yml`:
+
+```yaml
+name: Set Up Pixi Environment
+description: Install Pixi and restore the cached environment.
+
+inputs:
+  pixi-version:
+    description: Pixi version to install
+    required: false
+    default: latest
+  cache:
+    description: Whether to enable Pixi built-in caching
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        pixi-version: ${{ inputs.pixi-version }}
+        cache: ${{ inputs.cache }}
+```
+
+### Workflow reference
+
+```yaml
+- name: Set up Pixi
+  uses: ./.github/actions/setup-pixi
+```
+
+### Outcome
+
+- 9 workflows updated from inline to composite action
+- 1 workflow deleted (`dependency-audit.yml`) merged into `security.yml`
+- Workflow count: 23 -> 22 yml files
+- All pre-commit hooks passed


### PR DESCRIPTION
## Summary

Documents CI workflow deduplication pattern for replacing repeated inline
`prefix-dev/setup-pixi` blocks with a composite action across 9+ workflows,
and merging a standalone dependency-audit workflow into a unified security workflow.

- Bulk Python script pattern for safe multi-file workflow updates
- Event-guarded job merging (schedule/workflow_dispatch guards)
- Key failure modes to avoid (Edit tool, rm, git restore pitfalls)

## Key Findings

**What Worked**:
- Python `content.replace()` bulk script for batch workflow file edits
- Running all replacements in one script invocation avoids per-file read requirements
- Appending jobs to security.yml with `if: github.event_name == 'schedule'` guards
- `pixi run pre-commit run --all-files` with Check YAML hook catches workflow errors

**What Failed**:
- Edit tool parallel calls on files not read in same response -> "File has not been read yet"
- `rm` mixed with shell text in single Bash call -> shell parsed text as filenames, deleted files
- `git restore .github/workflows/` after accidental deletion -> wiped all uncommitted edits

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with CI consolidation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
