### PR TITLE
feat: add mojo-narrowing-cast-tests skill

### DIFF
--- a/skills/testing/mojo-narrowing-cast-tests/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-narrowing-cast-tests/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-narrowing-cast-tests",
+  "version": "1.0.0",
+  "description": "Add narrowing conversion tests to Mojo test files documenting truncation semantics of .cast[DType.uint8]() on values > 255. Use when: (1) a Mojo test file covers widening conversions but not narrowing, (2) an issue asks to document truncation/modulo semantics of integer casts, (3) you need to add boundary value tests for UInt64 -> UInt8 cast behavior.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "testing", "narrowing-conversion", "cast", "uint8", "uint64", "truncation", "boundary-values"]
+}

--- a/skills/testing/mojo-narrowing-cast-tests/references/notes.md
+++ b/skills/testing/mojo-narrowing-cast-tests/references/notes.md
@@ -1,0 +1,49 @@
+# Session Notes: Mojo Narrowing Cast Tests (Issue #3179)
+
+## Session Context
+
+- **Project**: ProjectOdyssey
+- **Issue**: #3179 — Add narrowing conversion tests (UInt64 -> UInt8 truncation)
+- **PR**: #3672
+- **Branch**: `3179-auto-impl`
+- **Date**: 2026-03-07
+
+## Objective
+
+Add tests to `tests/shared/core/test_unsigned.mojo` documenting the truncation semantics
+of `.cast[DType.uint8]()` on `UInt64` values > 255. The file already tested widening
+conversions (UInt8 -> UInt16 -> UInt32 -> UInt64) but had no narrowing tests.
+
+## Existing File State
+
+The file had ~420 lines of real tests covering construction, arithmetic, bitwise operations,
+comparisons, widening conversion, and boundary values. The assertion pattern used throughout
+was `if actual != expected: raise Error("message")` (NOT `assert_equal`).
+
+## Implementation
+
+Added `test_uint_narrowing_conversion()` (36 lines) before `main()` with 6 assertions
+for boundary values 0, 255, 256, 257, 511, 512. Wired into `main()` in the same
+try/except/print pattern as all other tests.
+
+## Environment Notes
+
+- `mojo` cannot run on host (GLIBC 2.31 installed, mojo requires 2.32+)
+- `just` not in PATH on this host
+- `pixi run pre-commit run --all-files` works for hooks
+- Docker image `ghcr.io/homericintelligence/projectodyssey:main` not locally available
+- CI runs tests in Docker — local verification not possible
+
+## Pre-commit Result
+
+All hooks passed without `SKIP=`:
+- Mojo Format: Passed
+- Check for deprecated List syntax: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## Files Changed
+
+- `tests/shared/core/test_unsigned.mojo`: +43 lines (1 new function + main() wiring)

--- a/skills/testing/mojo-narrowing-cast-tests/skills/mojo-narrowing-cast-tests/SKILL.md
+++ b/skills/testing/mojo-narrowing-cast-tests/skills/mojo-narrowing-cast-tests/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: mojo-narrowing-cast-tests
+description: "Add narrowing conversion tests to Mojo test files documenting truncation semantics. Use when: a test file covers widening but not narrowing casts, or an issue asks to document truncation behavior of .cast[DType.uint8]() on UInt64 values > 255."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-narrowing-cast-tests |
+| **Category** | testing |
+| **Complexity** | Low |
+| **Mojo runs locally** | No (GLIBC mismatch on host — Docker/CI only) |
+| **Key pattern** | `if v.cast[DType.uint8]() != expected: raise Error(...)` |
+
+This skill documents how to add narrowing conversion tests to an existing Mojo test file.
+Narrowing casts (e.g. `UInt64 -> UInt8`) truncate to the low N bits, equivalent to
+`value % 256` for uint8. Tests document this behavior at key boundary values.
+
+## When to Use
+
+- A Mojo test file covers widening conversions (UInt8 -> UInt16 -> UInt64) but not narrowing
+- An issue asks to document `.cast[DType.uint8]()` truncation semantics on values > 255
+- You need boundary value tests for integer narrowing casts
+- A follow-up issue on an existing unsigned integer test file requests truncation documentation
+
+## Verified Workflow
+
+### 1. Read the existing test file
+
+Identify the pattern used for assertions. In ProjectOdyssey the pattern is:
+
+```mojo
+if actual != expected:
+    raise Error("description")
+```
+
+NOT `assert_equal` — the unsigned test files use raw `if/raise` style.
+
+### 2. Identify the boundary values to test
+
+For `UInt64 -> UInt8` (modulo 256):
+
+| Input (UInt64) | `.cast[DType.uint8]()` | Expected | Rationale |
+|----------------|------------------------|----------|-----------|
+| 0 | -> uint8 | 0 | No-op passthrough |
+| 255 | -> uint8 | 255 | Fits exactly, no truncation |
+| 256 | -> uint8 | 0 | 256 mod 256 = 0 |
+| 257 | -> uint8 | 1 | 257 mod 256 = 1 |
+| 511 | -> uint8 | 255 | 511 mod 256 = 255 |
+| 512 | -> uint8 | 0 | 512 mod 256 = 0 |
+
+### 3. Add the test function before `main()`
+
+```mojo
+fn test_uint_narrowing_conversion() raises:
+    """Test narrowing conversions that truncate via modulo 2^N semantics.
+
+    When casting a UInt64 value > 255 to UInt8, the result is the low 8 bits
+    of the original value, equivalent to value % 256.
+    """
+    # 256 % 256 = 0
+    var v256: UInt64 = 256
+    if v256.cast[DType.uint8]() != 0:
+        raise Error("UInt64(256).cast[DType.uint8]() should be 0")
+
+    # 257 % 256 = 1
+    var v257: UInt64 = 257
+    if v257.cast[DType.uint8]() != 1:
+        raise Error("UInt64(257).cast[DType.uint8]() should be 1")
+
+    # 511 % 256 = 255
+    var v511: UInt64 = 511
+    if v511.cast[DType.uint8]() != 255:
+        raise Error("UInt64(511).cast[DType.uint8]() should be 255")
+
+    # 512 % 256 = 0
+    var v512: UInt64 = 512
+    if v512.cast[DType.uint8]() != 0:
+        raise Error("UInt64(512).cast[DType.uint8]() should be 0")
+
+    # 255 fits exactly — no truncation
+    var v255: UInt64 = 255
+    if v255.cast[DType.uint8]() != 255:
+        raise Error("UInt64(255).cast[DType.uint8]() should be 255")
+
+    # 0 is a no-op
+    var v0: UInt64 = 0
+    if v0.cast[DType.uint8]() != 0:
+        raise Error("UInt64(0).cast[DType.uint8]() should be 0")
+```
+
+### 4. Wire into `main()` after the widening conversion test
+
+```mojo
+    try:
+        test_uint_narrowing_conversion()
+        print("OK test_uint_narrowing_conversion")
+    except e:
+        print("FAIL test_uint_narrowing_conversion:", e)
+```
+
+### 5. Commit — pre-commit hooks pass without SKIP
+
+Unlike some Mojo test work, this change is pure `.mojo` formatting that `mojo format`
+handles cleanly. All pre-commit hooks pass without needing `SKIP=`:
+
+```bash
+git add tests/shared/core/test_unsigned.mojo
+git commit -m "test(unsigned): add narrowing conversion tests (UInt64 -> UInt8 truncation)
+
+Add test_uint_narrowing_conversion() to document the truncation semantics
+of .cast[DType.uint8]() on UInt64 values > 255. Tests boundary values:
+- 256 -> 0 (256 mod 256 = 0)
+- 257 -> 1 (257 mod 256 = 1)
+- 511 -> 255 (511 mod 256 = 255)
+- 512 -> 0 (512 mod 256 = 0)
+- 255 -> 255 (fits exactly, no truncation)
+- 0 -> 0 (no-op)
+
+Closes #<issue-number>"
+```
+
+### 6. Create PR with auto-merge
+
+```bash
+git push -u origin <branch>
+gh pr create --title "test(unsigned): add narrowing conversion tests" \
+  --body "Closes #<issue-number>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run `pixi run mojo -I . tests/shared/core/test_unsigned.mojo` locally | Executed mojo on host | GLIBC_2.32/2.33/2.34 not found — Mojo requires newer libc | Mojo tests can only be verified in CI (Docker). Trust correct boundary math and submit to CI. |
+| Use `assert_equal` from `testing` module | Considered importing `from testing import assert_equal` | The existing file uses raw `if/raise` pattern, not `assert_equal` | Match the existing test file's assertion style. Read the file before deciding on pattern. |
+
+## Results & Parameters
+
+### Truncation math for common narrowing casts
+
+| Target | Modulus | Key boundary |
+|--------|---------|-------------|
+| uint8 | 256 | 256->0, 257->1, 511->255, 512->0 |
+| uint16 | 65536 | 65536->0, 65537->1 |
+| uint32 | 2^32 | 2^32->0, 2^32+1->1 |
+
+### Complete function template
+
+```mojo
+fn test_uint_narrowing_conversion() raises:
+    """Test narrowing conversions that truncate via modulo 2^N semantics."""
+    var v256: UInt64 = 256
+    if v256.cast[DType.uint8]() != 0:
+        raise Error("UInt64(256).cast[DType.uint8]() should be 0")
+    var v257: UInt64 = 257
+    if v257.cast[DType.uint8]() != 1:
+        raise Error("UInt64(257).cast[DType.uint8]() should be 1")
+    var v511: UInt64 = 511
+    if v511.cast[DType.uint8]() != 255:
+        raise Error("UInt64(511).cast[DType.uint8]() should be 255")
+    var v512: UInt64 = 512
+    if v512.cast[DType.uint8]() != 0:
+        raise Error("UInt64(512).cast[DType.uint8]() should be 0")
+    var v255: UInt64 = 255
+    if v255.cast[DType.uint8]() != 255:
+        raise Error("UInt64(255).cast[DType.uint8]() should be 255")
+    var v0: UInt64 = 0
+    if v0.cast[DType.uint8]() != 0:
+        raise Error("UInt64(0).cast[DType.uint8]() should be 0")
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3672 (Issue #3179) | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern for adding narrowing conversion tests to Mojo test files, capturing truncation semantics of `.cast[DType.uint8]()` on `UInt64` values > 255.

- Boundary values to test: 0, 255, 256, 257, 511, 512
- Assertion style: raw `if/raise` (not `assert_equal`) to match existing file conventions
- Mojo cannot run on host due to GLIBC mismatch — CI/Docker only

## Key Findings

**What Worked**:
- Reading existing file before writing to match the `if actual != expected: raise Error(...)` assertion style
- `mojo format` pre-commit hook passes cleanly for this type of test addition (no `SKIP=` needed)
- All 6 boundary value assertions cover the key truncation behavior

**What Failed**:
- Running `pixi run mojo` locally → GLIBC_2.32/2.33/2.34 not found; Mojo requires Docker
- Considered using `assert_equal` from `testing` module → wrong pattern for this file style

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates on "narrowing cast", "uint8 truncation", "cast[DType.uint8]" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
