### PR TITLE
feat: add dataloader-reset-verification skill

### DIFF
--- a/skills/testing/dataloader-reset-verification/.claude-plugin/plugin.json
+++ b/skills/testing/dataloader-reset-verification/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dataloader-reset-verification",
+  "version": "1.0.0",
+  "description": "Test pattern to verify DataLoader reset behavior in training/validation loops. Use when: (1) implementing tests that confirm an iterator's reset() is called before iteration, (2) verifying a loop does not silently skip batches when passed a partially-consumed loader, (3) writing self-proving tests where the failure mode (division by zero) is distinct from success.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["dataloader", "reset", "validation-loop", "mojo", "tdd", "iterator"]
+}

--- a/skills/testing/dataloader-reset-verification/references/notes.md
+++ b/skills/testing/dataloader-reset-verification/references/notes.md
@@ -1,0 +1,41 @@
+# Session Notes: DataLoader Reset Verification
+
+## Raw Session Details
+
+**Issue**: ProjectOdyssey #3186 — "Verify ValidationLoop.run_subset() resets DataLoader correctly"
+
+**Problem statement**: The existing `test_validation_loop_run_subset_limited` created a fresh
+`DataLoader` for each call, so it never tested whether `run_subset()` internally resets a
+partially-consumed loader. A pre-advanced loader would produce fewer batches than `max_batches`.
+
+**Files modified**:
+
+- `tests/shared/training/test_validation_loop.mojo` — added `test_validation_loop_run_subset_resets_loader()`
+
+**Key source reference**:
+
+- `shared/training/loops/validation_loop.mojo:255` — `val_loader.reset()` call
+- `shared/training/trainer_interface.mojo:352-354` — `DataLoader.reset()` implementation
+- `shared/training/trainer_interface.mojo:362` — `has_next()`: `current_batch < num_batches`
+
+**Approach chosen**: Direct field mutation (`loader.current_batch = loader.num_batches`) rather
+than mock objects. Mojo structs expose public fields so this is idiomatic. The failure mode
+(division by zero at `total_loss / Float64(0)`) is categorically distinguishable from success.
+
+**PR created**: ProjectOdyssey #3687
+
+**Pre-commit hooks**: All passed (mojo format, trailing whitespace, end-of-file-fixer,
+check-added-large-files, validate-test-coverage).
+
+**Local test execution**: Not possible — GLIBC version mismatch on host (requires 2.32+, host
+has older libc). Tests validated by code review and CI instead.
+
+## Generalizable Pattern
+
+The "self-proving via catastrophic failure" pattern applies whenever:
+
+1. A loop computes `total / count` and count can be 0 if reset() is absent
+2. The struct fields are accessible for direct mutation (no encapsulation barrier)
+3. The success outcome (finite number) is categorically distinct from failure (NaN/raise/zero)
+
+This avoids the need for mock objects, spy wrappers, or test doubles entirely.

--- a/skills/testing/dataloader-reset-verification/skills/dataloader-reset-verification/SKILL.md
+++ b/skills/testing/dataloader-reset-verification/skills/dataloader-reset-verification/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: dataloader-reset-verification
+description: "Test pattern to verify DataLoader reset behavior in training/validation loops. Use when: confirming an iterator's reset() is called before iteration, or verifying a loop does not silently skip batches on a partially-consumed loader."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Category | testing |
+| Language | Mojo |
+| Issue | #3186 (ProjectOdyssey) |
+| Pattern | Self-proving test via catastrophic failure mode |
+
+## When to Use
+
+- You need to prove an iterator-consuming loop calls `reset()` before iteration
+- A validation/training loop accepts a pre-existing loader that may be partially consumed
+- The failure mode (division by zero from zero batches) is clearly distinct from success (valid finite loss)
+- You want a test that doesn't require mock objects — direct field mutation suffices
+
+## Verified Workflow
+
+### 1. Identify the reset call in the implementation
+
+Read the source to confirm where `reset()` is called (e.g., `validation_loop.mojo:255`):
+
+```mojo
+val_loader.reset()
+while val_loader.has_next() and num_batches < max_batches:
+    ...
+var avg_loss = total_loss / Float64(num_batches)  # division by zero if reset() absent
+```
+
+### 2. Pre-exhaust the loader via direct field mutation
+
+```mojo
+var loader = create_val_loader(n_batches=2)
+# Advance current_batch to num_batches so has_next() returns False
+loader.current_batch = loader.num_batches
+assert_true(not loader.has_next())
+```
+
+### 3. Call the function under test with max_batches matching loader capacity
+
+```mojo
+var val_loss = vloop.run_subset(simple_forward, simple_loss, loader, 2, metrics)
+```
+
+### 4. Assert the result is a valid finite number
+
+```mojo
+# Valid loss proves 2 batches were processed after reset (not 0)
+assert_greater(val_loss, Float64(-1e-10))
+assert_less(val_loss, Float64(1e10))
+```
+
+Without `reset()`: `num_batches == 0` → `total_loss / 0.0` → `NaN` or raises.
+With `reset()`: `num_batches == 2` → valid finite loss.
+
+### 5. Why this is self-proving
+
+The test does not require mocking. The failure mode (division by zero / NaN / raise) is
+categorically different from the success mode (valid bounded Float64). No spy object needed.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Mock-based approach | Wrapping DataLoader to count reset() calls | Mojo structs don't support vtable-based mocking easily; no trait for spy | Use direct field mutation + observable side effects instead |
+| Checking batch count post-call | Asserting `loader.current_batch == 2` after run_subset | run_subset may call reset() again at end or leave loader in partial state | Assert on the output (loss) not loader state after the call |
+| Asserting exact loss value | `assert_almost_equal(val_loss, Float64(1.0), ...)` | Relies on loss function returning exactly 1.0; brittle if loss function changes | Use range assertions (`> -eps` and `< large`) for robustness |
+
+## Results & Parameters
+
+```mojo
+# Copy-paste test template
+fn test_run_subset_resets_loader() raises:
+    var vloop = ValidationLoop()
+    var loader = create_val_loader(n_batches=2)  # small loader to keep test fast
+    loader.current_batch = loader.num_batches    # exhaust loader
+    assert_true(not loader.has_next())           # confirm pre-condition
+    var metrics = TrainingMetrics()
+    var val_loss = vloop.run_subset(
+        simple_forward, simple_loss, loader, 2, metrics
+    )
+    assert_greater(val_loss, Float64(-1e-10))    # finite: reset() was called
+    assert_less(val_loss, Float64(1e10))
+    print("  test_run_subset_resets_loader: PASSED")
+```
+
+**Key parameters:**
+
+- `n_batches=2`: Minimum batches that allows `max_batches=2` to be meaningful
+- `max_batches=2`: Must equal `n_batches` so that all batches are consumed after reset
+- Range bounds: `-1e-10` to `1e10` — wide enough to tolerate any valid loss function


### PR DESCRIPTION
## Summary

Documents the self-proving test pattern for verifying DataLoader reset() behavior in Mojo training/validation loops, derived from ProjectOdyssey issue #3186.

- Pre-exhaust a DataLoader via direct field mutation (current_batch = num_batches)
- Call the function under test — division by zero occurs if reset() is absent
- Assert valid finite loss to prove reset() was called
- No mock objects or spy wrappers required

## Key Findings

**What Worked**:
- Direct field mutation cleanly exhausts the loader without mock objects
- Self-proving via catastrophic failure: total/0 is categorically distinct from valid loss
- Range assertions (> -1e-10, < 1e10) are robust across different loss function implementations

**What Failed**:
- Mock-based approach: Mojo structs lack vtable mocking; use field mutation instead
- Asserting loader state post-call: not a reliable signal
- Asserting exact loss value: brittle; range assertions are more durable

## Test Plan
- [ ] Validate plugin with python3 scripts/validate_plugins.py skills/ plugins/
- [ ] Install plugin and verify skill appears in registry

Generated with Claude Code