### PR TITLE
feat: add mojo-nd-slice-copy-semantics skill

### DIFF
--- a/skills/debugging/mojo-nd-slice-copy-semantics/.claude-plugin/plugin.json
+++ b/skills/debugging/mojo-nd-slice-copy-semantics/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-nd-slice-copy-semantics",
+  "version": "1.0.0",
+  "description": "Fix Mojo multi-dimensional tensor slicing bugs caused by pointer-offset view approach on non-contiguous data. Use when: (1) N-D tensor slice tests are skipped/disabled, (2) __getitem__(*slices) returns wrong values for 2D/3D/ND slices, (3) multi-dim slicing uses self.copy() + data pointer offset which fails for non-contiguous results.",
+  "category": "debugging",
+  "date": "2026-03-07",
+  "tags": ["mojo", "tensor", "slicing", "memory", "copy-semantics", "extensor", "nd-array"]
+}

--- a/skills/debugging/mojo-nd-slice-copy-semantics/references/notes.md
+++ b/skills/debugging/mojo-nd-slice-copy-semantics/references/notes.md
@@ -1,0 +1,105 @@
+# Session Notes: Mojo N-D Slice Copy Semantics Fix
+
+## Context
+
+- **Issue**: #3190 — Enable multi-dimensional slicing tests in test_extensor_slicing.mojo
+- **Parent Issue**: #3086 — Copy vs view semantics documentation
+- **PR**: #3691
+- **Date**: 2026-03-07
+- **Branch**: `3190-auto-impl`
+
+## Problem Statement
+
+Tests `test_slice_2d_single_dim`, `test_slice_2d_both_dims`, `test_slice_3d_partial`, and
+three batch extraction tests were commented out in `main()` with `# Skip for now - needs debugging`.
+
+The tests themselves were well-written and correct. The underlying implementation of
+`ExTensor.__getitem__(self, *slices: Slice)` had a fundamental bug.
+
+## Investigation
+
+### File: `shared/core/extensor.mojo`
+
+ExTensor struct:
+- `_data`: `UnsafePointer[UInt8]` — raw byte storage (type-erased)
+- `_shape`: `List[Int]` — dimension sizes
+- `_strides`: `List[Int]` — row-major strides in elements (NOT bytes)
+- `_numel`: `Int` — total element count
+- `_is_view`: `Bool` — whether this shares data with another tensor
+- `_refcount`: `UnsafePointer[Int]` — shared reference count
+
+ExTensor implements `Copyable` trait, which provides `.copy()` backed by `__copyinit__`.
+The `__copyinit__` is a **shallow copy** — shares `_data` pointer, increments `_refcount`.
+
+### Three `__getitem__` Overloads
+
+1. `__getitem__(self, index: Int) -> Float32` — element access
+2. `__getitem__(self, slice: Slice) -> Self` — 1D slice, proper copy, `_is_view = False`
+3. `__getitem__(self, *slices: Slice) -> Self` — N-D slice, BUGGY view approach
+
+### The Bug in Overload 3
+
+```mojo
+var result = self.copy()          # shallow copy, shared _data, refcount++
+result._is_view = True
+var offset_bytes = 0
+for dim in range(num_dims):
+    start = ...
+    result._shape[dim] = end - start
+    offset_bytes += start * result._strides[dim] * dtype_size
+result._data = self._data.offset(offset_bytes)  # ❌
+result._numel = ...
+return result^
+```
+
+`self._data.offset(offset_bytes)` sets a pointer to the START of the slice region.
+For first-axis-only slices (e.g., `t[1:4, :, :]`), data is contiguous after this offset.
+For inner-dimension slices (e.g., `t[1:4, 1:3]`), selected elements have gaps — offset alone
+cannot address them.
+
+### Memory Layout Visualization
+
+5×4 row-major tensor, bytes (float32, 4 bytes each):
+```
+Row 0: [0  4  8  12]   (bytes 0-15)
+Row 1: [16 20 24 28]   (bytes 16-31)
+Row 2: [32 36 40 44]   (bytes 32-47)
+Row 3: [48 52 56 60]   (bytes 48-63)
+Row 4: [64 68 72 76]   (bytes 64-79)
+```
+
+For `t[1:4, 1:3]` (rows 1-3, cols 1-2), selected elements at bytes:
+`[20, 24, 36, 40, 52, 56]` — NOT contiguous, gaps of 8 bytes between pairs.
+
+Pointer offset of `16 + 4 = 20` bytes gets to the first element, but then reading
+sequentially gives bytes 20-44, which includes wrong elements (byte 28 = col 3, not wanted).
+
+## Fix Applied
+
+Replaced the body of `__getitem__(self, *slices: Slice)` with an explicit N-D element copy:
+
+1. Parse all slices into `starts[]` + `result_shape[]`
+2. Allocate fresh `ExTensor(result_shape, dtype)` — independent memory, `_is_view = False`
+3. Early return for empty result
+4. For each `out_flat` in `range(result_numel)`:
+   - Decompose via `result._strides` into per-dim output indices
+   - Map each dim: `src_idx = starts[dim] + out_idx`
+   - Accumulate: `src_flat += src_idx * self._strides[dim]`
+   - Copy `dtype_size` bytes from `src_data + src_flat * dtype_size` to `dst_data + out_flat * dtype_size`
+
+## Environment Constraints
+
+- Mojo binary not runnable locally (GLIBC version mismatch on the test host)
+- Fix was validated through code analysis + pre-commit hooks + CI
+- Pre-commit runs `mojo format` which validates syntax
+
+## Pre-commit Result
+
+All hooks passed:
+- Mojo Format: PASSED
+- Check for deprecated List[Type](args) syntax: PASSED
+- Validate Test Coverage: PASSED
+- Trim Trailing Whitespace: PASSED
+- Fix End of Files: PASSED
+- Check for Large Files: PASSED
+- Fix Mixed Line Endings: PASSED

--- a/skills/debugging/mojo-nd-slice-copy-semantics/skills/mojo-nd-slice-copy-semantics/SKILL.md
+++ b/skills/debugging/mojo-nd-slice-copy-semantics/skills/mojo-nd-slice-copy-semantics/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: mojo-nd-slice-copy-semantics
+description: "Fix Mojo multi-dimensional tensor slicing bugs caused by pointer-offset view approach on non-contiguous data. Use when: (1) N-D tensor slice tests are skipped/disabled, (2) __getitem__(*slices) returns wrong values for 2D/3D/ND slices, (3) multi-dim slicing uses self.copy() + data pointer offset which fails for non-contiguous results."
+category: debugging
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Multi-dimensional tensor slicing returns wrong values or is disabled with "needs debugging" comment |
+| **Root Cause** | `__getitem__(*slices)` uses `self.copy()` (shallow refcount copy) + `result._data = self._data.offset(offset_bytes)` — valid only for first-axis slicing (contiguous rows) |
+| **Fix** | Replace with explicit N-D element-wise copy using per-dimension starts + original strides |
+| **Files** | `shared/core/extensor.mojo` — `__getitem__(self, *slices: Slice)` |
+| **Issue** | #3190 (follow-up from #3086) |
+| **PR** | #3691 |
+
+## When to Use
+
+Trigger this skill when:
+
+1. Multi-dimensional slice tests (`test_slice_2d_*`, `test_slice_3d_*`, `test_batch_extraction_*`) are commented out with `# Skip for now - needs debugging`
+2. `__getitem__(self, *slices: Slice)` returns a tensor with correct shape but wrong values
+3. The implementation does `self.copy()` followed by `result._data = self._data.offset(...)` for N-D slicing
+4. Batch extraction tests for training loops fail (e.g., `data[0:batch_size, :, :, :]`)
+5. A pointer-offset view approach is used for non-contiguous multi-dimensional slices
+
+## Root Cause Analysis
+
+### Why Pointer-Offset Fails for N-D Slicing
+
+For a 5×4 row-major tensor, `t[1:4, 1:3]` selects rows 1-3 AND columns 1-2:
+
+```
+Source (5x4):          Result (3x2):
+[  0  1  2  3 ]       [  5  6 ]
+[  4  5  6  7 ]  -->  [  9 10 ]
+[  8  9 10 11 ]       [ 13 14 ]
+[ 12 13 14 15 ]
+[ 16 17 18 19 ]
+```
+
+The selected elements are at flat indices `[5, 6, 9, 10, 13, 14]` — NOT contiguous. A single `data_pointer + offset` cannot represent this selection. Only first-axis slicing (selecting contiguous rows) is representable as a pointer offset.
+
+### The Buggy Pattern
+
+```mojo
+fn __getitem__(self, *slices: Slice) raises -> Self:
+    var result = self.copy()          # shallow copy: shares data pointer
+    result._is_view = True
+    var offset_bytes = 0
+    for dim in range(num_dims):
+        # ...compute start, end...
+        result._shape[dim] = end - start
+        offset_bytes += start * result._strides[dim] * dtype_size
+    result._data = self._data.offset(offset_bytes)  # ❌ only correct for dim 0
+    result._numel = ...
+    return result^
+```
+
+This works for `t[1:4, :, :]` (first dim only, remaining dims full) but fails for `t[1:4, 1:3]` because the inner dimension selection creates gaps.
+
+### The `Copyable` Trait and `self.copy()`
+
+`ExTensor` implements `Copyable`, giving a `.copy()` method backed by `__copyinit__`. This is a **shallow copy** — it shares the data pointer and increments the refcount. It is NOT a deep copy. The subsequent `result._data = self._data.offset(...)` overwrites the shared pointer with a correctly-offset pointer into the original buffer — this is valid for view semantics, but insufficient for non-contiguous N-D slices.
+
+## Verified Workflow
+
+### Step 1: Identify the Buggy Implementation
+
+```bash
+grep -n "__getitem__.*slices" shared/core/extensor.mojo
+# Look for: self.copy() + result._data = self._data.offset(offset_bytes)
+```
+
+### Step 2: Replace with Element-wise N-D Copy
+
+Replace the entire `__getitem__(self, *slices: Slice)` body:
+
+```mojo
+fn __getitem__(self, *slices: Slice) raises -> Self:
+    """Get multi-dimensional slice — returns an independent copy."""
+    var num_slices = len(slices)
+    var num_dims = len(self._shape)
+
+    if num_slices != num_dims:
+        raise Error(
+            "Number of slices ("
+            + String(num_slices)
+            + ") must match number of dimensions ("
+            + String(num_dims)
+            + ")"
+        )
+
+    # Compute per-dimension starts and result shape
+    var starts = List[Int]()
+    var result_shape = List[Int]()
+    for dim in range(num_dims):
+        var s = slices[dim]
+        var size = self._shape[dim]
+        var start = s.start.or_else(0)
+        var end = s.end.or_else(size)
+        if start < 0:
+            start = size + start
+        if end < 0:
+            end = size + end
+        start = max(0, min(start, size))
+        end = max(0, min(end, size))
+        starts.append(start)
+        result_shape.append(max(0, end - start))
+
+    # Allocate result tensor (independent copy, not a view)
+    var result = Self(result_shape, self._dtype)
+    result._is_view = False
+
+    var result_numel = result._numel
+    if result_numel == 0:
+        return result^
+
+    # Copy each element: map output flat index -> source flat index
+    var dtype_size = self._get_dtype_size()
+    var src_ptr = self._data
+    var dst_ptr = result._data
+
+    for out_flat in range(result_numel):
+        var src_flat = 0
+        var remaining = out_flat
+        for dim in range(num_dims):
+            var out_idx = remaining // result._strides[dim]
+            remaining = remaining % result._strides[dim]
+            var src_idx = starts[dim] + out_idx
+            src_flat += src_idx * self._strides[dim]
+        var src_offset = src_flat * dtype_size
+        var dst_offset = out_flat * dtype_size
+        for b in range(dtype_size):
+            dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+
+    return result^
+```
+
+### Step 3: Re-enable Skipped Tests
+
+In `tests/shared/core/test_extensor_slicing.mojo`, uncomment the skipped calls in `main()`:
+
+```mojo
+# Before (skipped):
+# print("Testing multi-dimensional slicing...")
+# test_slice_2d_single_dim()
+# test_slice_2d_both_dims()
+# test_slice_3d_partial()
+# print("Multi-dimensional slicing: PASSED")
+
+# After (enabled):
+print("Testing multi-dimensional slicing...")
+test_slice_2d_single_dim()
+test_slice_2d_both_dims()
+test_slice_3d_partial()
+print("Multi-dimensional slicing: PASSED")
+```
+
+Also re-enable batch extraction tests and any other `# Skip for now` tests.
+
+### Step 4: Verify
+
+```bash
+pixi run pre-commit run --files shared/core/extensor.mojo tests/shared/core/test_extensor_slicing.mojo
+# All hooks should pass; CI will run the full test suite
+```
+
+## Key Insights
+
+### Semantic Contract: Copy vs View
+
+The 1D `__getitem__(Slice)` and the N-D `__getitem__(*slices: Slice)` should have **consistent copy semantics**:
+- Both return `_is_view = False`
+- Both allocate independent memory
+- Mutations to the result do NOT affect the original
+
+This is documented in `docs/adr/` and the module docstring comment block.
+
+### When Pointer-Offset IS Correct
+
+The view/pointer-offset approach IS correct and used in:
+- `slice(start, end, axis)` — extracts a contiguous block along one axis only
+- `reshape()` — same total elements, same memory layout (contiguous)
+
+It is WRONG for `__getitem__(*slices)` when any inner dimension is non-trivially sliced.
+
+### Strides Decomposition Algorithm
+
+The index decomposition in the N-D copy loop is row-major standard:
+```
+for dim in range(num_dims):
+    out_idx = remaining // result._strides[dim]
+    remaining = remaining % result._strides[dim]
+    src_idx = starts[dim] + out_idx
+    src_flat += src_idx * self._strides[dim]
+```
+This correctly maps output flat index → per-dim index → source flat index using original strides.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Pointer-offset view approach | `self.copy()` + `result._data = self._data.offset(offset_bytes)` | Only handles first-axis slices; inner dimension gaps are invisible to pointer arithmetic | N-D slicing is inherently non-contiguous; a single pointer offset cannot represent arbitrary dimension selections |
+| Marking result as view | Setting `result._is_view = True` after shallow copy + pointer offset | View semantics imply shared memory, but test asserts `_is_view = False` for slice results; also doesn't fix the data correctness bug | Copy vs view semantics must be consistent across all `__getitem__` overloads |
+| Diagnosing via local mojo run | Running `pixi run mojo test` locally | GLIBC version mismatch (`GLIBC_2.32/2.33/2.34` not found) — Mojo binary requires newer libc than available | Must rely on CI or Docker for test execution; code analysis + pattern matching is the primary debugging tool |
+
+## Results & Parameters
+
+### Test Coverage After Fix
+
+| Test | Expected Result |
+|------|----------------|
+| `test_slice_2d_single_dim` | `t2d[1:4, :]` → shape `[3, 4]`, correct values |
+| `test_slice_2d_both_dims` | `t2d[1:4, 1:3]` → shape `[3, 2]`, correct values |
+| `test_slice_3d_partial` | `t3d[1:3, :, :]` → shape `[2, 3, 2]`, correct values |
+| `test_batch_extraction_basic` | `data[0:16, :, :, :]` → shape `[16, 3, 32, 32]` |
+| `test_batch_extraction_offset` | `data[16:32, :, :, :]` → shape `[16, 3, 32, 32]` |
+| `test_batch_extraction_last_partial` | `data[48:50, :, :, :]` → shape `[2, 3, 32, 32]` |
+| `test_slice_1d_reverse` | `t[::-1]` → reversed 1D tensor |
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `shared/core/extensor.mojo` | Rewrote `__getitem__(self, *slices: Slice)` body |
+| `tests/shared/core/test_extensor_slicing.mojo` | Uncommented 7 skipped test calls in `main()` |


### PR DESCRIPTION
## Summary

Documents how to diagnose and fix Mojo multi-dimensional tensor slicing bugs
where `__getitem__(*slices: Slice)` uses a pointer-offset view approach that
fails for non-contiguous inner-dimension selections.

- Root cause: `self.copy()` + `result._data = self._data.offset(offset_bytes)` only handles first-axis slices
- Fix: explicit N-D element-wise copy using per-dimension starts and original strides
- Re-enables 7 previously skipped tests covering 2D/3D slicing and batch extraction

## Key Findings

**What Worked**:
- Replacing pointer-offset view with element-wise copy using stride decomposition
- Computing `src_flat` via: decompose `out_flat` → per-dim `out_idx` → `src_idx = starts[dim] + out_idx` → `src_flat += src_idx * self._strides[dim]`
- Consistent `_is_view = False` semantics across 1D and N-D `__getitem__` overloads

**What Failed**:
- Pointer-offset approach → only works when all inner dimensions are fully selected (no column slicing)
- Marking result `_is_view = True` → inconsistent with test expectations and doesn't fix data bug
- Running Mojo locally → GLIBC version mismatch on test host; must use CI or Docker

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears as `mojo-nd-slice-copy-semantics`
- [ ] Check skill triggers when encountering N-D slice debugging scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
