### PR TITLE
feat: add bf16-precision-recommendation skill

### DIFF
--- a/skills/tooling/bf16-precision-recommendation/.claude-plugin/plugin.json
+++ b/skills/tooling/bf16-precision-recommendation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bf16-precision-recommendation",
+  "version": "1.0.0",
+  "description": "Add hardware-guarded BF16 support to dtype recommendation functions. Use when: (1) enabling BF16 for large ML models in Mojo dtype utilities, (2) adding Apple Silicon hardware guard for BF16 precision selection, (3) extending precision recommendation with hardware capability parameters.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["mojo", "dtype", "bfloat16", "precision", "hardware-guard", "apple-silicon"]
+}

--- a/skills/tooling/bf16-precision-recommendation/references/notes.md
+++ b/skills/tooling/bf16-precision-recommendation/references/notes.md
@@ -1,0 +1,65 @@
+# Session Notes: BF16 Precision Recommendation
+
+## Context
+
+- **Date**: 2026-03-07
+- **Issue**: ProjectOdyssey #3202
+- **PR**: ProjectOdyssey #3710
+- **Branch**: `3202-auto-impl`
+- **File Modified**: `shared/training/dtype_utils.mojo`
+- **Test File Modified**: `tests/shared/training/test_dtype_utils.mojo`
+
+## Problem
+
+`recommend_precision_dtype()` returned `DType.float16` for BOTH medium (100-999 MB) and
+large (>= 1000 MB) models. The large model branch was effectively dead code with a comment
+saying "FP16 strongly recommended" but never using BF16 despite `bfloat16_dtype` being
+natively supported in the file.
+
+Issue #3202 is a follow-up to #3088 which added native `DType.bfloat16` support.
+
+## Root Cause
+
+The large model `else` branch was written as a placeholder before BF16 support was confirmed
+and never updated:
+
+```mojo
+else:
+    # Large model - FP16 strongly recommended
+    return DType.float16  # should have been bfloat16
+```
+
+## Implementation
+
+Added `hardware_has_bf16: Bool = True` parameter. Apple Silicon does not support BF16,
+so callers on Apple hardware must pass `hardware_has_bf16=False`. The default `True` is
+safe because most x86/CUDA hardware supports BF16.
+
+## Environment
+
+- Mojo v0.26.1 (via pixi)
+- Local GLIBC: 2.31 — cannot run Mojo tests locally
+- Tests validated via CI (Docker container with GLIBC 2.32+)
+- Pre-commit hooks: all passed locally
+
+## Files Changed
+
+- `shared/training/dtype_utils.mojo` — added `hardware_has_bf16` param, updated large model branch
+- `tests/shared/training/test_dtype_utils.mojo` — updated large model assertion, added 2 new test cases
+
+## Commit
+
+```
+feat(training): enable BF16 in recommend_precision_dtype for large models
+```
+
+## Pre-commit Output
+
+```
+Mojo Format..............................................................Passed
+Check for deprecated List[Type](args) syntax.............................Passed
+Validate Test Coverage...................................................Passed
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Fix Mixed Line Endings...................................................Passed
+```

--- a/skills/tooling/bf16-precision-recommendation/skills/bf16-precision-recommendation/SKILL.md
+++ b/skills/tooling/bf16-precision-recommendation/skills/bf16-precision-recommendation/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: bf16-precision-recommendation
+description: "Add hardware-guarded BF16 support to dtype recommendation functions. Use when: enabling BF16 for large Mojo ML models, adding Apple Silicon hardware guard for BF16, or extending precision recommendation with hardware capability parameters."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+# BF16 Precision Recommendation with Hardware Guard
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Objective** | Enable BF16 in `recommend_precision_dtype()` for large models (>= 1000 MB) with Apple Silicon guard |
+| **Outcome** | Implemented `hardware_has_bf16` parameter, large models return `DType.bfloat16` by default, fall back to FP16 on Apple Silicon |
+| **Root Cause** | Original function returned `DType.float16` for both medium and large models — large model branch was unimplemented |
+| **Key Learning** | Add `hardware_has_bf16: Bool = True` parameter alongside existing `hardware_has_fp16`; BF16 is not supported on Apple Silicon so the guard is critical |
+
+## When to Use
+
+- Adding BF16 support to a Mojo `recommend_precision_dtype`-style function
+- Implementing hardware capability guards (Apple Silicon, legacy GPU) for BF16
+- Extending dtype recommendation APIs with new hardware parameters while preserving backward compatibility
+- Updating corresponding Mojo tests when a function's return value changes for a model size tier
+
+## Verified Workflow
+
+### Step 1: Identify the Unimplemented Branch
+
+The function had a `model_size_mb >= 1000.0` branch that still returned `DType.float16`. Confirmed by reading the source:
+
+```mojo
+else:
+    # Large model - FP16 strongly recommended
+    return DType.float16  # <-- never used BF16
+```
+
+### Step 2: Add `hardware_has_bf16` Parameter
+
+Add with default `True` so existing callers are unaffected (BF16 supported on most non-Apple hardware):
+
+```mojo
+fn recommend_precision_dtype(
+    model_size_mb: Float64,
+    hardware_has_fp16: Bool = True,
+    hardware_has_bf16: Bool = True,
+) -> DType:
+```
+
+### Step 3: Implement Large Model Branch
+
+```mojo
+else:
+    # Large model - BF16 strongly recommended for wider exponent range
+    if hardware_has_bf16:
+        return DType.bfloat16
+    else:
+        return DType.float16
+```
+
+### Step 4: Update Docstring
+
+- Add `hardware_has_bf16` to `Args:` section with Apple Silicon note
+- Update Recommendations table: "Large models (>1GB): BF16 strongly recommended (FP16 if no BF16 hardware)"
+
+### Step 5: Update Tests
+
+Three test cases for the large-model tier:
+
+```mojo
+# Large model with BF16 hardware - should recommend BF16
+var large_dtype = recommend_precision_dtype(2000.0, hardware_has_fp16=True)
+assert_equal(large_dtype, DType.bfloat16, "Large models should use BF16")
+
+# Apple Silicon guard: large model without BF16 - fall back to FP16
+var large_no_bf16_dtype = recommend_precision_dtype(
+    2000.0, hardware_has_fp16=True, hardware_has_bf16=False
+)
+assert_equal(large_no_bf16_dtype, DType.float16, "Large models without BF16 hardware should use FP16")
+
+# No FP16 or BF16 hardware: fall back to FP32
+var no_hw_dtype = recommend_precision_dtype(
+    2000.0, hardware_has_fp16=False, hardware_has_bf16=False
+)
+assert_equal(no_hw_dtype, DType.float32, "Without FP16 hardware should use FP32")
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run tests locally via `pixi run mojo test` | Executed test file directly | GLIBC version mismatch — system GLIBC 2.31, Mojo requires 2.32+ | Tests must run in Docker/CI; local Mojo execution fails on this machine due to GLIBC constraints |
+| Run `just test-group` | Used `just` command runner | `just` not in PATH in the worktree shell | Use `pixi run mojo test <file>` directly, not `just` wrapper, or verify `just` is installed |
+
+## Results & Parameters
+
+### Final Signature
+
+```mojo
+fn recommend_precision_dtype(
+    model_size_mb: Float64,
+    hardware_has_fp16: Bool = True,
+    hardware_has_bf16: Bool = True,
+) -> DType
+```
+
+### Return Value by Configuration
+
+| model_size_mb | hardware_has_fp16 | hardware_has_bf16 | Returns |
+|---------------|-------------------|-------------------|---------|
+| < 100 | any | any | `DType.float32` |
+| 100-999 | True | any | `DType.float16` |
+| 100-999 | False | any | `DType.float32` |
+| >= 1000 | True | True | `DType.bfloat16` |
+| >= 1000 | True | False (Apple Silicon) | `DType.float16` |
+| >= 1000 | False | any | `DType.float32` |
+
+### Pre-commit Result
+
+All hooks passed: `Mojo Format`, `Check for deprecated List[Type](args) syntax`,
+`Validate Test Coverage`, `Trim Trailing Whitespace`, `Fix End of Files`, `Fix Mixed Line Endings`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3710 / Issue #3202 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern for adding hardware-guarded BF16 support to Mojo dtype recommendation functions.

- Add `hardware_has_bf16: Bool = True` parameter alongside `hardware_has_fp16`
- Large models (>= 1000 MB) return `DType.bfloat16` by default, fall back to `DType.float16` on Apple Silicon
- Local Mojo test execution unavailable (GLIBC 2.31 < 2.32 required); validation via CI Docker only

## Key Findings

**What Worked**:
- Default `True` for `hardware_has_bf16` preserves backward compatibility for all non-Apple callers
- Pre-commit hooks (`mojo format`, coverage check) caught no issues — minimal, focused change

**What Failed**:
- `just test-group` — `just` not in PATH in worktree shell; use `pixi run mojo test <file>` directly
- `pixi run mojo test` locally — GLIBC 2.31 on host, Mojo requires 2.32+; tests must run in CI

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `tooling` category
- [ ] Confirm `## Failed Attempts` table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
