### PR TITLE
feat: add constant-centralization skill

### DIFF
--- a/skills/architecture/constant-centralization/.claude-plugin/plugin.json
+++ b/skills/architecture/constant-centralization/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "constant-centralization",
+  "version": "1.0.0",
+  "description": "Centralize shared constants to their canonical module and update importers. Use when: (1) duplicate constant definitions exist across modules, (2) a utility module defines constants that belong in a lower-level dependency, (3) refactoring to clarify ownership of shared configuration values.",
+  "category": "architecture",
+  "date": "2026-03-07",
+  "tags": ["refactoring", "constants", "imports", "dry", "mojo", "deduplication"]
+}

--- a/skills/architecture/constant-centralization/references/notes.md
+++ b/skills/architecture/constant-centralization/references/notes.md
@@ -1,0 +1,35 @@
+# Session Notes: constant-centralization
+
+## Context
+
+- **Issue**: #3207 — Add GRADIENT_CHECK_EPSILON constants to gradient_checker.mojo
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3207-auto-impl
+- **PR**: #3713
+
+## Problem
+
+`GRADIENT_CHECK_EPSILON_FLOAT32` (3e-4) and `GRADIENT_CHECK_EPSILON_OTHER` (1e-3)
+were defined as `alias` constants in `shared/testing/layer_testers.mojo`. However,
+`shared/testing/gradient_checker.mojo` is the module that defines `compute_numerical_gradient`
+and `compute_sampled_numerical_gradient` — the functions that actually use epsilon.
+Centralizing the constants there makes gradient_checker.mojo the single source of truth,
+and allows other future callers to import from the right place.
+
+## Files Changed
+
+- `shared/testing/gradient_checker.mojo` — added constant block after imports
+- `shared/testing/layer_testers.mojo` — added 2 names to existing import, removed local aliases
+
+## Environment Notes
+
+- Mojo compiler not runnable locally (GLIBC_2.32/2.33/2.34 missing on host Debian)
+- CI runs in Docker `ghcr.io/homericintelligence/projectodyssey:main`
+- Pre-commit hooks (mojo format, trailing-whitespace, etc.) ran successfully
+- No pytest tests needed — pure Mojo refactor with no Python components
+
+## Outcome
+
+- PR #3713 created, auto-merge enabled
+- All pre-commit hooks passed
+- 2 files changed, 16 insertions(+), 14 deletions(-)

--- a/skills/architecture/constant-centralization/skills/constant-centralization/SKILL.md
+++ b/skills/architecture/constant-centralization/skills/constant-centralization/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: constant-centralization
+description: "Centralize shared constants to their canonical module and update importers. Use when: duplicate constants exist across modules, or a higher-level module defines values that belong in a lower-level dependency."
+category: architecture
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | architecture |
+| **Effort** | Low (minutes) |
+| **Risk** | Very Low (no logic changes) |
+| **Languages** | Mojo, Python, any |
+
+Moves constant definitions from a higher-level module (e.g., a test utility) to the
+lower-level module that owns the concept (e.g., the core utility it configures). The
+higher-level module then imports from the canonical source.
+
+## When to Use
+
+- Two or more modules define the same constant with the same value
+- A utility module (e.g., `layer_testers.mojo`) defines constants that semantically
+  belong in a dependency (e.g., `gradient_checker.mojo`)
+- Issue/PR asks to "centralize", "deduplicate", or "move" constants
+- Refactoring to clarify ownership before adding new callers of the constant
+
+## Verified Workflow
+
+1. **Identify the canonical module** — the one that owns the concept. For gradient
+   checking epsilon, that is `gradient_checker.mojo` (defines `compute_numerical_gradient`),
+   not `layer_testers.mojo` (a consumer).
+
+2. **Read both files** to understand current definitions and all usage sites.
+
+3. **Add constants to canonical module** — insert after imports, before first struct/fn,
+   with a comment block explaining the values.
+
+   ```mojo
+   # ============================================================================
+   # Gradient Checking Constants
+   # ============================================================================
+
+   # Epsilon for float32 gradient checking in matmul-heavy layers.
+   alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
+
+   # Epsilon for non-float32 dtypes (BF16, FP16).
+   alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
+   ```
+
+4. **Update importers** — add the constants to the existing import block from the
+   canonical module; remove the local `alias` definitions.
+
+   ```mojo
+   # Before
+   from shared.testing.gradient_checker import (
+       check_gradients,
+       compute_numerical_gradient,
+   )
+   alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
+   alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
+
+   # After
+   from shared.testing.gradient_checker import (
+       check_gradients,
+       compute_numerical_gradient,
+       GRADIENT_CHECK_EPSILON_FLOAT32,
+       GRADIENT_CHECK_EPSILON_OTHER,
+   )
+   ```
+
+5. **Verify no remaining local definitions** — grep for the constant name in the
+   importer file to confirm removal.
+
+6. **Run pre-commit** — Mojo format, trailing whitespace, and other hooks should all pass.
+
+7. **Commit and PR** — purely a refactor commit; no logic or value changes.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Local compiler build | Ran `pixi run mojo build` to verify compilation | GLIBC version mismatch on local host (CI uses Docker) | Mojo compilation can only be verified in CI Docker environment; syntactic changes are safe to push without local compile verification |
+| N/A | No other approaches tried | N/A | Straightforward refactor with no ambiguity |
+
+## Results & Parameters
+
+**Commit message format**:
+```
+refactor(testing): move <CONSTANT_NAME> constants to <canonical_module>
+
+Centralizes <CONST_A> and <CONST_B> in <canonical_module> (the canonical
+source), and imports them in <importer_module> to avoid duplication and
+clarify ownership.
+
+Closes #<issue>
+```
+
+**Search command to find duplicate constants**:
+```bash
+grep -rn "alias GRADIENT_CHECK_EPSILON" shared/
+```
+
+**Validation grep after refactor**:
+```bash
+# Should show constants only in canonical module
+grep -rn "^alias GRADIENT_CHECK_EPSILON" shared/testing/
+# Should show import only in importer
+grep -n "GRADIENT_CHECK_EPSILON" shared/testing/layer_testers.mojo
+```
+
+**Pre-commit result**: All hooks pass (mojo format, trailing whitespace,
+end-of-file-fixer, check-large-files, mixed-line-endings).


### PR DESCRIPTION
## Summary

Documents the pattern for centralizing shared constants to their canonical module and updating importers to avoid duplication.

- Derived from ProjectOdyssey issue #3207: `GRADIENT_CHECK_EPSILON_FLOAT32` and `GRADIENT_CHECK_EPSILON_OTHER` moved from `layer_testers.mojo` to `gradient_checker.mojo`
- Pattern applies broadly to any language where constants are defined in a consumer module rather than the owning module

## Key Findings

**What Worked**:
- Identify the canonical module by concept ownership (the one that defines the functions that use the constant)
- Add constants after imports, before first struct/fn, with an explanatory comment block
- Extend the existing import statement in consumers rather than adding a new import line
- Syntactic-only refactors can be pushed for CI validation when the local compiler is unavailable

**What Failed**:
- Local Mojo compilation not possible (GLIBC version mismatch on host) — not a workflow blocker for purely syntactic changes

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with "centralize constants" or "deduplicate alias" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
