### PR TITLE
feat: add batchnorm-epsilon-audit skill

### DIFF
--- a/skills/documentation/batchnorm-epsilon-audit/.claude-plugin/plugin.json
+++ b/skills/documentation/batchnorm-epsilon-audit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "batchnorm-epsilon-audit",
+  "version": "1.0.0",
+  "description": "Audit backward-pass tester methods for undocumented epsilon/tolerance magic numbers and apply structured NOTE comment pattern. Use when: (1) following up a backward-pass epsilon audit (e.g. after #3090 pattern), (2) a tester method lacks gradient-checking constants documentation, (3) BatchNorm or Pooling backward testers need epsilon/tolerance rationale added.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["batchnorm", "epsilon", "tolerance", "gradient-checking", "layer-testers", "mojo", "audit"]
+}

--- a/skills/documentation/batchnorm-epsilon-audit/references/notes.md
+++ b/skills/documentation/batchnorm-epsilon-audit/references/notes.md
@@ -1,0 +1,64 @@
+# Session Notes: batchnorm-epsilon-audit
+
+## Date
+2026-03-07
+
+## Session Objective
+Issue #3208 (follow-up from #3090): Audit remaining backward-pass tester methods in
+`shared/testing/layer_testers.mojo` for undocumented epsilon/tolerance magic numbers.
+Specifically `test_batchnorm_layer_backward` and any pooling backward testers.
+
+## Repository
+HomericIntelligence/ProjectOdyssey — worktree: `.worktrees/issue-3208`, branch: `3208-auto-impl`
+
+## What Was Audited
+
+### Methods checked
+- `test_conv_layer_backward` — already addressed in #3090 (has `GRADIENT_CHECK_EPSILON_FLOAT32`, `GRADIENT_CHECK_EPSILON_OTHER`, tolerance `1e-1`)
+- `test_linear_layer_backward` — already addressed in #3090
+- `test_activation_layer_backward` — already addressed in #3090
+- `test_batchnorm_layer_backward` — **needed upgrade** (had vague 4-line placeholder comment)
+- Pooling backward tester — **does not exist** in the file
+
+### File location
+`shared/testing/layer_testers.mojo`, lines 1085–1164 (BatchNorm section)
+
+## Change Made
+
+**Before** (lines 1150–1153):
+```
+# Note: Actual BatchNorm backward gradient checking would be implemented
+# when BatchNorm forward pass is available
+# Epsilon and tolerance values will be dtype-specific when gradient checking is added
+# For now, we validate that we can compute numerical gradients on the input
+```
+
+**After** (lines 1150–1157):
+```mojo
+# Note: Actual BatchNorm backward gradient checking will be implemented
+# when BatchNorm forward pass is available.
+# NOTE: When adding gradient checking, use epsilon=3e-4 for float32 to avoid
+# precision loss in normalization ops (consistent with conv2d/linear, see #2704).
+# BatchNorm accumulates division errors across N*H*W elements, so use
+# tolerance=1e-1 (10%) for all dtypes — same as conv2d backward (see #3090).
+# NOTE: For other dtypes use epsilon=1e-3, tolerance=1e-1 (same pattern as #3090).
+# For now, we validate that we can compute numerical gradients on the input.
+```
+
+## Tools/Commands Used
+- `Grep` — searched for existing epsilon/tolerance patterns, known magic numbers, method signatures
+- `Read` — read context around the target comment block
+- `Edit` — single targeted edit to upgrade the comment
+- `pixi run pre-commit run --all-files` — all 14 hooks passed
+
+## PR Created
+- PR #3718: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3718
+- Auto-merge enabled
+
+## Key Insight
+The scope check (grepping for all backward tester methods and magic numbers) is essential before
+making any changes. The issue said "if they also use hardcoded epsilon" — confirming absence of
+pooling backward tester meant scope was only BatchNorm.
+
+For BatchNorm, the tolerance should match conv2d (10%) not activation (1%/10%) because normalization
+divides across N×H×W spatial positions, accumulating floating-point errors similarly to matmul.

--- a/skills/documentation/batchnorm-epsilon-audit/skills/batchnorm-epsilon-audit/SKILL.md
+++ b/skills/documentation/batchnorm-epsilon-audit/skills/batchnorm-epsilon-audit/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: batchnorm-epsilon-audit
+description: "Audit backward-pass tester methods for undocumented epsilon/tolerance magic numbers and apply structured NOTE comment pattern. Use when: following up a backward-pass epsilon audit, or when BatchNorm/Pooling backward testers lack gradient-checking constant documentation."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | batchnorm-epsilon-audit |
+| **Category** | documentation |
+| **Scope** | `shared/testing/layer_testers.mojo` |
+| **Issue** | #3208 (follow-up from #3090) |
+| **Outcome** | Structured NOTE comments added to `test_batchnorm_layer_backward` |
+
+This skill captures the pattern for auditing ML layer tester methods that use hardcoded epsilon and
+tolerance values in gradient checking, and upgrading vague placeholder comments to structured NOTE
+comments that document rationale and cross-reference related issues.
+
+## When to Use
+
+- A follow-up issue asks to audit backward-pass tester methods not covered in a prior sweep
+- A tester method has a vague comment like "Epsilon and tolerance values will be dtype-specific when gradient checking is added" without specifying the actual values or rationale
+- You need to apply the same constant-extraction pattern as conv2d/linear/activation backward testers to BatchNorm or Pooling testers
+- A method's gradient checking is not yet implemented but the planned constants should be documented for future implementers
+
+## Verified Workflow
+
+1. **Read the issue and prior work**: `gh issue view <N> --comments` — understand what #3090 established (epsilon aliases, tolerance rationale, issue #2704 cross-reference)
+
+2. **Search for target methods**: Grep `layer_testers.mojo` for `test_batchnorm_layer_backward`, `NOTE.*epsilon`, `NOTE.*tolerance`, and known magic numbers (`3e-4`, `1e-3`, `1e-1`, `0\.10`)
+
+3. **Read surrounding context**: Read the existing comment block at the site to understand what placeholder language is present
+
+4. **Apply the structured NOTE pattern**: Replace vague placeholders with comments that include:
+   - Planned `epsilon` values per dtype (float32 → `GRADIENT_CHECK_EPSILON_FLOAT32` = `3e-4`; other dtypes → `GRADIENT_CHECK_EPSILON_OTHER` = `1e-3`)
+   - Planned `tolerance` value with rationale (BatchNorm accumulates division errors across N×H×W, so use `1e-1` = 10%, same as conv2d)
+   - Issue cross-references (`#2704` for matmul precision, `#3090` for the audit pattern)
+
+5. **Check for pooling tester**: Grep for any `test_pool*_backward` or `test_maxpool*_backward` — confirm absent (nothing to audit)
+
+6. **Run pre-commit hooks**: `pixi run pre-commit run --all-files` — verify Mojo Format, markdownlint, trailing whitespace all pass
+
+7. **Commit, push, PR**: Conventional commit `docs(layer_testers): document planned epsilon/tolerance for BatchNorm backward`, include `Closes #<N>` and enable auto-merge
+
+## Results & Parameters
+
+### Epsilon/Tolerance Constants (from #3090)
+
+```mojo
+# float32 matmul-heavy layers
+alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
+
+# Non-float32 dtypes
+alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
+```
+
+### Tolerance values by layer type
+
+| Layer | Tolerance | Rationale |
+|-------|-----------|-----------|
+| Conv2d backward | `1e-1` (10%) | Accumulated matmul errors |
+| Linear backward | `0.10` wide + `0.01` abs | Matrix op accumulated errors, see #2704 |
+| Activation backward | `1e-2` float32, `1e-1` other | Elementwise, less accumulation |
+| **BatchNorm backward** | `1e-1` (10%) all dtypes | Normalization divides across N×H×W, same regime as conv2d |
+
+### NOTE Comment Pattern Applied
+
+```mojo
+# Note: Actual BatchNorm backward gradient checking will be implemented
+# when BatchNorm forward pass is available.
+# NOTE: When adding gradient checking, use epsilon=3e-4 for float32 to avoid
+# precision loss in normalization ops (consistent with conv2d/linear, see #2704).
+# BatchNorm accumulates division errors across N*H*W elements, so use
+# tolerance=1e-1 (10%) for all dtypes — same as conv2d backward (see #3090).
+# NOTE: For other dtypes use epsilon=1e-3, tolerance=1e-1 (same pattern as #3090).
+# For now, we validate that we can compute numerical gradients on the input.
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Looking for pooling backward tester | Searched for `test_pool*_backward` methods in `layer_testers.mojo` | No such method exists in the file | Always confirm scope first — issue says "if they also use hardcoded epsilon"; absence means nothing to audit |
+| Assuming BatchNorm tolerance matches activation | Initially considered `1e-2` (activation pattern) for BatchNorm float32 | BatchNorm normalization accumulates division errors across all N×H×W elements, making it closer to conv2d than elementwise ops | Match tolerance to the accumulation regime of the operation, not to its layer category |


### PR DESCRIPTION
## Summary

Documents the pattern for auditing backward-pass tester methods for undocumented epsilon/tolerance magic numbers and applying structured NOTE comments (originated from issue #3208 in ProjectOdyssey, follow-up to #3090).

- Captures the full audit workflow: grep for target methods, confirm scope, apply structured NOTE pattern
- Documents planned epsilon/tolerance constants for BatchNorm backward (not yet implemented)
- Records that pooling backward tester does not exist (no audit needed)

## Key Findings

**What Worked**:
- Grep-first approach to confirm method existence before editing
- Matching BatchNorm tolerance to conv2d (1e-1) based on N×H×W error accumulation regime
- Structured NOTE comments citing exact values, dtype variants, and cross-referenced issues (#2704, #3090)

**What Failed**:
- Initially assumed pooling backward tester existed — grep confirmed absence
- Considered activation-style tolerance (1e-2) for BatchNorm — incorrect due to normalization accumulation

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 525/525 PASS, no warnings on new skill
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (backward-pass epsilon audit, BatchNorm gradient checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)