### PR TITLE
feat: add mojo-shallow-copy-tensor-hazard skill

### DIFF
--- a/skills/debugging/mojo-shallow-copy-tensor-hazard/.claude-plugin/plugin.json
+++ b/skills/debugging/mojo-shallow-copy-tensor-hazard/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-shallow-copy-tensor-hazard",
+  "version": "1.0.0",
+  "description": "Fix Mojo tensor mutation caused by shallow copy sharing _data pointer. Use when: (1) a function that receives a tensor modifies a copy but unexpectedly corrupts the caller's tensor, (2) numerical gradient checking produces wrong results despite correct math, (3) debugging silent data corruption in Mojo tensor operations.",
+  "category": "debugging",
+  "date": "2026-03-07",
+  "tags": ["mojo", "tensor", "memory-safety", "shallow-copy", "deep-copy", "gradient-checker"]
+}

--- a/skills/debugging/mojo-shallow-copy-tensor-hazard/references/notes.md
+++ b/skills/debugging/mojo-shallow-copy-tensor-hazard/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: Mojo Shallow-Copy Tensor Hazard
+
+## Date
+
+2026-03-07
+
+## Issue
+
+HomericIntelligence/ProjectOdyssey#3225 — "Investigate check_gradients (plural) shallow copy memory hazard"
+
+Follow-up from #3120.
+
+## Root Cause
+
+`check_gradients` and `check_gradients_verbose` in `shared/testing/gradient_checker.mojo` used
+`input.copy()` to create temporary perturbed tensors for finite-difference gradient checking.
+
+In Mojo, `tensor.copy()` calls `__copyinit__`, which for `ExTensor` is a **shallow copy**: the new
+struct shares the same `_data` pointer as the original. When the finite-difference loop then calls
+`input_copy_plus._set_float64(i, original_val + epsilon)`, it writes through the shared pointer and
+mutates the caller's tensor.
+
+The singular `check_gradient` function at lines 766/775 already used `_deep_copy` correctly.
+
+## Fix
+
+Replace all four `input.copy()` calls (two in `check_gradients`, two in `check_gradients_verbose`)
+with `_deep_copy(input)`.
+
+## Files Changed
+
+- `shared/testing/gradient_checker.mojo` — lines 120–121, 229–230
+- `tests/shared/testing/test_gradient_checker_meta.mojo` — added regression test
+  `test_check_gradients_does_not_mutate_input`
+
+## Key Observations
+
+- Mojo's `__copyinit__` for custom structs does NOT guarantee deep copy unless the struct
+  explicitly implements it. When a struct holds a raw pointer field, `__copyinit__` copies
+  the pointer value, not the pointed-to data.
+- The restoration at the end of each loop iteration (`_set_float64(i, original_val)`) was
+  misleading — it wrote back through the same shared pointer, so the caller's tensor was already
+  corrupted on each iteration before restoration.
+- The fix is minimal: 4-line change + regression test. No API changes needed.
+- Pre-commit hooks (mojo format, coverage validation) passed without modification.
+
+## Regression Test Pattern
+
+```mojo
+fn test_function_does_not_mutate_input() raises:
+    var x = full([2, 2], 1.0, DType.float32)
+    var before = List[Float64]()
+    for i in range(x.numel()):
+        before.append(x._get_float64(i))
+
+    _ = check_gradients(forward, backward, x, epsilon=1e-5, tolerance=1e-2)
+
+    for i in range(x.numel()):
+        assert_equal(x._get_float64(i), before[i],
+            "check_gradients mutated input at index " + String(i))
+```

--- a/skills/debugging/mojo-shallow-copy-tensor-hazard/skills/mojo-shallow-copy-tensor-hazard/SKILL.md
+++ b/skills/debugging/mojo-shallow-copy-tensor-hazard/skills/mojo-shallow-copy-tensor-hazard/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: mojo-shallow-copy-tensor-hazard
+description: "Fix Mojo tensor mutation caused by shallow copy sharing _data pointer. Use when: a function mutates a tensor copy but silently corrupts the caller's original tensor."
+category: debugging
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `tensor.copy()` in Mojo is `__copyinit__` — a shallow copy sharing the underlying `_data` buffer |
+| **Symptom** | Mutations to the copy silently corrupt the caller's original tensor |
+| **Fix** | Replace `tensor.copy()` with `_deep_copy(tensor)` to get an independent buffer |
+| **Context** | Discovered in `shared/testing/gradient_checker.mojo` during finite-difference gradient checking |
+| **Affects** | Any code that copies a tensor and then calls `_set_float64` / `_set_float32` on the copy |
+
+## When to Use
+
+- A function receives a tensor argument, makes a "copy", mutates the copy, and the caller sees unexpected value changes
+- Numerical gradient checks produce wrong results despite correct mathematical derivations
+- Tests pass individually but fail when run together (shared buffer corruption)
+- Debugging silent data corruption in Mojo tensor operations involving `.copy()`
+
+## Verified Workflow
+
+1. **Identify the shallow copy** — search for `.copy()` on tensor variables passed into functions that mutate them:
+
+   ```bash
+   grep -n "\.copy()" shared/testing/gradient_checker.mojo
+   ```
+
+2. **Confirm shared buffer** — add a debug print of the pointer address before and after mutation to verify the addresses match.
+
+3. **Replace with deep copy** — swap `input.copy()` for `_deep_copy(input)`:
+
+   ```mojo
+   # Before (shallow copy — shares _data pointer)
+   var input_copy_plus = input.copy()
+   var input_copy_minus = input.copy()
+
+   # After (deep copy — independent buffer)
+   var input_copy_plus = _deep_copy(input)
+   var input_copy_minus = _deep_copy(input)
+   ```
+
+4. **Add regression test** — snapshot all element values before the call, run the function, assert values unchanged:
+
+   ```mojo
+   fn test_function_does_not_mutate_input() raises:
+       var x = full([2, 2], 1.0, DType.float32)
+
+       var before = List[Float64]()
+       for i in range(x.numel()):
+           before.append(x._get_float64(i))
+
+       _ = check_gradients(forward, backward, x, epsilon=1e-5, tolerance=1e-2)
+
+       for i in range(x.numel()):
+           assert_equal(x._get_float64(i), before[i],
+               "function mutated input at index " + String(i))
+   ```
+
+5. **Apply to all sites** — grep for every `input.copy()` / `.copy()` call in functions that subsequently call `_set_float64` / `_set_float32` on the copy.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Restoring value after each loop iteration | Already done — `input_copy_plus._set_float64(i, original_val)` at end of loop | Does not help: restoration writes to the same shared buffer, so the caller's tensor is already mutated before restoration | Restoration cannot fix a shared buffer; only independent allocation can |
+| Using `__copyinit__` directly | `__copyinit__` is exactly what `.copy()` calls — same shallow behaviour | Identical to the original bug | Mojo `__copyinit__` for ExTensor is explicitly shallow |
+
+## Results & Parameters
+
+**Working fix** (two call sites in `gradient_checker.mojo`):
+
+```mojo
+# check_gradients (lines 120-121)
+var input_copy_plus = _deep_copy(input)
+var input_copy_minus = _deep_copy(input)
+
+# check_gradients_verbose (lines 229-230, inside diagnostic recompute block)
+var input_copy_plus = _deep_copy(input)
+var input_copy_minus = _deep_copy(input)
+```
+
+**`_deep_copy` signature** (already in same file, line 672):
+
+```mojo
+fn _deep_copy(tensor: ExTensor) raises -> ExTensor:
+    ...  # allocates fresh _data buffer and copies element by element
+```
+
+**PR reference**: HomericIntelligence/ProjectOdyssey#3755
+**Issue reference**: HomericIntelligence/ProjectOdyssey#3225


### PR DESCRIPTION
## Summary

Documents how to identify and fix silent tensor mutation in Mojo caused by
shallow copies sharing the underlying `_data` pointer.

- `tensor.copy()` (`__copyinit__`) shares the `_data` buffer — mutations to the copy corrupt the caller's tensor
- Fix: replace `.copy()` with `_deep_copy()` for an independent buffer
- Regression test pattern: snapshot values before call, assert unchanged after

## Key Findings

**What Worked**:
- Replacing `input.copy()` with `_deep_copy(input)` at both call sites in `check_gradients` and `check_gradients_verbose`
- Adding a regression test that snapshots all element values before the function call and asserts they are unchanged after

**What Failed**:
- Value restoration at end of loop (`_set_float64(i, original_val)`) → writes through the same shared pointer; caller's tensor is already corrupted before restoration runs

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates on triggers: "shallow copy tensor", "check_gradients mutates input", "mojo copy hazard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
