### PR TITLE
feat: add migrate-skill-aux-dirs skill

### DIFF
--- a/skills/tooling/migrate-skill-aux-dirs/.claude-plugin/plugin.json
+++ b/skills/tooling/migrate-skill-aux-dirs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "migrate-skill-aux-dirs",
+  "version": "1.0.0",
+  "description": "Migrate skills that contain auxiliary subdirectories (scripts/, templates/, hooks/) alongside SKILL.md. Use when: (1) a skill dir has subdirs beyond SKILL.md that would be silently dropped, (2) fixing migrate_odyssey_skills.py to copy auxiliary content.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["migration", "skills", "tooling", "subdirectories", "shutil"]
+}

--- a/skills/tooling/migrate-skill-aux-dirs/references/notes.md
+++ b/skills/tooling/migrate-skill-aux-dirs/references/notes.md
@@ -1,0 +1,66 @@
+# Session Notes — migrate-skill-aux-dirs
+
+## Context
+
+- **Issue**: #3228 — Migration script doesn't handle skills with multiple SKILL.md files / auxiliary subdirs
+- **Follow-up from**: #3140
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3228`
+- **Branch**: `3228-auto-impl`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3763
+
+## Root Cause
+
+`scripts/migrate_odyssey_skills.py` `migrate_skill()` only wrote:
+1. `.claude-plugin/plugin.json`
+2. `skills/<name>/SKILL.md`
+
+It never iterated `source_skill_md.parent` for subdirectories. Skills like `gh-create-pr-linked`
+(which has `scripts/` and `templates/`) lost those files silently.
+
+## Fix Summary
+
+Added a subdir-copy loop after writing `SKILL.md`:
+
+```python
+import shutil
+
+source_dir = source_skill_md.parent
+for subdir in sorted(source_dir.iterdir()):
+    if not subdir.is_dir() or subdir.name.startswith("."):
+        continue
+    if subdir.name == "references":
+        dest = plugin_dir / "references"
+    else:
+        dest = skill_md_dir / subdir.name
+    shutil.copytree(subdir, dest, dirs_exist_ok=True)
+```
+
+Also updated dry-run branch to print which subdirs would be copied.
+
+## Tests Written (11 total)
+
+All in `tests/scripts/test_migrate_odyssey_skills.py`:
+
+- `test_skill_with_only_skill_md` — baseline passes
+- `test_skill_with_scripts_subdir_copies_scripts`
+- `test_skill_with_templates_subdir_copies_templates`
+- `test_skill_with_references_subdir_copies_to_plugin_root`
+- `test_skill_with_multiple_subdirs_copies_all`
+- `test_skill_with_nested_scripts_content`
+- `test_dry_run_does_not_copy_files`
+- `test_missing_skill_md_returns_false`
+- `test_hidden_directories_not_copied`
+- `test_custom_subdir_hooks_copied`
+- `test_existing_destination_does_not_raise`
+
+## Actual Subdirs Found in Odyssey Skills
+
+```
+gh-create-pr-linked/  scripts/, templates/
+agent-run-orchestrator/  scripts/
+phase-test-tdd/  scripts/, templates/
+```
+
+## Import Added
+
+`import shutil` — standard library, no new dependencies.

--- a/skills/tooling/migrate-skill-aux-dirs/skills/migrate-skill-aux-dirs/SKILL.md
+++ b/skills/tooling/migrate-skill-aux-dirs/skills/migrate-skill-aux-dirs/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: migrate-skill-aux-dirs
+description: "Copy auxiliary subdirectories (scripts/, templates/, hooks/) when migrating skills. Use when: fixing a migration script that silently drops subdirs, or porting skills with non-SKILL.md content."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+# migrate-skill-aux-dirs
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Name | migrate-skill-aux-dirs |
+| Category | tooling |
+| Problem | Migration scripts that only copy SKILL.md silently drop scripts/, templates/, hooks/ subdirs |
+| Solution | After writing SKILL.md, iterate source subdirs and copy each to the correct destination |
+| Key Tool | `shutil.copytree(..., dirs_exist_ok=True)` |
+
+## When to Use
+
+- A skill migration script copies only `SKILL.md` and ignores subdirectories
+- Skills like `gh-create-pr-linked` have `scripts/` and `templates/` that disappear after migration
+- Adding auxiliary subdir support to `migrate_skill()` or any analogous function
+- Writing tests for subdir-copy behavior (TDD: confirm failure first, then fix)
+
+## Verified Workflow
+
+### 1. Identify the Pattern
+
+The bug manifests when `migrate_skill()` only creates target dirs and writes `SKILL.md`/`plugin.json`
+without iterating the source skill directory for other subdirectories.
+
+```python
+# BEFORE (broken) — only SKILL.md is copied
+skill_md_path.write_text(transformed)
+# subdirs silently dropped
+
+# AFTER (fixed) — iterate all subdirs
+source_dir = source_skill_md.parent
+for subdir in sorted(source_dir.iterdir()):
+    if not subdir.is_dir() or subdir.name.startswith("."):
+        continue
+    if subdir.name == "references":
+        dest = plugin_dir / "references"  # plugin root
+    else:
+        dest = skill_md_dir / subdir.name  # alongside SKILL.md
+    shutil.copytree(subdir, dest, dirs_exist_ok=True)
+```
+
+### 2. Routing Rules
+
+| Subdir | Destination in Mnemosyne |
+|--------|--------------------------|
+| `scripts/` | `skills/<category>/<name>/skills/<name>/scripts/` |
+| `templates/` | `skills/<category>/<name>/skills/<name>/templates/` |
+| `hooks/` | `skills/<category>/<name>/skills/<name>/hooks/` |
+| `references/` | `skills/<category>/<name>/references/` (plugin root) |
+| `.hidden/` | **Skipped** (starts with `.`) |
+
+### 3. Use `dirs_exist_ok=True`
+
+```python
+import shutil
+shutil.copytree(src, dest, dirs_exist_ok=True)
+```
+
+This allows merging into pre-existing destination directories without raising `FileExistsError`.
+Without this flag, re-running migration would fail if any subdir already exists.
+
+### 4. Update dry-run to report subdirs
+
+```python
+else:
+    print(f"  [DRY RUN] Would create: {plugin_dir}")
+    source_dir = source_skill_md.parent
+    for subdir in sorted(source_dir.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith("."):
+            continue
+        if subdir.name == "references":
+            print(f"  [DRY RUN] Would copy references/ -> skills/{category}/{skill_name}/references/")
+        else:
+            print(f"  [DRY RUN] Would copy {subdir.name}/ -> skills/{category}/{skill_name}/skills/{skill_name}/{subdir.name}/")
+```
+
+### 5. Write Tests First (TDD)
+
+Key test cases to cover before fixing:
+
+```python
+def test_skill_with_scripts_subdir_copies_scripts(tmp_path, migrate_module):
+    # Make skill dir with scripts/create_pr.sh
+    # Call migrate_skill(...)
+    expected = mnemosyne_skills / "tooling" / "name" / "skills" / "name" / "scripts"
+    assert expected.exists()
+    assert (expected / "create_pr.sh").exists()
+
+def test_hidden_directories_not_copied(tmp_path, migrate_module):
+    # .hidden/ must NOT appear in output
+
+def test_dry_run_does_not_copy_files(tmp_path, migrate_module):
+    # plugin_dir must not exist after dry_run=True
+
+def test_existing_destination_does_not_raise(tmp_path, migrate_module):
+    # Pre-create dest subdir; copytree with dirs_exist_ok=True must merge, not error
+```
+
+### 6. Import `shutil`
+
+Add `import shutil` at the top of the script — the standard library module is all that's needed.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Putting `references/` alongside SKILL.md | Placed `references/` inside `skills/<name>/` | Mnemosyne convention puts `references/` at plugin root, not alongside SKILL.md | Check the Mnemosyne plugin layout spec before routing subdirs |
+| Using `shutil.copytree` without `dirs_exist_ok` | Called `copytree(src, dest)` | Raises `FileExistsError` on second migration run if dest already exists | Always use `dirs_exist_ok=True` for idempotent behavior |
+| Skipping dry-run subdir reporting | Only dry-run printed the plugin_dir line | Users had no visibility into what subdirs would be copied | Dry-run branch should mirror the real branch's output with `[DRY RUN]` prefix |
+
+## Results & Parameters
+
+```python
+# Full fixed migrate_skill() subdir block — drop into any similar migration function
+import shutil
+
+source_dir = source_skill_md.parent
+for subdir in sorted(source_dir.iterdir()):
+    if not subdir.is_dir() or subdir.name.startswith("."):
+        continue
+    if subdir.name == "references":
+        dest = plugin_dir / "references"
+        shutil.copytree(subdir, dest, dirs_exist_ok=True)
+    else:
+        dest = skill_md_dir / subdir.name
+        shutil.copytree(subdir, dest, dirs_exist_ok=True)
+```
+
+Key parameters:
+- `dirs_exist_ok=True` — required for idempotent re-runs
+- Skip hidden dirs (`name.startswith(".")`) — avoids copying `.git`, `.cache`, etc.
+- `references/` routing to plugin root — follows Mnemosyne plugin layout convention
+- 11 unit tests, all using `unittest.mock.patch.object` to override `MNEMOSYNE_SKILLS_DIR`


### PR DESCRIPTION
## Summary

Documents how to fix migration scripts that silently drop auxiliary subdirectories (`scripts/`, `templates/`, `hooks/`) when only `SKILL.md` is copied during skill migration.

- Root cause: `migrate_skill()` only wrote `plugin.json` and `SKILL.md`, never iterating source dir for other content
- Fix: loop over source subdirs, routing `references/` to plugin root and everything else alongside `SKILL.md`
- Key API: `shutil.copytree(..., dirs_exist_ok=True)` for idempotent merging

## Key Findings

**What Worked**:
- `shutil.copytree(src, dest, dirs_exist_ok=True)` handles pre-existing destination dirs safely
- Skipping hidden dirs prevents copying `.git` etc.
- TDD: 11 failing tests written first, then fix applied — all pass

**What Failed**:
- `shutil.copytree` without `dirs_exist_ok` → `FileExistsError` on re-runs
- Placing `references/` alongside `SKILL.md` → violates Mnemosyne plugin layout

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)