### PR TITLE
fix: merge orphaned ## Quick Reference into ## Verified Workflow on transform

### DIFF
--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -111,6 +111,9 @@ When the user invokes this command:
    - ✅ **Overview section** with `## Overview` header and table
    - ✅ **When to Use** with specific trigger conditions
    - ✅ **Verified Workflow** (exact header — NOT "## Workflow")
+     > 📝 If the source skill has a `## Quick Reference` section, demote it to
+     > `### Quick Reference` as the **first subsection** of `## Verified Workflow`.
+     > Do NOT preserve it as a top-level `## Quick Reference` section.
    - ✅ **Failed Attempts table** (MUST be table format, not prose):
      ```markdown
      ## Failed Attempts
@@ -250,7 +253,7 @@ The next `/advise` or `/retrospective` will re-clone automatically.
 | **YAML frontmatter** | Starts with `---`, includes name/description/category/date/user-invocable |
 | **Overview section** | `## Overview` header with table |
 | When to Use | Specific trigger conditions |
-| Verified Workflow | Steps that worked (exact header) |
+| Verified Workflow | Steps that worked (exact header) + `### Quick Reference` subsection if source had one |
 | **Failed Attempts** | **TABLE format** (not prose) |
 | Results & Parameters | Copy-paste configs |
 

--- a/scripts/fix_remaining_warnings.py
+++ b/scripts/fix_remaining_warnings.py
@@ -62,6 +62,56 @@ def add_verified_workflow_wrapper(content: str) -> str:
     return content
 
 
+def has_orphan_quick_reference(content: str) -> bool:
+    """Check if ## Quick Reference exists as a top-level section (not under ## Verified Workflow).
+
+    Returns True when the content contains a top-level '## Quick Reference' heading,
+    indicating it needs to be demoted to a subsection of '## Verified Workflow'.
+    """
+    return bool(re.search(r'^## Quick Reference', content, re.MULTILINE))
+
+
+def merge_quick_reference_into_verified_workflow(content: str) -> str:
+    """Demote top-level ## Quick Reference to ### Quick Reference under ## Verified Workflow.
+
+    Extracts the entire ## Quick Reference section, removes it from its current
+    position, and inserts it as the first subsection (###) of ## Verified Workflow.
+    If ## Quick Reference is already a subsection (### level), the content is
+    returned unchanged.
+    """
+    # Nothing to do if already a subsection only
+    if not re.search(r'^## Quick Reference', content, re.MULTILINE):
+        return content
+
+    # Extract the full ## Quick Reference section (everything up to the next ## heading or EOF)
+    qr_match = re.search(
+        r'^(## Quick Reference\s*\n.*?)(?=^##|\Z)',
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not qr_match:
+        return content
+
+    qr_block = qr_match.group(1)
+
+    # Demote the heading from ## to ###
+    qr_as_subsection = re.sub(r'^## Quick Reference', '### Quick Reference', qr_block, count=1)
+
+    # Remove the original top-level block from content
+    content_without_qr = content[:qr_match.start()] + content[qr_match.end():]
+
+    # Insert the demoted block immediately after the ## Verified Workflow heading line
+    vw_match = re.search(r'^## Verified Workflow[^\n]*\n', content_without_qr, re.MULTILINE)
+    if not vw_match:
+        # No Verified Workflow section — put it back unchanged
+        return content
+
+    insert_pos = vw_match.end()
+    # Ensure there's a blank line before the subsection
+    subsection_text = '\n' + qr_as_subsection.lstrip('\n')
+    return content_without_qr[:insert_pos] + subsection_text + content_without_qr[insert_pos:]
+
+
 def improve_failed_attempts_table(content: str) -> str:
     """Improve Failed Attempts tables that were flagged."""
 
@@ -120,6 +170,13 @@ def fix_skill_file(skill_path: Path) -> Tuple[bool, List[str]]:
         if new_content != content:
             content = new_content
             fixes.append("Added ## Verified Workflow wrapper")
+
+    # Fix 3: Merge orphaned ## Quick Reference into ## Verified Workflow
+    if has_verified_workflow_section(content) and has_orphan_quick_reference(content):
+        new_content = merge_quick_reference_into_verified_workflow(content)
+        if new_content != content:
+            content = new_content
+            fixes.append("Merged ## Quick Reference into ## Verified Workflow as subsection")
 
     # Fix 2: Improve Failed Attempts table
     if not has_failed_attempts_table(content):

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -181,6 +181,13 @@ def validate_skill_md(plugin_dir: Path, plugin_data: dict) -> Tuple[List[str], L
         if "|" not in failed_section:
             warnings.append("Failed Attempts section should contain a table")
 
+    # Warn if ## Quick Reference appears as a top-level section alongside ## Verified Workflow
+    if "## Verified Workflow" in content and re.search(r'^## Quick Reference', content, re.MULTILINE):
+        warnings.append(
+            "## Quick Reference should be a subsection (### Quick Reference) of "
+            "## Verified Workflow, not a top-level section"
+        )
+
     return errors, warnings
 
 

--- a/tests/test_quick_reference_transform.py
+++ b/tests/test_quick_reference_transform.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Tests for Quick Reference section handling in fix_remaining_warnings.py.
+
+Verifies that:
+- Top-level ## Quick Reference alongside ## Verified Workflow is merged as subsection
+- Quick Reference ONLY (no Verified Workflow) still triggers the wrapper path
+- Idempotency: running fix twice produces the same result
+- No change when file has no Quick Reference or already has it as subsection
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from fix_remaining_warnings import (
+    add_verified_workflow_wrapper,
+    has_orphan_quick_reference,
+    has_verified_workflow_section,
+    merge_quick_reference_into_verified_workflow,
+)
+from validate_plugins import validate_skill_md
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+FRONTMATTER = """\
+---
+name: test-skill
+description: "A test skill for unit testing purposes."
+category: tooling
+date: 2026-01-01
+user-invocable: false
+---
+"""
+
+OVERVIEW = """\
+# Test Skill
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Test |
+| Outcome | Test |
+
+## When to Use
+
+- Condition A
+- Condition B
+
+"""
+
+QUICK_REFERENCE_CONTENT = """\
+## Quick Reference
+
+```bash
+# Key commands
+git status
+git log
+```
+
+"""
+
+VERIFIED_WORKFLOW_CONTENT = """\
+## Verified Workflow
+
+### Step 1
+
+Do the thing.
+
+### Step 2
+
+Do another thing.
+
+"""
+
+FAILED_ATTEMPTS = """\
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| N/A | No failures yet | Document failures as they occur |
+
+"""
+
+RESULTS = """\
+## Results & Parameters
+
+N/A - workflow pattern skill.
+"""
+
+
+def make_skill(
+    has_quick_reference: bool = True,
+    has_verified_workflow: bool = True,
+    qr_before_vw: bool = True,
+    qr_as_subsection: bool = False,
+) -> str:
+    """Build a SKILL.md string with configurable section layout."""
+    parts = [FRONTMATTER, OVERVIEW]
+
+    if qr_as_subsection:
+        # Quick Reference already nested under Verified Workflow
+        vw = VERIFIED_WORKFLOW_CONTENT.rstrip("\n") + "\n\n### Quick Reference\n\n```bash\ngit status\n```\n\n"
+        parts.append(vw)
+    elif has_quick_reference and has_verified_workflow:
+        if qr_before_vw:
+            parts.append(QUICK_REFERENCE_CONTENT)
+            parts.append(VERIFIED_WORKFLOW_CONTENT)
+        else:
+            parts.append(VERIFIED_WORKFLOW_CONTENT)
+            parts.append(QUICK_REFERENCE_CONTENT)
+    elif has_quick_reference:
+        parts.append(QUICK_REFERENCE_CONTENT)
+    elif has_verified_workflow:
+        parts.append(VERIFIED_WORKFLOW_CONTENT)
+
+    parts.append(FAILED_ATTEMPTS)
+    parts.append(RESULTS)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Tests for has_orphan_quick_reference()
+# ---------------------------------------------------------------------------
+
+
+class TestHasOrphanQuickReference:
+    def test_returns_true_when_top_level_quick_reference_present(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        assert has_orphan_quick_reference(content) is True
+
+    def test_returns_false_when_quick_reference_is_subsection(self) -> None:
+        content = make_skill(qr_as_subsection=True)
+        assert has_orphan_quick_reference(content) is False
+
+    def test_returns_false_when_no_quick_reference(self) -> None:
+        content = make_skill(has_quick_reference=False)
+        assert has_orphan_quick_reference(content) is False
+
+    def test_returns_false_when_quick_reference_only_as_subsection_marker(self) -> None:
+        # Content where ### Quick Reference appears but not ## Quick Reference
+        content = FRONTMATTER + OVERVIEW + "## Verified Workflow\n\n### Quick Reference\n\n```bash\ngit x\n```\n\n" + FAILED_ATTEMPTS
+        assert has_orphan_quick_reference(content) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for merge_quick_reference_into_verified_workflow()
+# ---------------------------------------------------------------------------
+
+
+class TestMergeQuickReferenceIntoVerifiedWorkflow:
+    def test_qr_before_vw_is_moved_under_vw(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True, qr_before_vw=True)
+        result = merge_quick_reference_into_verified_workflow(content)
+
+        # Top-level ## Quick Reference must be gone
+        import re
+        assert not re.search(r'^## Quick Reference', result, re.MULTILINE)
+        # Subsection ### Quick Reference must exist
+        assert re.search(r'^### Quick Reference', result, re.MULTILINE)
+        # ## Verified Workflow must still be there
+        assert "## Verified Workflow" in result
+        # ### Quick Reference must appear after ## Verified Workflow
+        vw_pos = result.index("## Verified Workflow")
+        qr_pos = result.index("### Quick Reference")
+        assert qr_pos > vw_pos
+
+    def test_qr_after_vw_is_moved_under_vw(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True, qr_before_vw=False)
+        result = merge_quick_reference_into_verified_workflow(content)
+
+        import re
+        assert not re.search(r'^## Quick Reference', result, re.MULTILINE)
+        assert re.search(r'^### Quick Reference', result, re.MULTILINE)
+        vw_pos = result.index("## Verified Workflow")
+        qr_pos = result.index("### Quick Reference")
+        assert qr_pos > vw_pos
+
+    def test_no_change_when_already_subsection(self) -> None:
+        content = make_skill(qr_as_subsection=True)
+        result = merge_quick_reference_into_verified_workflow(content)
+        assert result == content
+
+    def test_content_of_quick_reference_preserved(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        result = merge_quick_reference_into_verified_workflow(content)
+        # The bash commands inside Quick Reference must still be present
+        assert "git status" in result
+        assert "git log" in result
+
+    def test_idempotent(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        first_pass = merge_quick_reference_into_verified_workflow(content)
+        second_pass = merge_quick_reference_into_verified_workflow(first_pass)
+        assert first_pass == second_pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for add_verified_workflow_wrapper() regression
+# (existing path: ## Quick Reference ONLY, no ## Verified Workflow)
+# ---------------------------------------------------------------------------
+
+
+class TestAddVerifiedWorkflowWrapperRegression:
+    def test_quick_reference_only_gets_wrapped(self) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=False)
+        assert not has_verified_workflow_section(content)
+        result = add_verified_workflow_wrapper(content)
+        assert has_verified_workflow_section(result)
+
+    def test_no_change_when_already_has_verified_workflow(self) -> None:
+        content = make_skill(has_quick_reference=False, has_verified_workflow=True)
+        result = add_verified_workflow_wrapper(content)
+        # The wrapper function should leave the content unchanged (no Quick Reference to wrap)
+        assert result == content
+
+
+# ---------------------------------------------------------------------------
+# Integration: fix_skill_file() behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestFixSkillFileIntegration:
+    def test_fix_skill_file_handles_orphan_qr(self, tmp_path: Path) -> None:
+        from fix_remaining_warnings import fix_skill_file
+        import re
+
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(content)
+
+        modified, fixes = fix_skill_file(skill_file)
+
+        assert modified is True
+        assert any("Quick Reference" in fix for fix in fixes)
+        result = skill_file.read_text()
+        assert not re.search(r'^## Quick Reference', result, re.MULTILINE)
+        assert re.search(r'^### Quick Reference', result, re.MULTILINE)
+
+    def test_fix_skill_file_is_idempotent(self, tmp_path: Path) -> None:
+        from fix_remaining_warnings import fix_skill_file
+
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(content)
+
+        fix_skill_file(skill_file)
+        content_after_first = skill_file.read_text()
+
+        modified, fixes = fix_skill_file(skill_file)
+
+        assert modified is False
+        assert skill_file.read_text() == content_after_first
+
+    def test_fix_skill_file_no_change_when_clean(self, tmp_path: Path) -> None:
+        from fix_remaining_warnings import fix_skill_file
+
+        content = make_skill(has_quick_reference=False, has_verified_workflow=True)
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(content)
+
+        modified, fixes = fix_skill_file(skill_file)
+
+        assert modified is False
+        assert fixes == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for validate_plugins.py warning
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginsQuickReferenceWarning:
+    def _make_plugin_dir(self, tmp_path: Path, skill_content: str) -> Path:
+        """Set up a minimal plugin directory structure."""
+        plugin_dir = tmp_path / "test-plugin"
+        skill_subdir = plugin_dir / "skills" / "test-plugin"
+        skill_subdir.mkdir(parents=True)
+        (skill_subdir / "SKILL.md").write_text(skill_content)
+
+        plugin_json_dir = plugin_dir / ".claude-plugin"
+        plugin_json_dir.mkdir()
+        import json
+        (plugin_json_dir / "plugin.json").write_text(json.dumps({
+            "name": "test-plugin",
+            "version": "1.0.0",
+            "description": "A test plugin for unit testing purposes.",
+            "category": "tooling",
+            "date": "2026-01-01",
+        }))
+        return plugin_dir
+
+    def test_warns_on_orphaned_top_level_quick_reference(self, tmp_path: Path) -> None:
+        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
+        plugin_dir = self._make_plugin_dir(tmp_path, content)
+
+        errors, warnings = validate_skill_md(plugin_dir, {})
+
+        warning_texts = " ".join(warnings)
+        assert "Quick Reference" in warning_texts
+        assert "subsection" in warning_texts.lower() or "###" in warning_texts
+
+    def test_no_warning_when_quick_reference_is_subsection(self, tmp_path: Path) -> None:
+        content = make_skill(qr_as_subsection=True)
+        plugin_dir = self._make_plugin_dir(tmp_path, content)
+
+        errors, warnings = validate_skill_md(plugin_dir, {})
+
+        qr_warnings = [w for w in warnings if "Quick Reference" in w and "subsection" in w.lower()]
+        assert qr_warnings == []
+
+    def test_no_warning_when_no_quick_reference(self, tmp_path: Path) -> None:
+        content = make_skill(has_quick_reference=False, has_verified_workflow=True)
+        plugin_dir = self._make_plugin_dir(tmp_path, content)
+
+        errors, warnings = validate_skill_md(plugin_dir, {})
+
+        qr_warnings = [w for w in warnings if "Quick Reference" in w]
+        assert qr_warnings == []


### PR DESCRIPTION
## Summary

- Add `has_orphan_quick_reference()` and `merge_quick_reference_into_verified_workflow()` helpers to `fix_remaining_warnings.py`
- Wire Fix 3 into `fix_skill_file()` to demote top-level `## Quick Reference` to `### Quick Reference` under `## Verified Workflow`
- Add validation warning in `validate_plugins.py` for structural smell
- Update `retrospective.md` with explicit instructions to demote `## Quick Reference` on transform
- Add 17 unit tests covering all edge cases (QR before/after VW, idempotency, regression, validation)

## Test plan

- [x] `python -m pytest tests/test_quick_reference_transform.py -v` — 17/17 passing
- [x] No regressions in existing tests
- [x] `validate_plugins.py` warns on 54 existing skills with orphaned `## Quick Reference`

Fixes HomericIntelligence/Odyssey2#3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)