### PR TITLE
feat: add mojo-python-interop-to-stdlib skill

### DIFF
--- a/skills/architecture/mojo-python-interop-to-stdlib/.claude-plugin/plugin.json
+++ b/skills/architecture/mojo-python-interop-to-stdlib/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-python-interop-to-stdlib",
+  "version": "1.0.0",
+  "description": "Replace Python interop (Python.import_module) with Mojo native stdlib equivalents. Use when: (1) a Mojo function uses Python.import_module for os/pathlib/builtins operations that Mojo stdlib now supports, (2) refactoring away from Python interop overhead for file system operations, (3) eliminating 'from python import Python' imports from ML/AI Mojo modules.",
+  "category": "architecture",
+  "date": "2026-03-07",
+  "tags": ["mojo", "python-interop", "stdlib", "refactoring", "os", "pathlib", "file-system"]
+}

--- a/skills/architecture/mojo-python-interop-to-stdlib/references/notes.md
+++ b/skills/architecture/mojo-python-interop-to-stdlib/references/notes.md
@@ -1,0 +1,100 @@
+# Session Notes: mojo-python-interop-to-stdlib
+
+## Context
+
+- **Repository**: ProjectOdyssey
+- **Issue**: #3240 - refactor(serialization): replace Python pathlib with Mojo stdlib pathlib in load_named_tensors()
+- **PR**: #3789
+- **Branch**: 3240-auto-impl
+- **File changed**: `shared/utils/serialization.mojo`
+
+## Objective
+
+Replace Python interop in `load_named_tensors()` with Mojo's native stdlib to eliminate:
+
+1. `Python.import_module("os")`
+2. `Python.import_module("pathlib")`
+3. `Python.import_module("builtins")`
+
+## Original Code (lines 313-325)
+
+```mojo
+try:
+    # Use Python to list directory contents
+    var _ = Python.import_module("os")
+    var pathlib = Python.import_module("pathlib")
+    var builtins = Python.import_module("builtins")
+    var p = pathlib.Path(dirpath)
+    var weight_files = builtins.sorted(p.glob("*.weights"))
+
+    # Load each weights file
+    for file in weight_files:
+        var filepath = String(file)
+        var (name, tensor) = load_tensor_with_name(filepath)
+        result.append(NamedTensor(name, tensor))
+```
+
+## Discovery Process
+
+1. Read `.claude-prompt-3240.md` for issue description
+2. Read `shared/utils/serialization.mojo` around lines 311-329
+3. Searched for existing Mojo `from pathlib import Path` usage in tests — confirmed it's available
+4. Inspected `std.mojopkg` with `strings` to confirm `listdir` is in Mojo stdlib
+5. Confirmed `listdir(::Path)` and `listdir[::PathLike]($0)` exist in stdlib
+6. Chose `import os; os.listdir(dirpath)` as simplest approach
+
+## Key Findings
+
+- `os.listdir()` in Mojo returns `List[String]` of **filenames only** (not full paths)
+- No Mojo equivalent of `glob("*.weights")` — must filter manually with `.endswith()`
+- No built-in `sorted()` for `List[String]` in Mojo — insertion sort works fine for small dirs
+- String comparison with `>` operator works for lexicographic sort in Mojo
+- Mojo's `pathlib.Path` does NOT expose `.glob()` — confirmed by inspecting stdlib symbols
+
+## Pre-commit Hook Results
+
+All hooks passed on commit:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## Environment Limitation
+
+Mojo cannot run locally on this host due to GLIBC version mismatch:
+- Required: GLIBC 2.32, 2.33, 2.34
+- Available: older version
+
+Tests validated by CI only (Docker container has compatible GLIBC).
+
+## Diff Summary
+
+```diff
+-from python import Python
++import os
+
+-        var _ = Python.import_module("os")
+-        var pathlib = Python.import_module("pathlib")
+-        var builtins = Python.import_module("builtins")
+-        var p = pathlib.Path(dirpath)
+-        var weight_files = builtins.sorted(p.glob("*.weights"))
+-        for file in weight_files:
+-            var filepath = String(file)
++        var entries = os.listdir(dirpath)
++        var weight_files: List[String] = []
++        for i in range(len(entries)):
++            var entry = entries[i]
++            if entry.endswith(".weights"):
++                weight_files.append(entry)
++        for i in range(1, len(weight_files)):
++            var key = weight_files[i]
++            var j = i - 1
++            while j >= 0 and weight_files[j] > key:
++                weight_files[j + 1] = weight_files[j]
++                j -= 1
++            weight_files[j + 1] = key
++        for i in range(len(weight_files)):
++            var filepath = dirpath + "/" + weight_files[i]
+```

--- a/skills/architecture/mojo-python-interop-to-stdlib/skills/mojo-python-interop-to-stdlib/SKILL.md
+++ b/skills/architecture/mojo-python-interop-to-stdlib/skills/mojo-python-interop-to-stdlib/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: mojo-python-interop-to-stdlib
+description: "Replace Python.import_module calls with Mojo native stdlib. Use when: eliminating Python interop for file system ops (os, pathlib, builtins), refactoring load_named_tensors or similar functions, or migrating from Python glob/sorted to native Mojo os.listdir + sort."
+category: architecture
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Category** | architecture |
+| **Objective** | Replace Python interop in Mojo file-system operations with native Mojo stdlib |
+| **Outcome** | Success - eliminated 3 Python.import_module calls, no Python import needed |
+
+## When to Use
+
+Invoke this skill when:
+
+- A Mojo function uses `Python.import_module("os")`, `Python.import_module("pathlib")`, or `Python.import_module("builtins")` for file listing or sorting
+- You see `from python import Python` imported only for file system operations
+- You need to list and filter directory contents (e.g., glob for `*.weights` files)
+- You need deterministic sorted output of directory entries in Mojo
+- Mojo stdlib now covers what was previously a Python workaround
+
+## Verified Workflow
+
+### Step 1: Identify Python Interop Usage
+
+Search for Python imports used only for file operations:
+
+```bash
+grep -n "Python.import_module" <file>.mojo
+```
+
+Common pattern to replace:
+
+```mojo
+# BEFORE (Python interop)
+var _ = Python.import_module("os")
+var pathlib = Python.import_module("pathlib")
+var builtins = Python.import_module("builtins")
+var p = pathlib.Path(dirpath)
+var weight_files = builtins.sorted(p.glob("*.weights"))
+```
+
+### Step 2: Replace with Mojo Native os.listdir
+
+Mojo stdlib provides `os.listdir()` which returns `List[String]` of filenames (not full paths):
+
+```mojo
+# AFTER (native Mojo)
+import os
+
+var entries = os.listdir(dirpath)
+```
+
+Key differences from Python's `pathlib.Path.glob()`:
+
+- Returns bare filenames only (not full paths) — must construct full path manually
+- Returns all entries (no filtering) — must filter by extension manually
+- No guaranteed ordering — must sort explicitly
+
+### Step 3: Filter by Extension
+
+```mojo
+var weight_files: List[String] = []
+for i in range(len(entries)):
+    var entry = entries[i]
+    if entry.endswith(".weights"):
+        weight_files.append(entry)
+```
+
+### Step 4: Sort for Deterministic Ordering
+
+Mojo stdlib has no built-in `sorted()` for `List[String]`. Use insertion sort (correct for small
+lists, O(n^2) is fine for typical checkpoint directories):
+
+```mojo
+# Insertion sort (ascending)
+for i in range(1, len(weight_files)):
+    var key = weight_files[i]
+    var j = i - 1
+    while j >= 0 and weight_files[j] > key:
+        weight_files[j + 1] = weight_files[j]
+        j -= 1
+    weight_files[j + 1] = key
+```
+
+### Step 5: Construct Full Paths
+
+```mojo
+for i in range(len(weight_files)):
+    var filepath = dirpath + "/" + weight_files[i]
+    # use filepath...
+```
+
+### Step 6: Update Imports
+
+Remove `from python import Python` if it is no longer used elsewhere in the file.
+Add `import os`.
+
+### Step 7: Verify No Other Python Usage
+
+```bash
+grep -n "Python\." <file>.mojo
+```
+
+If no other uses remain, the `from python import Python` import can be removed entirely.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Direct Mojo execution for test verification | Ran `pixi run mojo test` to validate changes | GLIBC version mismatch (requires 2.32+, host has older) | Tests only runnable in CI via Docker; validate logic correctness by code review |
+| Using `Path.glob()` from Mojo pathlib | Looked for a Mojo equivalent of Python's `Path.glob("*.weights")` | Mojo's pathlib.Path does not expose a glob() method; only listdir() is available | Use `os.listdir()` + manual extension filtering instead of glob |
+| Importing `from pathlib import Path` for directory listing | Tried `Path(dirpath).listdir()` pattern | The method signature is `listdir(::Path)` — available but returns filenames, not full paths | Still works, but `import os; os.listdir(dirpath)` is simpler and equivalent |
+
+## Results & Parameters
+
+**Import change**:
+
+```mojo
+# Remove
+from python import Python
+
+# Add
+import os
+```
+
+**Complete replacement pattern** for `load_named_tensors`-style functions:
+
+```mojo
+var entries = os.listdir(dirpath)
+
+var filtered: List[String] = []
+for i in range(len(entries)):
+    var entry = entries[i]
+    if entry.endswith(".<extension>"):
+        filtered.append(entry)
+
+# Insertion sort for deterministic ordering
+for i in range(1, len(filtered)):
+    var key = filtered[i]
+    var j = i - 1
+    while j >= 0 and filtered[j] > key:
+        filtered[j + 1] = filtered[j]
+        j -= 1
+    filtered[j + 1] = key
+
+for i in range(len(filtered)):
+    var filepath = dirpath + "/" + filtered[i]
+    # process filepath...
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3240, PR #3789 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to replace Python interop (`Python.import_module`) with Mojo's native stdlib for file system operations.

- Pattern for replacing `pathlib.Path.glob()` + `builtins.sorted()` with `os.listdir()` + extension filter + insertion sort
- Key insight: `os.listdir()` returns filenames only, not full paths — must construct paths manually
- Verified on ProjectOdyssey issue #3240 (serialization refactor)

## Key Findings

**What Worked**:
- `import os; os.listdir(dirpath)` is the native Mojo equivalent of Python's `os.listdir()`
- `String.endswith()` works for extension filtering
- Insertion sort with `>` operator gives lexicographic ordering for `List[String]`

**What Failed**:
- `pathlib.Path.glob("*.weights")` — Mojo's pathlib.Path does not expose a glob() method
- Could not run tests locally due to GLIBC version incompatibility on the host

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates on "Python.import_module" or "os.listdir" search terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)