### PR TITLE
feat: add normalization-backward-grad-output-warning skill

### DIFF
--- a/skills/testing/normalization-backward-grad-output-warning/.claude-plugin/plugin.json
+++ b/skills/testing/normalization-backward-grad-output-warning/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "normalization-backward-grad-output-warning",
+  "version": "1.0.0",
+  "description": "Document the grad_output=ones cancellation hazard in normalization backward tests as a shared testing guide warning. Use when: (1) a normalization layer backward test produced a false failure due to sum(x_norm)=0 cancellation, (2) you want to prevent teammates from repeating the same mistake by adding a warning to testing-patterns.md or equivalent shared guide.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["batch-norm", "normalization", "gradient-checking", "backward-pass", "documentation", "testing-patterns", "cancellation", "grad-output"]
+}

--- a/skills/testing/normalization-backward-grad-output-warning/references/notes.md
+++ b/skills/testing/normalization-backward-grad-output-warning/references/notes.md
@@ -1,0 +1,44 @@
+# Session Notes: Issue #3249 — Document batch_norm2d_backward cancellation property
+
+## Context
+
+- **Repository**: ProjectOdyssey
+- **Issue**: #3249 — "Document batch_norm2d_backward cancellation property in shared testing guide"
+- **PR**: #3816 — `docs(testing): document batch_norm2d_backward cancellation property`
+- **Branch**: `3249-auto-impl`
+- **Date**: 2026-03-07
+
+## Background
+
+Issue #3249 was a follow-up to #2724. The fix in #2724 corrected the test
+`test_batch_norm2d_backward_gradient_input` in `tests/shared/core/test_normalization.mojo`
+to use a non-uniform `grad_output` instead of `ones_like(output)`.
+
+Issue #3249 asked that the root cause be documented in the shared testing guide
+(`docs/dev/testing-patterns.md`) so future engineers don't repeat the same mistake.
+
+## What Was Done
+
+1. Read `docs/dev/testing-patterns.md` — identified Pattern 3 (Gradient Checking) as the
+   right location for the warning.
+2. Read `tests/shared/core/test_normalization.mojo` lines 280–370 to extract the canonical
+   correct pattern.
+3. Added a `### Warning: Normalization Backward — Never Use grad_output=ones` subsection
+   immediately after `### Gradient Checking Tolerances` and before the `---` separator.
+4. The subsection includes: scope, math explanation, failing pattern (❌), correct pattern (✅),
+   and the rule statement.
+5. Ran `pixi run pre-commit run --files docs/dev/testing-patterns.md` — all hooks passed.
+6. Committed, pushed, created PR #3816, enabled auto-merge.
+
+## Key File Paths
+
+- `docs/dev/testing-patterns.md` — modified (Pattern 3, ~line 305)
+- `tests/shared/core/test_normalization.mojo:316-360` — canonical correct pattern reference
+
+## Math Summary
+
+Batch norm computes `x_norm = (x - mean) / std`. By the definition of mean-centering,
+`sum(x_norm) = 0` always. The backward formula contains `dotp = sum(grad_output * x_norm)`.
+When `grad_output = ones`, `dotp = sum(x_norm) = 0`, which cancels all gradient terms,
+yielding `dL/dx = 0` analytically. This is mathematically correct but means the test
+verifies nothing useful about the backward implementation.

--- a/skills/testing/normalization-backward-grad-output-warning/skills/normalization-backward-grad-output-warning/SKILL.md
+++ b/skills/testing/normalization-backward-grad-output-warning/skills/normalization-backward-grad-output-warning/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: normalization-backward-grad-output-warning
+description: "Document the grad_output=ones cancellation hazard in normalization backward tests as a shared testing guide warning. Use when: a normalization backward test produced a false failure due to sum(x_norm)=0 cancellation and you want to prevent recurrence via shared documentation."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Objective | Add a warning to the shared testing guide (testing-patterns.md) about `grad_output=ones` causing false-zero gradients in normalization backward tests |
+| Outcome | Section added to Pattern 3 (Gradient Checking) with math, failing pattern, correct pattern, and canonical code reference |
+| Applies To | Any project with a shared Mojo/Python testing guide and normalization layer backward tests |
+| Related Skill | `batch-norm-gradient-test-fix` — covers fixing the test itself; this skill covers documenting the pattern for the team |
+
+## When to Use
+
+1. A normalization backward test silently passed trivially (or falsely failed) due to `grad_output=ones`
+2. You want to prevent future engineers from repeating the same mistake by documenting it in a shared guide
+3. A GitHub issue asks you to document a testing anti-pattern in `docs/dev/testing-patterns.md`
+4. A code review or follow-up issue (e.g. "document this in the shared guide") was filed after fixing the actual test
+
+## Verified Workflow
+
+### Step 1: Read the existing shared guide
+
+Find the gradient checking section in the shared testing patterns document:
+
+```bash
+grep -n "Gradient Checking" docs/dev/testing-patterns.md
+```
+
+Locate the existing tolerances block — the warning belongs immediately after it, before the
+next `---` section separator.
+
+### Step 2: Identify the correct insertion point
+
+The warning should be inside **Pattern 3: Gradient Checking Pattern**, after the tolerances
+table and before the `---` separator. This groups it logically with gradient checking guidance.
+
+### Step 3: Write the warning subsection
+
+Include all four components:
+
+1. **Scope** — which layers are affected (batch norm, layer norm, any normalization)
+2. **Math** — explain why `sum(x_norm) = 0` by construction
+3. **Failing pattern** (❌) — show the `ones_like(output)` antipattern with a comment
+4. **Correct pattern** (✅) — show the non-uniform `grad_output` + `forward_for_grad` closure,
+   with a reference to the canonical implementation in the test file
+
+### Step 4: Run markdown linting
+
+```bash
+pixi run pre-commit run --files docs/dev/testing-patterns.md
+```
+
+All hooks must pass (markdownlint, trailing whitespace, end-of-file).
+
+### Step 5: Commit and PR
+
+```bash
+git add docs/dev/testing-patterns.md
+git commit -m "docs(testing): document batch_norm2d_backward cancellation property warning
+
+Add warning subsection to Pattern 3 (Gradient Checking) explaining
+sum(x_norm)=0 cancellation with grad_output=ones.
+
+Closes #<issue>"
+```
+
+## The Warning Content (Copy-Paste Ready)
+
+Insert after the Gradient Checking Tolerances code block and before `---`:
+
+````markdown
+### Warning: Normalization Backward — Never Use `grad_output=ones`
+
+**Applies to**: `batch_norm2d_backward`, `layer_norm_backward`, and any normalization layer
+that computes normalized inputs `x_norm = (x - mean) / std`.
+
+**The problem**: Passing `grad_output=ones` into a normalization backward pass produces
+analytically-zero gradients for `dL/dx`. This is not a bug — it is a mathematical identity.
+The zero result will match numerical finite differences (which also converge to zero), so the
+gradient check passes trivially without actually validating anything.
+
+**Mathematical explanation**: Batch normalization normalizes each channel across the spatial
+and batch dimensions. By construction, the normalized values sum to zero:
+
+```text
+x_norm = (x - mean(x)) / std(x)
+=> sum(x_norm) = 0   (always, by definition of mean-centering)
+```
+
+The gradient of the loss with respect to the input contains a term proportional to
+`sum(grad_output * x_norm)`. When `grad_output = ones`, this term is `sum(x_norm) = 0`,
+which cancels other gradient terms and yields `dL/dx = 0` for every element — a false result
+that hides implementation errors entirely.
+
+**Rule**: For normalization layers, never use `grad_output=ones` in backward gradient checks.
+````
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3249, PR #3816 | [notes.md](../references/notes.md) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Create a new standalone doc | Draft a new `normalization-testing-guide.md` | Duplication — content belongs in the existing shared guide | Always extend the existing doc rather than creating a parallel one |
+| Add the warning to the Troubleshooting section | Place it under "Gradient Check Failing" | The existing troubleshooting entry is about discontinuities (ReLU), not cancellation; mixing them confused the pattern | Group normalization-specific warnings in the Gradient Checking Pattern section, not in general troubleshooting |
+| Use `---` before the subsection | Added a horizontal rule before the warning | Created visual separation that broke the logical grouping within Pattern 3 | Insert warning as a `###` subsection inside the existing pattern, after the tolerances block |
+
+## Results & Parameters
+
+### Insertion location in testing-patterns.md
+
+```text
+## Pattern 3: Gradient Checking Pattern
+  ### Using check_gradients Helper
+  ### Verbose Mode for Debugging
+  ### Pattern for Mixed Positive/Negative Inputs
+  ### Gradient Checking Tolerances      ← insert after this block
+  ### Warning: Normalization Backward — Never Use `grad_output=ones`   ← new
+---                                     ← existing section separator
+## Pattern 4: Model Testing Pattern
+```
+
+### Canonical test reference
+
+`tests/shared/core/test_normalization.mojo:316-360` — the `test_batch_norm2d_backward_gradient_input`
+function is the authoritative example of the correct `forward_for_grad` closure pattern.


### PR DESCRIPTION
## Summary

Documents the workflow for adding a shared testing guide warning when a normalization
backward test causes false results due to `sum(x_norm)=0` cancellation with `grad_output=ones`.

- Adds skill to `skills/testing/normalization-backward-grad-output-warning/`
- Covers: where in the guide to insert the warning, what content to include, and what to avoid
- References canonical fix at `test_normalization.mojo:316-360` in ProjectOdyssey

## Key Findings

**What Worked**:
- Insert the warning as `### Warning:` subsection inside Pattern 3 (Gradient Checking), after
  the tolerances block — keeps it logically grouped
- Include math, failing pattern (❌), correct pattern (✅), and a rule statement
- Run markdownlint pre-commit hook to verify formatting before committing

**What Failed**:
- Creating a new standalone doc → duplication; belongs in the existing shared guide
- Placing in the Troubleshooting section → wrong context (that section covers ReLU discontinuities)
- Adding `---` before the subsection → breaks logical grouping within the pattern

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates on relevant triggers (normalization, grad_output, testing-patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)