### PR TITLE
feat: add adr-directory-tree-accuracy skill

### DIFF
--- a/skills/documentation/adr-directory-tree-accuracy/.claude-plugin/plugin.json
+++ b/skills/documentation/adr-directory-tree-accuracy/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr-directory-tree-accuracy",
+  "version": "1.0.0",
+  "description": "Update ADR directory tree listings to reflect actual filesystem contents after file deletions or additions. Use when: (1) a file is deleted/added but the ADR still shows the old listing, (2) a GitHub issue requests verifying helpers/tests directories are accurately documented, (3) an ADR directory tree shows only a subset of the files actually present.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["adr", "directory-tree", "stale-docs", "helpers", "cleanup", "accuracy"]
+}

--- a/skills/documentation/adr-directory-tree-accuracy/references/notes.md
+++ b/skills/documentation/adr-directory-tree-accuracy/references/notes.md
@@ -1,0 +1,76 @@
+# Session Notes: adr-directory-tree-accuracy
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: ProjectOdyssey #3252 — "Remove empty tests/helpers/ directory after stub deletion"
+- **Branch**: `3252-auto-impl`
+- **Follow-up from**: #3061 (which deleted `gradient_checking.mojo`)
+
+## What Actually Happened
+
+The issue title was misleading. It said "remove empty tests/helpers/ directory" but the directory
+was not empty — it contained 5 active files: `__init__.mojo`, `fixtures.mojo`, `utils.mojo`,
+`test_fixtures.mojo`, `test_utils.mojo`.
+
+The real task (per the issue description body) was:
+> "If all remaining helpers are also deprecated or unused, the directory should be cleaned up.
+> Otherwise, verify these files are actively used and update ADR-004 to reflect accurate directory
+> contents."
+
+Since the files are actively used (self-tests and fixture utilities), the correct resolution was
+updating the ADR directory tree listing — not deleting any files.
+
+## ADR-004 State Before Fix
+
+Line 143-144 of `docs/adr/ADR-004-testing-strategy.md`:
+```text
+└── helpers/
+    └── fixtures.mojo                     # Test fixtures
+```
+
+This was incomplete — only listed one file when five existed.
+
+## ADR-004 State After Fix
+
+```text
+└── helpers/
+    ├── __init__.mojo                     # Package re-exports
+    ├── fixtures.mojo                     # Test fixture utilities
+    ├── utils.mojo                        # Tensor debugging utilities
+    ├── test_fixtures.mojo                # Self-tests for fixtures.mojo
+    └── test_utils.mojo                   # Self-tests for utils.mojo
+```
+
+## Why `gradient_checking.mojo` Was Not In ADR
+
+The prior PR (#3061) that deleted `gradient_checking.mojo` had already removed it from ADR-004's
+"Related Files" section (line 321+). However, the directory tree at line 143 was only partially
+updated — it removed the `gradient_checking.mojo` entry but didn't expand the listing to show the
+other files that remained.
+
+## Commands Used
+
+```bash
+# Discover actual directory contents
+ls tests/helpers/
+
+# Find relevant ADR section
+grep -n "helpers\|gradient_checker\|gradient_checking" docs/adr/ADR-004-testing-strategy.md
+
+# Run markdown lint
+pixi run pre-commit run markdownlint-cli2 --files docs/adr/ADR-004-testing-strategy.md
+
+# Commit
+git add docs/adr/ADR-004-testing-strategy.md
+git commit -m "docs(adr): update ADR-004 helpers directory tree to reflect active files"
+git push -u origin 3252-auto-impl
+gh pr create --title "docs(adr): update ADR-004 helpers directory tree to reflect active files" \
+  --body "Closes #3252" --label "documentation"
+gh pr merge --auto --rebase
+```
+
+## Time Taken
+
+Very fast — under 5 minutes total. The task was purely a documentation accuracy fix with no
+ambiguity once the filesystem state was confirmed.

--- a/skills/documentation/adr-directory-tree-accuracy/skills/adr-directory-tree-accuracy/SKILL.md
+++ b/skills/documentation/adr-directory-tree-accuracy/skills/adr-directory-tree-accuracy/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: adr-directory-tree-accuracy
+description: "Update ADR directory tree listings to reflect actual filesystem contents after file deletions or additions. Use when: (1) a file is deleted/added but the ADR still shows the old listing, (2) a GitHub issue requests verifying helpers/tests directories are accurately documented, (3) an ADR directory tree shows only a subset of the files actually present."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+# Skill: adr-directory-tree-accuracy
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-07 |
+| Objective | Update ADR-004 directory tree to reflect actual `tests/helpers/` contents after `gradient_checking.mojo` was deleted in a prior PR |
+| Outcome | Success — single-file listing replaced with accurate 5-file listing, PR #3820 created and auto-merge enabled |
+| Category | documentation |
+
+## When to Use
+
+Use this skill when:
+
+- A file is deleted or added in a PR but the ADR directory tree was not updated alongside that change
+- A follow-up issue (e.g., "verify helpers directory" or "clean up after stub deletion") asks you to check whether documentation reflects reality
+- `grep` finds a directory tree in an ADR that lists fewer files than `ls` shows on disk
+- An issue describes the directory as "possibly empty" or "needing verification" when it actually still contains active files
+
+## Verified Workflow
+
+### 1. Read the issue and confirm the actual state
+
+```bash
+gh issue view <number> --comments
+ls tests/helpers/     # or the relevant directory
+```
+
+Key check: verify whether the deletion actually happened (the file may already be gone from a prior PR).
+
+### 2. Find the stale ADR reference
+
+```bash
+grep -n "helpers\|<deleted-file>" docs/adr/ADR-*.md
+```
+
+Identify which ADR contains the directory tree and which line needs updating.
+
+### 3. Compare ADR listing vs. actual filesystem
+
+Read the ADR section around the directory tree, then cross-reference with `ls`.
+Look for:
+
+- Files listed in the ADR that no longer exist (phantom references)
+- Files that exist on disk but are missing from the ADR listing (incomplete listing)
+
+### 4. Update the directory tree
+
+Use the Edit tool to replace the stale listing with an accurate one.
+Match the tree format already used in the ADR (ASCII tree with `├──` / `└──` connectors and trailing comments).
+
+Example replacement:
+
+**Before:**
+```text
+└── helpers/
+    └── fixtures.mojo                     # Test fixtures
+```
+
+**After:**
+```text
+└── helpers/
+    ├── __init__.mojo                     # Package re-exports
+    ├── fixtures.mojo                     # Test fixture utilities
+    ├── utils.mojo                        # Tensor debugging utilities
+    ├── test_fixtures.mojo                # Self-tests for fixtures.mojo
+    └── test_utils.mojo                   # Self-tests for utils.mojo
+```
+
+### 5. Validate with markdownlint
+
+```bash
+pixi run pre-commit run markdownlint-cli2 --files docs/adr/ADR-*.md
+```
+
+### 6. Commit and create PR
+
+```bash
+git add docs/adr/ADR-<N>-<name>.md
+git commit -m "docs(adr): update ADR-<N> <section> directory tree to reflect active files"
+git push -u origin <branch>
+gh pr create --title "docs(adr): update ADR-<N> <section> directory tree to reflect active files" \
+  --body "Closes #<issue>" --label "documentation"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Searching for `gradient_checking` in ADR-004 | Used `grep` to find stale reference to deleted file | No matches — file was already deleted from ADR in a prior PR | Always check both the filesystem AND the ADR independently; the issue may describe a state that has already been partially fixed |
+| Looking for "Related Files" section at a specific line | Issue description referenced line 326 as the location of a stale entry | The line number referenced an earlier state of the file | Don't rely on line numbers from issue descriptions; grep for the actual pattern instead |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Files changed | `docs/adr/ADR-004-testing-strategy.md` |
+| Lines changed | 1 removed, 5 added |
+| Pre-commit hooks | All passed (markdownlint, trailing whitespace, end-of-file) |
+| PR | https://github.com/HomericIntelligence/ProjectOdyssey/pull/3820 |
+| Issue | #3252 |
+| Branch | `3252-auto-impl` |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3252 follow-up from #3061 | [notes.md](../references/notes.md) |
+
+## Key Insight
+
+When an issue says "verify this directory or clean it up," the actual task is often just a
+documentation accuracy fix — not code deletion. Confirm the filesystem state first, then update
+the ADR to match. The deleted file may already be gone from both disk and the ADR; the remaining
+work is ensuring the *rest* of the directory listing is complete and accurate.


### PR DESCRIPTION
## Summary

Documents the pattern for correcting stale ADR directory tree listings after file deletions
or additions leave the documentation out of sync with the actual filesystem.

- Issue titles can be misleading — the real task was updating an incomplete listing, not deleting files
- Confirm filesystem state first before acting; the deletion may already be done in a prior PR
- An incomplete listing (too few files shown) is as wrong as a phantom reference to a deleted file

## Key Findings

**What Worked**:
- `ls` the directory first to get ground truth, then grep the ADR for the stale listing
- Using `Edit` to replace the old tree block with an accurate one matching the existing ASCII format
- Running `pixi run pre-commit run markdownlint-cli2 --files <file>` to verify before committing

**What Failed**:
- Searching for the deleted filename (`gradient_checking`) in the ADR — it was already removed in the prior PR
- Relying on issue-body line numbers — the file had changed since the issue was written

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] SKILL.md has YAML frontmatter, Verified Workflow, and Failed Attempts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)