### PR TITLE
feat: add mojo-extensor-bool-method skill

### DIFF
--- a/skills/architecture/mojo-extensor-bool-method/.claude-plugin/plugin.json
+++ b/skills/architecture/mojo-extensor-bool-method/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-extensor-bool-method",
+  "version": "1.0.0",
+  "description": "Implement __bool__ on a Mojo tensor/struct for single-element truthiness. Use when: (1) adding Python/NumPy/PyTorch-compatible boolean context to a Mojo struct, (2) un-commenting placeholder tests for __bool__, (3) following up on existing item() / __int__ / __float__ implementations.",
+  "category": "architecture",
+  "date": "2026-03-07",
+  "tags": ["mojo", "extensor", "bool", "dunder", "truthiness", "tensor"]
+}

--- a/skills/architecture/mojo-extensor-bool-method/references/notes.md
+++ b/skills/architecture/mojo-extensor-bool-method/references/notes.md
@@ -1,0 +1,40 @@
+# Session Notes: mojo-extensor-bool-method
+
+**Date**: 2026-03-07
+**Issue**: ProjectOdyssey #3255
+**PR**: ProjectOdyssey #3825
+**Branch**: 3255-auto-impl
+
+## Objective
+
+Implement `fn __bool__(self) raises -> Bool` on `ExTensor` in `shared/core/extensor.mojo`.
+Tests in `tests/shared/core/test_utility.mojo` had placeholder commented-out code to be activated.
+
+## Session Timeline
+
+1. Read `.claude-prompt-3255.md` — issue description: add `__bool__` delegating to `item()`
+2. Searched for existing `__bool__` / `test_bool` occurrences — found in 4 files
+3. Located `fn item`, `fn __int__`, `fn __float__` in extensor.mojo (lines ~2904, 2751, 2768)
+4. Read placeholder tests in test_utility.mojo (lines 346-381)
+5. Inserted `__bool__` before `__int__` (line 2751) — 20 lines
+6. Updated `test_bool_single_element` — replaced `pass` with direct boolean assertions
+7. Updated `test_bool_requires_single_element` — changed `item(t)` call to `Bool(t)`, updated docstring
+8. Attempted `pixi run mojo test` — GLIBC incompatibility (host OS too old)
+9. Committed — all 8 pre-commit hooks passed
+10. Pushed to `origin/3255-auto-impl`
+11. Created PR #3825 with `--label implementation`, enabled auto-merge with `--rebase`
+
+## Key Code Locations
+
+- Implementation: `shared/core/extensor.mojo` line ~2751 (between `__len__` and `__int__`)
+- Tests: `tests/shared/core/test_utility.mojo` lines 346-381
+
+## Environment Notes
+
+- Mojo tests cannot run locally on this host (GLIBC too old — needs 2.32+, host has older)
+- Tests validated by CI (Docker container with correct GLIBC)
+- Pre-commit hooks: `pixi run mojo format` + `Validate Test Coverage` both passed
+
+## Related Skills
+
+- `mojo-extensor-utility-methods` — broader coverage of ExTensor dunders (issue #2722, PR #3161)

--- a/skills/architecture/mojo-extensor-bool-method/skills/mojo-extensor-bool-method/SKILL.md
+++ b/skills/architecture/mojo-extensor-bool-method/skills/mojo-extensor-bool-method/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: mojo-extensor-bool-method
+description: "Implement __bool__ on a Mojo tensor/struct for single-element truthiness. Use when: adding Python/NumPy/PyTorch-compatible boolean context to a Mojo struct, un-commenting placeholder tests for __bool__, or following up on existing item()/__int__/__float__ implementations."
+category: architecture
+date: 2026-03-07
+user-invocable: false
+---
+
+# Skill: Mojo ExTensor `__bool__` Method
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Objective** | Add `fn __bool__(self) raises -> Bool` to `ExTensor` so single-element tensors work in boolean context |
+| **Outcome** | Implementation added in 20 lines; placeholder tests activated; all pre-commit hooks passed; PR #3825 created |
+| **PRs** | [#3825](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3825) |
+| **Issue** | [#3255](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3255) |
+
+## Overview
+
+ExTensor already had `item()`, `__int__`, and `__float__` that all delegate to `item()`.
+Adding `__bool__` follows the exact same pattern: delegate to `item()`, compare to `0.0`.
+The only wrinkle is that the test file had the tests commented out as placeholders — they
+need to be un-commented and updated to call `Bool(t)` for the multi-element error test.
+
+## When to Use
+
+1. Adding boolean-context support to a Mojo struct that already has `item()`
+2. Un-commenting placeholder `test_bool_*` tests after implementing `__bool__`
+3. Implementing PyTorch/NumPy semantics: single-element tensor usable in `if` statements
+4. Following up issue `_Follow-up from #NNNN_` patterns where the PR added `item()` but not `__bool__`
+
+## Verified Workflow
+
+### Step 1: Locate insertion point
+
+Find where `__int__` is defined — `__bool__` goes immediately before it:
+
+```bash
+grep -n "fn __int__\|fn __float__\|fn __len__\|fn item" shared/core/extensor.mojo | head -20
+```
+
+### Step 2: Insert `__bool__` before `__int__`
+
+```mojo
+fn __bool__(self) raises -> Bool:
+    """Return the boolean value of a single-element tensor.
+
+    Follows PyTorch/NumPy convention: a single-element tensor can be
+    used in boolean context. Returns True if the value is non-zero.
+
+    Returns:
+        True if the single element is non-zero, False otherwise.
+
+    Raises:
+        Error: If tensor has more than one element.
+
+    Example:
+        ```mojo
+        var x = full([], 5.0, DType.float32)
+        if x:  # True
+            print("non-zero")
+        ```
+    """
+    return self.item() != 0.0
+```
+
+**Placement rule**: After `__len__`, before `__int__`. This keeps conversion methods grouped.
+
+### Step 3: Activate placeholder tests
+
+The test file had commented-out assertions. Replace the `pass` placeholder pattern:
+
+**Before** (placeholder):
+
+```mojo
+fn test_bool_single_element() raises:
+    # if t_zero:  # Should be False
+    #     raise Error("Zero tensor should be falsy")
+    # if not t_nonzero:  # Should be True
+    #     raise Error("Non-zero tensor should be truthy")
+    pass  # Placeholder
+```
+
+**After** (active tests):
+
+```mojo
+fn test_bool_single_element() raises:
+    if t_zero:
+        raise Error("Zero tensor should be falsy")
+    if not t_nonzero:
+        raise Error("Non-zero tensor should be truthy")
+```
+
+### Step 4: Update multi-element error test
+
+The `test_bool_requires_single_element` test originally called `item(t)` to indirectly test
+the single-element requirement. Update it to call `Bool(t)` directly and update the error message:
+
+```mojo
+fn test_bool_requires_single_element() raises:
+    """Test that __bool__ raises for multi-element tensor."""
+    var shape = List[Int]()
+    shape.append(5)
+    var t = ones(shape, DType.float32)
+
+    var error_raised = False
+    try:
+        var val = Bool(t)  # Should raise error for multi-element tensor
+        _ = val
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        if (
+            "single" not in error_msg.lower()
+            and "element" not in error_msg.lower()
+        ):
+            raise Error("Error message should mention single-element requirement")
+
+    if not error_raised:
+        raise Error("__bool__ on multi-element tensor should raise error")
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests locally | `pixi run mojo test tests/shared/core/test_utility.mojo` | GLIBC version incompatibility on host OS (requires 2.32-2.34, host has older version) | Tests only run in Docker/CI; validate correctness by code review and pre-commit hooks |
+| Placing `__bool__` after `__float__` | Considered grouping bool with other conversions after float | Minor ordering concern — no technical failure | Convention is `__bool__` near `__len__` (both are "meta" methods), before numeric conversions |
+
+## Results & Parameters
+
+**Files modified**: 2
+
+| File | Change |
+|------|--------|
+| `shared/core/extensor.mojo` | Added `__bool__` method (+20 lines) |
+| `tests/shared/core/test_utility.mojo` | Activated placeholder tests (+7/-12 lines net) |
+
+**Implementation** (complete, copy-paste ready):
+
+```mojo
+fn __bool__(self) raises -> Bool:
+    return self.item() != 0.0
+```
+
+**Test patterns**:
+
+```mojo
+# Boolean context test (single-element)
+if t_zero:
+    raise Error("Zero tensor should be falsy")
+if not t_nonzero:
+    raise Error("Non-zero tensor should be truthy")
+
+# Error test (multi-element)
+var val = Bool(t)  # raises for multi-element
+```
+
+**Pre-commit hooks that run on this change**:
+
+- `Mojo Format` — auto-formats; always passes
+- `Validate Test Coverage` — checks test count; passes if test functions exist
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3255, PR #3825 | Follow-up from #2722 (item() implementation) |


### PR DESCRIPTION
## Summary

Documents implementing `__bool__` on Mojo's `ExTensor` struct for single-element truthiness,
following PyTorch/NumPy conventions.

- Delegates to `item() != 0.0`, consistent with existing `__int__`/`__float__` methods
- Covers how to activate placeholder tests and switch from `item(t)` to `Bool(t)` for direct testing
- Notes GLIBC environment constraint (tests only run in Docker/CI on older hosts)

## Key Findings

**What Worked**:
- Inserting `__bool__` between `__len__` and `__int__` for logical grouping
- Using `Bool(t)` to directly invoke `__bool__` in the multi-element error test
- All 8 pre-commit hooks passed without any fixups needed

**What Failed**:
- Local Mojo test execution → GLIBC version incompatibility on host OS

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears as `mojo-extensor-bool-method`
- [ ] Check skill activates for \"add __bool__\" or \"boolean context tensor\" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)