### PR TITLE
feat: update mojo-deprecated-alias-removal skill with follow-up learnings

### DIFF
--- a/skills/architecture/mojo-deprecated-alias-removal/references/notes-3267.md
+++ b/skills/architecture/mojo-deprecated-alias-removal/references/notes-3267.md
@@ -1,0 +1,76 @@
+# Session Notes: Mojo Deprecated Alias Removal — Follow-up (#3267)
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: `3267-auto-impl`
+- **Issue**: #3267 - Audit all remaining deprecated aliases in shared/core
+- **PR**: #3833
+- **Parent Issue**: #3059 (type consolidation cleanup series)
+- **Prior Issue**: #3065 (removed linear aliases), #3064 (partial conv2d cleanup)
+
+## Task Description
+
+Remove remaining 8 deprecated `comptime` type aliases from `shared/core`:
+- `LinearBackwardResult`, `LinearNoBiasBackwardResult`
+- `Conv2dBackwardResult`, `Conv2dNoBiasBackwardResult`
+- `DepthwiseConv2dBackwardResult`, `DepthwiseConv2dNoBiasBackwardResult`
+- `DepthwiseSeparableConv2dBackwardResult`, `DepthwiseSeparableConv2dNoBiasBackwardResult`
+
+The issue plan described changes to 6 files (linear.mojo, conv.mojo, __init__.mojo,
+layers/conv2d.mojo, test_backward_compat_aliases.mojo, test_conv.mojo).
+
+## What Actually Happened
+
+All source-level changes had already been applied by prior sessions. A comprehensive grep
+across all `.mojo` files for all 8 deprecated alias names returned exactly ONE match:
+
+```
+tests/shared/core/test_conv.mojo:1115:
+    # Backward pass tests (Conv2dBackwardResult is GradientTriple which is Copyable)
+```
+
+This was a stale comment — not a code reference. The fix was a single line update:
+
+```mojo
+# BEFORE
+# Backward pass tests (Conv2dBackwardResult is GradientTriple which is Copyable)
+
+# AFTER
+# Backward pass tests (return type is GradientTriple which is Copyable)
+```
+
+## Key Observations
+
+1. **Always grep first, plan second**: The detailed issue plan described 18+ changes across
+   6 files. In reality, only 1 comment update was needed. Reading the grep output before
+   the plan would have saved time.
+
+2. **Comments are not caught by import/code grepping**: The final stale reference was in a
+   comment. Grep with no file-type restriction or `--include` filter ensures comments
+   are also searched.
+
+3. **`test_backward_compat_aliases.mojo` was already deleted**: The plan said to delete it;
+   it was already gone. Check for file existence before planning deletions.
+
+4. **Multi-session cleanups leave partial state**: When an issue is a follow-up to prior
+   cleanup issues, assume most work is done. Verify first.
+
+## Verification
+
+```bash
+# Confirmed 0 remaining occurrences
+grep -rn "LinearBackwardResult|LinearNoBiasBackwardResult|Conv2dBackwardResult|..." \
+  --include="*.mojo" shared/ tests/
+# Result: 0 matches
+```
+
+Local mojo compilation unavailable (GLIBC incompatibility) — CI validates correctness.
+
+## Git Summary
+
+```
+1 file changed, 1 insertion(+), 1 deletion(-)
+ tests/shared/core/test_conv.mojo | 2 +-
+```

--- a/skills/architecture/mojo-deprecated-alias-removal/skills/mojo-deprecated-alias-removal/SKILL.md
+++ b/skills/architecture/mojo-deprecated-alias-removal/skills/mojo-deprecated-alias-removal/SKILL.md
@@ -193,6 +193,8 @@ The `test_backward_compat_aliases.mojo` file typically tests multiple aliases. O
 |---------|----------------|---------------|----------------|
 | Local `pixi run mojo build` | Ran mojo build locally to verify | GLIBC version incompatibility (`GLIBC_2.32/2.33/2.34` not found) — mojo requires newer glibc than available on the host | Mojo compilation must run in Docker container or CI; local verification is not possible on older Linux hosts |
 | Deleting only alias definitions | Only removed the `comptime X = Y` lines, didn't search for usages | Function return types still referenced the removed alias, would cause compile errors | Always grep for all occurrences before removing — aliases appear in return types, docstrings, and test files |
+| Grepping only code, not comments | On follow-up issue #3267, only searched for aliases in code/imports | Missed one stale comment in `test_conv.mojo` that still referenced `Conv2dBackwardResult` — the plan said 18+ changes but prior sessions had done all the real work already | Grep with no `--include` type filter to catch alias names in comments too; the final verification grep must return 0 results across ALL file content |
+| Assuming a detailed plan means lots of work remains | Issue #3267 plan described removing 8 aliases from 6 files; assumed this was all unimplemented | All source/import changes had already been done by prior sessions; only 1 comment update remained | Always grep for remaining occurrences FIRST before reading the plan — the actual work may be a tiny fraction of what the plan describes |
 
 ## Results & Parameters
 
@@ -237,7 +239,8 @@ Closes #<issue-number>
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3065, PR #3262 | [notes.md](../references/notes.md) |
+| ProjectOdyssey | Issue #3065, PR #3262 — initial linear alias removal | [notes.md](../references/notes.md) |
+| ProjectOdyssey | Issue #3267, PR #3833 — follow-up: remaining conv2d aliases (all already removed; only 1 stale comment remained) | [notes-3267.md](../references/notes-3267.md) |
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

Updates the existing `mojo-deprecated-alias-removal` skill with follow-up learnings from
issue #3267 (ProjectOdyssey) — the second cleanup pass targeting Conv2d deprecated aliases.

- Added 2 new rows to the Failed Attempts table capturing traps in multi-session cleanups
- Added session notes for issue #3267 in `references/notes-3267.md`
- Updated Verified On table with the follow-up session

## Key Findings

**What Worked**:
- Grep-first approach: run exhaustive grep across all `.mojo` files before reading the plan
- Unrestricted grep (no `--include` filter) catches alias references in comments too
- Verifying prior work before implementing: all 8 source-level changes were already done

**What Failed**:
- Assuming a detailed issue plan means lots of work remains — the actual change was 1 comment line
- Grepping only code/imports misses stale references in comments

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] Existing skill still PASS after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
