### PR TITLE
feat: add stale-ci-pattern-removal skill

### DIFF
--- a/skills/ci-cd/stale-ci-pattern-removal/.claude-plugin/plugin.json
+++ b/skills/ci-cd/stale-ci-pattern-removal/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "stale-ci-pattern-removal",
+  "version": "1.0.0",
+  "description": "Remove stale file references from CI workflow test pattern strings after test files are deleted. Use when: (1) a test file was deleted but its name still appears in a GitHub Actions workflow pattern string, (2) CI fails because it references a non-existent file, (3) closing a cleanup issue where the only remaining work is a dangling workflow reference.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["ci", "github-actions", "cleanup", "test-files", "workflow", "pattern-string"]
+}

--- a/skills/ci-cd/stale-ci-pattern-removal/references/notes.md
+++ b/skills/ci-cd/stale-ci-pattern-removal/references/notes.md
@@ -1,0 +1,39 @@
+# Session Notes — stale-ci-pattern-removal
+
+## Context
+
+- **Date**: 2026-03-07
+- **Issue**: HomericIntelligence/ProjectOdyssey #3266
+- **PR**: HomericIntelligence/ProjectOdyssey #3832
+- **Branch**: `3266-auto-impl`
+
+## Objective
+
+Remove `tests/shared/core/test_backward_compat_aliases.mojo` entirely (GitHub issue #3266).
+The file only tested `LinearBackwardResult`, `LinearNoBiasBackwardResult`, and
+`BenchmarkStatistics` aliases — all deprecated and removed in parent cleanup issue #3059.
+
+## Steps Taken
+
+1. Read the issue prompt from `.claude-prompt-3266.md`
+2. Attempted `Glob` for the test file — it did not exist in the worktree (already deleted)
+3. Launched a background `find` to confirm across the full repo (wasn't needed)
+4. Grepped for all references to `test_backward_compat_aliases` across the repo
+5. Found one reference in `.github/workflows/comprehensive-tests.yml` pattern string
+6. Used `Edit` tool to remove the stale token from the space-separated pattern string
+7. Verified no remaining references in `.yml`, `.toml`, or `.mojo` files
+8. Committed with pre-commit hooks passing, pushed, created PR #3832
+9. Enabled auto-merge (`gh pr merge 3832 --auto --rebase`)
+
+## Key Finding
+
+The test file was already deleted in a prior commit (`64a55f87`). The issue was purely about
+removing the leftover CI workflow reference — a 1-line change.
+
+## Lessons
+
+- When an issue says "delete a file", check if the file already exists before planning deletion
+- Issue descriptions can lag behind actual codebase state — always verify with `Glob`/`ls` first
+- Space-separated pattern strings in YAML workflows are a common place for stale file references
+- The `Edit` tool is preferred over `sed` for these changes — creates a reviewable, auditable diff
+- Background `find` commands are wasteful for simple existence checks; use synchronous `Glob`

--- a/skills/ci-cd/stale-ci-pattern-removal/skills/stale-ci-pattern-removal/SKILL.md
+++ b/skills/ci-cd/stale-ci-pattern-removal/skills/stale-ci-pattern-removal/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: stale-ci-pattern-removal
+description: "Remove stale file references from CI workflow test pattern strings after test files are deleted. Use when: (1) a test file was deleted but still appears in a GitHub Actions workflow pattern string, (2) closing a cleanup issue where the only remaining work is a dangling workflow reference."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | stale-ci-pattern-removal |
+| **Category** | ci-cd |
+| **Complexity** | Low |
+| **Risk** | Low |
+| **Time** | < 5 minutes |
+
+When a test file is deleted from the codebase, its filename often lingers in CI workflow
+pattern strings (e.g. `just test-group` invocations in GitHub Actions). This causes no
+immediate CI failure (since the test runner simply skips missing files), but leaves misleading
+dead references. This skill documents the minimal workflow to identify and remove them.
+
+## When to Use
+
+- A GitHub issue asks to "remove a test file entirely" and the file no longer exists on disk
+- CI workflow contains a space-separated pattern string that lists individual test filenames
+- The only remaining work to close an issue is removing a stale filename from a YAML workflow
+- A cleanup/deprecation issue where the test file itself is already gone
+
+## Verified Workflow
+
+1. **Confirm the file is gone**: Check the filesystem — do not assume the issue description
+   is current. The file may already have been deleted in a prior commit.
+
+   ```bash
+   ls tests/shared/core/test_<name>.mojo 2>/dev/null || echo "File does not exist"
+   ```
+
+2. **Grep for all references** to find every place the filename appears:
+
+   ```bash
+   grep -r "test_<name>" . --include="*.yml" --include="*.yaml" --include="*.toml" --include="*.mojo"
+   ```
+
+3. **Edit the workflow file**: Remove only the stale filename token from the pattern string.
+   The pattern strings are space-separated, so remove the token and its surrounding space.
+
+   Use the `Edit` tool (not `sed`) to make a precise, reviewable change.
+
+4. **Verify no remaining references** (excluding prompt/issue files):
+
+   ```bash
+   grep -r "test_<name>" . --include="*.yml" --include="*.toml" --include="*.mojo"
+   ```
+
+5. **Commit, push, create PR** following the standard branch workflow:
+   - Branch: `<issue-number>-auto-impl`
+   - Commit message: `refactor(tests): remove <name> from CI`
+   - PR body: `Closes #<issue>`
+   - Enable auto-merge: `gh pr merge <pr> --auto --rebase`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Glob for the file in worktree | `Glob tests/shared/core/test_backward_compat_aliases.mojo` | File did not exist — already deleted in a prior commit | Always verify file existence first; issue descriptions may lag behind actual state |
+| Background `find` command | Used `find /home/mvillmow/Odyssey2 -name "test_backward_compat_aliases.mojo"` | Ran as background task, output wasn't available when needed | For quick existence checks, use `ls` or `Glob` synchronously instead of background `find` |
+
+## Results & Parameters
+
+### Pattern string location (example)
+
+```yaml
+# .github/workflows/comprehensive-tests.yml
+pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo test_backward_compat_aliases.mojo ..."
+```
+
+After removal:
+
+```yaml
+pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo ..."
+```
+
+### Grep command to find all references
+
+```bash
+grep -r "<test_filename>" . \
+  --include="*.yml" --include="*.yaml" \
+  --include="*.toml" --include="*.mojo" \
+  -l
+```
+
+### Minimal commit message template
+
+```
+refactor(tests): remove <test_filename> from CI
+
+The test file <path> has been deleted; this removes the dangling
+reference from the CI workflow pattern string.
+
+Closes #<issue>
+```


### PR DESCRIPTION
## Summary

Documents the workflow for removing stale test file references from CI workflow pattern strings after test files have been deleted.

- Verified workflow for identifying and removing dangling filenames from space-separated CI pattern strings
- Failed attempts table documenting background `find` vs synchronous `Glob` trade-offs
- Copy-paste grep and commit message templates

## Key Findings

**What Worked**:
- Synchronous `Glob`/`ls` to quickly confirm file non-existence before acting
- `Edit` tool for precise, reviewable 1-line workflow changes
- Grepping across `.yml`, `.toml`, and `.mojo` to ensure no references remain

**What Failed**:
- Background `find` command → output not available when needed for simple existence check
- Assuming issue description reflects current file state → file was already deleted in a prior commit

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
