### PR TITLE
feat: add nd-tensor-dataloader-fix skill

### DIFF
--- a/skills/testing/nd-tensor-dataloader-fix/.claude-plugin/plugin.json
+++ b/skills/testing/nd-tensor-dataloader-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "nd-tensor-dataloader-fix",
+  "version": "1.0.0",
+  "description": "Fix DataLoader.next() to support N-D tensors by replacing hardcoded 2D shape assumptions with ExTensor.slice(). Use when: (1) DataLoader.next() crashes or produces wrong shapes for 3D/4D/N-D tensors, (2) image batches with shape (N, C, H, W) lose trailing dimensions, (3) adding tests for batch slicing of multi-dimensional tensors in Mojo.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["dataloader", "n-d-tensor", "batch-slicing", "mojo", "extensor", "training"]
+}

--- a/skills/testing/nd-tensor-dataloader-fix/references/notes.md
+++ b/skills/testing/nd-tensor-dataloader-fix/references/notes.md
@@ -1,0 +1,63 @@
+# Session Notes: nd-tensor-dataloader-fix
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: ProjectOdyssey #3277 — DataLoader.next() only supports 2D data tensors
+- **PR**: #3846 (https://github.com/HomericIntelligence/ProjectOdyssey/pull/3846)
+- **Branch**: `3277-auto-impl`
+- **Worktree**: `/home/mvillmow/Odyssey2/.worktrees/issue-3277`
+
+## Root Cause
+
+`DataLoader.next()` in `shared/training/trainer_interface.mojo` (line 383) contained:
+
+```mojo
+batch_data_shape.append(self.data.shape()[1])
+```
+
+This hardcoded index `[1]` assumes the data is 2D `(N, features)`. For 3D `(N, seq, feat)` or
+4D `(N, C, H, W)` tensors, the remaining dimensions were silently dropped.
+
+## Files Changed
+
+- `shared/training/trainer_interface.mojo` — 9 lines removed, 2 lines added
+- `tests/shared/training/test_training_loop.mojo` — 105 lines added (4 new test functions + main calls)
+
+## Key Discovery
+
+`ExTensor.slice(start, end, axis=0)` was already implemented and documented with a 4D example
+in the docstring (`shared/core/extensor.mojo:629`):
+
+```
+# Extract batch 0-32 from (112800, 1, 28, 28)
+var batch = dataset.slice(0, 32, axis=0)  # Returns (32, 1, 28, 28)
+```
+
+The fix was simply to use the existing API instead of manually re-constructing the shape.
+
+## Pre-commit Hook Results
+
+All hooks passed without skipping:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## Environment Note
+
+`pixi run mojo test` fails locally with GLIBC_2.32/2.33/2.34 not found errors.
+The mojo *format* binary works (different binary from the test runner).
+Tests validated by CI in Docker where correct GLIBC is available.
+
+## Test Coverage Added
+
+Four new test functions in `test_training_loop.mojo`:
+
+1. `test_dataloader_4d_batch_slicing` — `(8,2,4,4)` data, batch_size=4, checks both batches are `(4,2,4,4)`
+2. `test_dataloader_4d_partial_last_batch` — `(6,2,4,4)` data, batch_size=4, second batch is `(2,2,4,4)`
+3. `test_dataloader_3d_batch_slicing` — `(8,10,16)` data, batch_size=4, batch is `(4,10,16)`
+4. `test_dataloader_nd_shape_preserved` — `(9,3,8,8)` data, batch_size=4, all 3 batches have dims `(3,8,8)`

--- a/skills/testing/nd-tensor-dataloader-fix/skills/nd-tensor-dataloader-fix/SKILL.md
+++ b/skills/testing/nd-tensor-dataloader-fix/skills/nd-tensor-dataloader-fix/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: nd-tensor-dataloader-fix
+description: "Fix DataLoader.next() to support N-D tensors by replacing hardcoded 2D shape assumption with ExTensor.slice(). Use when: DataLoader produces wrong batch shapes for 3D/4D data, or adding N-D batch slicing tests in Mojo."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Skill Name** | nd-tensor-dataloader-fix |
+| **Category** | testing |
+| **Language** | Mojo |
+| **Issue Type** | DataLoader N-D tensor shape bug |
+| **Resolution** | Replace manual shape construction with `ExTensor.slice()` |
+
+## When to Use
+
+- `DataLoader.next()` crashes with an index-out-of-range on tensors with fewer or more than 2 dimensions
+- Batch slices of image data `(N, C, H, W)` collapse to wrong shape (e.g., `(batch, width)` instead of `(batch, C, H, W)`)
+- Adding tests for 3D, 4D, or N-D batch extraction from a `DataLoader`
+- Labels slicing also returns a wrong shape when labels are multi-dimensional
+
+## Verified Workflow
+
+### Step 1: Identify the hardcoded 2D assumption
+
+In `shared/training/trainer_interface.mojo`, `DataLoader.next()` contained:
+
+```mojo
+var batch_data_shape = List[Int]()
+batch_data_shape.append(actual_batch_size)
+batch_data_shape.append(self.data.shape()[1])   # ← 2D-only, crashes for 1D or 4D
+var batch_data = ExTensor(batch_data_shape, self.data.dtype())
+```
+
+This allocates a *new* zero tensor with only 2 dimensions, ignoring channels and spatial dims.
+
+### Step 2: Replace with ExTensor.slice()
+
+`ExTensor.slice(start, end, axis=0)` already returns a view preserving all trailing dimensions:
+
+```mojo
+# Extract batch slice — supports N-D tensors (2D, 3D, 4D, etc.)
+var batch_data = self.data.slice(start_idx, end_idx)
+var batch_labels = self.labels.slice(start_idx, end_idx)
+```
+
+No shape list needed. The returned tensor has shape `(end-start, d1, d2, ...)` for any N-D input.
+
+### Step 3: Add N-D tests to the test file
+
+Import `DataLoader` directly from the submodule (not from `shared.training` parent — Mojo re-export limitation):
+
+```mojo
+from shared.training.trainer_interface import DataLoader
+```
+
+Test pattern for 4D (image) data:
+
+```mojo
+fn test_dataloader_4d_batch_slicing() raises:
+    var data = ones([8, 2, 4, 4], DType.float32)
+    var labels = zeros([8], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    var batch = loader.next()
+    assert_equal(batch.data.shape()[0], 4)
+    assert_equal(batch.data.shape()[1], 2)
+    assert_equal(batch.data.shape()[2], 4)
+    assert_equal(batch.data.shape()[3], 4)
+```
+
+Test all batches preserve trailing dims (including partial last batch):
+
+```mojo
+fn test_dataloader_nd_shape_preserved() raises:
+    var data = ones([9, 3, 8, 8], DType.float32)
+    var labels = zeros([9], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    while loader.has_next():
+        var batch = loader.next()
+        assert_equal(batch.data.shape()[1], 3)
+        assert_equal(batch.data.shape()[2], 8)
+        assert_equal(batch.data.shape()[3], 8)
+```
+
+### Step 4: Handle GLIBC mismatch on local host
+
+If `mojo test` fails with `GLIBC_2.32/2.33/2.34 not found`, the local host has too old a libc.
+Pre-commit hooks include `mojo format` which also fails. Use `SKIP=mojo-format` only when
+the host cannot run the mojo binary, and let CI validate format in Docker:
+
+```bash
+# All pre-commit hooks pass when mojo binary IS available
+git add <files> && git commit -m "fix(...): ..."
+# If GLIBC blocks mojo format:
+SKIP=mojo-format git commit -m "fix(...): ..."
+```
+
+In this session, `mojo format` ran successfully (pre-commit passed clean), so no skip was needed.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests locally | `pixi run mojo test tests/shared/training/test_training_loop.mojo` | GLIBC_2.32/2.33/2.34 not found on host | Local host GLIBC too old; Mojo tests must run in Docker/CI |
+| Manual shape construction | Considered building `batch_data_shape` with a loop over `self.data.shape()` | More complex than needed, would still allocate new tensor | `ExTensor.slice()` is already implemented and returns a shared-memory view |
+
+## Results & Parameters
+
+### Minimal fix (2 lines changed)
+
+```mojo
+# Before (2D-only):
+var batch_data_shape = List[Int]()
+batch_data_shape.append(actual_batch_size)
+batch_data_shape.append(self.data.shape()[1])
+var batch_data = ExTensor(batch_data_shape, self.data.dtype())
+
+var batch_labels_shape = List[Int]()
+batch_labels_shape.append(actual_batch_size)
+var batch_labels = ExTensor(batch_labels_shape, self.labels.dtype())
+
+# After (N-D):
+var batch_data = self.data.slice(start_idx, end_idx)
+var batch_labels = self.labels.slice(start_idx, end_idx)
+```
+
+### Mojo submodule import pattern
+
+```mojo
+# Use direct submodule import — Mojo re-export limitations prevent using parent package
+from shared.training.trainer_interface import DataLoader
+# NOT: from shared.training import DataLoader  (may fail)
+```
+
+### ExTensor.slice() signature
+
+```mojo
+fn slice(self, start: Int, end: Int, axis: Int = 0) raises -> ExTensor
+# Returns a shared-memory view. Modifying the slice modifies the original.
+# Shape of result: (end-start, d1, d2, ...) for any number of trailing dims.
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #3846, Issue #3277 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to fix `DataLoader.next()` 2D-only hardcoded shape assumption in Mojo by
replacing manual shape construction with `ExTensor.slice()` which preserves all trailing
dimensions for N-D tensors.

- Root cause: `self.data.shape()[1]` hardcoded 2D assumption drops C, H, W for image data
- Fix: 2-line replacement using `ExTensor.slice(start_idx, end_idx)` (already N-D aware)
- Tests: 4 new test cases covering 4D image batches, 3D sequence batches, and partial last batches

## Key Findings

**What Worked**:
- `ExTensor.slice()` was already implemented and documented with a 4D example in its docstring
- Importing `DataLoader` directly from `shared.training.trainer_interface` (submodule import) works; parent package re-export may not (Mojo limitation)
- Testing partial last batch specifically catches trailing-dim preservation bugs

**What Failed**:
- Running `mojo test` locally fails with GLIBC version mismatch — must use Docker/CI
- Manual shape loop would be more complex and still allocate a new (non-view) tensor

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates on triggers: "dataloader 4D", "N-D tensor batch", "shape()[1] hardcoded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)