### PR TITLE
feat: add mojo-pythonobject-to-native-type-migration skill

### DIFF
--- a/skills/architecture/mojo-pythonobject-to-native-type-migration/.claude-plugin/plugin.json
+++ b/skills/architecture/mojo-pythonobject-to-native-type-migration/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-pythonobject-to-native-type-migration",
+  "version": "1.0.0",
+  "description": "Migrate Mojo function signatures from PythonObject placeholder parameters to native Mojo struct types. Use when: (1) a function accepts PythonObject as a placeholder pending interop infrastructure, (2) the native Mojo struct is now available and has has_next()/next() iteration, (3) tests use Python.none() as a placeholder argument that needs updating to real data.",
+  "category": "architecture",
+  "date": "2026-03-07",
+  "tags": ["mojo", "python-interop", "migration", "native-types", "dataloader", "pythonobject"]
+}

--- a/skills/architecture/mojo-pythonobject-to-native-type-migration/references/notes.md
+++ b/skills/architecture/mojo-pythonobject-to-native-type-migration/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes: Issue #3278 - run_epoch() PythonObject to DataLoader Migration
+
+## Context
+
+- **Issue**: #3278 — `TrainingLoop.run_epoch()` in `shared/training/__init__.mojo` accepted
+  `PythonObject` instead of the native `DataLoader` struct from `trainer_interface.mojo`
+- **Branch**: `3278-auto-impl`
+- **PR**: #3850
+
+## Root Cause
+
+The `run_epoch()` function was written with `PythonObject` as a placeholder while Track 4
+(Python-Mojo interop infrastructure) was being built. The native `DataLoader` struct already
+existed in `trainer_interface.mojo` with full `has_next()`/`next()` iteration but was unused.
+
+The function body was entirely a no-op:
+```mojo
+_ = data_loader  # Suppress unused variable warning
+return Float32(0.0)
+```
+
+## Files Changed
+
+1. `shared/training/__init__.mojo`
+   - Removed `from python import PythonObject`
+   - Added `from shared.training.trainer_interface import DataLoader, DataBatch`
+   - Changed `run_epoch()` parameter type and implemented real batch loop
+   - Removed stale "PythonObject" reference from TrainingLoop docstring
+
+2. `tests/shared/training/test_training_loop.mojo`
+   - Added `from shared.training.trainer_interface import DataLoader` import
+   - Removed `create_mock_dataloader` import (no longer used)
+   - Replaced `Python.none()` placeholder with real `DataLoader(ones([100,10])^, zeros([100,1])^, 10)`
+   - Changed assertion from `assert_equal(Int(avg_loss), 0)` to `assert_greater(Float64(avg_loss), -0.001)`
+   - Updated print message from "PASSED (placeholder)" to "PASSED"
+
+## Key Observations
+
+- `DataLoader.next()` still creates placeholder zero tensors (ExTensor.slice() not integrated yet)
+  so loss will be 0.0 per batch — assertion uses `>= -0.001` not `> 0`
+- The `mut` keyword is needed on `data_loader` parameter since `next()` mutates `current_batch`
+- Pre-commit hooks (mojo format, trailing whitespace, etc.) all passed on first attempt
+- Mojo cannot run locally (GLIBC 2.31 < required 2.32); CI validates the actual compilation
+
+## Commit
+
+`fix(training): migrate run_epoch() from PythonObject to native DataLoader`

--- a/skills/architecture/mojo-pythonobject-to-native-type-migration/skills/mojo-pythonobject-to-native-type-migration/SKILL.md
+++ b/skills/architecture/mojo-pythonobject-to-native-type-migration/skills/mojo-pythonobject-to-native-type-migration/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: mojo-pythonobject-to-native-type-migration
+description: "Migrate Mojo function signatures from PythonObject placeholder parameters to native Mojo struct types. Use when: a function accepts PythonObject as a temporary placeholder pending interop infrastructure, and the native struct is now ready."
+category: architecture
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Category** | architecture |
+| **Objective** | Replace PythonObject placeholder parameters with native Mojo struct types once interop infrastructure is available |
+| **Outcome** | Success - run_epoch() migrated from PythonObject to DataLoader; tests updated; all pre-commit hooks pass |
+
+## When to Use
+
+Invoke this skill when:
+
+- A Mojo function accepts `PythonObject` as a stopgap while native struct was being built
+- The native Mojo struct (e.g., `DataLoader`) now exists with `has_next()`/`next()` iteration
+- Tests use `Python.none()` or a dummy `PythonObject` as a placeholder argument
+- The function body has a `_ = data_loader  # Suppress unused variable` pattern (no real work done)
+- A NOTE comment references "Track 4", "blocked by interop", or "TODO: implement when X is ready"
+
+## Verified Workflow
+
+1. **Read the function** with `PythonObject` parameter to understand the intended behavior from its docstring
+2. **Locate the native struct** (`DataLoader`, etc.) — usually in `trainer_interface.mojo` or adjacent file
+3. **Verify the struct's iteration API**: confirm `reset()`, `has_next()`, `next()` exist and return the right types
+4. **Update the import block** — remove `from python import PythonObject` if no longer used elsewhere; add import for the native struct
+5. **Change the function signature**: `data_loader: PythonObject` → `mut data_loader: DataLoader` (needs `mut` for stateful iteration)
+6. **Implement the loop body**:
+   ```mojo
+   data_loader.reset()
+   while data_loader.has_next():
+       var batch = data_loader.next()
+       var loss = self.step(batch.data, batch.labels)
+       total_loss += Float64(loss._get_float32(0))
+       num_batches += 1
+   ```
+7. **Update tests** — replace `Python.none()` / `py_loader` with a real struct constructed from `ExTensor` data
+8. **Update test assertions** — old placeholder assertion (e.g., `assert_equal(Int(avg_loss), 0)`) must reflect real processing
+9. **Remove unused imports** from the test file (e.g., `create_mock_dataloader` if switched to inline construction)
+10. **Run pre-commit hooks** to verify mojo format, trailing whitespace, large files pass
+
+## Results & Parameters
+
+### Signature change pattern
+
+```mojo
+# Before
+fn run_epoch(mut self, data_loader: PythonObject) raises -> Float32:
+    _ = data_loader  # suppress unused warning
+    return Float32(0.0)
+
+# After
+fn run_epoch(mut self, mut data_loader: DataLoader) raises -> Float32:
+    var total_loss = Float64(0.0)
+    var num_batches = Int(0)
+    data_loader.reset()
+    while data_loader.has_next():
+        var batch = data_loader.next()
+        var loss = self.step(batch.data, batch.labels)
+        total_loss += Float64(loss._get_float32(0))
+        num_batches += 1
+    if num_batches > 0:
+        return Float32(total_loss / Float64(num_batches))
+    else:
+        return Float32(0.0)
+```
+
+### Import change pattern
+
+```mojo
+# Before
+from python import PythonObject
+
+# After
+from shared.training.trainer_interface import DataLoader, DataBatch
+```
+
+### Test change pattern
+
+```mojo
+# Before
+from python import Python
+var py_loader = Python.none()
+var avg_loss = training_loop.run_epoch(py_loader)
+assert_equal(Int(avg_loss), 0)  # Placeholder returns 0.0
+
+# After
+var data_tensor = ones([100, 10], DType.float32)
+var label_tensor = zeros([100, 1], DType.float32)
+var data_loader = DataLoader(data_tensor^, label_tensor^, batch_size=10)
+var avg_loss = training_loop.run_epoch(data_loader)
+assert_greater(Float64(avg_loss), Float64(-0.001))
+```
+
+### Key constraints
+
+- DataLoader's `next()` requires `mut self` — the parameter must be `mut data_loader`
+- If `DataLoader.next()` still returns placeholder zero tensors internally (pending ExTensor.slice()), the loss will be 0.0 — use `assert_greater(loss, -0.001)` not `assert_equal(loss, positive_value)`
+- The `DataBatch` struct exposes `.data` and `.labels` fields
+- If `PythonObject` was imported only for this one use, remove the entire import line
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests locally | `pixi run mojo test` | GLIBC too old on host (needs 2.32+, host has 2.31) | Tests must run in CI or Docker; verify code correctness by reading the struct APIs instead |
+| Using Docker CI image | `docker run ghcr.io/homericintelligence/projectodyssey:main` | Image not pulled locally, registry access denied outside CI | Local test execution not available; rely on CI and pre-commit hooks |
+| Keeping `_ = data_loader` | Left the suppress line when switching to real iteration | Compiler would warn / suppress is no longer needed once data_loader is consumed | Remove the suppress line entirely when implementing real iteration |


### PR DESCRIPTION
## Summary

Documents the pattern for migrating Mojo functions that accepted `PythonObject` as a
temporary placeholder to native Mojo struct types, once the struct's iteration API is ready.

- Captures the exact signature change (`PythonObject` → `mut DataLoader`)
- Documents the batch loop implementation using `reset()`/`has_next()`/`next()`
- Records test update pattern (replacing `Python.none()` with real `ExTensor`-backed structs)

## Key Findings

**What Worked**:
- Adding `mut` to the parameter so stateful `next()` can mutate `current_batch`
- Using `assert_greater(avg_loss, -0.001)` when `DataLoader.next()` still returns placeholder zeros
- Removing `from python import PythonObject` entirely once it becomes unused

**What Failed**:
- Running tests locally — GLIBC 2.31 too old (needs 2.32+); must rely on CI
- Docker image not available locally (registry access denied outside CI)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates when searching "mojo pythonobject migration" or "dataloader interop"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
