### PR TITLE
feat: add mojo-python-interop-placeholder-replacement skill

### DIFF
--- a/skills/architecture/mojo-python-interop-placeholder-replacement/.claude-plugin/plugin.json
+++ b/skills/architecture/mojo-python-interop-placeholder-replacement/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-python-interop-placeholder-replacement",
+  "version": "1.0.0",
+  "description": "Workflow for replacing Mojo stdlib-gap placeholders with Python interop using Python.import_module(). Use when: (1) a Mojo function has a placeholder body because Mojo v0.26.1 lacks a stdlib operation (e.g. os.remove, os.rename), (2) replacing a no-op stub that silently returns True/False without doing real work, (3) implementing filesystem operations in Mojo before native stdlib support exists.",
+  "category": "architecture",
+  "date": "2026-03-07",
+  "tags": ["mojo", "python-interop", "placeholder", "stdlib-gap", "file-io", "os-remove"]
+}

--- a/skills/architecture/mojo-python-interop-placeholder-replacement/references/notes.md
+++ b/skills/architecture/mojo-python-interop-placeholder-replacement/references/notes.md
@@ -1,0 +1,79 @@
+# Session Notes: mojo-python-interop-placeholder-replacement
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3283 — Replace file_io.mojo placeholder remove_file() with real implementation
+- **Branch**: 3283-auto-impl
+- **PR**: #3874
+
+## Problem
+
+`shared/utils/file_io.mojo:671` contained a `remove_safely()` function that:
+- Checked `file_exists()` (real check)
+- Returned `True` unconditionally without deleting anything
+- Had a NOTE comment: "Mojo v0.26.1 doesn't have os.remove() or file system operations"
+- Called itself a "placeholder"
+
+This was a silent correctness bug: callers (e.g. checkpoint cleanup) believed files were
+removed when they were not.
+
+## Root Cause
+
+Mojo v0.26.1 stdlib lacks `os.remove()` and other filesystem mutation operations.
+The same file already used `Python.import_module("os").rename()` in `safe_write_file()`
+for the same reason — there was a clear pattern to follow.
+
+## Files Changed
+
+- `shared/utils/file_io.mojo:662-679` — replaced placeholder with Python interop
+- `tests/shared/utils/test_io.mojo:233-253` — replaced TODO stub with real test
+
+## Verification
+
+Pre-commit passed locally:
+```
+Mojo Format..............................................................Passed
+Check for deprecated List[Type](args) syntax.............................Passed
+Validate Test Coverage...................................................Passed
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Check for Large Files....................................................Passed
+Fix Mixed Line Endings...................................................Passed
+```
+
+Mojo tests could NOT run locally due to GLIBC version mismatch (host: 2.31, required: 2.32+).
+CI is the authoritative test runner.
+
+## Implementation
+
+```mojo
+fn remove_safely(filepath: String) -> Bool:
+    """Remove file using Python os.remove() interop."""
+    if not file_exists(filepath):
+        return False
+    try:
+        var python = Python.import_module("os")
+        python.remove(filepath)
+        return True
+    except:
+        return False
+```
+
+## Test
+
+```mojo
+fn test_safe_remove() raises:
+    from shared.utils.file_io import remove_safely, safe_write_file, file_exists
+    var test_path = "/tmp/test_remove_safely_3283.txt"
+    var written = safe_write_file(test_path, "test content")
+    assert_true(written)
+    assert_true(file_exists(test_path))
+    var removed = remove_safely(test_path)
+    assert_true(removed)
+    assert_false(file_exists(test_path))
+    var removed_again = remove_safely(test_path)
+    assert_false(removed_again)
+    print("PASS: test_safe_remove")
+```

--- a/skills/architecture/mojo-python-interop-placeholder-replacement/skills/mojo-python-interop-placeholder-replacement/SKILL.md
+++ b/skills/architecture/mojo-python-interop-placeholder-replacement/skills/mojo-python-interop-placeholder-replacement/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: mojo-python-interop-placeholder-replacement
+description: "Workflow for replacing Mojo stdlib-gap placeholders with Python interop. Use when: a Mojo function has a no-op placeholder body due to missing stdlib support (e.g. os.remove, os.rename), or when callers silently believe work was done when it was not."
+category: architecture
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-07 |
+| Objective | Replace no-op `remove_safely()` placeholder in file_io.mojo with real file deletion |
+| Outcome | Implemented using `Python.import_module("os").remove()` interop; pre-commit passes; PR created |
+| Issue | ProjectOdyssey #3283 |
+
+## When to Use
+
+- A Mojo function body is a stub/placeholder because a stdlib operation doesn't exist in Mojo v0.26.1
+- The placeholder returns `True`/`False` without actually performing the operation (silent failure risk)
+- You need filesystem operations (`os.remove`, `os.rename`, `os.mkdir`, etc.) before Mojo adds them natively
+- A NOTE comment in the code says "Mojo v0.26.1 doesn't have X"
+
+## Verified Workflow
+
+1. **Find the placeholder**: look for NOTE comments referencing Mojo version limitations
+   ```bash
+   grep -rn "NOTE (Mojo v0.26.1)" shared/
+   ```
+
+2. **Check existing Python interop usage** in the same file to find the established pattern:
+   ```bash
+   grep -n "Python.import_module" shared/utils/file_io.mojo
+   ```
+
+3. **Implement using the established pattern** (`safe_write_file` uses `os.rename` this way):
+   ```mojo
+   fn remove_safely(filepath: String) -> Bool:
+       if not file_exists(filepath):
+           return False
+       try:
+           var python = Python.import_module("os")
+           python.remove(filepath)
+           return True
+       except:
+           return False
+   ```
+
+4. **Replace the test stub** with a real test that verifies the operation actually occurred:
+   ```mojo
+   fn test_safe_remove() raises:
+       var test_path = "/tmp/test_remove_<unique>.txt"
+       var written = safe_write_file(test_path, "test content")
+       assert_true(written)
+       assert_true(file_exists(test_path))
+       var removed = remove_safely(test_path)
+       assert_true(removed)
+       assert_false(file_exists(test_path))  # file is actually gone
+       assert_false(remove_safely(test_path))  # nonexistent → False
+   ```
+
+5. **Run pre-commit hooks** to verify formatting:
+   ```bash
+   pixi run pre-commit run --files <changed files>
+   ```
+
+6. **Commit, push, and create PR** following conventional commits format with `Closes #<issue>`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run mojo tests locally | `pixi run mojo test tests/shared/utils/test_io.mojo` | GLIBC 2.32/2.33/2.34 not found on host OS (Debian Buster has GLIBC 2.31) | Mojo tests must run in Docker/CI; pre-commit hooks are the local verification boundary |
+| Use Docker images | `docker run ghcr.io/homericintelligence/projectodyssey:main` | Project Docker images not pulled on local machine | CI is the authoritative test runner for Mojo; don't block PR on local Mojo execution |
+| `just test-group` | `just test-group tests/shared/utils test_io.mojo` | `just` not installed on host | Same constraint as above; use `pixi run pre-commit` for local checks |
+
+## Results & Parameters
+
+**Pattern**: `Python.import_module("os").<method>(args)` inside a `try/except` block
+
+**Imports required** (already at top of file_io.mojo):
+```mojo
+from python import Python, PythonObject
+```
+
+**Key design decisions**:
+- Return `False` for nonexistent files *before* attempting removal (matches original guard)
+- Catch all exceptions and return `False` (consistent with rest of file_io error handling)
+- Do NOT add `raises` to the function signature — callers expect `Bool` return, not exception propagation
+
+**Pre-commit verification** (works without GLIBC constraint):
+```bash
+pixi run pre-commit run --files shared/utils/file_io.mojo tests/shared/utils/test_io.mojo
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3283, PR #3874 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

- Documents the pattern for replacing Mojo stdlib-gap placeholders with `Python.import_module()` interop
- Captured from ProjectOdyssey issue #3283 (`remove_safely()` file deletion no-op)
- Category: `architecture`

## Key Findings

**What Worked**:
- `Python.import_module("os").remove(filepath)` inside `try/except` returns `Bool` (no `raises`)
- Follow the existing interop pattern already in the same file (`safe_write_file` uses `os.rename` this way)
- Pre-commit hooks (`pixi run pre-commit run --files ...`) work locally even when Mojo can't execute due to GLIBC constraints

**What Failed**:
- Local `mojo test` → GLIBC 2.32/2.33/2.34 not found on Debian Buster (has 2.31); CI is the authoritative runner
- `just test-group` → `just` not installed on host
- Project Docker images not available locally

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates on queries about Mojo stdlib gaps or placeholder replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)