### PR TITLE
feat: add mojo-dataloader-deferral-resolution skill

### DIFF
--- a/skills/training/mojo-dataloader-deferral-resolution/.claude-plugin/plugin.json
+++ b/skills/training/mojo-dataloader-deferral-resolution/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-dataloader-deferral-resolution",
+  "version": "1.0.0",
+  "description": "Resolve PythonObject interop deferral placeholders in Mojo training loops by replacing them with real DataLoader iteration. Use when: (1) a Mojo function accepts PythonObject as a data loader but a native DataLoader struct already exists, (2) run_epoch() or similar training loop methods always return 0.0 due to a deferred interop placeholder, (3) Track 4 / Python-Mojo interop deferral comments exist in training code.",
+  "category": "training",
+  "date": "2026-03-07",
+  "tags": ["mojo", "dataloader", "training-loop", "python-interop", "deferral", "placeholder", "run-epoch"]
+}

--- a/skills/training/mojo-dataloader-deferral-resolution/references/notes.md
+++ b/skills/training/mojo-dataloader-deferral-resolution/references/notes.md
@@ -1,0 +1,41 @@
+# Session Notes: Mojo DataLoader Deferral Resolution
+
+## Issue
+
+GitHub issue #3284 — "Resolve Track 4 Python-Mojo interop deferral in batch iteration"
+
+Two `NOTE` comments in `shared/training/__init__.mojo` (line 412) and
+`shared/training/script_runner.mojo` (line 99) documented that batch iteration
+was deferred pending Track 4 Python-Mojo interop infrastructure. This meant
+`run_epoch()` always returned `0.0` (silent correctness bug).
+
+## Key Discovery
+
+`DataLoader` was **already fully implemented** in `shared/training/trainer_interface.mojo`
+as a pure Mojo struct with `has_next()`, `next()`, `reset()`. The deferral assumption
+(that Python interop was required) was incorrect — the infrastructure was already there.
+
+## Files Changed
+
+- `shared/training/__init__.mojo`: removed `from python import PythonObject`, added
+  `from shared.training.trainer_interface import DataLoader`, rewrote `run_epoch()` loop
+- `shared/training/script_runner.mojo`: same import swap, added `step_fn` parameter to
+  `run_epoch_with_batches()`, implemented real batch loop
+- `tests/shared/training/test_training_loop.mojo`: `test_training_loop_full_epoch()`
+  now uses real `DataLoader` with 2D tensors and asserts `avg_loss > -0.001`
+
+## Environment Constraints
+
+- Mojo cannot be run locally (GLIBC 2.31 on host, requires 2.32+)
+- Tests run via Docker / GitHub Actions CI
+- `pixi run mojo test` fails with GLIBC version errors locally
+
+## Pre-commit Results
+
+All hooks passed:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed

--- a/skills/training/mojo-dataloader-deferral-resolution/skills/mojo-dataloader-deferral-resolution/SKILL.md
+++ b/skills/training/mojo-dataloader-deferral-resolution/skills/mojo-dataloader-deferral-resolution/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: mojo-dataloader-deferral-resolution
+description: "Resolve PythonObject interop deferral placeholders in Mojo training loops by replacing them with real DataLoader iteration. Use when: a Mojo training function accepts PythonObject as a loader but a native DataLoader struct already exists, or run_epoch() silently returns 0.0 due to a deferred placeholder."
+category: training
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Problem** | `run_epoch()` and `run_epoch_with_batches()` silently return `0.0` due to `PythonObject` interop deferral placeholders |
+| **Root Cause** | Track 4 interop deferral comments like `# NOTE: Batch iteration blocked by Track 4` suppress real iteration, leaving `num_batches = 0` always |
+| **Solution** | The Mojo `DataLoader` struct was already implemented — replace `PythonObject` with it and add `has_next()`/`next()` loop |
+| **Files Changed** | `shared/training/__init__.mojo`, `shared/training/script_runner.mojo`, tests |
+| **Test Impact** | Update test to pass real `DataLoader` instead of `Python.none()` and assert `avg_loss > -0.001` |
+
+## When to Use
+
+- A Mojo training function's signature is `fn run_epoch(mut self, data_loader: PythonObject)` and a `DataLoader` struct exists in the codebase
+- `run_epoch()` always returns `0.0` regardless of data
+- Comments like `# Blocked: Track 4 (Python↔Mojo interop)` or `_ = data_loader  # Suppress unused variable warning` exist
+- Issue describes "silent correctness issue" where evaluate/train always returns zero
+
+## Verified Workflow
+
+1. **Locate all deferral sites**: `grep -r "Track 4\|PythonObject.*loader\|_ = data_loader" shared/training/`
+
+2. **Confirm DataLoader already exists**: Check `shared/training/trainer_interface.mojo` for `struct DataLoader` with `has_next()`, `next()`, `reset()` and `struct DataBatch` with `.data` / `.labels` fields.
+
+3. **Update imports in `__init__.mojo`**:
+   ```mojo
+   # Remove:
+   from python import PythonObject
+   # Add:
+   from shared.training.trainer_interface import DataLoader
+   ```
+
+4. **Replace `run_epoch` signature and body**:
+   ```mojo
+   # Before:
+   fn run_epoch(mut self, data_loader: PythonObject) raises -> Float32:
+       _ = data_loader  # Suppress unused variable warning
+       return Float32(0.0)
+
+   # After:
+   fn run_epoch(mut self, mut data_loader: DataLoader) raises -> Float32:
+       var total_loss = Float64(0.0)
+       var num_batches = Int(0)
+       data_loader.reset()
+       while data_loader.has_next():
+           var batch = data_loader.next()
+           var loss = self.step(batch.data, batch.labels)
+           total_loss += Float64(loss._get_float32(0))
+           num_batches += 1
+       if num_batches > 0:
+           return Float32(total_loss / Float64(num_batches))
+       else:
+           return Float32(0.0)
+   ```
+
+5. **Update `script_runner.mojo`** — add `step_fn` parameter so the caller controls the training step:
+   ```mojo
+   fn run_epoch_with_batches(
+       mut loader: DataLoader,
+       callbacks: TrainingCallbacks,
+       step_fn: fn (ExTensor, ExTensor) raises -> ExTensor,
+   ) raises -> Float32:
+       loader.reset()
+       var total_loss = Float64(0.0)
+       var num_batches = Int(0)
+       while loader.has_next():
+           var batch = loader.next()
+           var loss = step_fn(batch.data, batch.labels)
+           var loss_val = loss._get_float32(0)
+           total_loss += Float64(loss_val)
+           num_batches += 1
+           callbacks.on_batch_end(0, num_batches, Float32(loss_val))
+       if num_batches > 0:
+           return Float32(total_loss / Float64(num_batches))
+       return Float32(0.0)
+   ```
+
+6. **Update tests** — replace `Python.none()` with a real 2D `DataLoader`:
+   ```mojo
+   from shared.training.trainer_interface import DataLoader
+   var data = ones([10, 10], DType.float32)   # num_samples x input_dim
+   var labels = zeros([10, 1], DType.float32) # num_samples x output_dim
+   var data_loader = DataLoader(data^, labels^, 5)
+   var avg_loss = training_loop.run_epoch(data_loader)
+   assert_greater(Float64(avg_loss), Float64(-0.001))
+   ```
+
+7. **Check for other callers**: Confirm no other call sites pass `PythonObject` to the changed signatures (use `grep -r "run_epoch\|run_epoch_with_batches"`). Different `TrainingLoop` structs (e.g., in `loops/training_loop.mojo`) have their own `run_epoch` with different signatures — do not conflate them.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests locally | `pixi run mojo test tests/shared/training/test_training_loop.mojo` | GLIBC version mismatch — Mojo requires GLIBC 2.32+ but host has 2.31 | This project runs tests in Docker/CI; local mojo execution is not available in this environment |
+| Assuming `DataLoader.next()` extracts real slices | Expected `batch.data` to be a real slice of the dataset | `DataLoader.next()` creates placeholder tensors (not actual slices) due to a separate NOTE comment | The fix for correct slicing is a separate issue; the deferral resolution is just removing the loop-bypass |
+| Looking for `run_epoch` in `trainer.mojo` | Found `self.training_loop.run_epoch(...)` with many args | This calls a different `TrainingLoop` from `loops/training_loop.mojo`, not the generic `TrainingLoop[M,L,O]` struct | There are two separate `TrainingLoop` implementations — be precise about which one the issue targets |
+
+## Results & Parameters
+
+**Commit message format**:
+
+```text
+fix(training): replace Track 4 deferral with real DataLoader iteration
+
+Resolves the silent correctness bug where run_epoch() always returned 0.0.
+DataLoader was already fully implemented with has_next()/next()/reset() —
+the PythonObject interop assumption was never necessary.
+```
+
+**Key diagnostic pattern** — deferral placeholders always have this shape:
+
+```mojo
+_ = data_loader  # Suppress unused variable warning
+# or
+return Float32(0.0)
+```
+
+With a comment referencing `Track 4`, `Python↔Mojo interop`, or an issue number like `#3076`.
+
+**DataLoader 2D shape requirement**: `DataLoader.__init__` calls `self.data.shape()[1]` in `next()`,
+so data must be 2D (`[num_samples, features]`). 1D data causes an index-out-of-bounds error.


### PR DESCRIPTION
## Summary

Documents how to resolve `PythonObject` interop deferral placeholders in Mojo training loops when a native `DataLoader` struct already exists, eliminating silent correctness bugs where `run_epoch()` always returns `0.0`.

- Check whether `DataLoader` is already implemented before assuming Python interop is needed
- Replace `PythonObject` argument + `_ = data_loader` no-op with `has_next()`/`next()`/`reset()` loop
- `DataLoader.next()` requires 2D input tensors — 1D data causes index-out-of-bounds

## Key Findings

**What Worked**:
- Importing `DataLoader` from `shared.training.trainer_interface` and replacing `PythonObject` directly
- Passing `mut data_loader: DataLoader` to get mutable iteration
- Creating test `DataLoader` with 2D tensors `[num_samples, input_dim]`

**What Failed**:
- Assuming local `pixi run mojo test` would work (GLIBC version mismatch on host)
- Initially conflating two different `TrainingLoop` implementations (generic `TrainingLoop[M,L,O]` vs `loops/training_loop.mojo::TrainingLoop`)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "run_epoch returns 0.0" or "Track 4 deferral" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
