### PR TITLE
feat: add strip-note-prefix-comments skill

### DIFF
--- a/skills/documentation/strip-note-prefix-comments/.claude-plugin/plugin.json
+++ b/skills/documentation/strip-note-prefix-comments/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "strip-note-prefix-comments",
+  "version": "1.0.0",
+  "description": "Strip NOTE: prefix variants from plain comments in Mojo files without functional changes. Use when: (1) a follow-up cleanup issue asks to remove # NOTE: markers from test/example/script files, (2) files have # NOTE(#N): or # NOTE (version): variant patterns, (3) scope must be verified against actual file state before editing.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["mojo", "comments", "cleanup", "note", "refactoring"]
+}

--- a/skills/documentation/strip-note-prefix-comments/references/notes.md
+++ b/skills/documentation/strip-note-prefix-comments/references/notes.md
@@ -1,0 +1,57 @@
+# Session Notes: strip-note-prefix-comments
+
+## Session Details
+
+- **Date**: 2026-03-07
+- **Issue**: HomericIntelligence/ProjectOdyssey #3289
+- **Branch**: 3289-auto-impl
+- **PR**: #3882
+
+## Objective
+
+Convert remaining `# NOTE:` markers in test, example, `__init__`, benchmark, and script
+files to plain comments. Follow-up from #3072 which handled production source files.
+
+## Files in Issue Scope
+
+| File | Lines (issue) | Actual state |
+|------|---------------|--------------|
+| tests/models/test_alexnet_layers.mojo | 1101, 1114, 1128 | Had markers at 1119, 1132, 1146 (shifted) |
+| tests/shared/core/test_conv.mojo | 602 | No NOTE marker found |
+| examples/lenet-emnist/run_infer.mojo | 340 | Had `# NOTE (Mojo v0.26.1):` at 340 |
+| examples/googlenet-cifar10/train.mojo | 97 | Had `# NOTE(#3084):` at 97 |
+| shared/__init__.mojo | 52, 127 | Had markers at 51, 128 |
+| tests/shared/training/test_training_loop.mojo | 39 | Already clean |
+| tests/shared/utils/test_logging.mojo | 208 | Already clean |
+| benchmarks/scripts/compare_results.mojo | 595 | Had `# NOTE (Mojo v0.26.1):` at 595 |
+| scripts/verify_installation.mojo | 42 | Had marker at 42 |
+
+## Key Observations
+
+1. Issue line numbers were approximate — actual lines differed by a few due to edits since filing.
+2. Three files from the issue (`test_conv.mojo`, `test_training_loop.mojo`, `test_logging.mojo`)
+   had no remaining NOTE markers — already cleaned in an earlier session.
+3. Two files used `# NOTE (Mojo v0.26.1):` format (with space before paren).
+4. One file used `# NOTE(#3084):` format (issue reference, no space).
+5. All were appropriate as plain comments — none needed docstring `Note:` conversion.
+
+## Commit Message Used
+
+```text
+fix(comments): remove NOTE: prefix from test/example comment markers
+
+Converts remaining # NOTE: markers in test, example, __init__,
+benchmark, and script files to plain comments by stripping the
+NOTE:/NOTE(...): prefix. No functional changes.
+
+Files changed:
+- tests/models/test_alexnet_layers.mojo (3 NOTEs)
+- examples/lenet-emnist/run_infer.mojo (1 NOTE)
+- examples/googlenet-cifar10/train.mojo (1 NOTE)
+- shared/__init__.mojo (2 NOTEs)
+- benchmarks/scripts/compare_results.mojo (1 NOTE)
+- scripts/verify_installation.mojo (1 NOTE)
+
+Closes #3289
+Follow-up from #3072
+```

--- a/skills/documentation/strip-note-prefix-comments/skills/strip-note-prefix-comments/SKILL.md
+++ b/skills/documentation/strip-note-prefix-comments/skills/strip-note-prefix-comments/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: strip-note-prefix-comments
+description: "Strip NOTE: prefix variants from plain comments in Mojo files without functional changes. Use when: a follow-up cleanup issue targets # NOTE: markers in test/example/script files, files contain # NOTE(#N): or # NOTE (version): variants, or scope must be verified against actual file state before editing."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+# Skill: strip-note-prefix-comments
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | strip-note-prefix-comments |
+| **Category** | documentation |
+| **Language** | Mojo |
+| **Trigger** | Follow-up cleanup issue stripping `# NOTE:` prefix from test/example/script files |
+| **Outcome** | Success — 9 markers stripped across 6 files, all pre-commit hooks passed, PR created |
+| **Related** | Follow-up from issue #3072; see also `note-comment-cleanup` skill |
+
+## When to Use
+
+- A GitHub issue is a follow-up from a prior `# NOTE:` cleanup pass that left test/example files untouched
+- Issue lists specific files and line numbers but they may have already been partially fixed
+- Files contain variant patterns: `# NOTE(#N):`, `# NOTE (Mojo vX.Y):`, `# NOTE:` (bare)
+- Changes are comment-only (no functional impact) and must pass `mojo format` pre-commit hook
+
+## Verified Workflow
+
+### 1. Verify actual state before editing
+
+The issue description may be stale — some files may have already been cleaned in previous sessions.
+Always grep first; do NOT trust the line numbers in the issue body.
+
+```bash
+grep -rn "# NOTE" tests/ examples/ shared/ benchmarks/ scripts/ --include="*.mojo"
+```
+
+This catches all variants:
+
+- `# NOTE: text`
+- `# NOTE(#3084): text`
+- `# NOTE (Mojo v0.26.1): text`
+
+Compare results against the issue's file list. Files with zero hits are already done — skip them.
+
+### 2. Categorize variant patterns
+
+| Pattern | Conversion |
+|---------|-----------|
+| `# NOTE: text` | `# text` |
+| `# NOTE(#N): text` | `# text (#N):` — preserve issue reference at end |
+| `# NOTE (Mojo vX.Y): text` | `# text (Mojo vX.Y).` — preserve version context inline |
+
+The version/issue context is valuable — move it inline rather than dropping it.
+
+### 3. Edit in parallel
+
+All edits are independent. Use parallel Edit tool calls for all files. Each call targets
+the exact multi-line block (including the continuation line) to avoid ambiguity.
+
+### 4. Verify
+
+```bash
+grep -rn "# NOTE" <all scoped files> --include="*.mojo"
+```
+
+Expected: zero output.
+
+### 5. Stage only the modified files (never `git add -A`)
+
+```bash
+git add tests/models/... examples/... shared/__init__.mojo benchmarks/... scripts/...
+```
+
+### 6. Commit — all pre-commit hooks should pass
+
+Comment-only Mojo edits pass `mojo format`, `trailing-whitespace`, and `end-of-file-fixer`.
+No compilation or test execution needed locally (CI is authoritative for Mojo builds).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trusting issue line numbers | Read files at the exact lines from the issue body | Several files had no `# NOTE` at those lines — already cleaned | Always grep first to discover actual state |
+| Searching only `# NOTE:` (colon) | `grep -n "# NOTE:"` | Missed `# NOTE(#3084):` and `# NOTE (Mojo v0.26.1):` variants | Use `# NOTE` (no colon) to catch all variants |
+| Dropping issue/version context | `# NOTE(#3084): text` → `# text` | Loses traceability to the referenced issue | Move context inline: `# text (#3084)` |
+
+## Results & Parameters
+
+```text
+Files modified: 6
+NOTE markers removed: 9
+Variants encountered:
+  # NOTE:            — 6 occurrences (bare, test/init/script files)
+  # NOTE(#N):        — 1 occurrence (googlenet train.mojo)
+  # NOTE (Mojo vX):  — 2 occurrences (run_infer.mojo, compare_results.mojo)
+Pre-commit hooks: all passed (mojo format, trailing-whitespace, end-of-file-fixer)
+PR: created with auto-merge enabled
+```
+
+### Grep command to scope work
+
+```bash
+grep -rn "# NOTE" tests/ examples/ shared/ benchmarks/ scripts/ --include="*.mojo"
+```
+
+### Edit pattern for `# NOTE (Mojo vX.Y): text`
+
+```text
+old: # NOTE (Mojo v0.26.1): PNG/JPEG image loading requires external image processing libraries.
+new: # PNG/JPEG image loading requires external image processing libraries (Mojo v0.26.1).
+```


### PR DESCRIPTION
## Summary

Documents the workflow for stripping `# NOTE:` prefix variants from Mojo comment markers
in test, example, benchmark, and script files.

- Captures the critical lesson: always grep to verify actual file state before editing (issue lists can be stale)
- Documents the three `# NOTE` variant patterns and how to convert each
- Complements the existing `note-comment-cleanup` skill with a Mojo-specific, prefix-stripping focus

## Key Findings

**What Worked**:

- `grep -rn "# NOTE" --include="*.mojo"` (no colon) catches all 3 variant patterns in one pass
- Parallel Edit calls for all independent files complete the work in a single round
- Comment-only Mojo edits pass all pre-commit hooks without needing local Mojo compiler

**What Failed**:

- Trusting issue line numbers directly → files had shifted or were already clean
- Searching for `# NOTE:` with colon → missed `# NOTE(#N):` and `# NOTE (vX.Y):` variants
- Dropping issue/version context when stripping → loses traceability

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
