### PR TITLE
feat: add mojo-note-format-compliance skill

### DIFF
--- a/skills/ci-cd/mojo-note-format-compliance/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mojo-note-format-compliance/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-note-format-compliance",
+  "version": "1.0.0",
+  "description": "Enforce # NOTE (Mojo vX.Y.Z): format in Mojo files via pre-commit hook and Python audit script. Use when: (1) adding a CI check for a comment format standard in Mojo source files, (2) implementing a pygrep pre-commit hook that requires negative lookahead regex, (3) auditing and bulk-fixing non-compliant NOTE comments across a codebase.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["mojo", "pre-commit", "pygrep", "note-format", "regex", "compliance", "ci"]
+}

--- a/skills/ci-cd/mojo-note-format-compliance/references/notes.md
+++ b/skills/ci-cd/mojo-note-format-compliance/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes: mojo-note-format-compliance
+
+**Date**: 2026-03-07
+**Issue**: ProjectOdyssey #3285
+**PR**: ProjectOdyssey #3885
+
+## Context
+
+Issue #3071 required manual review of NOTE formats. This task added a lightweight CI check
+so `# NOTE:` patterns without `(Mojo vX.Y.Z)` are caught automatically going forward.
+
+## Files Created/Modified
+
+- `scripts/check_note_format.py` — new Python audit script
+- `tests/scripts/test_check_note_format.py` — 28 pytest tests
+- `.pre-commit-config.yaml` — new `check-note-format` pygrep hook
+- ~20 `.mojo` source files — ~37 violations fixed
+
+## Key Bug: Wrong Regex
+
+First attempt used `# NOTE[^(]` which seemed correct but failed because:
+
+```
+"# NOTE (Mojo v0.26.1): explanation"
+       ^--- space here, not '('
+```
+
+`[^(]` means "any character that is not `(`". Space is not `(`, so the pattern matched
+the compliant `# NOTE ` prefix. This caused 7 test failures when the tests correctly
+asserted that compliant lines should not be flagged.
+
+**Fix**: Use negative lookahead `(?!\s*\()` which means "not followed by optional
+whitespace then `(`". This handles both `# NOTE(` and `# NOTE (` as compliant.
+
+## GLIBC Issue
+
+The `mojo-format` pre-commit hook fails on this dev host (Debian 10, GLIBC 2.28)
+because Mojo requires GLIBC 2.32+. Used `SKIP=mojo-format` per the documented
+workaround in CLAUDE.md. CI runs on Ubuntu 24.04 where it passes.
+
+## Violation Classification
+
+Violations fell into two categories:
+
+1. **Mojo-specific limitations** (language/stdlib gaps) → add `(Mojo v0.26.1)`
+   - `__all__` not supported, Dict iteration incomplete, no atof, etc.
+
+2. **General code annotations** (design decisions, not Mojo limitations) → remove NOTE prefix
+   - `# NOTE: Check is inside else block` — just a code comment, not a Mojo quirk
+   - `# NOTE: These imports are commented out` — informational, not version-specific
+
+## Test Pattern
+
+28 tests structured as:
+- `TestNoteViolationPattern` — regex unit tests (6 cases)
+- `TestIsExcluded` — directory exclusion logic (6 cases)
+- `TestFindViolations` — file scanning (9 cases)
+- `TestScanSourceDirs` — repo-root scanning (2 cases)
+- `TestMainExitCodes` — integration tests via subprocess (5 cases)

--- a/skills/ci-cd/mojo-note-format-compliance/skills/mojo-note-format-compliance/SKILL.md
+++ b/skills/ci-cd/mojo-note-format-compliance/skills/mojo-note-format-compliance/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: mojo-note-format-compliance
+description: "Enforce # NOTE (Mojo vX.Y.Z): format in Mojo files via pre-commit hook and Python audit script. Use when: adding a CI check for a comment format standard, implementing a pygrep hook with negative lookahead, or bulk-fixing non-compliant NOTE comments."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Enforce `# NOTE (Mojo vX.Y.Z):` format in `.mojo` files via CI |
+| **Scope** | Pre-commit hook + standalone Python audit script |
+| **Pattern** | `re.compile(r"# NOTE(?!\s*\()")` — negative lookahead |
+| **Hook type** | `language: pygrep` (same as `check-list-constructor`) |
+| **Test count** | 28 pytest unit tests |
+| **Files fixed** | ~37 violations across 20 source files |
+
+## When to Use
+
+- Adding a pre-commit hook to enforce a comment format standard in Mojo files
+- Implementing a `pygrep` hook that requires negative lookahead regex
+- Writing a Python script to audit and bulk-fix non-compliant `# NOTE` comments
+- Any codebase-wide comment normalization task before enabling a new lint rule
+
+## Verified Workflow
+
+### 1. Write the audit script (`scripts/check_note_format.py`)
+
+```python
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+EXCLUDED_DIRS = {".worktrees", ".pixi", "build", ".git", "__pycache__", ".mypy_cache"}
+SOURCE_DIRS = ["benchmarks", "examples", "papers", "scripts", "shared", "tests"]
+
+# CRITICAL: Use negative lookahead, NOT [^(]
+# '# NOTE[^(]' falsely matches '# NOTE (' because space != '('
+NOTE_VIOLATION_PATTERN = re.compile(r"# NOTE(?!\s*\()")
+```
+
+Key design decisions:
+- Excludes `.worktrees/`, `.pixi/`, `build/`, `.git/` to avoid false positives from dependencies
+- Defaults to scanning repo source dirs only (not the entire filesystem)
+- Accepts optional directory argument for targeted scans
+- Exits 0 on clean, 1 on any violations
+- Prints `file:line: content` to stdout, summary to stderr
+
+### 2. Fix existing violations before enabling the hook
+
+**Order matters**: Fix all violations first, then add the hook. Adding the hook first blocks all commits.
+
+Categorize violations into two types:
+- **Mojo-limitation notes** → annotate with `(Mojo v0.26.1)`: e.g., `# NOTE: Dict iteration not supported` → `# NOTE (Mojo v0.26.1): Dict iteration not supported`
+- **General code comments** → remove `# NOTE:` prefix or replace with plain comment: e.g., `# NOTE: Check is inside else block to avoid...` → `# Check is inside else block to avoid...`
+
+### 3. Add the pre-commit hook (`.pre-commit-config.yaml`)
+
+```yaml
+- id: check-note-format
+  name: Check NOTE format compliance
+  description: Enforce # NOTE (Mojo vX.Y.Z): format in Mojo files (issue #3285)
+  entry: '# NOTE(?!\s*\()'
+  language: pygrep
+  files: ^(benchmarks|examples|papers|scripts|shared|tests)/.*\.(mojo|🔥)$
+  types: [text]
+```
+
+Place it immediately after `check-list-constructor` in the same local repo block.
+
+### 4. Verify clean state
+
+```bash
+python3 scripts/check_note_format.py  # exits 0
+pixi run python -m pytest tests/scripts/test_check_note_format.py -v  # 28 passed
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `# NOTE[^(]` as regex | Used character class negation to exclude `(` | `# NOTE (Mojo v0.26.1):` has a space before `(`, so `# NOTE ` matches because space ≠ `(` | Always use negative lookahead `(?!\s*\()` when the separator between keyword and delimiter may vary |
+| `language: pygrep` with `[^(]` pattern | Same pattern in pre-commit hook | Same false-positive: compliant lines were flagged and hook blocked all commits | Negative lookaheads work fine in `language: pygrep` hooks — pre-commit uses Python's `re` module |
+| Checking existing violations manually | Tried to enumerate violations from memory | Missed several files; grep output was the source of truth | Always run `grep -rn "# NOTE[^(]" --include="*.mojo" shared/ tests/ ...` first to get the definitive list |
+
+## Results & Parameters
+
+### Regex pattern (copy-paste)
+
+```python
+import re
+NOTE_VIOLATION_PATTERN = re.compile(r"# NOTE(?!\s*\()")
+```
+
+### Pre-commit hook entry (copy-paste)
+
+```yaml
+entry: '# NOTE(?!\s*\()'
+language: pygrep
+```
+
+### Violation categories and fixes
+
+| Type | Example Before | Example After |
+|------|----------------|---------------|
+| Mojo limitation | `# NOTE: Mojo doesn't support __all__` | `# NOTE (Mojo v0.26.1): Mojo doesn't support __all__` |
+| Mojo limitation w/issue | `# NOTE: Batch iteration blocked by #3076` | `# NOTE (Mojo v0.26.1, #3076): Batch iteration blocked` |
+| General comment | `# NOTE: Check is inside else block` | `# Check is inside else block` |
+| Commented-out imports | `# NOTE: These imports are commented out` | `# These imports are commented out` |
+
+### Test coverage pattern
+
+```python
+class TestNoteViolationPattern:
+    def test_does_not_flag_compliant_format(self):
+        assert not NOTE_VIOLATION_PATTERN.search("    # NOTE (Mojo v0.26.1): explanation")
+
+    def test_does_not_flag_compliant_with_issue(self):
+        assert not NOTE_VIOLATION_PATTERN.search("    # NOTE (Mojo v0.26.1, #3092): reason")
+
+    def test_does_not_flag_note_with_open_paren(self):
+        assert not NOTE_VIOLATION_PATTERN.search("    # NOTE(#3092): issue ref")
+
+    def test_detects_note_colon(self):
+        assert NOTE_VIOLATION_PATTERN.search("    # NOTE: some text")
+```


### PR DESCRIPTION
## Summary

Documents the pattern for enforcing `# NOTE (Mojo vX.Y.Z):` format compliance in Mojo files via a pre-commit `pygrep` hook and a standalone Python audit script.

- Correct regex: `# NOTE(?!\s*\()` (negative lookahead) — not `# NOTE[^(]`
- Fix-before-enable workflow: audit and fix all existing violations before adding the hook
- Violation classification: Mojo-limitation notes vs. general code comments

## Key Findings

**What Worked**:
- Negative lookahead `(?!\s*\()` correctly handles both `# NOTE(` and `# NOTE (` as compliant
- `language: pygrep` hooks in pre-commit support Python regex lookaheads natively
- Classifying violations into "Mojo limitation" vs. "general comment" guides the correct fix

**What Failed**:
- `# NOTE[^(]` → falsely flagged compliant `# NOTE (Mojo v0.26.1):` lines because space ≠ `(`
- Enabling hook before fixing violations → blocked all commits immediately

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activates for "pygrep hook negative lookahead" and "NOTE format compliance" searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
