### PR TITLE
feat: add consolidate-duplicate-adr-references skill

### DIFF
--- a/skills/documentation/consolidate-duplicate-adr-references/.claude-plugin/plugin.json
+++ b/skills/documentation/consolidate-duplicate-adr-references/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "consolidate-duplicate-adr-references",
+  "version": "1.0.0",
+  "description": "Consolidate duplicate inline comments or docstring Notes into a single ADR as the canonical source of truth, then replace each duplicate with a short cross-reference. Use when: (1) two or more functions contain nearly identical limitation/workaround comments, (2) an issue requests reducing documentation maintenance burden by centralizing a limitation note, (3) a follow-up issue from a PR asks to create a dedicated ADR for a cross-cutting concern.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["adr", "documentation", "consolidation", "refactor", "mojo", "cross-reference", "limitation"]
+}

--- a/skills/documentation/consolidate-duplicate-adr-references/references/notes.md
+++ b/skills/documentation/consolidate-duplicate-adr-references/references/notes.md
@@ -1,0 +1,101 @@
+# Session Notes — consolidate-duplicate-adr-references
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Project**: ProjectOdyssey
+- **Issue**: #3291 — Consolidate duplicate FP16 SIMD limitation references
+- **Branch**: 3291-auto-impl
+- **PR**: #3886
+
+## Objective
+
+Issue #3291 was a follow-up from #3072. After the FP16 SIMD scalar workaround was implemented
+in `convert_to_fp32_master()` and `update_model_from_master()`, both functions contained
+nearly identical multi-line `# NOTE:` comment blocks. The issue asked whether a single ADR
+would be cleaner than cross-referencing between two function docstrings.
+
+## Steps Taken
+
+1. Read `gh issue view 3291 --comments` — full implementation plan was already posted as a
+   comment, specifying exact lines to change and ADR structure to follow.
+
+2. Read existing ADR files to match structure:
+   - `docs/adr/ADR-009-heap-corruption-workaround.md` (most recent, used as template)
+   - `docs/adr/README.md` (to find index format and next ADR number)
+
+3. Read `shared/training/mixed_precision.mojo` around lines 239–360 to see the exact
+   comment blocks in both functions.
+
+4. Created `docs/adr/ADR-010-fp16-simd-mojo-limitation.md` with full ADR structure.
+
+5. Added ADR-010 row to `docs/adr/README.md` index table.
+
+6. Edited `convert_to_fp32_master()` docstring: replaced 6-line `Note:` block with 3-line
+   version pointing to ADR-010.
+
+7. Edited `update_model_from_master()` body comment: changed "see sibling function" to
+   "see ADR-010".
+
+8. Also updated the inline body comment in `convert_to_fp32_master()` body (line 288)
+   from "see docstring Note" to "see ADR-010".
+
+9. Ran `pixi run pre-commit run --all-files` — got MD013 error on line 198 of ADR (138 chars).
+
+10. Fixed by wrapping the long issue link:
+    ```markdown
+    - [Issue #3291](https://...):
+      Consolidate FP16 SIMD limitation references (this ADR)
+    ```
+
+11. Committed, pushed, created PR #3886, enabled auto-merge.
+
+## Exact Files Changed
+
+- `docs/adr/ADR-010-fp16-simd-mojo-limitation.md` — created (new file)
+- `docs/adr/README.md` — added 1 row to index table
+- `shared/training/mixed_precision.mojo` — 3 comment edits (2 inline body, 1 docstring Note)
+
+## Comment Before/After
+
+### `convert_to_fp32_master()` docstring Note (lines 259–264 before)
+
+**Before** (6 lines):
+```
+Note:
+    FP16 SIMD vectorization is blocked by a Mojo compiler limitation.
+    Mojo v0.26.1+ does not support SIMD load/store for FP16 types, so
+    FP16→FP32 conversion uses a scalar loop (~10-15x slower than FP32→FP32).
+    When Mojo adds FP16 SIMD load support, use DTypePointer[Float16].load[width]()
+    for ~4x speedup matching the FP32→FP32 path.
+```
+
+**After** (3 lines):
+```
+Note:
+    FP16 SIMD vectorization is blocked by a Mojo v0.26.1 compiler limitation;
+    FP16→FP32 conversion uses a scalar loop (~10-15x slower than FP32→FP32).
+    See docs/adr/ADR-010-fp16-simd-mojo-limitation.md for full rationale.
+```
+
+### Body comment in `convert_to_fp32_master()` (line 288 before)
+
+**Before**: `# If FP16, use scalar conversion (FP16 SIMD blocked, see docstring Note)`
+**After**: `# If FP16, use scalar conversion (FP16 SIMD blocked, see ADR-010)`
+
+### Body comment in `update_model_from_master()` (line 351 before)
+
+**Before**: `# If FP16, use scalar conversion (FP16 SIMD blocked, see convert_to_fp32_master docstring)`
+**After**: `# If FP16, use scalar conversion (FP16 SIMD blocked, see ADR-010)`
+
+## Pitfalls Encountered
+
+### MD013 line-length violation on issue link
+- `pixi run npx markdownlint-cli2` fails with `npx: command not found`
+- Use `pixi run pre-commit run --all-files` instead
+- Issue links in bullet lists are NOT exempt from MD013 — wrap after the closing `)` of the URL
+
+### Background task confusion
+- Tried `pixi run npx markdownlint-cli2` as a background task first — saw it was failing
+  but continued with the correct pre-commit approach
+- Background task failure was benign (command not found, not a linting error)

--- a/skills/documentation/consolidate-duplicate-adr-references/skills/consolidate-duplicate-adr-references/SKILL.md
+++ b/skills/documentation/consolidate-duplicate-adr-references/skills/consolidate-duplicate-adr-references/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: consolidate-duplicate-adr-references
+description: "Consolidate duplicate inline comments or docstring Notes into a single ADR, then replace each duplicate with a short cross-reference. Use when: two or more functions have nearly identical limitation comments, or an issue asks to reduce maintenance burden by centralizing a workaround note in an ADR."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Purpose** | Replace duplicate inline limitation comments with a single ADR + concise cross-references |
+| **Trigger** | Follow-up issue requesting ADR consolidation of a workaround documented in multiple places |
+| **Scope** | Any language; illustrated with Mojo `.mojo` files and `docs/adr/` directory |
+| **Output** | New ADR file, updated ADR index, shortened inline comments pointing to the ADR |
+
+## When to Use
+
+- A GitHub issue says "consider a single shared ADR instead of cross-referencing between two function docstrings"
+- Two or more functions contain nearly identical `# NOTE:` or `Note:` blocks describing the same limitation/workaround
+- A follow-up from a PR asks to make a limitation "easier to update" when the underlying constraint is resolved
+- An audit finds that updating a limitation note requires editing multiple files
+
+## Verified Workflow
+
+1. **Read the issue and its plan** to confirm scope:
+
+   ```bash
+   gh issue view <number> --comments
+   ```
+
+2. **Locate all duplicate comment blocks** with Grep before editing anything:
+
+   ```
+   Grep pattern="NOTE.*<keyword>" glob="**/*.mojo" output_mode="content"
+   ```
+
+3. **Check the next ADR number** and read existing ADR structure:
+
+   ```bash
+   ls docs/adr/
+   ```
+
+   Read one recent ADR (e.g., ADR-009) to match structure — Status, Date, Issue Reference,
+   Executive Summary, Context, Decision, Rationale, Consequences, Alternatives, Implementation
+   Plan, References, Revision History, Document Metadata.
+
+4. **Create the ADR** at `docs/adr/ADR-NNN-<kebab-name>.md`. Key sections to fill:
+
+   - **Executive Summary**: One paragraph — what the limitation is and what workaround is used
+   - **Context / Key Findings**: Bullet list of compiler/runtime facts discovered
+   - **Decision**: The workaround approach (e.g., scalar loop, file split, etc.)
+   - **Consequences**: Performance or maintenance impact (quantify if known)
+   - **Alternatives Considered**: Include "keep duplicate comments" as an alternative and explain why rejected
+   - **Supersession Criteria**: Explicit conditions under which this ADR becomes Superseded
+   - **Implementation Plan**: Check boxes — mark Phase 1 (consolidation) complete
+
+5. **Update `docs/adr/README.md`** — add one row to the index table:
+
+   ```markdown
+   | [ADR-NNN](ADR-NNN-<name>.md) | <Title> | Accepted | YYYY-MM-DD |
+   ```
+
+6. **Edit source files** — replace each verbose block with 2–3 lines:
+
+   ```mojo
+   # <Short description of limitation>; using <workaround>.
+   # See docs/adr/ADR-NNN-<name>.md for rationale.
+   ```
+
+   Also update any inline body comments that cross-reference the sibling function
+   (e.g., "see convert_to_fp32_master docstring") to reference the ADR directly instead.
+
+7. **Run pre-commit**:
+
+   ```bash
+   pixi run pre-commit run --all-files
+   ```
+
+   Watch for markdown line-length violations (MD013, 120-char limit). URLs in list items
+   are NOT automatically exempt — wrap the line if the link text + URL exceeds 120 chars.
+
+8. **Commit, push, and open PR**:
+
+   ```bash
+   git add docs/adr/ADR-NNN-<name>.md docs/adr/README.md <source-files>
+   git commit -m "docs(adr): add ADR-NNN for <topic>\n\nCloses #<number>"
+   git push -u origin <branch>
+   gh pr create --title "docs(adr): add ADR-NNN for <topic>" --body "Closes #<number>" --label documentation
+   gh pr merge --auto --rebase
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Manual `npx markdownlint-cli2` | Ran `pixi run npx markdownlint-cli2 <file>` to lint ADR before committing | `npx: command not found` even inside pixi environment | Use `pixi run pre-commit run --all-files` instead — it invokes markdownlint correctly |
+| Long URL list item on one line | Put `[Issue #NNN](https://...): description text (this ADR)` on one line | MD013 fired: line was 138 chars (limit 120) | Wrap after the closing `)` of the URL: `[Issue #NNN](https://...):↵  description text` |
+| Referencing sibling function in comment | Left "see sibling_fn() for details" in inline comment instead of pointing to ADR | Defeats the purpose — still requires navigating to another function | Update ALL cross-references to point directly to the new ADR path |
+
+## Results & Parameters
+
+**ADR file naming**: `docs/adr/ADR-NNN-<kebab-description>.md`
+(NNN = next integer after highest existing ADR)
+
+**Replacement comment pattern** (2–3 lines max):
+
+```mojo
+# <Limitation summary>; using <workaround>.
+# See docs/adr/ADR-NNN-<name>.md for rationale.
+```
+
+**Docstring Note replacement** (keep the `Note:` label, shorten body):
+
+```
+Note:
+    <Limitation> uses <workaround> (~Xx slower than optimized path).
+    See docs/adr/ADR-NNN-<name>.md for full rationale.
+```
+
+**Markdown line-length fix** for long issue links:
+
+```markdown
+- [Issue #NNN](https://github.com/Org/Repo/issues/NNN):
+  Description text that would have exceeded 120 chars
+```
+
+**Pre-commit command** (works in ProjectOdyssey with pixi):
+
+```bash
+pixi run pre-commit run --all-files
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3291 — FP16 SIMD limitation | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to consolidate duplicate inline limitation comments across multiple functions
into a single ADR, then replace each duplicate with a concise cross-reference.

- Extracted from ProjectOdyssey issue #3291 (follow-up from #3072)
- FP16 SIMD limitation was documented in two function docstrings; centralized to ADR-010
- Captures the exact markdown pitfall (MD013 on URL-in-list-items) and the correct lint command

## Key Findings

**What Worked**:
- Create ADR following existing ADR structure (read latest ADR as template)
- Replace all cross-references: docstring Note block, body comments, AND sibling-function references
- `pixi run pre-commit run --all-files` correctly invokes markdownlint (npx not available directly)

**What Failed**:
- `pixi run npx markdownlint-cli2 <file>` → `npx: command not found` inside pixi environment
- Long URL in list item exceeded MD013 120-char limit — URL items are NOT automatically exempt
- Leaving a body comment that cross-references a sibling function defeats the consolidation purpose

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 525 passed, 0 failed
- [ ] Install plugin and verify skill appears in `/advise` results for "duplicate adr limitation"
- [ ] Check skill activation for "consolidate comments ADR" trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
