### PR TITLE
feat: add mojo-view-semantics-test skill

### DIFF
--- a/skills/testing/mojo-view-semantics-test/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-view-semantics-test/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-view-semantics-test",
+  "version": "1.0.0",
+  "description": "Add Mojo tests asserting view/shared-memory semantics for tensor slicing. Use when: (1) a slice() method claims view semantics but lacks a mutation test, (2) adding regression coverage for copy-vs-view bugs in tensor ops, (3) writing TDD tests for slice() before implementing view semantics.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "tensor", "slice", "view-semantics", "shared-memory", "regression", "tdd"]
+}

--- a/skills/testing/mojo-view-semantics-test/references/notes.md
+++ b/skills/testing/mojo-view-semantics-test/references/notes.md
@@ -1,0 +1,62 @@
+# Session Notes: mojo-view-semantics-test
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: HomericIntelligence/ProjectOdyssey#3298
+- **PR**: HomericIntelligence/ProjectOdyssey#3898
+- **Branch**: `3298-auto-impl`
+- **File modified**: `tests/shared/core/test_slicing.mojo`
+
+## Objective
+
+The `slice()` method docstring claimed view semantics (shared memory with original tensor).
+Existing tests verified that reads through the slice returned correct values and that `_is_view`
+was set to `True`, but no test verified the reverse direction: writing through the slice and
+checking the original tensor reflects the change.
+
+Issue #3298 (follow-up from #3086) requested this missing regression test.
+
+## Steps Taken
+
+1. Read the prompt file (`.claude-prompt-3298.md`) to understand the task
+2. Located `tests/shared/core/test_slicing.mojo` via glob search
+3. Read the full file to understand existing patterns:
+   - `zeros([N], DType.float32)` to create tensors
+   - `tensor._set_float32(idx, Float32(val))` to write
+   - `tensor._get_float32(idx)` to read
+   - `assert_almost_equal(Float64(...), expected, tolerance=1e-6)` for float assertions
+   - `assert_equal(value, expected, "label")` for exact comparisons
+4. Added `test_slice_mutation_visible_in_original()` after `test_multiple_slices_share_refcount`
+5. Registered the call in `main()` under "View semantics tests"
+6. Committed with conventional commits format
+7. Pushed branch and created PR with `gh pr create --label "testing"`
+8. Enabled auto-merge with `gh pr merge --auto --rebase`
+
+## Local Execution Failures
+
+- `pixi run mojo test tests/shared/core/test_slicing.mojo` → GLIBC version mismatch
+- `just test-group ...` → `just` not found in PATH
+- Both expected — this project runs in Docker for test execution
+
+## Key Observations
+
+- The existing test `test_multiple_slices_share_refcount` already tested forward direction
+  (mutate original → visible in slice) at line 187. The new test covers reverse direction.
+- The `_is_view` flag and refcount tests already existed — only the mutation direction was missing.
+- Pre-commit hook `mojo format` ran cleanly on the new code without requiring manual formatting.
+- All 7 pre-commit hooks passed on first attempt.
+
+## Commit
+
+```
+test(slicing): add test asserting slice() result shares memory with original
+
+Adds test_slice_mutation_visible_in_original() to verify that writes
+through a slice are visible in the original tensor, confirming true
+view semantics. The existing test only covered the forward direction
+(mutate original → visible in slice); this test covers the reverse
+direction (mutate slice → visible in original).
+
+Closes #3298
+```

--- a/skills/testing/mojo-view-semantics-test/skills/mojo-view-semantics-test/SKILL.md
+++ b/skills/testing/mojo-view-semantics-test/skills/mojo-view-semantics-test/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: mojo-view-semantics-test
+description: "Add Mojo tests asserting view/shared-memory semantics for tensor slicing. Use when: a slice() method claims view semantics but lacks a mutation test, or adding regression coverage for copy-vs-view bugs."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+# Mojo View Semantics Test
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-07 |
+| Objective | Add regression test asserting that `slice()` shares memory with the original tensor |
+| Outcome | Test added to `test_slicing.mojo`, PR created, all pre-commit hooks pass |
+
+## When to Use
+
+- A `slice()` method docstring claims view semantics but no test mutates through the slice
+- Adding regression coverage to catch copy-vs-view regressions in tensor ops
+- Writing TDD tests for a new `slice()` implementation before coding it
+- Completing a test suite that only checks values read from a slice (not writes through it)
+
+## Verified Workflow
+
+1. **Read the existing test file** to understand existing patterns (`_set_float32`, `_get_float32`, `assert_almost_equal`)
+2. **Add the test function** after the last view-semantics test:
+   - Create a tensor, fill with known values
+   - Slice a sub-range
+   - Write through the slice (`s._set_float32(0, 99.0)`)
+   - Assert the original tensor reflects the write at the corresponding index
+3. **Call the function in `main()`** under the "View semantics tests" block
+4. **Commit**: pre-commit hooks run `mojo format` automatically — no manual formatting needed
+5. **Push and create PR** with `gh pr create`, link to the issue with "Closes #N"
+
+### Pattern (copy-paste ready)
+
+```mojo
+fn test_slice_mutation_visible_in_original() raises:
+    """Verify that mutating a slice element is visible in the original tensor.
+
+    Asserts true view semantics: slice shares memory with original, so
+    writes through the slice are reflected when reading the original.
+    """
+    var tensor = zeros([10], DType.float32)
+    for i in range(10):
+        tensor._set_float32(i, Float32(i))
+
+    # slice [2:6] -> indices 2,3,4,5 of original
+    var s = tensor.slice(2, 6, axis=0)
+
+    # Mutate element 0 of the slice (corresponds to index 2 of original)
+    s._set_float32(0, 99.0)
+
+    # The original tensor must reflect the change at index 2
+    assert_almost_equal(
+        Float64(tensor._get_float32(2)), 99.0, tolerance=1e-6
+    )
+
+    print("PASS: test_slice_mutation_visible_in_original")
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3298, PR #3898 | [notes.md](../references/notes.md) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `pixi run mojo test` locally | Executed `mojo test tests/shared/core/test_slicing.mojo` on the host | GLIBC version mismatch — host has GLIBC 2.31, Mojo requires 2.32+ | This repo runs Mojo inside Docker/CI; local execution is not supported on older Linux hosts |
+| Using `just test-group` | Tried `just test-group "tests/shared/core" "test_slicing.mojo"` | `just` not in PATH on the host | Use `pixi run mojo test` or rely on CI — don't assume `just` is installed outside Docker |
+
+## Results & Parameters
+
+- **File modified**: `tests/shared/core/test_slicing.mojo`
+- **Test added at**: after `test_multiple_slices_share_refcount`, before `test_slice_empty_range`
+- **Registered in**: `main()` under `# View semantics tests`
+- **Commit message format**: `test(slicing): add test asserting slice() result shares memory with original`
+- **Pre-commit hooks that run**: `mojo format`, `trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`
+- **CI**: runs in Docker (`ghcr.io/homericintelligence/projectodyssey:main`)


### PR DESCRIPTION
## Summary

- Documents how to add Mojo tests asserting view/shared-memory semantics for tensor slicing
- Captured from ProjectOdyssey issue #3298 / PR #3898
- Covers the reverse-direction mutation test pattern (write through slice → assert original)

## Key Findings

**What Worked**:
- Add a test that calls `s._set_float32(0, 99.0)` then asserts `tensor._get_float32(2) == 99.0`
- Pre-commit `mojo format` runs cleanly on new test code without manual formatting
- `gh pr create --label "testing"` + `gh pr merge --auto --rebase` for clean PR workflow

**What Failed**:
- `pixi run mojo test` locally → GLIBC 2.31 host, Mojo requires 2.32+ — must use Docker/CI
- `just test-group ...` → `just` not in PATH outside Docker container

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [x] SKILL.md has all required sections including Failed Attempts table
- [x] plugin.json has all required fields (name, version, description, category, date, tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)