### PR TITLE
feat: add extensor-bfloat16-fix skill

### DIFF
--- a/skills/debugging/extensor-bfloat16-fix/.claude-plugin/plugin.json
+++ b/skills/debugging/extensor-bfloat16-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "extensor-bfloat16-fix",
+  "version": "1.0.0",
+  "description": "Fix pattern for adding bfloat16 dtype support to Mojo ExTensor float I/O methods. Use when: (1) _set_float64/_get_float64 silently write/read zeros for bfloat16 tensors, (2) a new dtype is missing from _get_dtype_size_static causing wrong byte offsets, (3) re-enabling skipped bfloat16 tests after dtype support is added.",
+  "category": "debugging",
+  "date": "2026-03-07",
+  "tags": ["mojo", "bfloat16", "extensor", "dtype", "float-io", "silent-failure"]
+}

--- a/skills/debugging/extensor-bfloat16-fix/references/notes.md
+++ b/skills/debugging/extensor-bfloat16-fix/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: extensor-bfloat16-fix
+
+## Issue
+
+GitHub Issue #3300: Fix ExTensor `_set_float64`/`_get_float64` for bfloat16
+
+Discovered during issue #3088 that `ExTensor._set_float64` and `_get_float64` silently
+write/read zeros when the tensor dtype is `DType.bfloat16`. The dtype metadata is correctly
+stored, but the float64 I/O path does not handle bfloat16 storage.
+
+## Root Cause Analysis
+
+Three separate gaps in `shared/core/extensor.mojo`:
+
+1. `_get_dtype_size_static` had no `bfloat16` case — fell through to `else: return 4`
+   (bfloat16 is 2 bytes, same as float16). This caused all reads/writes to use the wrong
+   byte offset, silently corrupting data.
+
+2. `_get_float64` had branches for float16, float32, float64 but not bfloat16 — fell
+   through to the integer path `Float64(self._get_int64(index))` which reads the raw
+   bit pattern as an integer, producing garbage values.
+
+3. `_set_float64` had branches for float16, float32, float64 but not bfloat16 — had no
+   `else` fallback, so writes were silently dropped entirely.
+
+## Files Changed
+
+- `shared/core/extensor.mojo`: lines 478-493, 1016-1048
+- `tests/shared/testing/test_special_values.mojo`: lines 265-268, 481-483
+
+## Key Technical Detail
+
+Direct `BFloat16 ↔ Float64` cast in Mojo 0.26.1 produces incorrect values. Must use
+two-step conversion via `Float32`:
+- Read: `BFloat16 → Float32 → Float64`
+- Write: `Float64 → Float32 → BFloat16`
+
+This works because bfloat16 is essentially a truncated float32 (same 8-bit exponent,
+7-bit mantissa vs 23-bit mantissa for float32).
+
+## Test Status
+
+`test_dtypes_bfloat16()` was previously skipped with `pass` and a comment saying
+"DType.bfloat16 not supported in Mojo's runtime". This comment was outdated —
+`DType.bfloat16` IS part of Mojo's DType enum. The test was re-enabled by:
+1. Uncommenting 3 test lines
+2. Removing the `pass` placeholder
+3. Updating the print message to remove "(skipped)" suffix
+4. Removing outdated comment "# BF16 dtype not yet supported in Mojo"
+
+## Environment
+
+- Mojo v0.26.1
+- Local host: GLIBC version too old to run Mojo directly
+- Tests verified via CI (Docker container with compatible GLIBC)
+- Pre-commit hooks pass locally (pixi run pre-commit run --all-files)
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/3903
+Branch: 3300-auto-impl

--- a/skills/debugging/extensor-bfloat16-fix/skills/extensor-bfloat16-fix/SKILL.md
+++ b/skills/debugging/extensor-bfloat16-fix/skills/extensor-bfloat16-fix/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: extensor-bfloat16-fix
+description: "Fix pattern for adding bfloat16 dtype support to Mojo ExTensor float I/O methods. Use when: _set_float64/_get_float64 silently write/read zeros for bfloat16 tensors, or a new dtype is missing from _get_dtype_size_static."
+category: debugging
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Issue | `ExTensor._set_float64`/`_get_float64` silently write/read zeros for `DType.bfloat16` |
+| Root Cause | Missing `bfloat16` branch in float I/O methods + wrong byte size (4 instead of 2) |
+| Fix | Add two-step cast branches `bf16 ↔ Float32 ↔ Float64` and correct size to 2 |
+| Files | `shared/core/extensor.mojo`, `tests/shared/testing/test_special_values.mojo` |
+
+## When to Use
+
+- `ExTensor` operations on bfloat16 tensors silently produce zeros
+- Adding a new float dtype to ExTensor that is missing from `_get_dtype_size_static`
+- Re-enabling skipped bfloat16 tests after dtype I/O support is implemented
+- Debugging "values read back as 0.0" from tensors with a non-standard dtype
+
+## Verified Workflow
+
+### Step 1: Find all three missing locations
+
+```bash
+grep -n "float16\|float32\|float64" shared/core/extensor.mojo | grep -v bfloat16 | grep "_get_dtype_size_static\|_get_float64\|_set_float64"
+```
+
+Three sites need updating:
+1. `_get_dtype_size_static` — missing size entry (bfloat16 = 2 bytes)
+2. `_get_float64` — missing read branch
+3. `_set_float64` — missing write branch
+
+### Step 2: Fix `_get_dtype_size_static`
+
+```mojo
+# Before (falls through to 4-byte default — WRONG for bfloat16):
+if dtype == DType.float16:
+    return 2
+elif dtype == DType.float32:
+    return 4
+
+# After:
+if dtype == DType.float16:
+    return 2
+elif dtype == DType.bfloat16:
+    return 2
+elif dtype == DType.float32:
+    return 4
+```
+
+### Step 3: Fix `_get_float64`
+
+```mojo
+# Add BEFORE the float32 branch:
+elif self._dtype == DType.bfloat16:
+    var ptr = (self._data + offset).bitcast[BFloat16]()
+    return Float64(Float32(ptr[]))
+```
+
+Two-step cast `BFloat16 → Float32 → Float64` is required. Direct `BFloat16 → Float64`
+produces incorrect values in Mojo 0.26.1.
+
+### Step 4: Fix `_set_float64`
+
+```mojo
+# Add BEFORE the float32 branch:
+elif self._dtype == DType.bfloat16:
+    var ptr = (self._data + offset).bitcast[BFloat16]()
+    ptr[] = BFloat16(Float32(value))
+```
+
+Two-step cast `Float64 → Float32 → BFloat16` matches the read path.
+
+### Step 5: Re-enable test
+
+```mojo
+# Uncomment 3 lines, remove `pass` placeholder:
+var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
+assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
+verify_special_value_invariants(tensor, 1.0)
+```
+
+Also update the surrounding print message and comment if they say "skipped".
+
+### Step 6: Run pre-commit to verify
+
+```bash
+pixi run pre-commit run --all-files
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Direct bf16↔f64 cast | `ptr[].cast[DType.float64]()` directly from BFloat16 | Produces incorrect values in Mojo 0.26.1 | Always use Float32 as intermediary for bf16 conversions |
+| Skipping `_get_dtype_size_static` fix | Only adding I/O branches without fixing size | 4-byte default causes reads/writes at wrong offsets | All three sites must be fixed together |
+
+## Results & Parameters
+
+**Key invariant**: bfloat16 shares float32's exponent range. All bf16 ↔ float conversions must go through `Float32` as an intermediary in Mojo 0.26.1.
+
+**Two-step cast pattern (copy-paste)**:
+```mojo
+# Read bfloat16
+var ptr = (self._data + offset).bitcast[BFloat16]()
+return Float64(Float32(ptr[]))
+
+# Write bfloat16
+var ptr = (self._data + offset).bitcast[BFloat16]()
+ptr[] = BFloat16(Float32(value))
+```
+
+**Checklist for adding a new float dtype to ExTensor**:
+1. `_get_dtype_size_static` — add size case
+2. `_get_float64` — add read branch
+3. `_set_float64` — add write branch
+4. Check `__setitem__` float condition list (currently `float16 or float32 or float64`)
+5. Re-enable any skipped tests


### PR DESCRIPTION
## Summary

Documents the fix pattern for adding bfloat16 dtype support to Mojo ExTensor float I/O
methods, discovered while implementing issue #3300 in ProjectOdyssey.

- Three separate sites must all be fixed together when adding a new float dtype
- bfloat16 must use a two-step cast via Float32 as intermediary
- Silent zero-read failure mode is easy to miss without targeted tests

## Key Findings

**What Worked**:
- Two-step cast `BFloat16 → Float32 → Float64` (read) and `Float64 → Float32 → BFloat16` (write)
- Fixing `_get_dtype_size_static` first (bfloat16 = 2 bytes, not the 4-byte default)
- Re-enabling the previously-skipped `test_dtypes_bfloat16()` test

**What Failed**:
- Direct `BFloat16 ↔ Float64` cast → produces incorrect values in Mojo 0.26.1
- Only fixing I/O branches without fixing size → wrong byte offsets, silent corruption

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `debugging` category
- [ ] Check skill activates for "bfloat16 reads zero" and "missing dtype branch" scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
