### PR TITLE
feat: add placeholder-doc-rewrite skill

### DIFF
--- a/skills/documentation/placeholder-doc-rewrite/.claude-plugin/plugin.json
+++ b/skills/documentation/placeholder-doc-rewrite/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "placeholder-doc-rewrite",
+  "version": "1.0.0",
+  "description": "Replace placeholder documentation files with accurate, verified content. Use when: (1) a markdown file contains stub/placeholder text (e.g. 'More examples.', 'Step 1/2/3'), (2) a README links to a doc that needs real content, (3) an issue asks to write a quickstart or getting-started guide.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["documentation", "markdown", "quickstart", "placeholder", "getting-started"]
+}

--- a/skills/documentation/placeholder-doc-rewrite/references/notes.md
+++ b/skills/documentation/placeholder-doc-rewrite/references/notes.md
@@ -1,0 +1,74 @@
+# Session Notes: placeholder-doc-rewrite
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: HomericIntelligence/ProjectOdyssey#3305
+- **Branch**: 3305-auto-impl
+- **PR**: HomericIntelligence/ProjectOdyssey#3917
+
+## Objective
+
+Replace `docs/getting-started/quickstart.md` (10-line placeholder) with a real
+quickstart guide covering: cloning, `pixi install`, running a first model test,
+and a minimal usage example from the shared library.
+
+## Files Read for Context
+
+- `docs/getting-started/quickstart.md` — placeholder (9 lines)
+- `docs/getting-started/installation.md` — also placeholder, noted for reference
+- `docs/getting-started/first_model.md` — real content, links back to quickstart
+- `shared/EXAMPLES.md` — aspirational API examples (NOT used — APIs unverified)
+- `shared/INSTALL.md` — setup patterns for pixi
+- `shared/core/__init__.mojo` — actual exports (ExTensor, zeros, ones, etc.)
+- `tests/shared/core/test_creation.mojo` — chosen as "first test" example
+- `pixi.toml` — confirmed `mojo >= 0.26.1`, confirmed `pixi run mojo` pattern
+
+## Key Decisions
+
+1. **Test to showcase**: `tests/shared/core/test_creation.mojo` — fast, self-contained,
+   exercises ExTensor which is the core type users will encounter first.
+
+2. **Usage example imports**: Grounded in `shared/core/__init__.mojo` exports (`zeros`,
+   `ones`, `ExTensor`) rather than aspirational APIs from EXAMPLES.md.
+
+3. **Markdown validation**: Used `pixi run pre-commit run markdownlint-cli2 --files`
+   because `pixi run npx` fails (npx not in conda env).
+
+## Commands That Worked
+
+```bash
+# Validate markdown
+pixi run pre-commit run markdownlint-cli2 --files docs/getting-started/quickstart.md
+
+# Stage and commit (pre-commit hooks ran automatically on commit)
+git add docs/getting-started/quickstart.md
+git commit -m "docs(getting-started): write real quickstart.md\n\nCloses #3305"
+git push -u origin 3305-auto-impl
+
+# Create PR
+gh pr create --title "docs(getting-started): write real quickstart.md" \
+  --body "..." --label "documentation"
+gh pr merge --auto --rebase 3917
+```
+
+## Commands That Failed
+
+```bash
+# Failed: npx not in pixi conda environment
+pixi run npx markdownlint-cli2 docs/getting-started/quickstart.md
+# Error: npx: command not found
+
+# Failed: background task pixi command timed out 3 times at 30s/60s/120s
+# (pixi env init alone takes ~2 minutes on first invocation in worktree)
+```
+
+## Pre-commit Hook Results
+
+All hooks passed on commit:
+- Mojo Format: Skipped (no .mojo files changed)
+- Markdown Lint: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed

--- a/skills/documentation/placeholder-doc-rewrite/skills/placeholder-doc-rewrite/SKILL.md
+++ b/skills/documentation/placeholder-doc-rewrite/skills/placeholder-doc-rewrite/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: placeholder-doc-rewrite
+description: "Replace placeholder documentation with accurate, verified content grounded in the actual codebase. Use when: a doc file contains stub text, a getting-started guide needs real commands, or a quickstart links to non-existent paths."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | placeholder-doc-rewrite |
+| **Category** | documentation |
+| **Trigger** | Placeholder docs with stub text; quickstart/installation guides needing real content |
+| **Output** | Verified, linting-compliant markdown replacing the placeholder |
+| **Validated On** | ML Odyssey `docs/getting-started/quickstart.md` (issue #3305) |
+
+## When to Use
+
+- A markdown file contains stub text like "More examples.", "Step 1/2/3", `import ml_odyssey`
+- A README or navigation page links to a doc that was never written
+- An issue asks to "write a real quickstart" or "replace placeholder"
+- Installation or getting-started guides reference commands/paths that may not exist
+
+## Verified Workflow
+
+### Step 1: Read the placeholder and related docs in parallel
+
+Read the target placeholder alongside any adjacent docs it references (e.g. `installation.md`,
+`first_model.md`) and the issue body with `gh issue view <n> --comments`.
+
+```bash
+gh issue view 3305 --comments
+```
+
+Use `Read` on all related files in a single parallel call, not sequentially.
+
+### Step 2: Verify all paths and imports before writing
+
+Before writing any command or import path, confirm it exists:
+
+- Use `Glob` to verify file paths mentioned in the doc
+- Use `Read` on `__init__.mojo` / package index files to confirm actual exports
+- Use `Bash ls` on directories referenced in code examples
+
+This prevents documenting paths or APIs that don't exist.
+
+### Step 3: Write the replacement doc
+
+Structure the content around what the issue specifies. For quickstarts, the standard
+sections are: Prerequisites, Clone/Install, Verify Environment, Run First Test,
+Minimal Usage Example, What's Next.
+
+Keep code examples minimal and executable — one file, real imports, real output.
+
+### Step 4: Validate markdown before committing
+
+`pixi run npx markdownlint-cli2` is unreliable (npx often not in pixi env).
+Use pre-commit instead:
+
+```bash
+pixi run pre-commit run markdownlint-cli2 --files docs/path/to/file.md
+```
+
+### Step 5: Commit and PR
+
+Stage only the target file (not backup files, not the prompt file):
+
+```bash
+git add docs/getting-started/quickstart.md
+git commit -m "docs(getting-started): write real quickstart.md
+
+<body>
+
+Closes #<n>"
+git push -u origin <branch>
+gh pr create --title "..." --body "..." --label "documentation"
+gh pr merge --auto --rebase <pr-number>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `pixi run npx markdownlint-cli2 <file>` | Run markdownlint via npx inside pixi env | `npx: command not found` — npx not installed in the pixi conda env | Use `pixi run pre-commit run markdownlint-cli2 --files <file>` instead |
+| Running pixi command as background task | Used `run_in_background=true` for markdownlint | Command took 3+ minutes just for pixi env init, causing repeated timeouts | Run markdownlint synchronously with a generous timeout (120s+), not in background |
+| Documenting APIs from `shared/EXAMPLES.md` | Copied import examples from the EXAMPLES doc | EXAMPLES.md uses aspirational/planned APIs, not what's actually implemented | Always read `__init__.mojo` or package index to find real exports |
+
+## Results & Parameters
+
+### Minimal Usage Example Pattern
+
+A quickstart usage example should:
+
+1. Import from the actual package index (read `__init__.mojo` first)
+2. Use 3–5 lines of real, runnable code
+3. Show expected terminal output as a `text` code block
+
+```mojo
+from shared.core import ExTensor, zeros, ones
+
+fn main() raises:
+    var shape = List[Int]()
+    shape.append(5)
+    var t = zeros(shape, DType.float32)
+    print("numel:", t.numel())
+```
+
+### Markdown Lint Command (Reliable)
+
+```bash
+pixi run pre-commit run markdownlint-cli2 --files <path/to/file.md>
+```
+
+### First-Test Selection Criteria
+
+Pick a test that is:
+
+- Self-contained (no external datasets, no network)
+- Fast (< 30 seconds)
+- Exercises a core primitive visible to new users
+
+For ML Odyssey: `tests/shared/core/test_creation.mojo` satisfies all three.


### PR DESCRIPTION
## Summary

Documents the workflow for replacing placeholder documentation files with accurate,
verified content grounded in the actual codebase.

- Grounded in real session rewriting ML Odyssey `docs/getting-started/quickstart.md`
- Captures the markdownlint validation pitfall (`npx` not in pixi conda env)
- Documents the "read `__init__.mojo` before writing import examples" pattern

## Key Findings

**What Worked**:
- Reading `__init__.mojo` / package index files to find real exports before documenting
- `pixi run pre-commit run markdownlint-cli2 --files <file>` for reliable lint validation
- Running pixi commands synchronously (not in background) to avoid timeout cascades
- Picking `tests/shared/core/test_creation.mojo` as "first test" — fast, self-contained

**What Failed**:
- `pixi run npx markdownlint-cli2 <file>` → `npx: command not found` in conda env
- Running pixi commands as background tasks → 3 consecutive timeouts (env init ~2 min)
- Copying import examples from `EXAMPLES.md` → aspirational APIs, not real exports

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "placeholder doc", "quickstart guide", "replace stub" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
