### PR TITLE
feat: add add-ci-badge-to-readme skill

### DIFF
--- a/skills/documentation/add-ci-badge-to-readme/.claude-plugin/plugin.json
+++ b/skills/documentation/add-ci-badge-to-readme/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "add-ci-badge-to-readme",
+  "version": "1.0.0",
+  "description": "Add a GitHub Actions CI status badge to a README badge block. Use when: (1) a README is missing a CI/build status badge, (2) a new workflow has been added and should be surfaced via a badge, (3) a reviewer requests a CI badge be added to the project home page.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["readme", "badge", "ci", "github-actions", "documentation"]
+}

--- a/skills/documentation/add-ci-badge-to-readme/references/notes.md
+++ b/skills/documentation/add-ci-badge-to-readme/references/notes.md
@@ -1,0 +1,37 @@
+# Session Notes: Add CI Badge to README
+
+## Context
+
+- **Issue**: HomericIntelligence/ProjectOdyssey #3306
+- **Branch**: 3306-auto-impl
+- **PR**: #3921
+- **Date**: 2026-03-07
+
+## What Was Done
+
+Added a single CI badge line to `README.md` after the existing Coverage badge:
+
+```markdown
+[![CI](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml)
+```
+
+## Steps
+
+1. Read `.claude-prompt-3306.md` for task context
+2. Listed `.github/workflows/` to confirm `comprehensive-tests.yml` exists
+3. Read first 20 lines of `README.md` to locate badge block (lines 8-11)
+4. Used `Edit` tool to insert badge after line 11 (Coverage badge)
+5. Ran `pixi run pre-commit run --files README.md` — all hooks passed
+6. Committed with conventional commit message including `Closes #3306`
+7. Pushed branch and created PR #3921 with auto-merge enabled
+
+## Environment Notes
+
+- `just` was not on PATH — used `pixi run pre-commit` directly
+- Pre-commit ran as background task — needed `TaskOutput` to retrieve result
+- Issue template mentioned writing pytest tests, but there was no Python code to test
+- The change was purely a one-line README edit
+
+## Time
+
+Under 5 minutes end-to-end.

--- a/skills/documentation/add-ci-badge-to-readme/skills/add-ci-badge-to-readme/SKILL.md
+++ b/skills/documentation/add-ci-badge-to-readme/skills/add-ci-badge-to-readme/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: add-ci-badge-to-readme
+description: "Add a GitHub Actions CI status badge to a README. Use when: a README is missing a CI badge, a new workflow should be surfaced via a badge, or a reviewer requests build status visibility."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | add-ci-badge-to-readme |
+| **Category** | documentation |
+| **Complexity** | Low |
+| **Time** | < 5 minutes |
+| **Risk** | Minimal — single line README edit |
+
+## When to Use
+
+- A README has Mojo/License/Tests badges but no CI build status badge
+- A new GitHub Actions workflow was added and should be visible on the project home page
+- A GitHub issue or reviewer requests a CI badge
+- Follow-up to adding a new workflow file
+
+## Verified Workflow
+
+1. **Find the workflow file** — confirm the target `.github/workflows/<name>.yml` exists:
+
+   ```bash
+   ls .github/workflows/
+   ```
+
+2. **Read the README badge block** — identify the line after which to insert the new badge:
+
+   ```bash
+   # Read lines 1-15 of README.md
+   ```
+
+3. **Insert the badge** using the Edit tool — append after the last existing badge:
+
+   ```markdown
+   [![CI](https://github.com/<org>/<repo>/actions/workflows/<workflow>.yml/badge.svg?branch=main)](https://github.com/<org>/<repo>/actions/workflows/<workflow>.yml)
+   ```
+
+   Badge URL pattern:
+   - **Image**: `https://github.com/<org>/<repo>/actions/workflows/<file>.yml/badge.svg?branch=main`
+   - **Link**: `https://github.com/<org>/<repo>/actions/workflows/<file>.yml`
+
+4. **Validate with pre-commit** — run markdownlint to confirm no linting issues:
+
+   ```bash
+   pixi run pre-commit run --files README.md
+   ```
+
+5. **Commit, push, and create PR**:
+
+   ```bash
+   git add README.md
+   git commit -m "docs(readme): add CI badge for <workflow> workflow"
+   git push -u origin <branch>
+   gh pr create --title "docs(readme): add CI badge for <workflow> workflow" \
+     --body "Closes #<issue>"
+   gh pr merge --auto --rebase
+   ```
+
+## Results & Parameters
+
+| Parameter | Value Used | Notes |
+|-----------|-----------|-------|
+| Workflow file | `comprehensive-tests.yml` | Confirmed present before editing |
+| Badge branch | `?branch=main` | Always pin to main for stability |
+| Badge placement | After last existing badge | Keeps badge block together |
+| Pre-commit hooks | All passed | markdownlint, trailing-whitespace, end-of-file |
+
+### Badge Template (copy-paste)
+
+```markdown
+[![CI](https://github.com/<ORG>/<REPO>/actions/workflows/<WORKFLOW>.yml/badge.svg?branch=main)](https://github.com/<ORG>/<REPO>/actions/workflows/<WORKFLOW>.yml)
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Writing tests | Issue template requested pytest tests for "new functionality" | There is no Python code — the change is a one-line README edit with no testable logic | Skip test writing for pure documentation changes; do not follow issue template boilerplate blindly |
+| Running `just pre-commit-all` | Tried the justfile shortcut | `just` not on PATH in this environment | Fall back to `pixi run pre-commit run --files README.md` directly |


### PR DESCRIPTION
## Summary

Documents the workflow for adding a GitHub Actions CI status badge to a README, captured from implementing ProjectOdyssey #3306.

- One-line README edit using the `Edit` tool — no Python code, no tests needed
- Badge URL pattern: `https://github.com/<org>/<repo>/actions/workflows/<file>.yml/badge.svg?branch=main`
- Pre-commit validation via `pixi run pre-commit run --files README.md`

## Key Findings

**What Worked**:
- Direct `Edit` tool insertion after the last existing badge line
- `pixi run pre-commit run --files README.md` for hook validation when `just` is unavailable
- Conventional commit message with `Closes #<issue>` + auto-merge PR

**What Failed**:
- `just pre-commit-all` — `just` not on PATH in this environment; use `pixi run pre-commit` directly
- Writing pytest tests — issue template boilerplate suggested tests, but there is no Python logic in a one-line README edit

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "add badge", "ci badge", "readme badge" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
