### PR TITLE
feat: add add-unit-tests-for-existing-script skill

### DIFF
--- a/skills/testing/add-unit-tests-for-existing-script/.claude-plugin/plugin.json
+++ b/skills/testing/add-unit-tests-for-existing-script/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "add-unit-tests-for-existing-script",
+  "version": "1.0.0",
+  "description": "Add comprehensive pytest unit tests for an existing Python script that has no tests. Use when: (1) a script has been identified as having no test coverage, (2) a follow-up issue asks for tests after bugs were found during implementation, (3) you need to cover multiple public functions with class-grouped tests.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["pytest", "unit-testing", "python", "test-coverage", "scripts"]
+}

--- a/skills/testing/add-unit-tests-for-existing-script/references/notes.md
+++ b/skills/testing/add-unit-tests-for-existing-script/references/notes.md
@@ -1,0 +1,46 @@
+# Session Notes: Issue #3309 — Unit Tests for migrate_odyssey_skills.py
+
+## Context
+
+- **Issue**: #3309 — Add unit tests for `scripts/migrate_odyssey_skills.py`
+- **Follow-up from**: #3140 (bugs found during implementation: unused variables, type annotation errors)
+- **Branch**: `3309-auto-impl`
+- **PR**: #3927
+
+## What Was Done
+
+Added 60 new tests across 5 new test classes in the existing
+`tests/scripts/test_migrate_odyssey_skills.py` file (which previously only had
+11 tests covering `migrate_skill()` auxiliary dir copying).
+
+### Functions Covered
+
+| Function | Tests | Key Cases |
+|----------|-------|-----------|
+| `parse_frontmatter()` | 10 | no frontmatter, unclosed `---`, quote stripping, colon-in-value, empty block |
+| `determine_category()` | 13 | override precedence, tier-1/tier-2 maps, CATEGORY_MAP, default fallback |
+| `generalize_content()` | 11 | all 9 PATH_REPLACEMENTS patterns, invariant content, regex compile check |
+| `transform_skill_md()` | 12 | Workflow rename, section injection, no-duplicate guard, frontmatter rebuild |
+| `find_all_skills()` | 14 | top-level/tier-1/tier-2 discovery, tier values, hidden dirs, empty root |
+
+Total: 71 tests (11 pre-existing + 60 new), all pass in 0.42s.
+
+## Key Decisions
+
+1. **Extended existing file** rather than creating a new one — avoids file bloat
+2. **Added `sys.path.insert`** at top for direct imports, kept `importlib` loader for
+   the existing `migrate_skill` tests that use `patch.object(module, "GLOBAL_VAR", ...)`
+3. **Explored behavior interactively** with `python3 -c` before writing assertions
+4. **Used `python3 -m pytest`** directly (not `pixi run`) for fast development iteration
+
+## Pre-Commit Gotcha
+
+First commit failed: ruff auto-removed `SKILL_CATEGORY_OVERRIDE` (imported but never
+used in assertions). Had to re-stage and commit a second time. The pre-commit hook
+auto-fixed the file and exited non-zero — re-staging after the auto-fix is the correct
+response.
+
+## Timing
+
+- Pixi activation: ~2+ min (too slow for iteration)
+- Direct `python3 -m pytest`: 0.42s for 71 tests

--- a/skills/testing/add-unit-tests-for-existing-script/skills/add-unit-tests-for-existing-script/SKILL.md
+++ b/skills/testing/add-unit-tests-for-existing-script/skills/add-unit-tests-for-existing-script/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: add-unit-tests-for-existing-script
+description: "Add comprehensive pytest unit tests for an existing Python script with no coverage. Use when: a script has no tests, bugs were found during implementation, or a follow-up issue requests test coverage."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+# add-unit-tests-for-existing-script
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Name | add-unit-tests-for-existing-script |
+| Category | testing |
+| Description | Add comprehensive pytest unit tests for an existing Python script that has no tests |
+| Language | Python / pytest |
+| Pattern | Class-grouped tests by function, sys.path.insert import, tmp_path fixtures |
+
+## When to Use
+
+- A Python script in `scripts/` has been identified as having zero test coverage
+- Bugs were discovered during manual use that unit tests would have caught
+- A follow-up GitHub issue explicitly requests tests for specific public functions
+- You need to retrofit tests onto existing code without modifying the script itself
+
+## Verified Workflow
+
+1. **Read the script** thoroughly before writing a single test — understand all public functions, their signatures, return types, and edge cases
+2. **Explore function behavior interactively** with quick `python3 -c` one-liners to verify assumptions before encoding them as assertions
+3. **Check the existing test file** (if any) — avoid duplicating tests that already exist; extend the file rather than creating a new one
+4. **Add `sys.path.insert`** at the top of the test file to allow direct imports from `scripts/`:
+   ```python
+   import sys
+   from pathlib import Path
+   sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+   from my_script import func_a, func_b
+   ```
+5. **Group tests into classes** — one `TestClassName` per public function, following `tests/scripts/` precedents
+6. **Use `tmp_path` fixtures** for any file I/O; never write to real directories
+7. **Cover edge cases first**: empty input, missing files, unclosed delimiters, unknown keys, None arguments
+8. **Run tests** with `python3 -m pytest tests/scripts/test_<script>.py -v` — use direct `python3` not `pixi run` to avoid slow env activation during development
+9. **Fix pre-commit auto-fixes**: ruff may auto-remove unused imports; re-stage and commit again
+10. **Commit only the test file** — never stage `.pyc`, prompt files, or build directories
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running tests via `pixi run python -m pytest` | Used pixi for test execution during development | Command timed out (>2 min env activation) | Use `python3 -m pytest` directly for fast iteration; only use pixi for final validation |
+| Running background pytest task | Launched pytest as a background task to avoid blocking | Output file was empty for minutes | Background tasks don't stream output — run pytest synchronously in foreground |
+| Importing unused constant in tests | Imported `SKILL_CATEGORY_OVERRIDE` for documentation but never asserted on it | Ruff auto-removed it, causing first commit to fail | Only import symbols you actually use in assertions; ruff-check runs in pre-commit |
+| Extending file without reading it | Attempted to write new test classes without reading existing file content | Edit tool rejected the change (file not read first) | Always `Read` the target file before any `Edit` — required by tool policy |
+
+## Results & Parameters
+
+### Import Pattern (preferred)
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from my_script import func_a, func_b, CONSTANT_A
+```
+
+### Dynamic Loader (for tests needing module-level patching)
+
+```python
+import importlib.util
+SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "my_script.py"
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("my_script", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+@pytest.fixture
+def mod():
+    return load_module()
+```
+
+Use `unittest.mock.patch.object(mod, "GLOBAL_CONSTANT", fake_value)` to override
+module-level constants (e.g., hardcoded paths) in tests.
+
+### Class Grouping Template
+
+```python
+class TestMyFunction:
+    def test_happy_path(self) -> None: ...
+    def test_empty_input(self) -> None: ...
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None: ...
+    def test_edge_case_colon_in_value(self) -> None: ...
+```
+
+### Quick Behavior Exploration
+
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'scripts')
+from my_script import parse_frontmatter
+fm, rest = parse_frontmatter('---\nname: foo\n---\nBody')
+print('fm:', fm)
+print('rest:', repr(rest))
+"
+```
+
+### Pre-Commit Fix Pattern
+
+If `ruff-check-python` fails with "files were modified by this hook":
+```bash
+git add tests/scripts/test_my_script.py  # re-stage after auto-fix
+git commit -m "..."                       # commit again — will pass this time
+```


### PR DESCRIPTION
## Summary

Documents the workflow for retrofitting comprehensive pytest unit tests onto an existing Python script that has no coverage (issue #3309 in ProjectOdyssey).

- Covers the full pattern: read script → explore behavior interactively → group tests by function → use tmp_path for file I/O → handle pre-commit auto-fixes
- Captures two import patterns: direct `sys.path.insert` and `importlib` dynamic loader for module-level patching
- Documents the ruff auto-fix gotcha that causes a two-commit workflow

## Key Findings

**What Worked**:
- `sys.path.insert(0, str(Path(...) / "scripts"))` for clean direct imports
- Exploring function behavior with `python3 -c` one-liners before writing assertions
- Grouping tests into `TestFunctionName` classes (one per public function)
- Running `python3 -m pytest` directly instead of via pixi for fast iteration (0.42s vs 2min+)

**What Failed**:
- `pixi run python -m pytest` → timed out (2+ min env activation, too slow for iteration)
- Running pytest as background task → output file was empty for minutes (no streaming)
- Importing unused constant → ruff auto-removed it, first commit failed; re-stage fixed it

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers correctly for "no test coverage" scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)