### PR TITLE
feat: add yaml-frontmatter-colon-fix skill

### DIFF
--- a/skills/tooling/yaml-frontmatter-colon-fix/.claude-plugin/plugin.json
+++ b/skills/tooling/yaml-frontmatter-colon-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "yaml-frontmatter-colon-fix",
+  "version": "1.0.0",
+  "description": "Fix silent data-loss when parsing YAML frontmatter containing colons in values by replacing line.partition(':') with yaml.safe_load(). Use when: (1) a markdown frontmatter parser splits on the first colon and truncates values, (2) skill descriptions or metadata fields contain colons and are silently corrupted on migration.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["yaml", "frontmatter", "parsing", "migration", "data-loss"]
+}

--- a/skills/tooling/yaml-frontmatter-colon-fix/references/notes.md
+++ b/skills/tooling/yaml-frontmatter-colon-fix/references/notes.md
@@ -1,0 +1,72 @@
+# Session Notes — yaml-frontmatter-colon-fix
+
+## Context
+
+- **Issue**: Odyssey2 #3310 — Migration script: handle description field with colons correctly
+- **PR**: HomericIntelligence/ProjectOdyssey #3928
+- **Branch**: `3310-auto-impl`
+- **File fixed**: `scripts/migrate_odyssey_skills.py`
+- **Follow-up from**: #3140
+
+## Root Cause
+
+`parse_frontmatter()` used `line.partition(':')` to split each frontmatter line:
+
+```python
+key, _, value = line.partition(":")
+```
+
+`str.partition(':')` always splits on the **first** colon, so:
+
+```
+description: "Create PR linked to issue: #123"
+```
+
+was parsed as:
+
+- key = `description`
+- value = `"Create PR linked to issue`  ← truncated at the colon inside the value
+
+The `.strip('"')` call afterwards could not recover the lost text.
+
+## Fix Applied
+
+Replaced the manual loop with `yaml.safe_load()`:
+
+```python
+import yaml
+
+frontmatter_text = "\n".join(frontmatter_lines)
+try:
+    parsed = yaml.safe_load(frontmatter_text)
+    frontmatter = parsed if isinstance(parsed, dict) else {}
+except yaml.YAMLError:
+    frontmatter = {}
+```
+
+PyYAML correctly handles:
+- Quoted strings with embedded colons
+- Unquoted strings (plain scalars)
+- Malformed YAML (returns `{}` instead of crashing)
+- Empty frontmatter (`yaml.safe_load("")` returns `None`, guarded by `isinstance`)
+
+## Tests Added
+
+7 new tests in `TestParseFrontmatter` class:
+
+1. `test_plain_value` — basic `key: value`
+2. `test_colon_in_quoted_value` — regression: `"value with: colon"` must not be truncated
+3. `test_colon_in_unquoted_value` — bare YAML string
+4. `test_no_frontmatter` — content without `---`
+5. `test_unclosed_frontmatter` — single `---` with no closing delimiter
+6. `test_invalid_yaml_returns_empty_dict` — malformed YAML returns `{}`
+7. `test_remaining_content_preserved` — body after `---` is returned correctly
+
+All 18 tests passed (7 new + 11 pre-existing).
+
+## Key Lessons
+
+1. **Never reimplement YAML parsing** — even "simple" frontmatter has edge cases (colons, quotes, multi-line) that the YAML spec handles and ad-hoc parsers miss.
+2. **Silent data loss is the worst kind of bug** — the value was just silently truncated; no error, no warning. A regression test for the exact input is essential.
+3. **`yaml.safe_load` not `yaml.load`** — `yaml.load` allows arbitrary Python object construction; always use `safe_load` for untrusted/user-provided files.
+4. **Guard the `isinstance` check** — `yaml.safe_load("")` returns `None`, not `{}`. Always check `isinstance(parsed, dict)`.

--- a/skills/tooling/yaml-frontmatter-colon-fix/skills/yaml-frontmatter-colon-fix/SKILL.md
+++ b/skills/tooling/yaml-frontmatter-colon-fix/skills/yaml-frontmatter-colon-fix/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: yaml-frontmatter-colon-fix
+description: "Fix silent data-loss when parsing YAML frontmatter containing colons in values by replacing line.partition(':') with yaml.safe_load(). Use when: a frontmatter parser truncates values at the first colon."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+# YAML Frontmatter Colon Fix
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Name | yaml-frontmatter-colon-fix |
+| Category | tooling |
+| Language | Python |
+| Root cause | `str.partition(':')` splits on first colon, silently truncating values that contain colons |
+| Fix | Replace manual loop with `yaml.safe_load()` on the frontmatter block |
+
+## When to Use
+
+- A Python script parses `---` YAML frontmatter using `line.partition(':')` or `line.split(':', 1)`
+- Values like `description: "Create PR linked to issue: #123"` are silently truncated to `"Create PR linked to issue"`
+- Migration or transformation scripts copy frontmatter fields and downstream consumers see incomplete data
+- You need to add a regression test for colons inside quoted YAML values
+
+## Verified Workflow
+
+### 1. Identify the faulty parser
+
+Look for patterns like:
+
+```python
+for line in frontmatter_lines:
+    if ":" in line:
+        key, _, value = line.partition(":")
+        value = value.strip().strip('"').strip("'")
+```
+
+### 2. Add the import
+
+```python
+import yaml
+```
+
+### 3. Replace the loop with yaml.safe_load()
+
+```python
+frontmatter_text = "\n".join(frontmatter_lines)
+try:
+    parsed = yaml.safe_load(frontmatter_text)
+    frontmatter = parsed if isinstance(parsed, dict) else {}
+except yaml.YAMLError:
+    frontmatter = {}
+```
+
+`yaml` is part of PyYAML which is a standard dependency in most Python projects. No new package needed.
+
+### 4. Add regression tests
+
+```python
+def test_colon_in_quoted_value(self) -> None:
+    """Regression: description with colon inside quoted value must not be truncated."""
+    content = '---\nname: gh-create-pr-linked\ndescription: "Create PR linked to issue: #123"\n---\n# Body'
+    fm, _ = parse_frontmatter(content)
+    assert fm["description"] == "Create PR linked to issue: #123"
+
+def test_invalid_yaml_returns_empty_dict(self) -> None:
+    """Malformed YAML in frontmatter returns {} without raising."""
+    content = "---\n: invalid: yaml: [\n---\n# Body"
+    fm, _ = parse_frontmatter(content)
+    assert fm == {}
+```
+
+### 5. Run tests
+
+```bash
+pixi run python -m pytest tests/scripts/test_migrate_odyssey_skills.py -v
+```
+
+All tests should pass, including the new regression cases.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Keep `partition(':')` but strip quotes | Strip `"` and `'` after splitting on first colon | Still wrong: `"Create PR linked to issue: #123"` → `"Create PR linked to issue` (truncated before strip) | The colon is inside the value, not separating key from value — stripping quotes does not help |
+| Use `split(':', 1)` | Split at most once, take `[1]` as value | Same root cause: still splits at the first colon even when it is inside a quoted string | Only a real YAML parser understands quoting rules |
+| Regex to detect quoted values | Match `key: "value with: colons"` | Fragile; does not handle multi-line values, escape sequences, or other YAML syntax | Use the YAML spec instead of reimplementing it |
+
+## Results & Parameters
+
+### Key parameters
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| PyYAML function | `yaml.safe_load()` | Use `safe_load`, never `load()` — avoids arbitrary code execution |
+| Fallback on parse error | `{}` | Catch `yaml.YAMLError`, return empty dict to avoid crashing |
+| Type check after parse | `isinstance(parsed, dict)` | `yaml.safe_load` on empty string returns `None`; guard against it |
+
+### Validated fix (from Odyssey2 PR #3928)
+
+```python
+import yaml
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    if not content.startswith("---"):
+        return {}, content
+    lines = content.split("\n")
+    end_idx = -1
+    for i, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+    if end_idx == -1:
+        return {}, content
+    frontmatter_lines = lines[1:end_idx]
+    remaining = "\n".join(lines[end_idx + 1 :])
+    frontmatter_text = "\n".join(frontmatter_lines)
+    try:
+        parsed = yaml.safe_load(frontmatter_text)
+        frontmatter = parsed if isinstance(parsed, dict) else {}
+    except yaml.YAMLError:
+        frontmatter = {}
+    return frontmatter, remaining
+```


### PR DESCRIPTION
## Summary

Documents the fix for silent data-loss when parsing YAML frontmatter with `line.partition(':')`, which truncates values containing colons (e.g. `description: "Create PR linked to issue: #123"` becomes `"Create PR linked to issue"`).

- Root cause: `str.partition(':')` always splits at the first colon, regardless of quoting
- Fix: replace the manual loop with `yaml.safe_load()` on the frontmatter block
- Regression tests: 7 new test cases including the exact colon-in-quoted-value case

## Key Findings

**What Worked**:
- `yaml.safe_load()` handles quoted strings, colons, and malformed YAML correctly out of the box
- Guarding with `isinstance(parsed, dict)` handles the `yaml.safe_load("") == None` edge case
- `yaml.YAMLError` catch ensures malformed frontmatter returns `{}` instead of crashing

**What Failed**:
- Keeping `partition(':')` and stripping quotes afterward → still truncated before the strip
- Using `split(':', 1)` → same root cause, first colon is still wrong split point
- Regex to detect quoted values → fragile and doesn't cover all YAML edge cases

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` → ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "frontmatter" / "yaml" / "partition" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)