### PR TITLE
feat: add deferred-doc-placeholder skill

### DIFF
--- a/skills/documentation/deferred-doc-placeholder/.claude-plugin/plugin.json
+++ b/skills/documentation/deferred-doc-placeholder/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "deferred-doc-placeholder",
+  "version": "1.0.0",
+  "description": "Pattern for adding an HTML comment placeholder to a docs navigation index when an entire section is removed due to stub deletion. Preserves awareness of missing topics without broken links. Use when: (1) a docs/index.md section is removed after stub deletion, (2) a follow-up issue tracks restoring the navigation hub, (3) you need to mark topics as deferred with acceptance criteria for future contributors.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["docs", "index", "placeholder", "deferred", "navigation", "stub-deletion", "html-comment"]
+}

--- a/skills/documentation/deferred-doc-placeholder/references/notes.md
+++ b/skills/documentation/deferred-doc-placeholder/references/notes.md
@@ -1,0 +1,78 @@
+# Session Notes: deferred-doc-placeholder
+
+## Session Details
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3312-auto-impl
+- **Issue**: #3312 — "docs/index.md lacks Core Documentation section after stub deletion"
+- **PR**: #3932
+
+## Problem
+
+After 17 placeholder stub files were deleted in PR/issue #3142 (under YAGNI), the
+`docs/index.md` Core Documentation section was removed entirely. The section included 8 topics:
+
+- project-structure
+- shared-library
+- paper-implementation
+- testing-strategy
+- mojo-patterns
+- agent-system
+- workflow
+- configuration
+
+Also removed from Advanced Topics: performance, custom-layers, distributed-training,
+visualization, debugging, integration.
+
+Also removed from Development Guides: architecture, api-reference, ci-cd.
+
+The issue asked for a reminder that the navigation hub is now sparse and these topics
+should be re-added when real docs are written.
+
+## Approach Taken
+
+Single file edit: inserted an HTML comment block into `docs/index.md` between the
+Getting Started section (line 18) and Advanced Topics section (line 19 post-edit).
+
+The comment lists all 17 deferred topics with:
+- Status (Deferred — doc not yet written)
+- Why (Stub deleted in #3142, YAGNI)
+- Acceptance criteria (Write <file>; re-add link here)
+
+Plus a `Tracking issue: #3312` footer.
+
+## Execution
+
+```bash
+# Read current state
+cat docs/index.md
+
+# Edit (used Edit tool to insert comment block at line 19)
+# Verified: grep -c "DEFERRED: Core Documentation" docs/index.md → 1
+# Verified: grep -n "\[.*\](core/" docs/index.md → no matches (no broken links)
+# Verified: awk 'length > 120' docs/index.md → 2 pre-existing long lines, not from edit
+
+# Commit
+git add docs/index.md
+git commit -m "docs(index): add deferred placeholder for Core Documentation section"
+# All pre-commit hooks passed
+
+# Push + PR
+git push -u origin 3312-auto-impl
+gh pr create --title "docs(index): add deferred placeholder for Core Documentation section"
+gh pr merge --auto --rebase 3932
+```
+
+## Key Observations
+
+1. HTML comments in Markdown pass `markdownlint-cli2` even with MD033 (allowed_elements list)
+   because comments are not HTML *elements*
+2. The pre-existing long lines (106, 112 chars) in the Community/License sections were
+   pre-existing — confirmed via `git diff HEAD`
+3. The task was trivial but important: making stub-deletion follow-ups explicit so future
+   contributors don't wonder why the nav hub is sparse
+
+## Commit Hash
+
+`d5d70c2f` (post-edit) — superseded by the new commit in this session

--- a/skills/documentation/deferred-doc-placeholder/skills/deferred-doc-placeholder/SKILL.md
+++ b/skills/documentation/deferred-doc-placeholder/skills/deferred-doc-placeholder/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: deferred-doc-placeholder
+description: "Pattern for adding an HTML comment placeholder to a docs navigation index when an entire section is removed due to stub deletion. Use when: a docs/index.md section disappears after placeholder stubs are deleted and a follow-up issue tracks restoring it."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+# Deferred Doc Placeholder
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Issue** | #3312 (ProjectOdyssey) |
+| **PR** | #3932 (ProjectOdyssey) |
+| **Objective** | Restore navigation awareness in `docs/index.md` after Core Documentation section was removed when 17 placeholder stubs were deleted in #3142 |
+| **Outcome** | HTML comment block added listing all 17 deferred topics with status, reason, and acceptance criteria; no broken links introduced |
+| **Status** | Completed and merged |
+
+## When to Use This Skill
+
+Apply this pattern when:
+
+1. A docs navigation index (`docs/index.md` or similar hub) had a **section removed** because the linked files were placeholder stubs deleted under YAGNI
+2. A follow-up issue explicitly tracks **restoring the navigation hub** when real docs are written
+3. You want to make the **absence visible** to future contributors without introducing broken links
+4. Multiple topics are deferred and each needs **acceptance criteria** for restoration
+
+**Do NOT use** when:
+
+- Only one or two links are missing (just add a TODO comment inline)
+- The section was intentionally removed permanently (no planned restoration)
+- The doc files actually exist — link them directly instead
+
+## Verified Workflow
+
+### 1. Read the issue and the current index file
+
+```bash
+gh issue view <number> --comments
+# Then read docs/index.md to see its current state
+```
+
+Confirm: which section is missing, which topics belong to it.
+
+### 2. Insert an HTML comment block at the section's former location
+
+Place the comment between the last real section above and the next real section below.
+Each deferred topic gets three sub-fields:
+
+```markdown
+<!-- DEFERRED: <Section Name> section
+  The following topics were linked in docs/index.md but their source files
+  were placeholder stubs deleted in #<stub-deletion-issue>. Re-add each entry
+  once the corresponding doc is written.
+
+  - <topic-slug> (<path/to/file.md>)
+    Status: Deferred — doc not yet written
+    Why: Stub deleted in #<issue> (YAGNI)
+    Acceptance criteria: Write <path/to/file.md>; re-add link here
+
+  ...
+
+  Tracking issue: #<follow-up-issue>
+-->
+```
+
+Key rules:
+
+- Use an **HTML comment** (`<!-- ... -->`), not a Markdown heading — the section should
+  not render in the output, only in source
+- List **every** topic that was in the removed section
+- Include **all related sections** that also lost entries (e.g., Advanced Topics, Dev Guides)
+- Add `Tracking issue: #<number>` at the bottom so the comment is self-referencing
+
+### 3. Verify no broken links were introduced
+
+```bash
+grep -n "\[.*\](<missing-path>" docs/index.md   # should return nothing
+```
+
+### 4. Check line length compliance (markdownlint MD013)
+
+```bash
+awk 'length > 120 {print NR": "length" chars"}' docs/index.md
+```
+
+Lines inside HTML comments are exempt from markdownlint rendering rules, but confirm
+any pre-existing long lines are not from your edit.
+
+### 5. Commit, push, PR
+
+Pure documentation change — no tests needed:
+
+```bash
+git add docs/index.md
+git commit -m "docs(index): add deferred placeholder for <Section> section
+
+<Brief explanation of what was removed and why the comment was added.>
+
+Closes #<issue-number>"
+
+git push -u origin <branch>
+gh pr create --title "docs(index): add deferred placeholder for <Section> section" \
+  --body "Closes #<issue-number>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | Single-pass implementation | — | Task was well-scoped: one file edit, HTML comment, no broken links |
+
+## Results & Parameters
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `docs/index.md` | +55 lines: HTML comment block between Getting Started and Advanced Topics sections |
+
+### Comment Block Template (copy-paste)
+
+```markdown
+<!-- DEFERRED: Core Documentation section
+  The following topics were linked in docs/index.md but their source files
+  were placeholder stubs deleted in #3142. Re-add each entry once the
+  corresponding doc is written.
+
+  - project-structure (core/project-structure.md)
+    Status: Deferred — doc not yet written
+    Why: Stub deleted in #3142 (YAGNI)
+    Acceptance criteria: Write core/project-structure.md; re-add link here
+
+  - shared-library (core/shared-library.md)
+    Status: Deferred — doc not yet written
+    Why: Stub deleted in #3142
+    Acceptance criteria: Write core/shared-library.md; re-add link here
+
+  Tracking issue: #3312
+-->
+```
+
+### Pre-commit Results
+
+All hooks passed with a pure HTML comment addition:
+
+- `Markdown Lint` — Passed (HTML comments are not HTML elements; MD033 allows-list not triggered)
+- `Trim Trailing Whitespace` — Passed
+- `Fix End of Files` — Passed
+- `Check for Large Files` — Passed
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3312, PR #3932 | 17-topic Core Documentation section restored as deferred comment after stubs deleted in #3142 |
+
+## Related Skills
+
+- **document-deferred-future-improvements** — Annotates *existing* Future Improvements items inside design docs with Status/Why/Acceptance Criteria; this skill is for a *missing navigation section* in an index file
+- **delete-placeholder-docs** — The upstream skill that removes stubs; this skill documents the follow-up pattern
+- **placeholder-note-to-status-tracking** — Similar pattern for converting bare placeholder notes to structured status entries


### PR DESCRIPTION
## Summary

- Adds `deferred-doc-placeholder` skill documenting the pattern for inserting an HTML comment placeholder in a docs navigation index when an entire section is removed due to stub deletion
- Captures how to list all deferred topics with status, reason, and acceptance criteria without introducing broken links

## Key Findings

**What Worked**:
- HTML comment block (`<!-- ... -->`) passes `markdownlint-cli2` MD033 even with an `allowed_elements` list, because comments are not HTML elements
- Including `Tracking issue: #<number>` inside the comment makes the placeholder self-referencing for future contributors

**What Failed**:
- N/A — single-pass implementation; no failed attempts

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 525/525 pass, 0 failures
- [x] SKILL.md has required YAML frontmatter, Failed Attempts table, Verified Workflow, Results & Parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
