### PR TITLE
feat: add workflow-binary-sha256-verification skill

### DIFF
--- a/skills/ci-cd/workflow-binary-sha256-verification/.claude-plugin/plugin.json
+++ b/skills/ci-cd/workflow-binary-sha256-verification/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "workflow-binary-sha256-verification",
+  "version": "1.0.0",
+  "description": "Add SHA256 checksum verification for binary downloads in GitHub Actions workflows to prevent supply chain attacks. Use when: (1) a workflow downloads a binary via wget/curl without integrity verification, (2) a tool is pinned to a version but the downloaded artifact is not checksummed, (3) reviewing CI security and noticing unverified binary execution.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["security", "sha256", "supply-chain", "github-actions", "binary-verification", "gitleaks", "workflow-hardening"]
+}

--- a/skills/ci-cd/workflow-binary-sha256-verification/references/notes.md
+++ b/skills/ci-cd/workflow-binary-sha256-verification/references/notes.md
@@ -1,0 +1,43 @@
+# Session Notes: workflow-binary-sha256-verification
+
+## Issue
+GitHub issue #3316: "Pin Gitleaks version and verify fetch-depth: 0 is set"
+Follow-up from #3143.
+
+## Context
+The `security.yml` workflow in ProjectOdyssey downloaded `gitleaks_8.18.0_linux_x64.tar.gz` via
+`wget` with no hash verification before extracting and executing the binary. This is a supply chain
+risk: a compromised mirror or MITM could serve a modified binary.
+
+The issue also asked to document/enforce `fetch-depth: 0` on the checkout step, which is required
+for gitleaks to scan the full git history.
+
+## Workflow file
+`.github/workflows/security.yml` (not `security-pr-scan.yml` as stated in the issue — always check
+`ls .github/workflows/` before assuming)
+
+## Key steps taken
+1. Read `.github/workflows/security.yml`
+2. Fetched official checksums: `wget -q -O - https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_checksums.txt`
+3. Extracted SHA256 for linux_x64: `6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb`
+4. Added `echo "<sha256>  <tarball>" | sha256sum --check` after wget, before tar
+5. Updated `fetch-depth: 0` comment to state it must not be removed
+6. Created `tests/workflows/__init__.py` and `tests/workflows/test_security_workflow.py` with 6 tests
+7. All 6 tests passed first run
+8. Pre-commit (ruff) auto-reformatted the test file on first commit; re-staged and committed
+9. Created PR #3934 with `gh pr merge --auto --rebase`
+
+## File locations
+- `.github/workflows/security.yml` — modified
+- `tests/workflows/__init__.py` — new (empty)
+- `tests/workflows/test_security_workflow.py` — new (6 tests)
+
+## SHA256 details
+- File: `gitleaks_8.18.0_linux_x64.tar.gz`
+- SHA256: `6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb`
+- Source: https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_checksums.txt
+
+## Pitfalls
+- Issue said `security-pr-scan.yml` but actual file is `security.yml`
+- `curl -s` without `-L` returns empty for GitHub Releases redirect URLs
+- Pre-commit ruff auto-formats Python; expect one failed commit + re-stage cycle

--- a/skills/ci-cd/workflow-binary-sha256-verification/skills/workflow-binary-sha256-verification/SKILL.md
+++ b/skills/ci-cd/workflow-binary-sha256-verification/skills/workflow-binary-sha256-verification/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: workflow-binary-sha256-verification
+description: "Add SHA256 checksum verification for binary downloads in GitHub Actions workflows to prevent supply chain attacks. Use when: a workflow downloads a binary via wget/curl without integrity verification before execution."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Add SHA256 checksum verification for binary downloads in GitHub Actions workflows |
+| **Context** | Security hardening — supply chain attack prevention |
+| **Trigger** | Workflow downloads a binary (wget/curl) and executes it without integrity check |
+| **Output** | Modified workflow YAML with `sha256sum --check` step + regression tests |
+
+## When to Use
+
+1. A GitHub Actions workflow downloads a binary via `wget` or `curl` with no hash check
+2. A tool is pinned to a version in the URL but the downloaded tarball is not checksummed
+3. Security audit identifies unverified binary execution before `tar`/`chmod`/execution
+4. Reviewing a follow-up issue requiring supply chain hardening for a specific CI tool
+
+## Verified Workflow
+
+### Step 1: Identify the download step
+
+Read the workflow YAML and find the `wget`/`curl` line downloading the binary. Note the exact
+filename and version.
+
+### Step 2: Fetch the official checksum
+
+Fetch from the tool's GitHub Releases page — most projects publish a `_checksums.txt` file:
+
+```bash
+curl -L -s https://github.com/<org>/<tool>/releases/download/<version>/<tool>_<version>_checksums.txt
+```
+
+Extract the SHA256 for the exact tarball used in the workflow (match OS/arch).
+
+### Step 3: Add the sha256sum check in the workflow
+
+Insert immediately after the `wget` line, before `tar`:
+
+```yaml
+- name: Run Gitleaks
+  run: |
+    # Pinned to v8.18.0 — update hash when upgrading version (see #3316)
+    wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_linux_x64.tar.gz
+    # Verify integrity before execution — SHA256 from https://github.com/.../gitleaks_8.18.0_checksums.txt
+    echo "6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb  gitleaks_8.18.0_linux_x64.tar.gz" | sha256sum --check
+    tar -xzf gitleaks_8.18.0_linux_x64.tar.gz
+    chmod +x gitleaks
+```
+
+Key formatting: `echo "<sha256>  <filename>"` — note **two spaces** between hash and filename
+(sha256sum standard format).
+
+### Step 4: Update any comments to document fetch-depth requirements
+
+If the binary is a git-scanning tool (like Gitleaks), ensure `fetch-depth: 0` is documented:
+
+```yaml
+with:
+  fetch-depth: 0  # Required: full history needed for gitleaks git-log mode (do not remove, see #NNNN)
+```
+
+### Step 5: Write regression tests
+
+Create `tests/workflows/test_<workflow>_security.py` asserting:
+
+1. SHA256 check line is present in the workflow file
+2. The SHA256 value is a real 64-char hex digest (not a placeholder)
+3. The actual hash matches the expected value from the official checksums
+4. `fetch-depth: 0` is present (if applicable)
+5. The version string is pinned in the download URL
+
+```python
+EXPECTED_SHA256 = "6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb"
+GITLEAKS_TARBALL = "gitleaks_8.18.0_linux_x64.tar.gz"
+
+def test_sha256_value_matches_expected(workflow_content: str) -> None:
+    match = re.search(r"([0-9a-f]{64})\s+" + re.escape(GITLEAKS_TARBALL), workflow_content)
+    assert match is not None
+    assert match.group(1) == EXPECTED_SHA256
+```
+
+### Step 6: Run tests, commit, and create PR
+
+```bash
+pixi run python -m pytest tests/workflows/ -v
+git add .github/workflows/<workflow>.yml tests/workflows/
+git commit -m "security(workflow): add SHA256 verification for <tool> binary download"
+gh pr create --title "..." --body "Closes #NNNN"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `curl` to checksums URL returned empty | Used `curl -s` without `-L` flag | GitHub releases redirect; without `-L`, curl follows no redirect and returns empty | Always use `curl -L -s` for GitHub Releases URLs, or use `wget -q -O -` |
+| Searching for `security-pr-scan.yml` | Issue description mentioned this filename | The actual file is `security.yml` — the issue description used an informal name | Always `ls .github/workflows/` to find actual filenames before assuming |
+
+## Results & Parameters
+
+**Gitleaks v8.18.0 SHA256 (linux_x64)**:
+```
+6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb
+```
+
+**Official checksums URL pattern**:
+```
+https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_checksums.txt
+```
+
+**sha256sum check format** (two spaces required):
+```bash
+echo "<hash>  <filename>" | sha256sum --check
+```
+
+**Test pattern** — regex to extract and verify SHA256 from workflow YAML:
+```python
+import re
+match = re.search(r"([0-9a-f]{64})\s+" + re.escape(TARBALL_FILENAME), workflow_content)
+```
+
+**CI outcome**: 6/6 tests passed, pre-commit auto-fixed ruff formatting on first commit attempt.


### PR DESCRIPTION
## Summary

Documents how to add SHA256 checksum verification for binary downloads in GitHub Actions workflows
to prevent supply chain attacks via tampered binaries.

- Covers the `echo "<sha256>  <file>" | sha256sum --check` pattern (two-space format required)
- Documents how to fetch official checksums from GitHub Releases
- Includes regression test pattern that asserts hash presence, format, and exact value
- Captures pitfalls: curl without `-L`, informal filenames in issue descriptions, ruff auto-format cycle

## Key Findings

**What Worked**:
- `wget -q -O -` or `curl -L -s` to fetch checksums from GitHub Releases redirect URLs
- Inserting `sha256sum --check` immediately after `wget`, before `tar`/`chmod`/execution
- Regex test `re.search(r"([0-9a-f]{64})\s+<tarball>", content)` to assert exact hash in workflow YAML

**What Failed**:
- `curl -s` without `-L` → returns empty due to GitHub Releases redirect; always use `curl -L -s`
- Assuming workflow filename from issue description → actual file was `security.yml` not `security-pr-scan.yml`; always `ls .github/workflows/`

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — PASS (525/525)
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
