### PR TITLE
feat: update agent-tier-consolidation skill with junior-only variant

### DIFF
--- a/skills/architecture/agent-tier-consolidation/references/notes.md
+++ b/skills/architecture/agent-tier-consolidation/references/notes.md
@@ -40,3 +40,46 @@ non-blocking style suggestions unrelated to this change).
 ## Time
 
 ~20 minutes total: read files, make edits, verify, commit, push, create PR.
+
+```text
+python3 tests/agents/validate_configs.py .claude/agents/
+Total files: 42, Passed: 42, Failed: 0, Errors: 0
+```
+
+---
+
+## Session Notes: Issue #3332 (junior-only variant, 2026-03-07)
+
+- **Issue**: #3332 — Apply same tier consolidation to test engineers (3 → 2)
+- **Branch**: 3332-auto-impl
+- **PR**: #3957
+
+### Problem
+
+Test engineer hierarchy had 3 tiers: `test-specialist (L3) → test-engineer (L4) → junior-test-engineer (L5)`.
+Same over-segmentation argument as #3146 — junior tier adds overhead without benefit at current stage.
+
+### Approach
+
+- This was a junior-only variant: no senior tier to handle
+- `test-engineer.md` already had Bash tool access; junior had a `PreToolUse` Bash block hook
+- Simply removed the junior, cleared `delegates_to` on test-engineer, updated test-specialist
+- Cross-references spread across 5 files beyond the agent configs themselves
+
+### Files Changed
+
+- `.claude/agents/junior-test-engineer.md` — deleted
+- `.claude/agents/test-engineer.md` — `delegates_to: [junior-test-engineer]` → `delegates_to: []`
+- `.claude/agents/test-specialist.md` — removed `junior-test-engineer` from `delegates_to`
+- `agents/hierarchy.md` — removed Junior Test Engineer section
+- `agents/README.md` — Level 5 count 2 → 1
+- `agents/docs/agent-catalog.md` — removed Junior Test Engineer catalog entry
+- `scripts/agents/setup_agents.sh` — removed from EXPECTED_AGENT_FILES array
+- `docs/dev/agent-claude4-update-status.md` — removed from Level 5 list
+
+### Validation
+
+```text
+python3 tests/agents/validate_configs.py .claude/agents/
+Total files: 30, Passed: 30, Failed: 0, Errors: 0
+```

--- a/skills/architecture/agent-tier-consolidation/skills/agent-tier-consolidation/SKILL.md
+++ b/skills/architecture/agent-tier-consolidation/skills/agent-tier-consolidation/SKILL.md
@@ -102,3 +102,99 @@ Closes #<issue>
 | Assuming hierarchy.md table already correct | Skipped table check because it showed 31 | L5 narrative ("3 types") was still wrong even though table count was right | Always check both the table AND the narrative prose separately |
 | Updating catalog Quick Reference table row | Tried to remove the Junior Documentation Engineer row without context | `old_string` not unique without surrounding rows | Include both flanking rows in `old_string` for uniqueness |
 
+## Results & Parameters
+
+### Consolidation from ProjectOdyssey issue #3146
+
+**Before**: 4 implementation tiers
+
+```text
+implementation-specialist (L3)
+  → senior-implementation-engineer (L4)
+  → implementation-engineer (L4)
+  → junior-implementation-engineer (L5)
+  → implementation-specialist (L3, also receives)
+```
+
+**After**: 2 tiers
+
+```text
+implementation-specialist (L3)
+  → implementation-engineer (L4, full spectrum)
+```
+
+**Agent count delta**: 44 → 42
+
+**Key merge decisions**:
+
+- Added `mojo-simd-optimize`, `mojo-memory-check` skills from senior tier
+- Added `quality-fix-formatting`, `gh-check-ci-status` skills from junior tier
+- Added performance-profiling workflow steps from senior tier
+- Added anti-pattern reference and escalation rules from junior tier
+- Kept two concrete examples: one standard, one performance-critical
+- Removed `hooks.PreToolUse` Bash block (junior-only restriction, not needed for consolidated agent)
+
+### Validation output
+
+```text
+Total files: 42
+Passed: 42
+Failed: 0
+Total errors: 0
+```
+
+### Hierarchy counts to update
+
+| Section | Before | After |
+|---------|--------|-------|
+| Level 4 count line | "6 agents" | "5 agents" |
+| Level 5 count line | "3 types" | "2 types" |
+| Agent Count table L4 | 6 | 5 |
+| Agent Count table L5 | 3 | 2 |
+| Total | 44 | 42 |
+| Diagram box L4 | Lists senior + regular | Lists only regular |
+| Diagram box L5 | Lists 3 juniors | Lists 2 juniors |
+
+### Consolidation from ProjectOdyssey issue #3332 (junior-only variant)
+
+**Before**: 3 test tiers
+
+```text
+test-specialist (L3)
+  → test-engineer (L4)
+  → junior-test-engineer (L5)
+```
+
+**After**: 2 tiers
+
+```text
+test-specialist (L3)
+  → test-engineer (L4, handles all complexity)
+```
+
+**Agent count delta**: 31 → 30
+
+**Key differences from implementation consolidation**:
+
+- No senior tier to merge — only junior-to-middle merge needed
+- `test-engineer.md` already had `Bash` tool access (unlike junior which blocked it via hook)
+- Removed `hooks.PreToolUse` Bash block from junior; test-engineer retained Bash access
+- Cross-references in `agents/hierarchy.md`, `agents/README.md`, `agents/docs/agent-catalog.md`,
+  `scripts/agents/setup_agents.sh`, and `docs/dev/agent-claude4-update-status.md` all needed updating
+- `test-specialist.md` `delegates_to` changed from `[test-engineer, junior-test-engineer]` to `[test-engineer]`
+
+**Validation output**:
+
+```text
+Total files: 30
+Passed: 30
+Failed: 0
+Total errors: 0
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3146 — implementation engineer tier consolidation | See Results above |
+| ProjectOdyssey | Issue #3332 — test engineer tier consolidation (junior-only variant) | See Results above |


### PR DESCRIPTION
## Summary

- Adds a second verified example to the `agent-tier-consolidation` skill documenting the simpler junior-only variant (3→2 tiers, no senior to handle)
- Updates `references/notes.md` with session notes from ProjectOdyssey issue #3332
- Adds `## Verified On` table per cross-repo compatibility guidelines

## Key Findings

**What Worked**:

- Junior-only consolidation is faster (~10 min): delete junior file, clear `delegates_to` on middle agent, update specialist
- Bash hook removal is a non-issue when the target middle-tier agent already has Bash access
- The same cross-reference update pattern holds: check `agents/`, `scripts/`, and `docs/dev/` for mentions

**What Was Observed**:

- 5 non-agent-config files referenced `junior-test-engineer` (hierarchy.md, README.md, agent-catalog.md, setup_agents.sh, agent-claude4-update-status.md)
- `grep -r "junior-test-engineer"` is the reliable way to find all references before deleting

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` — `agent-tier-consolidation` PASS, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)