### PR TITLE
feat: add mojo-jit-crash-doc skill

### DIFF
--- a/skills/documentation/mojo-jit-crash-doc/.claude-plugin/plugin.json
+++ b/skills/documentation/mojo-jit-crash-doc/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-jit-crash-doc",
+  "version": "1.0.0",
+  "description": "Document Mojo JIT compiler crashes (libKGENCompilerRTShared.so 'execution crashed') in docs/dev/ with diagnosis guide and retry workaround. Use when: (1) a CI flake produces 'execution crashed' before any test output, (2) developers report intermittent mojo test failures on known-good code, (3) a new Mojo compiler bug needs a dev-facing workaround doc.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["mojo", "jit", "crash", "workaround", "ci", "debugging", "documentation"]
+}

--- a/skills/documentation/mojo-jit-crash-doc/references/notes.md
+++ b/skills/documentation/mojo-jit-crash-doc/references/notes.md
@@ -1,0 +1,74 @@
+# Session Notes: mojo-jit-crash-doc
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Project**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3330-auto-impl
+- **Issue**: #3330 — Document Mojo JIT crash workaround in CLAUDE.md or dev docs
+- **Follow-up from**: #3120 (Core Loss test crashes)
+
+## Objective
+
+Document the intermittent `libKGENCompilerRTShared.so` JIT crash in Mojo v0.26.1 so future
+developers recognize it as a compiler flake rather than a test bug.
+
+## Issue Requirements (from #3330)
+
+1. What 'execution crashed' in mojo output means
+2. That it's a compiler bug not a test bug
+3. The retry pattern fix
+4. How to verify by checking if the crash appears before any test output
+
+## Files Changed
+
+- **Created**: `docs/dev/mojo-jit-crash-workaround.md` (new, ~120 lines)
+- **Modified**: `CLAUDE.md` — added Quick Links entry under Core Guidelines
+- **Modified**: `docs/dev/mojo-test-failure-patterns.md` — added blockquote callout
+
+## Key Technical Findings
+
+### CI Context (from comprehensive-tests.yml)
+
+The workflow uses `continue-on-error: true` for Core Tensors, Integration Tests, and
+Benchmarking test groups as a stopgap for the JIT crash. The comment at line 272:
+
+```
+# Some test groups have flaky Mojo runtime segfaults (libKGENCompilerRTShared.so crashes)
+# on CI runners due to memory/runtime constraints.
+```
+
+### Relationship to ADR-009
+
+ADR-009 documents a *different* `libKGENCompilerRTShared.so` crash — deterministic heap
+corruption after ~15 cumulative tests in one file. That was fixed by file splitting. The
+JIT crash (#3330) is non-deterministic and fixed by retrying.
+
+### markdownlint Command
+
+```bash
+pixi run pre-commit run markdownlint-cli2 --files <file1> <file2>
+```
+
+`npx` is not available in the pixi environment. `just` is not on PATH in worktree shells.
+
+## Approach Taken
+
+1. Read existing workaround docs (`mojo-glibc-compatibility.md`, ADR-009) for style reference
+2. Read CI workflow to understand current mitigation (`continue-on-error`)
+3. Created new doc with all 4 required items from the issue
+4. Added cross-references in CLAUDE.md and mojo-test-failure-patterns.md
+5. Ran `pixi run pre-commit run markdownlint-cli2` — passed
+6. Committed, pushed, created PR #3958, enabled auto-merge
+
+## Errors Encountered
+
+- `pixi run npx markdownlint-cli2` → `npx: command not found`
+- `just pre-commit-all` → `just: command not found`
+- Edit CLAUDE.md without prior Read → tool rejected with "File has not been read yet"
+
+## PR Result
+
+- PR #3958: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3958
+- Auto-merge enabled
+- Label: documentation

--- a/skills/documentation/mojo-jit-crash-doc/skills/mojo-jit-crash-doc/SKILL.md
+++ b/skills/documentation/mojo-jit-crash-doc/skills/mojo-jit-crash-doc/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: mojo-jit-crash-doc
+description: "Document Mojo JIT compiler crashes (libKGENCompilerRTShared.so 'execution crashed') with diagnosis guide and retry workaround. Use when: CI produces 'execution crashed' before any test output, or developers report intermittent mojo test failures on known-good code."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+# Skill: mojo-jit-crash-doc
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-07 |
+| Objective | Document the intermittent Mojo v0.26.1 JIT crash so developers recognize it as a compiler flake, not a test bug |
+| Outcome | Success — `docs/dev/mojo-jit-crash-workaround.md` created, CLAUDE.md Quick Links updated, cross-reference added to mojo-test-failure-patterns.md, PR #3958 created |
+| Category | documentation |
+
+## When to Use
+
+Use this skill when:
+
+- CI produces `execution crashed` (with no preceding test output) on a test group that passes
+  consistently on main
+- A developer spends time debugging test code for a crash that is actually a Mojo compiler flake
+- A new Mojo compiler bug with a known workaround needs a developer-facing doc under `docs/dev/`
+- Adding a quick-link to CLAUDE.md for a new workaround guide
+
+## Verified Workflow
+
+### 1. Read the issue and existing docs for context
+
+```bash
+gh issue view <number> --comments
+```
+
+Check `docs/dev/` for existing workaround docs (e.g., `mojo-glibc-compatibility.md`,
+`mojo-test-failure-patterns.md`) to match style. Read `ADR-009` for context on the
+related heap-corruption crash — it is **distinct** from the JIT flake.
+
+### 2. Create `docs/dev/mojo-jit-crash-workaround.md`
+
+Required sections:
+
+- **Problem** — what `execution crashed` means, that it originates in
+  `libKGENCompilerRTShared.so`, and that it is a Mojo compiler bug not a test bug
+- **Diagnosis table** — crash before any test output = compiler flake; crash after
+  test output = real test bug; specific assertion failure = real test bug
+- **Workaround: CI Retry Pattern** — shell retry loop + GitHub Actions
+  `nick-fields/retry` snippet
+- **Relationship to ADR-009** — comparison table distinguishing the two crashes
+- **Long-term resolution** — checklist for what to remove when upgrading Mojo
+
+Sample diagnosis table (copy-paste into the doc):
+
+```markdown
+| Symptom | Cause |
+|---------|-------|
+| `execution crashed` before any test output | Compiler flake — retry |
+| `execution crashed` after test output | Likely a real test bug |
+| Specific assertion failure message | Real test bug — investigate |
+```
+
+### 3. Update CLAUDE.md Quick Links
+
+Add a link under `### Core Guidelines`:
+
+```markdown
+- [Mojo JIT Crash Workaround](docs/dev/mojo-jit-crash-workaround.md) - `libKGENCompilerRTShared.so` flake
+```
+
+Insert it after the `Mojo Anti-Patterns` line so all Mojo-related links are grouped together.
+
+### 4. Add callout in `docs/dev/mojo-test-failure-patterns.md`
+
+Insert a blockquote after the `## Executive Summary` header:
+
+```markdown
+> **Note**: For `execution crashed` errors that appear _before_ any test output, see
+> [Mojo JIT Crash Workaround](mojo-jit-crash-workaround.md) — this is a compiler flake,
+> not a test bug. Retry the test run to confirm.
+```
+
+This surfaces the JIT crash doc when developers search "execution crashed" in the test
+failure patterns file.
+
+### 5. Run markdownlint
+
+```bash
+pixi run pre-commit run markdownlint-cli2 --files \
+  docs/dev/mojo-jit-crash-workaround.md \
+  docs/dev/mojo-test-failure-patterns.md \
+  CLAUDE.md
+```
+
+Expected output: `Markdown Lint............. Passed`
+
+### 6. Commit, push, create PR
+
+```bash
+git add docs/dev/mojo-jit-crash-workaround.md \
+        docs/dev/mojo-test-failure-patterns.md \
+        CLAUDE.md
+
+git commit -m "docs(dev): document Mojo JIT crash workaround for libKGENCompilerRTShared.so
+
+Add docs/dev/mojo-jit-crash-workaround.md explaining the intermittent
+'execution crashed' error in Mojo v0.26.1.
+
+Closes #<issue-number>"
+
+git push -u origin <branch>
+
+gh pr create \
+  --title "docs(dev): document Mojo JIT crash workaround for libKGENCompilerRTShared.so" \
+  --body "Closes #<issue-number>" \
+  --label "documentation"
+
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Direct `pixi run npx markdownlint-cli2` | Ran markdownlint via npx through pixi | `npx: command not found` — npx is not in the pixi environment | Use `pixi run pre-commit run markdownlint-cli2 --files <files>` instead |
+| Running `just pre-commit-all` | Tried the justfile recipe for pre-commit | `just: command not found` in the worktree shell | Use `pixi run pre-commit run <hook> --files <files>` directly |
+| Edit CLAUDE.md without Read | Tried to Edit CLAUDE.md before reading it | Tool rejected: "File has not been read yet" | Always Read before Edit, even for small targeted changes |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| New file | `docs/dev/mojo-jit-crash-workaround.md` |
+| Files modified | `CLAUDE.md`, `docs/dev/mojo-test-failure-patterns.md` |
+| Lines added | ~120 (new doc) + 2 (CLAUDE.md) + 4 (test-failure-patterns.md) |
+| Markdownlint hook | `pixi run pre-commit run markdownlint-cli2 --files <files>` |
+| PR | https://github.com/HomericIntelligence/ProjectOdyssey/pull/3958 |
+| Issue | #3330 |
+| Branch | `3330-auto-impl` |
+| Time to complete | ~10 minutes |
+
+## Key Insights
+
+1. **Diagnosis by output position**: The single most useful heuristic — if `execution crashed`
+   appears before any test output, it is always a JIT compiler flake. If tests ran first,
+   investigate the test code.
+
+2. **Distinguish from ADR-009**: The heap corruption crash (ADR-009) is deterministic (fires
+   after ~15 cumulative tests) and workarounded by file splitting. The JIT crash is
+   non-deterministic and workarounded by retrying. Both produce `libKGENCompilerRTShared.so`
+   in the crash, so documenting the difference prevents confusion.
+
+3. **Cross-reference placement matters**: Adding a blockquote at the top of
+   `mojo-test-failure-patterns.md` (not buried at the bottom) ensures developers see the
+   pointer to the JIT crash doc when they land on the patterns file looking for "execution
+   crashed".
+
+4. **markdownlint via pre-commit, not npx**: In this pixi environment, `npx` is unavailable.
+   The correct command is `pixi run pre-commit run markdownlint-cli2 --files <files>`.
+
+5. **`just` unavailable in worktree shells**: The `just` binary is not on PATH in bare
+   worktree shells. Use `pixi run <command>` directly.


### PR DESCRIPTION
## Summary

Documents the Mojo v0.26.1 JIT compiler crash (`libKGENCompilerRTShared.so` / `execution crashed`) — what it means, how to tell it apart from a real test bug, the retry workaround, and how it differs from the heap-corruption crash in ADR-009.

- New skill: `skills/documentation/mojo-jit-crash-doc`
- Covers all 4 items from the original issue: meaning of `execution crashed`, it's a compiler bug not a test bug, the retry pattern fix, and the "crash before any test output" verification heuristic

## Key Findings

**What Worked**:
- Writing the doc with a diagnosis table (crash position relative to test output) as the primary heuristic
- Adding a blockquote cross-reference at the top of `mojo-test-failure-patterns.md` for discoverability
- Using `pixi run pre-commit run markdownlint-cli2 --files <files>` for markdown validation

**What Failed**:
- `pixi run npx markdownlint-cli2` → `npx: command not found` (npx not in pixi env)
- `just pre-commit-all` → `just: command not found` (just not on PATH in worktree shells)
- Edit CLAUDE.md without prior Read → tool rejected the edit

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify `mojo-jit-crash-doc` skill appears
- [ ] Check skill activation on triggers: "execution crashed", "libKGENCompilerRTShared.so", "intermittent mojo test failure"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
