### PR TITLE
feat: add audit-stale-scripts skill

### DIFF
--- a/skills/tooling/audit-stale-scripts/.claude-plugin/plugin.json
+++ b/skills/tooling/audit-stale-scripts/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "audit-stale-scripts",
+  "version": "1.0.0",
+  "description": "Audit a scripts/ directory for stale one-time tools and safely remove confirmed candidates. Use when: (1) a scripts/ directory has grown with historical one-off files after bulk cleanup, (2) a follow-up audit is needed after a prior removal PR, (3) you need a repeatable caller-check pattern before deleting any script.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["scripts", "cleanup", "audit", "git", "stale"]
+}

--- a/skills/tooling/audit-stale-scripts/references/notes.md
+++ b/skills/tooling/audit-stale-scripts/references/notes.md
@@ -1,0 +1,50 @@
+# Session Notes — audit-stale-scripts
+
+## Context
+
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3337 — "Audit remaining scripts/ files for additional stale candidates"
+- **Follow-up to**: #3148 (removed 19 scripts)
+- **Branch**: `3337-auto-impl`
+- **Date**: 2026-03-07
+
+## What Was Done
+
+1. Listed all `scripts/*.py` and `scripts/*.sh` with `ls` + `Glob`
+2. Identified 10 candidates by name patterns (bisect, merge, fix, batch, add, document, migrate)
+3. For each candidate, grepped `.github/`, `justfile`, `scripts/` for callers
+4. Discovered `bisect_heap_test.py` referenced by `run_bisect_heap.sh` — removed both together
+5. Read `head -20` of `migrate_odyssey_skills.py` to confirm cross-project purpose
+6. Ran `git rm` on all 10 files
+7. Updated `scripts/README.md`: removed "Migration utilities" bullet, added "Removed Scripts" section
+8. Ran `pixi run pre-commit run --all-files` — all 14 hooks passed
+9. Committed and created PR #3967
+
+## Files Removed
+
+```
+scripts/execute_backward_tests_merge.py
+scripts/merge_backward_tests.py
+scripts/bisect_heap_test.py
+scripts/run_bisect_heap.sh
+scripts/fix-build-errors.py
+scripts/batch_planning_docs.py
+scripts/add_delegation_to_agents.py
+scripts/add_examples_to_agents.py
+scripts/document_foundation_issues.py
+scripts/migrate_odyssey_skills.py
+```
+
+## Key Decision Points
+
+- `migrate_odyssey_skills.py` had active git history and was well-maintained, but targeted a
+  different repo (ProjectMnemosyne) with zero callers in this repo — stale by that criterion
+- `convert_image_to_idx.py` was considered but kept — it's a user-facing utility with ADR-001
+  justification (PIL required, not available in Mojo stdlib)
+- Pre-commit passed first try (no formatting issues)
+
+## PR
+
+- URL: https://github.com/HomericIntelligence/ProjectOdyssey/pull/3967
+- Auto-merge enabled (rebase strategy)
+- Label: `cleanup`

--- a/skills/tooling/audit-stale-scripts/skills/audit-stale-scripts/SKILL.md
+++ b/skills/tooling/audit-stale-scripts/skills/audit-stale-scripts/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: audit-stale-scripts
+description: "Audit scripts/ for stale one-time tools and safely remove confirmed candidates. Use when: follow-up cleanup after a bulk script removal PR, scripts/ has grown with historical one-off files, or you need a caller-check pattern before deleting."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Category** | tooling |
+| **Complexity** | Low |
+| **Risk** | Low (read-only audit first, removal only after confirmation) |
+| **Repo** | Any project with a `scripts/` directory |
+
+Removes one-time and historical scripts that have no active callers, freeing the
+`scripts/` directory of technical debt without breaking CI or other tooling.
+
+## When to Use
+
+- A prior bulk-cleanup PR removed a batch of scripts and a follow-up audit was requested
+- `scripts/` contains files named with patterns like `bisect_*`, `fix-*`, `merge_*`, `add_*_to_*`, `migrate_*`, `batch_*`, `document_*`
+- You need to confirm zero callers before deletion
+- Preparing a `chore(scripts)` PR with a clear rationale for each removal
+
+## Verified Workflow
+
+### Step 1 — List all top-level scripts
+
+```bash
+ls scripts/*.py scripts/*.sh 2>/dev/null | sort
+```
+
+Use `Glob` for a full recursive view including subdirectories.
+
+### Step 2 — Identify candidates by name pattern
+
+Look for names that suggest one-time operations:
+
+- `bisect_*` / `run_bisect_*` — git bisect artifacts
+- `fix-*` / `fix_*` — autonomous one-time repair scripts
+- `merge_*` — branch merge workflows already completed
+- `execute_*` — one-off execution scripts
+- `add_*_to_*` — bulk attribute injection (agents, configs, etc.)
+- `batch_*` — one-time batch operations
+- `document_*` — one-time documentation generators
+- `migrate_*` — cross-project migrations
+
+### Step 3 — Verify zero callers for each candidate
+
+```bash
+for script in execute_backward_tests_merge merge_backward_tests bisect_heap_test; do
+  hits=$(grep -r "$script" .github/ justfile scripts/ \
+    --include="*.yml" --include="*.py" --include="*.sh" --include="*.yaml" 2>/dev/null \
+    | grep -v "^scripts/${script}" | grep -v "README" | grep -v "CHANGELOG")
+  [ -n "$hits" ] && echo "REFERENCED: $script" || echo "NO CALLERS: $script"
+done
+```
+
+**Important**: if script A references script B, both must be removed together or neither.
+Check cross-references within the removal set before finalising.
+
+### Step 4 — Read script headers to confirm purpose
+
+```bash
+head -20 scripts/candidate.py
+```
+
+Verify the docstring confirms a completed one-time operation.
+
+### Step 5 — Check git history for context (optional)
+
+```bash
+git log --oneline --follow scripts/candidate.py | head -5
+```
+
+### Step 6 — Remove confirmed candidates
+
+```bash
+git rm \
+  scripts/execute_backward_tests_merge.py \
+  scripts/merge_backward_tests.py \
+  scripts/bisect_heap_test.py \
+  scripts/run_bisect_heap.sh \
+  scripts/fix-build-errors.py \
+  scripts/batch_planning_docs.py \
+  scripts/add_delegation_to_agents.py \
+  scripts/add_examples_to_agents.py \
+  scripts/document_foundation_issues.py \
+  scripts/migrate_odyssey_skills.py
+```
+
+### Step 7 — Update scripts/README.md
+
+Add a "Removed Scripts" section under "Deprecated Scripts" listing each removed file
+with a one-line rationale.
+
+### Step 8 — Run pre-commit and commit
+
+```bash
+pixi run pre-commit run --all-files
+git commit -m "chore(scripts): remove N stale one-time tool scripts
+
+<list each script with reason>
+
+Closes #<issue>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Include `migrate_odyssey_skills.py` in "active" category | Assumed cross-project migration scripts might still be needed | Script targets a different repo (ProjectMnemosyne) with no callers in CI, justfile, or README | Always grep for callers before assuming a script is active; cross-project tools with no callers are stale |
+| Remove `bisect_heap_test.py` without checking its pair | Would have left `run_bisect_heap.sh` referencing a deleted file | `run_bisect_heap.sh` copies `bisect_heap_test.py` to /tmp | Always grep within the removal candidate set itself — scripts can reference each other |
+| Skip README update | Only remove files, skip documentation | `scripts/README.md` overview mentioned "Migration utilities" which became inaccurate after removal | Always update README when removing scripts; the overview bullet list needs to stay accurate |
+
+## Results & Parameters
+
+**Issue context** (ProjectOdyssey): #3337 — follow-up to #3148 (19 scripts removed earlier)
+
+**Scripts removed** (10 files, ~4,571 lines deleted):
+
+```text
+execute_backward_tests_merge.py  — one-time branch merge, already merged
+merge_backward_tests.py          — duplicate merge approach
+bisect_heap_test.py              — git bisect artifact (ADR-009 heap issue)
+run_bisect_heap.sh               — wrapper for bisect_heap_test.py
+fix-build-errors.py              — one-time autonomous repair
+batch_planning_docs.py           — one-time batch doc generation
+add_delegation_to_agents.py      — bulk agent update (completed)
+add_examples_to_agents.py        — bulk agent update (completed)
+document_foundation_issues.py    — one-time doc script (completed)
+migrate_odyssey_skills.py        — cross-project migration (completed)
+```
+
+**Grep command for caller check**:
+
+```bash
+grep -r "$script" .github/ justfile scripts/ \
+  --include="*.yml" --include="*.py" --include="*.sh" --include="*.yaml" 2>/dev/null \
+  | grep -v "^scripts/${script}" | grep -v "README" | grep -v "CHANGELOG"
+```
+
+**Pre-commit result**: All 14 hooks passed on first run.


### PR DESCRIPTION
## Summary

Documents the repeatable workflow for auditing `scripts/` directories after bulk cleanup PRs —
identifying one-time tools by name pattern, verifying zero callers, and safely removing confirmed
stale candidates.

- Extracted from ProjectOdyssey issue #3337 (follow-up to #3148 which removed 19 scripts)
- Removed 10 stale scripts (~4,571 lines) with zero CI/justfile callers
- Pattern generalises to any repo with a growing `scripts/` directory

## Key Findings

**What Worked**:
- Name-pattern heuristics (`bisect_*`, `fix-*`, `merge_*`, `add_*_to_*`, `migrate_*`) reliably identify candidates
- Caller grep across `.github/`, `justfile`, and `scripts/` catches all active references
- Checking cross-references *within* the removal set prevents broken script pairs

**What Failed**:
- Almost missed that `bisect_heap_test.py` was referenced by `run_bisect_heap.sh` — both needed removal together
- Initial assumption that `migrate_odyssey_skills.py` might be active (it had recent commits) — zero callers confirmed it stale

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 525/525 pass
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with "audit scripts", "stale scripts", "remove one-time tools" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
