### PR TITLE
feat: add pixi-cache-true-http400-fix skill

### DIFF
--- a/skills/ci-cd/pixi-cache-true-http400-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pixi-cache-true-http400-fix/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pixi-cache-true-http400-fix",
+  "version": "1.0.0",
+  "description": "Fix prefix-dev/setup-pixi cache:true HTTP 400 failures by replacing with explicit actions/cache@v4 step. Use when: (1) CI logs show HTTP 400 errors from setup-pixi built-in caching, (2) a composite action wrapping setup-pixi still passes cache:true, (3) migrating workflows to reliable explicit pixi environment caching.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["github-actions", "pixi", "caching", "composite-action", "http400", "setup-pixi"]
+}

--- a/skills/ci-cd/pixi-cache-true-http400-fix/references/notes.md
+++ b/skills/ci-cd/pixi-cache-true-http400-fix/references/notes.md
@@ -1,0 +1,93 @@
+# Session Notes: pixi-cache-true-http400-fix
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: #3341 — Extend setup-pixi composite to remaining 10 pixi-using workflows
+- **Branch**: `3341-auto-impl`
+- **PR**: #3966
+
+## What Was Found
+
+When starting the session, the implementation plan (from issue comments) indicated:
+
+1. The composite action `.github/actions/setup-pixi/action.yml` already existed
+2. All 10 target workflows already used `./.github/actions/setup-pixi` (the migration was done)
+3. BUT the composite action itself still used `cache: ${{ inputs.cache }}` which defaulted to `true`
+4. `prefix-dev/setup-pixi@v0.9.4` with `cache: true` fails with HTTP 400 from the GitHub cache service
+
+## State Before Fix
+
+```yaml
+# .github/actions/setup-pixi/action.yml (broken)
+name: Set Up Pixi Environment
+description: Install Pixi and restore the cached environment.
+
+inputs:
+  pixi-version:
+    description: Pixi version to install
+    required: false
+    default: latest
+  cache:
+    description: Whether to enable Pixi built-in caching
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        pixi-version: ${{ inputs.pixi-version }}
+        cache: ${{ inputs.cache }}    # HTTP 400!
+```
+
+## State After Fix
+
+```yaml
+# .github/actions/setup-pixi/action.yml (fixed)
+name: Set Up Pixi Environment
+description: Install Pixi with explicit ~/.pixi cache (avoids broken cache:true HTTP 400).
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        pixi-version: latest
+      # DO NOT use cache: true — broken, fails with HTTP 400 from GitHub cache service
+
+    - name: Cache pixi environments
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pixi
+          ~/.cache/rattler/cache
+        key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+        restore-keys: |
+          pixi-${{ runner.os }}-
+```
+
+## Key Discovery: Check Callers Before Removing Inputs
+
+Before removing the `inputs:` block, ran:
+```bash
+grep -rn -A3 "uses: ./.github/actions/setup-pixi" .github/workflows/ | grep -E "pixi-version|cache:"
+```
+Result: no output — confirmed no callers pass `with:` blocks, so inputs could be safely removed.
+
+## Workflows Already Converted (by Prior Work)
+
+All 10 originally listed workflows were already using the composite action:
+- `mojo-version-check.yml`, `paper-validation.yml`, `pre-commit.yml`, `release.yml`
+- `script-validation.yml`, `test-data-utilities.yml`, `test-gradients.yml`, `type-check.yml`
+- Note: `dependency-audit.yml` was merged into `security.yml` in issue #3149
+- Note: `validate-configs.yml` has no pixi steps at all
+
+## Related Skills
+
+- `fix-composite-action-migration` — covers the case where workflows weren't yet using the composite action
+- `github-actions-pytest-pixi` — general pixi + GitHub Actions pattern
+- `github-actions-ci-speedup` — source of the broken `cache: true` HTTP 400 knowledge

--- a/skills/ci-cd/pixi-cache-true-http400-fix/skills/pixi-cache-true-http400-fix/SKILL.md
+++ b/skills/ci-cd/pixi-cache-true-http400-fix/skills/pixi-cache-true-http400-fix/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: pixi-cache-true-http400-fix
+description: "Fix prefix-dev/setup-pixi cache:true HTTP 400 failures by replacing with explicit actions/cache@v4. Use when: CI shows HTTP 400 from setup-pixi caching, or a composite action still uses cache:true."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+# Fix setup-pixi cache:true HTTP 400 Failure
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-07 |
+| Objective | Replace broken `cache: true` in `prefix-dev/setup-pixi` with explicit `actions/cache@v4` |
+| Outcome | Reliable pixi environment caching; no HTTP 400 errors from GitHub cache service |
+| Issue | #3341 — Extend setup-pixi composite to remaining 10 workflows |
+
+## When to Use
+
+- CI logs show HTTP 400 errors during the `prefix-dev/setup-pixi` step with `cache: true`
+- A composite action wrapping `setup-pixi` still passes `cache: ${{ inputs.cache }}` or `cache: true`
+- Migrating workflows from the broken double-setup pattern to a unified composite action
+- The composite action has `inputs:` for `pixi-version` and `cache` that no callers actually use
+
+## Verified Workflow
+
+### 1. Identify the Problem
+
+Check if the composite action (`.github/actions/setup-pixi/action.yml`) uses `cache: true`:
+
+```bash
+cat .github/actions/setup-pixi/action.yml
+```
+
+Look for:
+
+```yaml
+with:
+  pixi-version: ${{ inputs.pixi-version }}
+  cache: ${{ inputs.cache }}   # <-- broken pattern
+```
+
+### 2. Check Callers for `with:` Blocks
+
+Verify no workflows pass `with:` inputs to the composite action — if they do, preserve the inputs:
+
+```bash
+grep -rn -A3 "uses: ./.github/actions/setup-pixi" .github/workflows/ | grep -E "pixi-version|cache:"
+```
+
+If no output: safe to remove inputs entirely. If output: preserve the `inputs:` block and only fix the cache step.
+
+### 3. Rewrite the Composite Action
+
+Replace the broken pattern with explicit caching. Remove unused `inputs:` block if no callers use it:
+
+```yaml
+name: Set Up Pixi Environment
+description: Install Pixi with explicit ~/.pixi cache (avoids broken cache:true HTTP 400).
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        pixi-version: latest
+      # DO NOT use cache: true — broken, fails with HTTP 400 from GitHub cache service
+
+    - name: Cache pixi environments
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pixi
+          ~/.cache/rattler/cache
+        key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+        restore-keys: |
+          pixi-${{ runner.os }}-
+```
+
+Key points:
+
+- Cache path is `.pixi` (repo-relative), NOT `~/.pixi`
+- Also cache `~/.cache/rattler/cache` (rattler package cache)
+- Key uses `pixi.lock` hash, NOT `pixi.toml` (lock file captures exact resolved versions)
+- Use `actions/cache@v4` (not v5 — v5 has its own instability issues)
+
+### 4. Validate YAML
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup-pixi/action.yml')); print('OK')"
+```
+
+### 5. Commit and Push
+
+```bash
+git add .github/actions/setup-pixi/action.yml
+git commit -m "ci(actions): replace broken cache:true with explicit pixi cache step"
+git push -u origin <branch>
+```
+
+## Cache Path Reference
+
+| Path | Purpose |
+|------|---------|
+| `.pixi` | Pixi environments (repo-relative, not `~/.pixi`) |
+| `~/.cache/rattler/cache` | Rattler package download cache |
+
+## Key File: Correct `pixi.lock` vs `pixi.toml` for Cache Key
+
+- `pixi.lock` — resolved dependency tree; changes when any dep version changes → correct cache key
+- `pixi.toml` — version constraints only; may not change when lock file changes → stale cache risk
+
+Always use `hashFiles('pixi.lock')` as the cache key.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `cache: true` in setup-pixi | Pass `cache: true` to `prefix-dev/setup-pixi@v0.9.4` | GitHub cache service returns HTTP 400; setup-pixi's built-in caching is unreliable | Use explicit `actions/cache@v4` instead |
+| Keying cache on `pixi.toml` | `hashFiles('pixi.toml')` as cache key | Lock file changes without toml changes → stale cache hits | Always key on `pixi.lock` |
+| Caching `~/.pixi` instead of `.pixi` | Used home-dir path for the pixi env cache | Pixi stores environments in the repo-local `.pixi/` directory, not `~/.pixi` | Use `.pixi` (repo-relative) |
+| Keeping unused `inputs:` block | Preserved `pixi-version` and `cache` inputs when no callers use them | Dead code; caused confusion and allowed accidental re-introduction of `cache: true` | Remove inputs when no callers pass `with:` blocks |
+
+## Results & Parameters
+
+### Working Composite Action Template
+
+```yaml
+name: Set Up Pixi Environment
+description: Install Pixi with explicit ~/.pixi cache (avoids broken cache:true HTTP 400).
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        pixi-version: latest
+
+    - name: Cache pixi environments
+      uses: actions/cache@v4
+      with:
+        path: |
+          .pixi
+          ~/.cache/rattler/cache
+        key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+        restore-keys: |
+          pixi-${{ runner.os }}-
+```
+
+### Verification Commands
+
+```bash
+# Check no workflows still use cache:true directly
+grep -rn "cache: true" .github/workflows/ .github/actions/
+
+# Verify all workflows use composite action (not direct prefix-dev call)
+grep -rn "prefix-dev/setup-pixi" .github/workflows/
+
+# Validate YAML
+python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup-pixi/action.yml')); print('OK')"
+```


### PR DESCRIPTION
## Summary

Documents how to fix `prefix-dev/setup-pixi` `cache: true` HTTP 400 failures by replacing
the broken built-in caching with an explicit `actions/cache@v4` step in a composite action wrapper.

- Removes broken `cache: true` / `cache: ${{ inputs.cache }}` from composite action
- Adds explicit `actions/cache@v4` caching `.pixi` + `~/.cache/rattler/cache`
- Keys cache on `pixi.lock` hash (not `pixi.toml`) for accurate invalidation
- Documents the caller-check pattern before removing unused `inputs:` blocks

## Key Findings

**What Worked**:
- Explicit `actions/cache@v4` with `.pixi` + `~/.cache/rattler/cache` paths
- Keying on `pixi.lock` hash for accurate cache invalidation
- Verifying no callers use `with:` blocks before removing the `inputs:` section

**What Failed**:
- `cache: true` in `prefix-dev/setup-pixi@v0.9.4` → HTTP 400 from GitHub cache service
- Caching `~/.pixi` instead of `.pixi` → wrong path (pixi uses repo-local `.pixi/`)
- Keying cache on `pixi.toml` → stale cache hits when lock file changes without toml changes

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears as `pixi-cache-true-http400-fix`
- [ ] Check skill activation with triggers: "cache:true", "HTTP 400", "setup-pixi", "pixi caching"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
