### PR TITLE
feat: add replace-printf-emoji-with-python-script skill

### DIFF
--- a/skills/ci-cd/replace-printf-emoji-with-python-script/.claude-plugin/plugin.json
+++ b/skills/ci-cd/replace-printf-emoji-with-python-script/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "replace-printf-emoji-with-python-script",
+  "version": "1.0.0",
+  "description": "Replace fragile shell printf emoji byte-escape encoding in CI workflows with a dedicated Python script. Use when: (1) a GitHub Actions workflow uses printf with \\xf0\\x9f byte escapes to embed emoji in shell output, (2) CI comments or report files use printf-based emoji that may fail in different locale/shell environments, (3) refactoring shell-heavy report-building steps into maintainable Python scripts.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["emoji", "printf", "python", "github-actions", "encoding", "locale", "shell"]
+}

--- a/skills/ci-cd/replace-printf-emoji-with-python-script/references/notes.md
+++ b/skills/ci-cd/replace-printf-emoji-with-python-script/references/notes.md
@@ -1,0 +1,62 @@
+# Session Notes: replace-printf-emoji-with-python-script
+
+## Context
+
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3345 — "coverage.yml PR comment uses fragile printf emoji encoding"
+- **Branch**: `3345-auto-impl`
+- **PR**: #3977
+
+## Problem
+
+`coverage.yml` had this step:
+
+```yaml
+- name: Build PR comment report
+  if: github.event_name == 'pull_request'
+  run: |
+    {
+      printf '## \xf0\x9f\x93\x8a Test Metrics Report\n\n'
+      cat metrics.md
+      printf '\n\n---\n*Note: Full code coverage requires Mojo coverage tooling (blocked - see ADR-008)*\n'
+    } > metrics-pr-comment.md
+```
+
+The `\xf0\x9f\x93\x8a` is the UTF-8 byte sequence for the 📊 emoji. If the shell uses a
+different locale or `printf` implementation, the bytes may not render correctly.
+
+Additionally, the `comment-marker` YAML field used `"\U0001F4CA Test Metrics Report"` — the
+Python unicode escape for the same emoji — creating a second encoding inconsistency.
+
+## Solution
+
+1. Created `scripts/build_pr_comment.py` — Python script with `HEADER`/`FOOTER` constants as
+   plain UTF-8 string literals (no escapes), `build_comment(metrics_file, output_file) -> int`,
+   and `main()` with argparse.
+
+2. Replaced the 6-line shell block in `coverage.yml` with:
+   ```yaml
+   run: python scripts/build_pr_comment.py --metrics-file metrics.md --output-file metrics-pr-comment.md
+   ```
+
+3. Updated `comment-marker` to plain ASCII `"Test Metrics Report"`.
+
+4. Added `tests/unit/scripts/test_build_pr_comment.py` with 4 tests (happy path, missing file,
+   empty file, no emoji byte escapes).
+
+## Pre-commit Behavior
+
+- First commit attempt: ruff-format reformatted `build_pr_comment.py` (line length in argparse
+  description), ruff-check fixed import ordering in `test_build_pr_comment.py`. Files modified
+  by hooks, commit aborted.
+- After re-staging the modified files, second commit succeeded cleanly.
+- There was also a transient SQLite database lock between the two attempts; simple retry resolved it.
+
+## Test Results
+
+```
+4 passed in 4.82s
+```
+
+All tests: `test_happy_path`, `test_missing_metrics_file`, `test_empty_metrics_file`,
+`test_output_contains_no_emoji_byte_escapes`.

--- a/skills/ci-cd/replace-printf-emoji-with-python-script/skills/replace-printf-emoji-with-python-script/SKILL.md
+++ b/skills/ci-cd/replace-printf-emoji-with-python-script/skills/replace-printf-emoji-with-python-script/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: replace-printf-emoji-with-python-script
+description: "Replace fragile shell printf emoji byte-escape encoding in CI workflows with a dedicated Python script. Use when: CI workflow uses printf with \\xf0\\x9f byte escapes for emoji, or report-building shell steps need to be made locale-independent."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `printf '\xf0\x9f\x93\x8a ...'` in shell CI steps is locale/shell-dependent and fragile |
+| **Solution** | Python script with plain UTF-8 string literals; invoked as a single workflow `run:` line |
+| **Language** | Python 3 |
+| **Test framework** | pytest with `tmp_path` fixtures |
+| **Pre-commit hooks** | ruff-format, ruff-check auto-fix on first commit; clean on second |
+
+## When to Use
+
+- A GitHub Actions workflow uses `printf` with `\xf0\x9f` (or similar) byte sequences to embed emoji
+- CI report-building steps span multiple shell lines and are hard to read/maintain
+- You need the same comment marker used in both the file content and a YAML field (emoji in YAML unicode escapes `\U0001F...` can also drift)
+- The project already has a `scripts/` directory with Python automation scripts
+
+## Verified Workflow
+
+1. **Read the workflow file** — locate the fragile `printf` step and identify:
+   - What content is being written (header, body, footer)
+   - The output filename
+   - Any related YAML fields referencing the same emoji string (e.g. `comment-marker`)
+
+2. **Create `scripts/build_<report>.py`** with:
+   - `HEADER` and `FOOTER` as plain Python string constants (UTF-8 literals, no escapes)
+   - `build_comment(input_file: Path, output_file: Path) -> int` function
+   - `main()` with `argparse` CLI (`--input-file`, `--output-file`)
+   - Returns `0` on success, `1` if input file missing (with stderr message)
+
+3. **Write pytest tests** in `tests/unit/scripts/test_build_<report>.py`:
+   - Happy path: header + content + footer present in output
+   - Missing input file: returns non-zero, no output file created
+   - Empty input file: header and footer still present
+   - No byte-escape check: assert `b"\xf0\x9f"` not in `output.read_bytes()`
+
+4. **Update the workflow** — replace the multi-line `printf` block with:
+   ```yaml
+   run: python scripts/build_<report>.py --input-file <in> --output-file <out>
+   ```
+   Also update any `comment-marker:` YAML fields referencing the same emoji to plain ASCII.
+
+5. **Run pre-commit** — ruff-format and ruff-check will auto-fix the new script on first attempt.
+   Stage the reformatted files and commit again (second attempt passes cleanly).
+
+6. **Run tests** — `pixi run python -m pytest tests/unit/scripts/ -v`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| First commit | Staged all files and ran `git commit` | ruff-format reformatted `build_pr_comment.py` and ruff-check fixed an import order issue; pre-commit hook modified files and aborted | Re-stage the linter-modified files and run `git commit` again — second attempt passes cleanly |
+| Database lock on second commit | Immediately retried the commit after first failure | SQLite pre-commit DB was locked from the previous hook run | Wait briefly or just retry; the lock clears on its own |
+| Emoji in `comment-marker` YAML field | Initially left `"\U0001F4CA Test Metrics Report"` in the workflow YAML | The marker is used to find existing bot comments; keeping it as a unicode escape is inconsistent with the plain-text file content | Update the marker to plain ASCII to match the new header string |
+
+## Results & Parameters
+
+### Script template
+
+```python
+#!/usr/bin/env python3
+"""Build PR comment markdown from <input> content.
+
+Usage:
+    python scripts/build_<report>.py --input-file <in>.md --output-file <out>.md
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+HEADER = "## Report Title\n\n"
+FOOTER = "\n\n---\n*Footer note*\n"
+
+
+def build_comment(input_file: Path, output_file: Path) -> int:
+    """Build the output file from input content."""
+    if not input_file.exists():
+        print(f"Error: input file not found: {input_file}", file=sys.stderr)
+        return 1
+    output_file.write_text(HEADER + input_file.read_text(encoding="utf-8") + FOOTER, encoding="utf-8")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-file", required=True, type=Path)
+    parser.add_argument("--output-file", required=True, type=Path)
+    args = parser.parse_args()
+    return build_comment(args.input_file, args.output_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Workflow replacement
+
+```yaml
+# Before (fragile):
+- name: Build report
+  run: |
+    {
+      printf '## \xf0\x9f\x93\x8a Report Title\n\n'
+      cat input.md
+      printf '\n\n---\n*Footer*\n'
+    } > output.md
+
+# After (robust):
+- name: Build report
+  run: python scripts/build_report.py --input-file input.md --output-file output.md
+```
+
+### Test pattern
+
+```python
+def test_no_emoji_byte_escapes(tmp_path: Path) -> None:
+    metrics = tmp_path / "in.md"
+    metrics.write_text("data\n", encoding="utf-8")
+    out = tmp_path / "out.md"
+    build_comment(metrics, out)
+    assert b"\xf0\x9f" not in out.read_bytes()
+```


### PR DESCRIPTION
## Summary

Documents how to replace fragile `printf` byte-escape emoji encoding in GitHub Actions CI
workflows with a dedicated Python script.

- Shell `printf '\xf0\x9f...'` is locale/shell-dependent and can fail silently
- Python string literals are always UTF-8 clean; wrap report-building in a script
- Update all emoji references (including YAML `comment-marker` fields) to plain ASCII

## Key Findings

**What Worked**:
- Python script with `HEADER`/`FOOTER` constants + argparse CLI replaces 6-line shell block
- Single `run: python scripts/build_X.py` line is readable and testable
- Four-test pattern covers all important cases including byte-escape assertion

**What Failed**:
- First commit attempt: ruff auto-modified files; re-stage and recommit resolves it
- Transient SQLite lock on immediate retry; just retry again
- Forgot to update `comment-marker` YAML field on first pass — must update all emoji references

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)