### PR TITLE
feat: add workflow-readme-audit skill

### DIFF
--- a/skills/documentation/workflow-readme-audit/.claude-plugin/plugin.json
+++ b/skills/documentation/workflow-readme-audit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "workflow-readme-audit",
+  "version": "1.0.0",
+  "description": "Audit a .github/workflows/README.md against actual workflow files on disk, update inventory table to match reality, and document remaining duplication. Use when: (1) workflows were added/deleted but README was not updated, (2) a consolidation pass removed workflows that are still listed, (3) inline setup steps exist across many workflows and need to be inventoried before extraction.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["github-actions", "workflows", "ci", "readme", "audit", "duplication", "inventory"]
+}

--- a/skills/documentation/workflow-readme-audit/references/notes.md
+++ b/skills/documentation/workflow-readme-audit/references/notes.md
@@ -1,0 +1,128 @@
+# Session Notes: workflow-readme-audit
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Repository**: ProjectOdyssey
+- **Issue**: #3344 — "Add workflow count badge or comment tracking remaining duplication"
+- **Branch**: `3344-auto-impl`
+- **PR**: #3978
+
+## What the Issue Asked For
+
+> The `.github/workflows/README.md` exists but may not reflect the current state after the
+> consolidation (3 workflows deleted, 1 added). Update the README to reflect the new workflow
+> inventory, composite actions created, and any remaining duplication that was intentionally
+> left (e.g. the 10 single-setup-pixi workflows not yet migrated).
+
+The reference consolidation was PR #3149.
+
+## Actual File State Found
+
+22 workflow files on disk:
+
+```text
+benchmark.yml
+claude-code-review.yml
+claude.yml
+comprehensive-tests.yml
+coverage.yml
+docker.yml
+docs.yml
+link-check.yml
+mojo-version-check.yml
+notebook-validation.yml
+paper-validation.yml
+pre-commit.yml
+readme-validation.yml
+release.yml
+script-validation.yml
+security.yml
+simd-benchmarks-weekly.yml
+test-agents.yml
+test-data-utilities.yml
+test-gradients.yml
+type-check.yml
+validate-configs.yml
+```
+
+## What the Old README Had (Before This Session)
+
+The old README documented these workflows:
+
+| Listed in README | Exists on Disk? |
+|------------------|-----------------|
+| `unit-tests.yml` | NO — deleted in #3149 |
+| `integration-tests.yml` | NO — deleted in #3149 |
+| `comprehensive-tests.yml` | YES |
+| `test-gradients.yml` | YES |
+| `test-data-utilities.yml` | YES |
+| `script-validation.yml` | YES |
+| `validate-configs.yml` | YES |
+| `test-agents.yml` | YES |
+| `pre-commit.yml` | YES |
+| `security-scan.yml` | NO — renamed to `security.yml` |
+| `dependency-audit.yml` | NO — merged into `security.yml` |
+| `mojo-version-check.yml` | YES |
+| `link-check.yml` | YES |
+| `simd-benchmarks-weekly.yml` | YES |
+
+Undocumented workflows (existed on disk but not in README):
+- `benchmark.yml`
+- `claude.yml`
+- `claude-code-review.yml`
+- `coverage.yml`
+- `docker.yml`
+- `docs.yml`
+- `notebook-validation.yml`
+- `paper-validation.yml`
+- `readme-validation.yml`
+- `release.yml`
+- `type-check.yml`
+
+## Inline setup-pixi Duplication
+
+13 workflows use `prefix-dev/setup-pixi` inline (no composite action exists yet):
+
+```
+benchmark.yml
+comprehensive-tests.yml
+mojo-version-check.yml
+paper-validation.yml
+pre-commit.yml
+readme-validation.yml
+release.yml
+script-validation.yml
+security.yml
+simd-benchmarks-weekly.yml
+test-data-utilities.yml
+test-gradients.yml
+type-check.yml
+```
+
+The issue mentioned "10 single-setup-pixi workflows" but the actual count was 13.
+Always run `grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml | wc -l` to get the real count.
+
+## markdownlint Errors Encountered
+
+```text
+.github/workflows/README.md:59:121 MD013/line-length Line length [Expected: 120; Actual: 125]
+.github/workflows/README.md:347:1 MD029/ol-prefix Ordered list item prefix [Expected: 1; Actual: 4; Style: 1/2/3]
+.github/workflows/README.md:348:1 MD029/ol-prefix Ordered list item prefix [Expected: 2; Actual: 5; Style: 1/2/3]
+.github/workflows/README.md:349:1 MD029/ol-prefix Ordered list item prefix [Expected: 3; Actual: 6; Style: 1/2/3]
+```
+
+Fix 1: Shorten a blockquote note from 125 chars to ≤120.
+Fix 2: The "Scanning Jobs (scheduled weekly)" list continued numbering (4/5/6) from the
+"Scanning Jobs (PR/push)" list above it. Reset to 1/2/3 since they are separate lists.
+
+## Files Changed
+
+```text
+.github/workflows/README.md | 477 ++++++++++++++++++++++++++++++-----
+ 1 file changed, 315 insertions(+), 162 deletions(-)
+```
+
+## Commit Hash
+
+`a5901eeb` (on branch `3344-auto-impl`, PR #3978)

--- a/skills/documentation/workflow-readme-audit/skills/workflow-readme-audit/SKILL.md
+++ b/skills/documentation/workflow-readme-audit/skills/workflow-readme-audit/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: workflow-readme-audit
+description: "Audit .github/workflows/README.md against actual files on disk, update inventory to match reality, and document remaining duplication. Use when: workflows were added/deleted but README was not updated, a consolidation pass removed workflows still listed, or inline setup steps exist across many workflows needing inventory before extraction."
+category: documentation
+date: 2026-03-07
+user-invocable: true
+---
+
+# Workflow README Audit
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-03-07 |
+| **Objective** | Audit `.github/workflows/README.md` against actual on-disk files after a consolidation pass removed/added workflows |
+| **Outcome** | README updated: removed 2 stale entries, added 13 undocumented workflows, corrected filename, documented 13 inline `setup-pixi` duplications; pre-commit passed; PR created |
+| **Related Issues** | ProjectOdyssey #3344, follow-up from #3149 |
+
+## When to Use This Skill
+
+Use this skill when:
+
+- A GitHub issue asks to update `workflows/README.md` to "reflect the current state" after a consolidation pass
+- Workflows were deleted (e.g., `unit-tests.yml`, `integration-tests.yml`) but the README still lists them
+- New workflows were added (e.g., `claude.yml`, `docker.yml`) that have no documentation entry
+- The README references a filename that does not match what exists on disk (e.g., `security-scan.yml` vs `security.yml`)
+- You need to inventory inline setup patterns (e.g., `prefix-dev/setup-pixi`) to plan composite action extraction
+
+**Triggers:**
+
+- Issue title contains "workflow README", "workflow inventory", "workflow count", "reflect current state"
+- `workflows/README.md` table references files that don't exist on disk
+- A consolidation PR merged but no follow-up README update happened
+- Issue mentions "remaining duplication" or "not yet migrated" workflows
+
+## Verified Workflow
+
+### Phase 1: Establish Ground Truth
+
+```bash
+# Get the definitive list of actual workflow files
+ls .github/workflows/*.yml
+
+# Get exact count
+ls .github/workflows/*.yml | wc -l
+```
+
+Cross-reference with the current README table. Identify:
+
+| Finding | Action |
+|---------|--------|
+| File in README but not on disk | Remove from README |
+| File on disk but not in README | Add to README |
+| Filename mismatch (e.g., `security-scan.yml` vs `security.yml`) | Correct the filename |
+
+### Phase 2: Read Each Undocumented Workflow
+
+For each workflow missing from the README, read the first 20 lines to extract:
+
+- `name:` field (display name)
+- `on:` triggers (PR, push, schedule, workflow_dispatch)
+- `paths:` filters if any
+
+```bash
+# Quick metadata extraction for multiple files
+for f in workflow1.yml workflow2.yml; do
+  echo "=== $f ==="
+  head -20 .github/workflows/$f
+done
+```
+
+### Phase 3: Audit Inline Duplication
+
+```bash
+# Find all workflows with inline setup step (e.g., setup-pixi)
+grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml
+
+# Count them
+grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml | wc -l
+```
+
+Create a table in the README listing each duplicated workflow, its category, and a note
+that this is intentional deferred work (not an oversight).
+
+### Phase 4: Rewrite the README Summary Table
+
+The table must reflect **only files that actually exist**. Add a shell command so future
+readers can verify without trusting a hardcoded number:
+
+```markdown
+To get the current workflow count:
+
+```bash
+ls .github/workflows/*.yml | wc -l
+```
+```
+
+### Phase 5: Fix Common markdownlint Failures
+
+The original README had closing ` ``` ` fences with `text` on the same line (e.g., ` ```text `).
+markdownlint-cli2 treats this as MD031/MD040 violations. Replace with bare ` ``` `.
+
+Also watch for:
+
+| Error | Fix |
+|-------|-----|
+| `MD013/line-length` (>120 chars) | Wrap blockquote or table cell content |
+| `MD029/ol-prefix` (out-of-sequence numbered list) | Reset list numbering to 1/2/3 when starting a new logical group |
+
+### Phase 6: Commit and PR
+
+```bash
+git add .github/workflows/README.md
+git commit -m "docs(ci): update workflow README to reflect post-consolidation inventory
+
+- Remove stale entries: <list deleted workflows>
+- Add documentation for: <list new workflows>
+- Correct filename: <old> -> <new>
+- Fix broken fenced code blocks (closing backticks had 'text' on same line)
+- Add Remaining Duplication section: N workflows with inline <step>
+- Add audit commands so inventory stays verifiable without hardcoded counts
+
+Closes #<issue>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+git push -u origin <branch>
+gh pr create \
+  --title "docs(ci): update workflow README to reflect post-consolidation inventory" \
+  --body "Closes #<issue>" \
+  --label "documentation"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `pixi run npx markdownlint-cli2` for pre-validation | Run markdownlint before committing | `npx` not in PATH in this shell context; pixi environment setup takes >2 min | Just commit — pre-commit hook runs markdownlint automatically and gives precise line numbers |
+| `find ~/.pixi -name "markdownlint*"` for binary | Locate markdownlint outside of pixi run | `find` on home dir ran for >3 min without completing | Use `git commit` directly; the pre-commit hook finds markdownlint via its own env |
+| Closing fences with `text` on same line (from original README) | Kept existing style of ` ```text ` | MD031/MD040 lint failures at commit time | Always use bare ` ``` ` for closing fences; only opening fences take a language tag |
+
+## Results & Parameters
+
+**Summary table structure** (copy-paste template for new projects):
+
+```markdown
+| Workflow | Trigger | Purpose | Duration |
+|----------|---------|---------|----------|
+| **Category** | | | |
+| [name.yml](#anchor) | PR, push main | Short description | < N min |
+```
+
+**Remaining Duplication section template:**
+
+```markdown
+## Remaining Duplication
+
+### <Step Name> Inline Usage (Not Yet Migrated to Composite Action)
+
+| Workflow | Category | Notes |
+|----------|----------|-------|
+| `workflow.yml` | Testing | Path-triggered |
+
+**Why not migrated**: <reason — scope of previous consolidation pass>
+**Follow-up work**: Create `.github/actions/<name>/action.yml` as composite action.
+```
+
+**Audit commands to include in README** (so counts stay verifiable):
+
+```bash
+# Count workflows using a specific inline step
+grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml | wc -l
+
+# List them
+grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml
+
+# Count total workflows
+ls .github/workflows/*.yml | wc -l
+```
+
+## Key Observations
+
+1. **README filenames drift from reality** — when workflows are renamed or deleted, the README
+   is rarely updated. Always cross-reference with `ls .github/workflows/*.yml`.
+
+2. **Read the first 20 lines of each file** — `name:`, `on:`, and `paths:` are always in the
+   first 20 lines of a GitHub Actions workflow. No need to read the full file for inventory purposes.
+
+3. **Ordered list numbering resets across logical groups** — markdownlint MD029 requires lists
+   to start at 1. If you have two separate numbered lists (e.g., "PR/push jobs" and "weekly jobs"),
+   each must start at 1 independently.
+
+4. **Document intentional deferred work explicitly** — a "Remaining Duplication" section is more
+   useful than silence. Readers need to know that 13 workflows sharing inline setup is a known
+   state, not an oversight, and what the migration path is.
+
+5. **Pre-commit hook is the authoritative linter** — use `git commit` to trigger it rather than
+   trying to run `npx markdownlint-cli2` directly. The hook provides line numbers and exact error text.
+
+6. **The note about non-existent files belongs in the table** — when a file mentioned in planning
+   doesn't exist on disk (e.g., `build-validation.yml`), add a blockquote note directly below the
+   table explaining its absence rather than either omitting it or listing it as if it exists.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3344, PR #3978 | 22 workflows; pre-commit passed (markdownlint, trailing-whitespace, end-of-file-fixer) |


### PR DESCRIPTION
## Summary

Documents how to audit `.github/workflows/README.md` against actual on-disk workflow files
after a consolidation pass, correct the inventory table, and explicitly track remaining
inline duplication for future composite action extraction.

- Verified on ProjectOdyssey issue #3344 / PR #3978
- 22 workflows audited; 13 inline `setup-pixi` usages inventoried

## Key Findings

**What Worked**:
- `ls .github/workflows/*.yml` as ground truth for the inventory (not the README)
- `grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml | wc -l` for duplication count
- Using `git commit` to trigger pre-commit markdownlint rather than running `npx` directly
- Adding shell audit commands to the README itself so future readers can re-verify counts

**What Failed**:
- `pixi run npx markdownlint-cli2` → `npx` not in PATH in this context
- `find ~/.pixi -name "markdownlint*"` → ran for >3 min without completing; skip this approach
- Continuing ordered list numbering (4/5/6) across two separate logical groups → MD029 failure

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes with no errors
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates on "workflow README", "workflow inventory", "remaining duplication" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
