### PR TITLE
feat: add dockerfile-env-version-pin skill

### DIFF
--- a/skills/ci-cd/dockerfile-env-version-pin/.claude-plugin/plugin.json
+++ b/skills/ci-cd/dockerfile-env-version-pin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dockerfile-env-version-pin",
+  "version": "1.0.0",
+  "description": "Pin installer versions in Dockerfiles via ENV variable injection (e.g. PIXI_VERSION, NVM_VERSION) for reproducible builds. Use when: (1) a Dockerfile curl-installs a tool without a version pin, (2) Dockerfile.ci is pinned but the main Dockerfile is not, (3) you need consistency across multi-Dockerfile repos.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["dockerfile", "pixi", "version-pin", "reproducibility", "env", "curl-install"]
+}

--- a/skills/ci-cd/dockerfile-env-version-pin/references/notes.md
+++ b/skills/ci-cd/dockerfile-env-version-pin/references/notes.md
@@ -1,0 +1,70 @@
+# Session Notes: dockerfile-env-version-pin
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Project**: ProjectOdyssey
+- **Issue**: #3350 — Pin Pixi version in main Dockerfile (not just Dockerfile.ci)
+- **PR**: #3986
+- **Branch**: `3350-auto-impl`
+
+## Objective
+
+`Dockerfile.ci` was already updated to pin `PIXI_VERSION=0.65.0` (via a prior fix), but the main
+`Dockerfile` still used the unpinned `curl -fsSL https://pixi.sh/install.sh | bash` at line 70 in
+the development stage. This was a consistency gap that could cause non-reproducible builds.
+
+## Exact Change Applied
+
+**File**: `Dockerfile`, development stage
+
+**Before** (line 69-70):
+```dockerfile
+# Install Pixi as dev user
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+```
+
+**After** (lines 69-71):
+```dockerfile
+# Install Pixi as dev user (pinned version for reproducible builds)
+ENV PIXI_VERSION=0.65.0
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
+```
+
+## Discovery Process
+
+1. Read `.claude-prompt-3350.md` — straightforward issue description with the exact fix pattern
+2. Found both `Dockerfile` and `Dockerfile.ci` via Glob
+3. Grep'd for `PIXI_VERSION` in both files — confirmed `Dockerfile.ci` already had the pattern
+4. Applied the 3-line change using the Edit tool
+5. Committed, pushed, created PR with auto-merge
+
+## Git Workflow Used
+
+```bash
+git add Dockerfile
+git commit -m "fix(docker): pin PIXI_VERSION in main Dockerfile development stage
+
+Adds ENV PIXI_VERSION=0.65.0 and passes it to the install script in
+the development stage, matching the pattern already used in Dockerfile.ci
+for consistency and reproducible builds.
+
+Closes #3350"
+
+git push -u origin 3350-auto-impl
+gh pr create --title "fix(docker): pin PIXI_VERSION in main Dockerfile development stage" \
+  --body "Closes #3350 ..."
+gh pr merge --auto --rebase 3986
+```
+
+## Pre-commit Hook Behavior
+
+Pre-commit hooks ran on commit. Only Trim Trailing Whitespace, Fix End of Files, Check for Large
+Files, and Fix Mixed Line Endings ran (all passed). Mojo format, markdownlint, etc. were skipped
+as no relevant files changed.
+
+## Key Insight
+
+When a multi-Dockerfile repo has one Dockerfile already pinned correctly (`Dockerfile.ci`), the fix
+for the unpinned Dockerfile (`Dockerfile`) is just to replicate the exact pattern. No version
+research needed — the version is already declared in the reference file.

--- a/skills/ci-cd/dockerfile-env-version-pin/skills/dockerfile-env-version-pin/SKILL.md
+++ b/skills/ci-cd/dockerfile-env-version-pin/skills/dockerfile-env-version-pin/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: dockerfile-env-version-pin
+description: "Pin installer versions in Dockerfiles via ENV variable injection (e.g. PIXI_VERSION, NVM_VERSION) for reproducible builds. Use when a Dockerfile curl-installs a tool without a pinned version, or when Dockerfile.ci is pinned but the main Dockerfile is not."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+# dockerfile-env-version-pin
+
+Pin installer tool versions in Dockerfiles using `ENV` + env var injection into the install script,
+matching the pattern used in CI Dockerfiles for consistency and reproducibility.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-07 |
+| Issue | #3350 (ProjectOdyssey) |
+| PR | #3986 |
+| Objective | Pin `PIXI_VERSION=0.65.0` in main `Dockerfile` development stage to match `Dockerfile.ci` |
+| Outcome | Success — 3-line change: comment + `ENV PIXI_VERSION=0.65.0` + updated `RUN` curl command |
+| Category | ci-cd |
+| Project | ProjectOdyssey |
+
+## When to Use
+
+- When a Dockerfile uses `curl -fsSL https://<tool>/install.sh | bash` without a version pin
+- When `Dockerfile.ci` already pins the version but the main `Dockerfile` does not
+- When you want reproducible Docker builds regardless of when the image is rebuilt
+- When the install script supports `TOOL_VERSION=x.y.z` environment variable injection (common pattern for pixi, nvm, rustup, etc.)
+- As a follow-up consistency fix after pinning one Dockerfile in a multi-Dockerfile repo
+
+## Verified Workflow
+
+### Step 1: Find unpinned install commands
+
+```bash
+grep -n "install.sh" Dockerfile Dockerfile.ci
+grep -n "ENV.*VERSION" Dockerfile Dockerfile.ci
+```
+
+Identify which Dockerfiles already pin and which do not.
+
+### Step 2: Identify the pinned version from the reference Dockerfile
+
+```bash
+grep "PIXI_VERSION" Dockerfile.ci
+# ENV PIXI_VERSION=0.65.0
+# RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
+```
+
+Use the same version that `Dockerfile.ci` already declares.
+
+### Step 3: Apply the fix in the target Dockerfile
+
+Replace:
+
+```dockerfile
+# Install Pixi as dev user
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+```
+
+With:
+
+```dockerfile
+# Install Pixi as dev user (pinned version for reproducible builds)
+ENV PIXI_VERSION=0.65.0
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
+```
+
+Key points:
+- Add `ENV PIXI_VERSION=x.y.z` on the line before the `RUN` curl command
+- Pass it via `PIXI_VERSION=${PIXI_VERSION}` in the inline env (not `export`) so it scopes to the install call
+- Update the comment to mention "pinned version for reproducible builds"
+- The `ENV` instruction also makes the version inspectable via `docker inspect`
+
+### Step 4: Commit and create PR
+
+```bash
+git add Dockerfile
+git commit -m "fix(docker): pin PIXI_VERSION in <stage> stage
+
+Adds ENV PIXI_VERSION=x.y.z and passes it to the install script,
+matching the pattern already used in Dockerfile.ci for consistency
+and reproducible builds.
+
+Closes #<issue>"
+
+git push -u origin <branch>
+gh pr create \
+  --title "fix(docker): pin PIXI_VERSION in <stage> stage" \
+  --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| None | The fix was straightforward — find, edit, commit | N/A | When a reference Dockerfile already has the pattern, just replicate it exactly |
+
+## Results & Parameters
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `Dockerfile` | +2 lines: `ENV PIXI_VERSION=0.65.0` + updated `RUN` curl; comment updated |
+
+### Pattern Template (generalize for any curl-installer)
+
+```dockerfile
+# Install <Tool> (pinned version for reproducible builds)
+ENV TOOL_VERSION=x.y.z
+RUN curl -fsSL https://<tool>.sh/install.sh | TOOL_VERSION=${TOOL_VERSION} bash
+```
+
+Works for tools whose install scripts honor an env var for version selection, including:
+
+| Tool | Env Var | Install URL |
+|------|---------|-------------|
+| Pixi | `PIXI_VERSION` | `https://pixi.sh/install.sh` |
+| nvm | `NVM_VERSION` | `https://raw.githubusercontent.com/nvm-sh/nvm/v.../install.sh` |
+| rustup | `RUSTUP_INIT_RELEASE` | `https://sh.rustup.rs` |
+
+### Why ENV vs inline export
+
+Using `ENV PIXI_VERSION=0.65.0` (Dockerfile `ENV` instruction):
+- Makes version visible in `docker inspect` output
+- Allows child stages to inherit and reference the same version
+- Can be overridden at build time via `--build-arg` if paired with `ARG`
+
+Using inline `TOOL_VERSION=x.y.z curl | bash`:
+- Scopes version only to that one `RUN` command
+- Doesn't propagate to child stages
+- Preferred only if version shouldn't bleed into the image env
+
+For consistency with `Dockerfile.ci` and cross-stage visibility, `ENV` is the correct choice.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3350, PR #3986 | [notes.md](../references/notes.md) |
+
+## Related Skills
+
+- **dockerfile-dep-pin** — Pin pip `install` dependencies in Dockerfile builder stages
+- **pin-npm-dockerfile** — Pin npm packages in Dockerfiles
+- **dockerfile-python-version-guard** — Static tests to prevent Python base image version drift
+- **dockerfile-layer-caching** — Docker build layer caching optimization patterns


### PR DESCRIPTION
## Summary

Documents pinning installer versions in Dockerfiles via `ENV` variable injection (e.g. `PIXI_VERSION=0.65.0`) for reproducible builds.

- Covers the pattern: `ENV TOOL_VERSION=x.y.z` + `RUN curl ... | TOOL_VERSION=${TOOL_VERSION} bash`
- Addresses the common inconsistency where `Dockerfile.ci` is pinned but the main `Dockerfile` is not
- Generalizes to any curl-installer that accepts a `TOOL_VERSION` env var (pixi, nvm, rustup, etc.)

## Key Findings

**What Worked**:
- Replicating the exact pattern from `Dockerfile.ci` — no version research needed when reference exists
- Using `ENV` instruction (not inline export) so the version appears in `docker inspect` and propagates to child stages

**What Failed**:
- Nothing — straightforward 3-line change once the reference pattern was identified in `Dockerfile.ci`

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Verify skill appears under `ci-cd` category in marketplace
- [ ] Check trigger conditions match `dockerfile` + `pixi` + `version-pin` queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
