### PR TITLE
feat: add pre-commit-pass-filenames-evaluation skill

### DIFF
--- a/skills/documentation/pre-commit-pass-filenames-evaluation/.claude-plugin/plugin.json
+++ b/skills/documentation/pre-commit-pass-filenames-evaluation/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pre-commit-pass-filenames-evaluation",
+  "version": "1.0.0",
+  "description": "Evaluate whether a pre-commit hook should use pass_filenames: true or false, then document the decision inline. Use when: (1) a hook has pass_filenames: false and it's unclear if that is intentional, (2) a follow-up issue asks you to review a hook's filename-passing behavior, (3) adding a clarifying comment to .pre-commit-config.yaml for a hook that does whole-repo scanning.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["pre-commit", "ci-cd", "documentation", "configuration", "hook"]
+}

--- a/skills/documentation/pre-commit-pass-filenames-evaluation/references/notes.md
+++ b/skills/documentation/pre-commit-pass-filenames-evaluation/references/notes.md
@@ -1,0 +1,60 @@
+# Session Notes: pre-commit pass_filenames evaluation
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: HomericIntelligence/ProjectOdyssey #3352
+- **PR**: HomericIntelligence/ProjectOdyssey #3992
+- **Branch**: 3352-auto-impl
+
+## Objective
+
+Evaluate whether the `validate-test-coverage` pre-commit hook should use
+`pass_filenames: true` instead of `pass_filenames: false`, following a similar
+change made to a sibling hook in issue #3154.
+
+## Hook Configuration (before change)
+
+```yaml
+- id: validate-test-coverage
+  name: Validate Test Coverage
+  description: Ensure all test_*.mojo files are covered by CI matrix
+  entry: python3 scripts/validate_test_coverage.py
+  language: system
+  files: (test_.*\.mojo|comprehensive-tests\.yml)$
+  pass_filenames: false
+```
+
+## Script Analysis: scripts/validate_test_coverage.py
+
+Key findings from reading the script:
+
+1. `main()` only checks `"--post-pr" in sys.argv` — no positional file argument processing
+2. `find_test_files(repo_root)` performs a whole-repo scan using `Path.glob`
+3. `parse_ci_matrix(workflow_file)` reads the CI YAML at a hardcoded path
+4. The script would silently ignore any positional filenames passed to it
+
+**Conclusion**: `pass_filenames: false` is intentional and correct.
+
+## Change Made
+
+Added a 3-line inline comment to `.pre-commit-config.yaml`:
+
+```yaml
+        # pass_filenames: false is intentional — this script performs a whole-repo
+        # coverage scan against the CI workflow YAML, not per-file validation.
+        # The files: pattern handles efficient triggering; the script ignores file args.
+        pass_filenames: false
+```
+
+## Verification
+
+- `pixi run pre-commit run validate-test-coverage --all-files` → `Passed` (exit 0)
+- Pre-commit hooks on commit → all passed
+
+## Timing
+
+- Read issue + explore files: ~2 min
+- Script analysis (grep for sys.argv/argparse): ~1 min
+- Edit + verify hook: ~5 min (mostly waiting for pixi env)
+- Commit + PR: ~1 min

--- a/skills/documentation/pre-commit-pass-filenames-evaluation/skills/pre-commit-pass-filenames-evaluation/SKILL.md
+++ b/skills/documentation/pre-commit-pass-filenames-evaluation/skills/pre-commit-pass-filenames-evaluation/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: pre-commit-pass-filenames-evaluation
+description: "Evaluate whether a pre-commit hook should use pass_filenames: true or false, then document the decision. Use when: (1) a hook has pass_filenames: false and intent is unclear, (2) asked to review a hook's filename-passing behavior, (3) adding an explanatory comment to .pre-commit-config.yaml."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | documentation |
+| **Complexity** | XS |
+| **Typical runtime** | < 10 minutes |
+| **Key tools** | Read, Grep, Edit, Bash (pre-commit), git, gh |
+
+## When to Use
+
+- Issue asks to evaluate if a pre-commit hook should use `pass_filenames: true` instead of `false`
+- A hook has `pass_filenames: false` and the rationale is undocumented
+- Follow-up from a PR that changed a sibling hook's `pass_filenames` setting
+- The hook's script needs to be inspected to determine whether it uses file arguments
+
+## Verified Workflow
+
+1. **Read `.pre-commit-config.yaml`** — locate the hook and note `entry:`, `files:`, and `pass_filenames:` values
+2. **Read the script referenced in `entry:`** — check how it handles arguments:
+   - Does it use `sys.argv` for positional args? → could support `pass_filenames: true`
+   - Does it do whole-repo scanning (e.g. `find_files(repo_root)`)? → `pass_filenames: false` is correct
+   - Does it ignore positional args entirely? → `pass_filenames: false` is correct
+3. **Grep for `sys.argv` and `argparse`** in the script to confirm argument handling
+4. **Decide**: if the script ignores file args or does a global scan, `pass_filenames: false` is intentional
+5. **Add a 3-line inline comment** directly above the `pass_filenames: false` line explaining the design
+6. **Run the hook** to verify no regression: `pixi run pre-commit run <hook-id> --all-files`
+7. **Commit, push, and create PR** linking to the issue
+
+### Key Decision Criteria
+
+| Script behavior | Correct setting |
+|----------------|-----------------|
+| Iterates over `sys.argv[1:]` as file paths | `pass_filenames: true` |
+| Uses `argparse` with positional `files` argument | `pass_filenames: true` |
+| Scans repo root with `Path.glob` / `os.walk` | `pass_filenames: false` |
+| Only checks `"--flag" in sys.argv` (no positional args) | `pass_filenames: false` |
+| Reads a fixed config/workflow file at a hardcoded path | `pass_filenames: false` |
+
+### Comment Template
+
+```yaml
+        # pass_filenames: false is intentional — this script performs a whole-repo
+        # <operation> against <target>, not per-file validation.
+        # The files: pattern handles efficient triggering; the script ignores file args.
+        pass_filenames: false
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Switching to `pass_filenames: true` without reading the script | Assumed symmetry with a sibling hook | Script does not process positional file args; passing them would be silently ignored | Always read the script before deciding |
+| Checking only the hook config | Looked at `files:` pattern and `entry:` only | Did not reveal whether the script actually processes `sys.argv[1:]` | Must grep the script for argument handling code |
+
+## Results & Parameters
+
+### Commit message format
+
+```text
+docs(pre-commit): document intentional pass_filenames: false for <hook-id> hook
+
+<Script> performs a whole-repo <operation>, not per-file validation.
+It ignores positional file arguments — pass_filenames: false is the correct setting.
+
+Added inline comment to clarify this design decision.
+
+Closes #<issue-number>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Verification command
+
+```bash
+pixi run pre-commit run <hook-id> --all-files
+# Expected: "<Hook Name>...Passed"
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3352, PR #3992 | validate-test-coverage hook; script uses `find_test_files(repo_root)` whole-repo scan |


### PR DESCRIPTION
## Summary

- Documents how to evaluate `pass_filenames: true` vs `false` for pre-commit hooks
- Captures the decision criteria based on script argument-handling patterns
- Provides a comment template for documenting intentional `pass_filenames: false` hooks

## Key Findings

**What Worked**:
- Grep the script for `sys.argv` and `argparse` to determine if it processes positional file args
- Scripts that do whole-repo scanning (e.g. `Path.glob` from `repo_root`) correctly use `pass_filenames: false`
- A 3-line inline comment directly above `pass_filenames: false` is the minimal, clear artifact

**What Failed**:
- Evaluating the hook config alone (without reading the script) is insufficient — the `files:` pattern only controls triggering, not what the script does with arguments

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — 525 passed, 0 failed
- [x] Verified on ProjectOdyssey issue #3352, PR #3992

🤖 Generated with [Claude Code](https://claude.com/claude-code)