### PR TITLE
feat: add ci-zero-discovery-guard skill

### DIFF
--- a/skills/ci-cd/ci-zero-discovery-guard/.claude-plugin/plugin.json
+++ b/skills/ci-cd/ci-zero-discovery-guard/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ci-zero-discovery-guard",
+  "version": "1.0.0",
+  "description": "Fix silent CI false-passes caused by zero test files discovered in just test-group. Use when: (1) a CI matrix entry uses a parent directory path with subdirectory glob patterns instead of a specific path, (2) just test-group exits 0 when no test files match, (3) splitting merged CI matrix entries to prevent silent renames going undetected.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["ci", "justfile", "test-group", "false-pass", "silent-failure", "ci-matrix", "mojo", "glob"]
+}

--- a/skills/ci-cd/ci-zero-discovery-guard/references/notes.md
+++ b/skills/ci-cd/ci-zero-discovery-guard/references/notes.md
@@ -1,0 +1,98 @@
+# Session Notes: CI Zero-Discovery Guard
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: ProjectOdyssey #3356 — Merge 'Autograd & Benchmarking' group uses parent path - verify glob
+- **PR**: ProjectOdyssey #3996
+- **Branch**: 3356-auto-impl
+
+## Problem Description
+
+The GitHub Actions CI matrix in `.github/workflows/comprehensive-tests.yml` had a merged entry:
+
+```yaml
+- name: "Autograd & Benchmarking"
+  path: "tests/shared"
+  pattern: "autograd/test_*.mojo benchmarking/test_*.mojo"
+```
+
+This used `tests/shared` (the parent directory) as the path, with subdirectory glob patterns.
+The `just test-group` recipe expanded these into full paths by prepending `tests/shared/`.
+
+The hazard: if either `tests/shared/autograd/` or `tests/shared/benchmarking/` was empty,
+renamed, or moved, the glob expansion would find 0 files. The recipe's empty-file check
+then did `exit 0` — a silent false-pass. CI would show green even though no tests ran.
+
+## Root Cause in justfile
+
+```bash
+# justfile lines 494-497 (BEFORE fix):
+if [ -z "$test_files" ]; then
+    echo "⚠️  No test files found"
+    exit 0   # <-- silent false-pass
+fi
+```
+
+## Fix Applied
+
+### 1. justfile — exit guard
+
+Changed `exit 0` to `exit 1` with descriptive error:
+
+```bash
+if [ -z "$test_files" ]; then
+    echo "❌ ERROR: No test files found in {{path}} matching {{pattern}}"
+    echo "   This usually means the directory is empty or was renamed."
+    echo "   Fix: update the test group path/pattern in comprehensive-tests.yml"
+    exit 1
+fi
+```
+
+### 2. comprehensive-tests.yml — split matrix entry
+
+Replaced the merged parent-path entry with two specific-path entries:
+
+```yaml
+# Added explanatory comment block:
+# Kept as separate entries (not merged under tests/shared parent path)
+# to avoid silent pass-with-0-tests if a subdirectory is empty/renamed.
+# See: https://github.com/homericintelligence/projectodyssey/issues/3356
+- name: "Autograd"
+  path: "tests/shared/autograd"
+  pattern: "test_*.mojo"
+- name: "Benchmarking"
+  path: "tests/shared/benchmarking"
+  pattern: "test_*.mojo"
+```
+
+## Continue-on-error Verification
+
+The workflow already had:
+```yaml
+continue-on-error: ${{ matrix.test-group.name == 'Integration Tests' || matrix.test-group.name == 'Core Tensors' || matrix.test-group.name == 'Benchmarking' }}
+```
+
+This already used `'Benchmarking'` (not `'Autograd & Benchmarking'`), so it correctly
+matches the new standalone "Benchmarking" entry without any change.
+
+## Files Changed
+
+- `justfile`: Lines 494-499
+- `.github/workflows/comprehensive-tests.yml`: Lines 219-226
+
+## Pre-commit Results
+
+All hooks passed:
+- Mojo Format: Skipped (no .mojo files changed)
+- Validate Test Coverage: Passed
+- Check YAML: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## Related Skills
+
+- `ci-cd/consolidate-ci-matrix`: The inverse pattern — merging CI groups to reduce overhead.
+  Our fix is the opposite: splitting merged groups for safety.
+- `ci-cd/mojo-flaky-segfault-mitigation`: Related `continue-on-error` usage in same workflow.

--- a/skills/ci-cd/ci-zero-discovery-guard/skills/ci-zero-discovery-guard/SKILL.md
+++ b/skills/ci-cd/ci-zero-discovery-guard/skills/ci-zero-discovery-guard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ci-zero-discovery-guard
+description: "Fix silent CI false-passes caused by zero test files discovered. Use when: (1) just test-group exits 0 on empty glob matches, (2) a CI matrix entry uses parent-path + subdirectory glob patterns, (3) splitting merged CI matrix entries to prevent undetected directory renames."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+# CI Zero-Discovery Guard
+
+Prevent silent CI false-passes when test file discovery returns zero results in `just test-group`.
+
+## Overview
+
+| Date | Objective | Outcome |
+|------|-----------|---------|
+| 2026-03-07 | Fix #3356: merged `Autograd & Benchmarking` CI entry silently passes with 0 tests if subdirectory is renamed | Two-part fix: exit guard in justfile + split CI matrix entry |
+
+## When to Use
+
+- `just test-group` exits 0 even though no test files were found (silent pass)
+- A CI matrix entry uses a parent directory as `path:` with `subdir/test_*.mojo` patterns, instead of pointing directly to the subdirectory
+- A directory containing tests is renamed or moved and CI still shows green
+- You want to split a merged CI matrix entry back into separate entries for safety
+
+## Verified Workflow
+
+### Step 1: Add zero-discovery guard to `just test-group`
+
+In `justfile`, find the empty-file check in the `test-group` recipe and change it from silent exit 0 to a loud exit 1:
+
+```bash
+# BEFORE (silent false-pass):
+if [ -z "$test_files" ]; then
+    echo "⚠️  No test files found"
+    exit 0
+fi
+
+# AFTER (loud failure):
+if [ -z "$test_files" ]; then
+    echo "❌ ERROR: No test files found in {{path}} matching {{pattern}}"
+    echo "   This usually means the directory is empty or was renamed."
+    echo "   Fix: update the test group path/pattern in comprehensive-tests.yml"
+    exit 1
+fi
+```
+
+### Step 2: Split merged CI matrix entry into separate entries
+
+In `.github/workflows/comprehensive-tests.yml`, replace any merged entry that uses a parent path with individual entries per subdirectory:
+
+```yaml
+# BEFORE (merged parent-path — silent false-pass risk):
+- name: "Autograd & Benchmarking"
+  path: "tests/shared"
+  pattern: "autograd/test_*.mojo benchmarking/test_*.mojo"
+
+# AFTER (separate entries — each fails loudly if empty):
+# Kept as separate entries (not merged under tests/shared parent path)
+# to avoid silent pass-with-0-tests if a subdirectory is empty/renamed.
+# See: https://github.com/homericintelligence/projectodyssey/issues/3356
+- name: "Autograd"
+  path: "tests/shared/autograd"
+  pattern: "test_*.mojo"
+- name: "Benchmarking"
+  path: "tests/shared/benchmarking"
+  pattern: "test_*.mojo"
+```
+
+### Step 3: Verify `continue-on-error` references still match
+
+If the workflow has a `continue-on-error` condition referencing a test group by name, ensure it still matches after a rename:
+
+```yaml
+# This already correctly references "Benchmarking" by name — no change needed
+continue-on-error: ${{ matrix.test-group.name == 'Integration Tests' || matrix.test-group.name == 'Core Tensors' || matrix.test-group.name == 'Benchmarking' }}
+```
+
+### Step 4: Verify locally
+
+```bash
+# Should find files and pass:
+just test-group tests/shared/autograd "test_*.mojo"
+just test-group tests/shared/benchmarking "test_*.mojo"
+
+# Should fail with error message:
+just test-group tests/shared/nonexistent "test_*.mojo"
+# Expected: exit 1, prints "❌ ERROR: No test files found..."
+```
+
+### Step 5: Run pre-commit and push
+
+```bash
+just pre-commit-all
+git add justfile .github/workflows/comprehensive-tests.yml
+git commit -m "fix(ci): split merged test group and add zero-discovery guard"
+gh pr create --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| No attempts failed | Both fixes were applied directly based on issue plan | N/A | Reading the issue comments/plan first gives all necessary context |
+| Checked if `continue-on-error` needed updating | Searched for `Benchmarking` reference in workflow | The existing condition already referenced `'Benchmarking'` by name, which matches the new standalone entry | Always verify downstream references when renaming matrix entries |
+
+## Results & Parameters
+
+**Root cause**: `just test-group` used `exit 0` when the glob expanded to no files. A CI matrix entry with `path: tests/shared` and `pattern: autograd/test_*.mojo` would silently pass if `tests/shared/autograd/` was empty or renamed.
+
+**Fix summary**:
+
+- `justfile`: `exit 0` → `exit 1` with descriptive error on zero test discovery
+- `comprehensive-tests.yml`: Split `"Autograd & Benchmarking"` (parent path) into `"Autograd"` + `"Benchmarking"` (specific paths)
+
+**Pattern to watch for**: Any CI matrix entry where `path:` is a parent directory and `pattern:` contains `/` (subdirectory traversal). These are candidates for silent false-passes.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3356, PR #3996 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to fix silent CI false-passes caused by zero test file discovery in `just test-group`, and the pattern of splitting merged parent-path CI matrix entries into separate specific-path entries.

- Root cause: `just test-group` used `exit 0` when glob expansion found 0 files — a silent false-pass
- Fix 1: Change `exit 0` → `exit 1` with descriptive error in the empty-file guard
- Fix 2: Split any merged CI matrix entry using a parent path + subdirectory glob patterns into separate entries, each with a specific path

## Key Findings

**What Worked**:
- Two targeted file edits (justfile + workflow) fully address both the symptom and root cause
- Reading the issue plan comment first provided the complete implementation strategy in one pass

**What Failed** (nothing major):
- Needed to verify `continue-on-error` name references after matrix entry rename — they already matched, but this is a common gotcha

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results for "ci false pass" or "zero test discovery"
- [ ] Check skill activation when investigating silent CI green on empty test directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)