### PR TITLE
feat: add audit-shared-links skill

### DIFF
--- a/skills/documentation/audit-shared-links/.claude-plugin/plugin.json
+++ b/skills/documentation/audit-shared-links/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "audit-shared-links",
+  "version": "1.0.0",
+  "description": "Audit shared documentation files for missing link-backs in a root markdown file. Use when: (1) adding new .claude/shared/ files that should appear in CLAUDE.md Quick Links, (2) setting up a pre-commit hook to prevent link drift, (3) implementing issue-driven documentation audits with pytest-based tests.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["documentation", "audit", "pre-commit", "links", "claude-md", "shared-files"]
+}

--- a/skills/documentation/audit-shared-links/references/notes.md
+++ b/skills/documentation/audit-shared-links/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes — audit-shared-links
+
+## Context
+
+- **Issue**: HomericIntelligence/ProjectOdyssey#3366
+- **Branch**: `3366-auto-impl`
+- **PR**: HomericIntelligence/ProjectOdyssey#4024
+- **Date**: 2026-03-07
+
+## Problem Statement
+
+After trimming CLAUDE.md, three `.claude/shared/` files existed on disk but were
+absent from the Quick Links / Core Guidelines section at the top of the file:
+
+- `git-commit-policy.md`
+- `output-style-guidelines.md`
+- `tool-use-optimization.md`
+
+The issue also requested a periodic audit mechanism to prevent future drift.
+
+## Approach
+
+1. Manual audit: `grep -n "shared/" CLAUDE.md` vs `ls .claude/shared/`
+2. Edit CLAUDE.md Quick Links to add the 3 missing files
+3. Write `scripts/audit_shared_links.py`:
+   - `list_shared_files(shared_dir)` → sorted list of `.claude/shared/*.md` paths
+   - `extract_quick_links_section(content)` → regex capture of `## Quick Links` section
+   - `extract_linked_shared_paths(section)` → set of linked paths (handles absolute,
+     relative, and `#anchor` variants)
+   - `audit(content, shared_dir)` → `(missing, present)` tuple
+   - `main(argv)` → CLI entry point with `argparse`, exits 0/1
+4. Write 20 pytest unit tests using `TemporaryDirectory` (no real repo dependency)
+5. Add `audit-shared-links` pre-commit hook triggered on `CLAUDE.md` or `.claude/shared/` changes
+
+## Key Bug Found During Implementation
+
+Initial regex `\(/?\.claude/shared/([^)#\s]+)\)` failed to match links with anchors
+like `(/.claude/shared/tool-use-optimization.md#agentic-loop-patterns)` because the
+character class `[^)#\s]` stops before `#`, but the closing `)` requires an immediate
+match after the capture group — which isn't the case when `#section` follows.
+
+Fix: `\(/?\.claude/shared/([^)#\s]+)(?:#[^)]*)?\)` — the optional non-capturing group
+`(?:#[^)]*)?` consumes the anchor before the required `)`.
+
+## Files Changed
+
+- `CLAUDE.md` — 3 entries added to Quick Links
+- `scripts/audit_shared_links.py` — new audit script (155 lines)
+- `tests/test_audit_shared_links.py` — 20 unit tests (280 lines)
+- `.pre-commit-config.yaml` — new `audit-shared-links` hook
+
+## Test Results
+
+```
+20 passed in 0.03s
+AUDIT PASSED: All 10 .claude/shared/ file(s) are linked in CLAUDE.md Quick Links.
+```
+
+All pre-commit hooks passed on staged files.

--- a/skills/documentation/audit-shared-links/skills/audit-shared-links/SKILL.md
+++ b/skills/documentation/audit-shared-links/skills/audit-shared-links/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: audit-shared-links
+description: "Audit shared documentation files for missing link-backs in a root markdown file. Use when: adding shared files that should appear in a Quick Links section, wiring a pre-commit hook to prevent drift, or implementing documentation audits with typed Python and pytest."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Skill** | audit-shared-links |
+| **Category** | documentation |
+| **Complexity** | Low |
+| **Typical Duration** | 15–30 min |
+| **Key Tools** | Edit, Write, Bash (pytest, pre-commit) |
+
+## When to Use
+
+- A shared documentation directory (e.g. `.claude/shared/`) has files that should be discoverable from a root file's Quick Links section
+- A new file was added to the shared directory but not linked from the index/root file
+- You want a pre-commit hook that prevents future link drift
+- You need typed Python with pytest for a lightweight documentation validation script
+
+## Verified Workflow
+
+### 1. Identify missing links
+
+Read the root file's Quick Links section and list the shared directory:
+
+```bash
+grep -n "shared/" CLAUDE.md | head -30
+ls .claude/shared/
+```
+
+Compare to find files present on disk but absent from Quick Links.
+
+### 2. Add missing entries to the root file
+
+Edit the Quick Links / Core Guidelines list directly:
+
+```markdown
+- [Git Commit Policy](/.claude/shared/git-commit-policy.md)
+- [Output Style Guidelines](/.claude/shared/output-style-guidelines.md)
+- [Tool Use Optimization](/.claude/shared/tool-use-optimization.md)
+```
+
+### 3. Write the audit script (`scripts/audit_shared_links.py`)
+
+Key functions with typed signatures:
+
+```python
+def list_shared_files(shared_dir: Path) -> List[str]:
+    return sorted(
+        f".claude/shared/{p.name}"
+        for p in shared_dir.iterdir()
+        if p.is_file() and p.suffix == ".md"
+    )
+
+def extract_quick_links_section(claude_md_content: str) -> str:
+    match = re.search(
+        r"^## Quick Links\b(.*?)(?=^## |\Z)",
+        claude_md_content,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group(0) if match else ""
+
+def extract_linked_shared_paths(section: str) -> Set[str]:
+    # Handle both absolute (/.claude/shared/foo.md) and relative links,
+    # and strip optional #anchor fragments
+    link_pattern = re.compile(r"\(/?\.claude/shared/([^)#\s]+)(?:#[^)]*)?\)")
+    return {f".claude/shared/{m.group(1)}" for m in link_pattern.finditer(section)}
+```
+
+### 4. Write hermetic pytest tests (`tests/test_audit_shared_links.py`)
+
+Use `TemporaryDirectory` for all file I/O — no dependency on real repo layout:
+
+```python
+def _make_shared_dir(tmp: Path, filenames: List[str]) -> Path:
+    shared = tmp / ".claude" / "shared"
+    shared.mkdir(parents=True)
+    for name in filenames:
+        (shared / name).write_text(f"# {name}")
+    return shared
+```
+
+Cover: `list_shared_files`, `extract_quick_links_section`,
+`extract_linked_shared_paths`, `audit`, and `main()` with 20 tests total.
+
+### 5. Wire pre-commit hook (`.pre-commit-config.yaml`)
+
+```yaml
+- repo: local
+  hooks:
+    - id: audit-shared-links
+      name: Audit shared/ links in CLAUDE.md
+      description: Ensure every .claude/shared/*.md file is listed in CLAUDE.md Quick Links
+      entry: python scripts/audit_shared_links.py
+      language: system
+      files: ^(CLAUDE\.md|\.claude/shared/.*)$
+      pass_filenames: false
+```
+
+### 6. Verify and commit
+
+```bash
+pixi run python -m pytest tests/test_audit_shared_links.py -v   # 20 passed
+python scripts/audit_shared_links.py                            # AUDIT PASSED
+pixi run pre-commit run --files CLAUDE.md scripts/audit_shared_links.py
+git add CLAUDE.md .pre-commit-config.yaml scripts/audit_shared_links.py tests/test_audit_shared_links.py
+git commit -m "feat(docs): audit .claude/shared/ links and add missing Quick Links entries"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Regex `[^)#\s]+` as full pattern | Pattern `\(/?\.claude/shared/([^)#\s]+)\)` — stops capture at `#` but then requires `)` immediately | Links with anchors like `foo.md#section` never match because `)` comes after `#section`, not right after the filename | Use `([^)#\s]+)(?:#[^]*)?` to capture filename separately, then allow optional anchor before closing paren |
+
+## Results & Parameters
+
+**Audit script exit codes:**
+
+- `0` — all `.claude/shared/*.md` files linked in Quick Links
+- `1` — one or more files missing, or CLAUDE.md/shared-dir not found
+
+**Pre-commit trigger pattern:**
+
+```text
+^(CLAUDE\.md|\.claude/shared/.*)$
+```
+
+**Regex for link extraction (handles absolute, relative, anchors):**
+
+```python
+re.compile(r"\(/?\.claude/shared/([^)#\s]+)(?:#[^)]*)?\)")
+```
+
+**Test count**: 20 unit tests, all hermetic (no real filesystem dependency).


### PR DESCRIPTION
## Summary

Documents how to audit shared documentation files for missing link-backs in a root
markdown file (e.g. `.claude/shared/` vs CLAUDE.md Quick Links), wire a pre-commit
hook to prevent future drift, and implement the audit as typed Python with hermetic
pytest tests.

- Typed public API: `list_shared_files`, `extract_quick_links_section`, `extract_linked_shared_paths`, `audit`, `main`
- Hermetic tests using `TemporaryDirectory` — no real repo dependency
- Pre-commit hook pattern fires on both root file and shared directory changes

## Key Findings

**What Worked**:
- Regex with optional `(?:#[^)]*)?` non-capturing group cleanly handles `#anchor` fragments in links
- `TemporaryDirectory` fixtures keep all 20 tests fast and hermetic
- `files: ^(CLAUDE\.md|\.claude/shared/.*)$` trigger covers both surfaces

**What Failed**:
- Initial regex `[^)#\s]+` stopped capture at `#` but required `)` immediately after — failed to match any link containing an anchor fragment

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with documentation/shared-file audit triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
