### PR TITLE
feat: add mypy-hook-extend-coverage skill

### DIFF
--- a/skills/ci-cd/mypy-hook-extend-coverage/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mypy-hook-extend-coverage/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mypy-hook-extend-coverage",
+  "version": "1.0.0",
+  "description": "Extend mypy pre-commit hook coverage to additional directories beyond the initial scope. Use when: (1) mypy hook covers only one directory but ruff covers more, (2) tests/ or tools/ dirs have type annotation drift needing baseline suppression, (3) hyphenated directory names cause module resolution conflicts in mypy.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["mypy", "pre-commit", "type-checking", "hooks", "python"]
+}

--- a/skills/ci-cd/mypy-hook-extend-coverage/references/notes.md
+++ b/skills/ci-cd/mypy-hook-extend-coverage/references/notes.md
@@ -1,0 +1,42 @@
+# Session Notes: Extend mypy Hook Coverage
+
+## Issue
+GitHub issue #3368 — Extend mypy hook from `^scripts/.*\.py$` to also cover `examples/`, `tests/`, `tools/`.
+
+## PR Created
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4029
+
+## Key Discovery: mypy.ini vs pyproject.toml
+
+The repo had BOTH `mypy.ini` AND `[tool.mypy]` in `pyproject.toml`. mypy's search order
+means `mypy.ini` wins. The `mirrors-mypy` pre-commit hook runs in an isolated virtualenv
+but still picks up `mypy.ini` from the repo root via CWD. It does NOT load `pyproject.toml`
+unless `--config-file` is explicitly passed.
+
+Adding `--config-file pyproject.toml` to the hook caused 221+ new errors in `scripts/`
+(previously passing) because `pyproject.toml` has `disallow_untyped_defs = true` while the
+hook standalone args do not enforce this.
+
+## Hyphenated Directory Problem
+
+`examples/alexnet-cifar10/` and `tools/paper-scaffold/` have hyphens in their names.
+With `--explicit-package-bases`, mypy tries to construct a dotted module path from the
+directory structure, but `alexnet-cifar10` is not a valid Python identifier. This causes:
+
+1. "Duplicate module" fatal errors (when multiple subdirs have the same filename)
+2. Module override patterns like `[mypy-tools.*]` fail to match files in hyphenated subdirs
+
+Solution: exclude `examples/` entirely (can't fix the hyphen issue without `__init__.py`
+and renaming), fix actual errors in `tools/paper-scaffold/prompts.py` directly.
+
+## Transitive Import Chain
+
+`tests/notebooks/test_utils.py` → imports → `notebooks.utils.progress` and `notebooks.utils.tensor_utils`
+When mypy checks `tests/` files, it follows imports into `notebooks/` and reports errors there.
+Fix: add `[mypy-notebooks.*] ignore_errors = True` to `mypy.ini`.
+
+## Files Changed
+
+- `.pre-commit-config.yaml`: widen `files:` pattern
+- `mypy.ini`: add `ignore_errors = True` for `tests.*`, `tools.*`, `notebooks.*`
+- `tools/paper-scaffold/prompts.py`: fix `callable` → `Callable[[str], tuple[bool, str]]`

--- a/skills/ci-cd/mypy-hook-extend-coverage/skills/mypy-hook-extend-coverage/SKILL.md
+++ b/skills/ci-cd/mypy-hook-extend-coverage/skills/mypy-hook-extend-coverage/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: mypy-hook-extend-coverage
+description: "Extend mypy pre-commit hook coverage to additional directories with baseline suppression. Use when: ruff covers more dirs than mypy, tests/tools have annotation drift, or hyphenated directory names cause module resolution conflicts."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Extend mypy pre-commit hook from `scripts/` to `tests/` and `tools/` directories |
+| **Languages** | Python, YAML, INI |
+| **Config Files** | `.pre-commit-config.yaml`, `mypy.ini`, `pyproject.toml` |
+| **Hook Type** | `mirrors-mypy` (isolated virtualenv) |
+| **Key Risk** | Hyphenated directory names + `ignore_errors` scoping |
+
+## When to Use
+
+- mypy hook `files:` pattern is narrower than ruff's (e.g., only `scripts/` but ruff covers `tests/` too)
+- New directories have Python files with type annotation drift that should be caught incrementally
+- Pre-existing type errors in expanded dirs would immediately break the hook if naively added
+- You need to understand why `[[tool.mypy.overrides]]` in `pyproject.toml` isn't suppressing errors
+
+## Verified Workflow
+
+### Step 1: Triage each directory for mypy errors
+
+```bash
+pixi run mypy --ignore-missing-imports --explicit-package-bases --python-version 3.10 tests/ 2>&1 | tail -3
+pixi run mypy --ignore-missing-imports --explicit-package-bases --python-version 3.10 tools/ 2>&1 | tail -3
+pixi run mypy --ignore-missing-imports --explicit-package-bases --python-version 3.10 examples/ 2>&1 | tail -3
+```
+
+Watch for **duplicate module** errors in directories with hyphenated subdirectory names
+(e.g., `alexnet-cifar10/`, `paper-scaffold/`). These are **not suppressible** via overrides —
+exclude those directories from the hook pattern.
+
+### Step 2: Identify which config file mypy auto-discovers
+
+```bash
+# mypy.ini takes precedence over pyproject.toml
+ls mypy.ini .mypy.ini setup.cfg pyproject.toml 2>/dev/null
+```
+
+The `mirrors-mypy` pre-commit hook runs in an **isolated virtualenv** but still auto-discovers
+`mypy.ini` from the repo root (CWD). It does NOT auto-discover `pyproject.toml` unless
+`--config-file pyproject.toml` is explicitly passed.
+
+### Step 3: Add baseline suppression in mypy.ini (NOT pyproject.toml)
+
+```ini
+# Baseline suppression for tests/, tools/ — fix incrementally (see #NNNN)
+[mypy-tests.*]
+ignore_errors = True
+
+[mypy-tools.*]
+ignore_errors = True
+```
+
+Add transitive import targets too (e.g., if `tests/notebooks/` imports from `notebooks/utils/`):
+
+```ini
+[mypy-notebooks.*]
+ignore_errors = True
+```
+
+### Step 4: Widen the hook files pattern
+
+```yaml
+# .pre-commit-config.yaml
+- id: mypy
+  files: ^(scripts|tests|tools)/.*\.py$  # was: ^scripts/.*\.py$
+  args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+```
+
+### Step 5: Fix genuine errors in newly covered files
+
+For small numbers of real errors (e.g., `callable` used as a type annotation — which is invalid):
+
+```python
+# Before (invalid):
+from typing import Optional
+validator: Optional[callable] = None
+
+# After (correct):
+from typing import Callable, Optional
+validator: Optional[Callable[[str], tuple[bool, str]]] = None
+```
+
+### Step 6: Verify
+
+```bash
+pixi run pre-commit run mypy --all-files
+pixi run pre-commit run --all-files
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `[[tool.mypy.overrides]]` in `pyproject.toml` | Added `ignore_errors = true` for `tests.*`, `tools.*` | `mirrors-mypy` hook virtualenv doesn't auto-load `pyproject.toml` | Use `mypy.ini` for overrides — it's auto-discovered by mypy regardless of invocation context |
+| `--config-file pyproject.toml` in hook args | Added to force config loading | `pyproject.toml` has `disallow_untyped_defs = true` which broke `scripts/` (269 new errors) | Config files have stricter settings than hook standalone args; mixing them causes regressions |
+| Including `examples/` in hook pattern | Added `examples` to `files:` regex | Directories like `alexnet-cifar10/` are not valid Python identifiers — duplicate module fatal error | Hyphenated directory names are incompatible with mypy module resolution; exclude them entirely |
+| `[mymy-tools.*]` override matching `tools/paper-scaffold/prompts.py` | Expected override to suppress errors in `paper-scaffold` subdir | `paper-scaffold` contains a hyphen — not a valid Python package name — so mypy resolves the module as top-level `prompts`, not `tools.paper-scaffold.prompts` | Fix the actual errors in hyphenated-dir files rather than relying on module-path overrides |
+| Forgetting transitive imports | Added `ignore_errors` only for directly covered dirs | `tests/notebooks/test_utils.py` imports `notebooks.utils` — mypy followed the import and reported errors in `notebooks/utils/*.py` | Always check which modules are imported transitively; add overrides for those too |
+
+## Results & Parameters
+
+### Final `.pre-commit-config.yaml` diff
+
+```yaml
+- id: mypy
+  files: ^(scripts|tests|tools)/.*\.py$   # Extended from ^scripts/.*\.py$
+  args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+  additional_dependencies: [types-PyYAML]
+```
+
+### Final `mypy.ini` additions
+
+```ini
+# Baseline suppression for tests/, tools/, notebooks/ — fix incrementally
+[mypy-tests.*]
+ignore_errors = True
+
+[mypy-tools.*]
+ignore_errors = True
+
+[mypy-notebooks.*]
+ignore_errors = True
+```
+
+### Key facts about mypy config file discovery
+
+- **Search order**: `mypy.ini` > `.mypy.ini` > `setup.cfg` > `pyproject.toml`
+- `mirrors-mypy` pre-commit hook: auto-discovers `mypy.ini` from repo root ✅
+- `mirrors-mypy` pre-commit hook: does NOT auto-discover `pyproject.toml` without `--config-file` ❌
+- `[mypy-module.*]` patterns only match when the module path is a valid Python identifier path
+- Hyphenated directory names (`paper-scaffold/`) prevent proper module path construction
+
+### Detecting transitive import issues
+
+```bash
+# Find which tested files import from outside the covered dirs
+grep -r "^from\|^import" tests/ | grep -v "^tests/" | grep "notebooks\|examples"
+```


### PR DESCRIPTION
## Summary

Documents the workflow for extending a mypy pre-commit hook to cover additional directories (`tests/`, `tools/`) with baseline `ignore_errors` suppression for pre-existing annotation drift.

- Covers the critical distinction between `mypy.ini` (auto-discovered by pre-commit) vs `pyproject.toml` (NOT auto-discovered without `--config-file`)
- Documents why hyphenated directory names (`paper-scaffold/`, `alexnet-cifar10/`) break module-path override matching
- Shows how to detect and handle transitive import chains that surface errors in uncovered directories

## Key Findings

**What Worked**:
- Adding `ignore_errors = True` per-module overrides to `mypy.ini` (not `pyproject.toml`)
- Widening the `files:` regex in `.pre-commit-config.yaml` from `^scripts/` to `^(scripts|tests|tools)/`
- Adding overrides for transitively imported modules (`notebooks.*`) discovered at runtime

**What Failed**:
- `[[tool.mypy.overrides]]` in `pyproject.toml` → not loaded by `mirrors-mypy` hook virtualenv
- `--config-file pyproject.toml` in hook args → caused 221+ regressions in `scripts/` due to stricter settings
- Including `examples/` with hyphenated subdirs → fatal "duplicate module" errors unresolvable via overrides
- `[mypy-tools.*]` override for `tools/paper-scaffold/prompts.py` → hyphen in dir name prevents module path construction

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers on "extend mypy" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
