### PR TITLE
feat(ci-cd): add enable-mypy-check-untyped-defs skill

### DIFF
--- a/skills/ci-cd/enable-mypy-check-untyped-defs/.claude-plugin/plugin.json
+++ b/skills/ci-cd/enable-mypy-check-untyped-defs/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "enable-mypy-check-untyped-defs",
+  "version": "1.0.0",
+  "description": "Enable mypy --check-untyped-defs flag and fix surfaced errors for full Python type-checking coverage. Use when: (1) mypy reports 'bodies of untyped functions are not checked', (2) adding stricter mypy coverage to a project, (3) enabling check_untyped_defs in pyproject.toml or pre-commit hook.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["mypy", "type-checking", "python", "pre-commit", "ci"],
+  "requires": {
+    "tools": [
+      {"name": "mypy", "version": ">=1.0.0"},
+      {"name": "pixi"}
+    ],
+    "languages": ["python"]
+  },
+  "verified_on": [
+    {
+      "project": "ProjectOdyssey",
+      "pr": 4036,
+      "issue": 3370,
+      "date": "2026-03-07"
+    }
+  ]
+}

--- a/skills/ci-cd/enable-mypy-check-untyped-defs/references/notes.md
+++ b/skills/ci-cd/enable-mypy-check-untyped-defs/references/notes.md
@@ -1,0 +1,81 @@
+# Reference Notes: enable-mypy-check-untyped-defs
+
+## Session Context
+
+**Date**: 2026-03-07
+**Project**: ProjectOdyssey
+**Issue**: #3370 — Add --check-untyped-defs to mypy hook for full body coverage
+**PR**: #4036
+**Branch**: 3370-auto-impl
+
+## Background
+
+Issue #3370 requested enabling `--check-untyped-defs` in the mypy pre-commit hook and
+`pyproject.toml` to ensure bodies of untyped functions are type-checked. Without this flag,
+mypy silently skips checking the body of any function lacking full type annotations, which
+can hide real bugs.
+
+## Files Modified
+
+- `pyproject.toml` — added `check_untyped_defs = true` to `[tool.mypy]`
+- `.pre-commit-config.yaml` — added `--check-untyped-defs` to mypy hook args
+- `scripts/analyze_warnings.py` — annotated `defaultdict(int)` as `defaultdict[str, int]`
+- `scripts/agents/tests/test_integration.py` — annotated empty list `[]` as `list[str]`
+- `scripts/convert_image_to_idx.py` — replaced deprecated Pillow 10+ attributes
+
+## Errors Fixed
+
+### 1. scripts/analyze_warnings.py — var-annotated
+
+```text
+error: Need type annotation for "file_counts" (hint: "file_counts: defaultdict[str, int] = ...")
+```
+
+Fix: Added explicit type annotation to `defaultdict(int)` assignment.
+
+### 2. scripts/agents/tests/test_integration.py — var-annotated
+
+```text
+error: Need type annotation for "optional" (hint: "optional: list[<type>] = ...")
+```
+
+Fix: Changed `optional = []` to `optional: list[str] = []`.
+
+### 3. scripts/convert_image_to_idx.py — attr-defined (Pillow 10+)
+
+```text
+error: Module has no attribute "LANCZOS"
+error: Module has no attribute "TRANSPOSE"
+error: Module has no attribute "FLIP_LEFT_RIGHT"
+```
+
+Pillow 10 removed deprecated module-level aliases. Fix: Use enum namespaces.
+
+- `Image.LANCZOS` → `Image.Resampling.LANCZOS`
+- `Image.TRANSPOSE` → `Image.Transpose.TRANSPOSE`
+- `Image.FLIP_LEFT_RIGHT` → `Image.Transpose.FLIP_LEFT_RIGHT`
+
+## Key Insight: Triage Before Config Change
+
+Running mypy with the new flag before touching config files is the key to a clean implementation:
+
+```bash
+pixi run mypy scripts/ --check-untyped-defs --exclude generators/
+```
+
+This reveals all errors upfront. Fix them all first, then add the flag to `pyproject.toml` and
+`.pre-commit-config.yaml`. This avoids a broken state where the config has the flag but errors
+remain.
+
+## Note on --exclude Consistency
+
+The `exclude = "generators/"` in `pyproject.toml` is a regex that applies when mypy is run
+without explicit paths. When invoking mypy directly with `scripts/` as the target, the
+exclusion must also be passed on the command line as `--exclude generators/` to maintain
+consistent behavior between CLI invocations and pre-commit hook runs.
+
+## Test Results
+
+- `pixi run mypy scripts/ --check-untyped-defs --exclude generators/` → Success: no issues found
+- `pixi run pre-commit run mypy --all-files` → mypy.....Passed
+- `pixi run pre-commit run --all-files` → All hooks passed

--- a/skills/ci-cd/enable-mypy-check-untyped-defs/skills/enable-mypy-check-untyped-defs/SKILL.md
+++ b/skills/ci-cd/enable-mypy-check-untyped-defs/skills/enable-mypy-check-untyped-defs/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: enable-mypy-check-untyped-defs
+description: "Enable mypy --check-untyped-defs for full Python body type coverage and fix surfaced errors. Use when: mypy reports untyped function bodies are not checked, or when enabling stricter type coverage."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Category | ci-cd |
+| Complexity | Low |
+| Risk | Low — purely additive type checking |
+| Time | 15–30 minutes |
+
+## When to Use
+
+- mypy reports: `note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs`
+- Adding stricter type-checking coverage to a project
+- Enabling `check_untyped_defs = true` in `pyproject.toml` or `--check-untyped-defs` in pre-commit mypy hook
+- After adding `disallow_untyped_defs = true` and wanting to also check function bodies
+
+## Verified Workflow
+
+### Step 1: Triage errors before enabling
+
+Always run mypy with the flag first (without committing config changes) to see all errors:
+
+```bash
+pixi run mypy scripts/ --check-untyped-defs --exclude generators/
+```
+
+Fix all surfaced errors before adding to config files.
+
+### Step 2: Common errors and fixes
+
+**`defaultdict` missing type annotation** (var-annotated):
+
+```python
+# Before (fails in untyped body)
+file_counts = defaultdict(int)
+
+# After
+file_counts: defaultdict[str, int] = defaultdict(int)
+```
+
+**Empty list missing annotation** (var-annotated):
+
+```python
+# Before
+optional = []
+
+# After
+optional: list[str] = []
+```
+
+**Deprecated Pillow attributes** (attr-defined — Pillow 10+):
+
+```python
+# Before (deprecated module-level aliases)
+img = img.resize((28, 28), Image.LANCZOS)
+img = img.transpose(Image.TRANSPOSE).transpose(Image.FLIP_LEFT_RIGHT)
+
+# After (use enum namespaces)
+img = img.resize((28, 28), Image.Resampling.LANCZOS)
+img = img.transpose(Image.Transpose.TRANSPOSE).transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+```
+
+### Step 3: Update pyproject.toml
+
+```toml
+[tool.mypy]
+disallow_untyped_defs = true
+check_untyped_defs = true
+```
+
+### Step 4: Update pre-commit hook
+
+```yaml
+- id: mypy
+  args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --check-untyped-defs, --python-version, "3.10"]
+```
+
+### Step 5: Verify
+
+```bash
+pixi run mypy scripts/ --check-untyped-defs --exclude generators/
+# → Success: no issues found in N source files
+
+pixi run pre-commit run mypy --all-files
+# → mypy.....Passed
+
+pixi run pre-commit run --all-files
+# → All hooks passed
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | No failed attempts — triage-first approach worked | — | Always run the flag manually before committing config to avoid surprise failures |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3370, PR #4036 | [notes.md](../../references/notes.md) |
+
+## Results & Parameters
+
+### pyproject.toml
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+explicit_package_bases = true
+mypy_path = "."
+exclude = "generators/"
+```
+
+### .pre-commit-config.yaml
+
+```yaml
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.8.0
+  hooks:
+    - id: mypy
+      files: ^scripts/.*\.py$
+      args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --check-untyped-defs, --python-version, "3.10"]
+      additional_dependencies: [types-PyYAML]
+```
+
+### Triage command
+
+```bash
+# Run before touching config files to see all errors upfront
+pixi run mypy <source-dir>/ --check-untyped-defs --exclude <excluded-dir>/
+```


### PR DESCRIPTION
## Summary

- Adds new skill `ci-cd/enable-mypy-check-untyped-defs` capturing learnings from ProjectOdyssey #3370
- Documents the triage-first approach: run mypy with the flag manually before touching config files
- Covers the three most common error types surfaced by `--check-untyped-defs`: `defaultdict` annotations, empty list annotations, and Pillow 10+ deprecated attributes

## Files Added

- `skills/ci-cd/enable-mypy-check-untyped-defs/.claude-plugin/plugin.json`
- `skills/ci-cd/enable-mypy-check-untyped-defs/skills/enable-mypy-check-untyped-defs/SKILL.md`
- `skills/ci-cd/enable-mypy-check-untyped-defs/references/notes.md`

## Validation

```
PASS: enable-mypy-check-untyped-defs
ALL VALIDATIONS PASSED
```

## Test plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes with no warnings
- [x] Skill structure matches required layout (`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `references/notes.md`)
- [x] YAML frontmatter is valid
- [x] Failed Attempts table is present
- [x] Verified On section links to references/notes.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)