### PR TITLE
feat: add extensor-hash-api-docs skill

### DIFF
--- a/skills/documentation/extensor-hash-api-docs/.claude-plugin/plugin.json
+++ b/skills/documentation/extensor-hash-api-docs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "extensor-hash-api-docs",
+  "version": "1.0.0",
+  "description": "Document trait-implementing special methods (__hash__, __eq__, etc.) in Mojo struct docstrings and package __init__.mojo API listings. Use when: (1) a new dunder/trait method is added to a Mojo struct but missing from docs, (2) the package __init__.mojo module listing or section comment does not mention the trait, (3) a follow-up issue requests API surface documentation for a newly added method.",
+  "category": "documentation",
+  "date": "2026-03-07",
+  "tags": ["mojo", "docstring", "api-docs", "hashable", "trait", "extensor", "init-mojo"]
+}

--- a/skills/documentation/extensor-hash-api-docs/references/notes.md
+++ b/skills/documentation/extensor-hash-api-docs/references/notes.md
@@ -1,0 +1,40 @@
+# Session Notes: extensor-hash-api-docs
+
+## Issue
+
+GitHub issue #3378 — "Add __hash__ to ExTensor docstring / public API docs"
+
+Follow-up from #3163 which added the `fn __hash__[H: Hasher](self, mut hasher: H)` method.
+
+## Context
+
+- File: `shared/core/extensor.mojo` (~3000 lines, exceeds 25K token read limit)
+- Package listing: `shared/core/__init__.mojo` (~670 lines)
+- The method existed with a minimal docstring Example (`hash(x)` only)
+- `__init__.mojo` had no mention of `__hash__` or `Hashable` anywhere
+
+## Changes Made
+
+### `shared/core/extensor.mojo` (line 2867)
+
+Expanded `__hash__` docstring:
+- Added trait description paragraph
+- Added `Note:` section explaining algorithm
+- Expanded `Example:` with equality and inequality cases
+
+### `shared/core/__init__.mojo`
+
+Two locations updated:
+1. `Modules:` table line 15 — appended `(ExTensor, implements Hashable via __hash__)`
+2. Section comment above `from shared.core.extensor import` — added 2-line note about Hashable
+
+## Key Decisions
+
+- Did NOT add `__hash__` to the import list — dunder methods are not re-exportable symbols
+- Used targeted `Grep` with `-C 10` context instead of reading the full file (too large)
+- Pre-commit hooks all passed (Mojo format, trailing whitespace, end-of-file, large files)
+
+## Timeline
+
+- Read issue prompt → grepped for `__hash__` → read `__init__.mojo` fully → made 2 edits → committed → pushed → PR created → auto-merge enabled
+- PR: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4046

--- a/skills/documentation/extensor-hash-api-docs/skills/extensor-hash-api-docs/SKILL.md
+++ b/skills/documentation/extensor-hash-api-docs/skills/extensor-hash-api-docs/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: extensor-hash-api-docs
+description: "Document trait-implementing special methods in Mojo struct docstrings and package __init__.mojo API listings. Use when: a new dunder method is added to a Mojo struct but not mentioned in docs or the package module listing."
+category: documentation
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Category** | documentation |
+| **Effort** | Low (docs-only, no logic changes) |
+| **Files Changed** | 2 (`extensor.mojo`, `shared/core/__init__.mojo`) |
+| **Scope** | Mojo struct docstrings + package `__init__.mojo` |
+
+## When to Use
+
+- A `__hash__`, `__eq__`, `__lt__`, or similar trait-implementing dunder method was added to a Mojo struct but is not mentioned in the module docstring or package listing
+- A follow-up issue explicitly asks to add the method to "API documentation" or "public API surface"
+- The package `__init__.mojo` module-level `Modules:` table or section comment is missing a trait mention
+- A PR review notes that a new method is undocumented
+
+## Verified Workflow
+
+1. **Locate the method** with `Grep` for `__hash__` (or the target method) in the `.mojo` file
+2. **Read surrounding context** — check both the method docstring and the struct-level docstring
+3. **Update the method docstring** in `extensor.mojo`:
+   - Add a sentence explaining the trait being implemented (`Hashable`, `Comparable`, etc.)
+   - Add a `Note:` section explaining the algorithm (what data is hashed, any edge cases)
+   - Expand the `Example:` block with equality and inequality cases
+4. **Update `shared/core/__init__.mojo`** in two places:
+   - Module-level `Modules:` table entry for `extensor` — append `(ExTensor, implements Hashable via __hash__)`
+   - Section comment above the `from shared.core.extensor import (` block — add a one-liner note
+5. **Run pre-commit** (`just precommit`) to verify Mojo format and markdown lint pass
+6. **Commit, push, create PR** — pre-commit hooks validate automatically on commit
+
+## Results & Parameters
+
+### Docstring Pattern
+
+```mojo
+fn __hash__[H: Hasher](self, mut hasher: H):
+    """Compute hash based on shape, dtype, and data.
+
+    ExTensor implements the `Hashable` trait, allowing tensors to be used as
+    dictionary keys or in hash-based data structures. Two tensors with identical
+    shape, dtype, and element values will produce the same hash.
+
+    Parameters:
+        H: The hasher type conforming to the Hasher trait.
+
+    Args:
+        hasher: The hasher to write values into.
+
+    Note:
+        The hash is computed from the tensor's shape dimensions, dtype ordinal,
+        and raw bit patterns of all element values. NaN values with different
+        bit representations will hash differently.
+
+    Example:
+        ```mojo
+        from hashlib import hash
+        var x = ones([3], DType.float32)
+        var h = hash(x)
+
+        # Tensors with identical shape, dtype, and values hash equally
+        var y = ones([3], DType.float32)
+        assert hash(x) == hash(y)
+
+        # Tensors with different shapes hash differently
+        var z = ones([4], DType.float32)
+        # hash(x) != hash(z)  (with overwhelming probability)
+        ```
+    """
+```
+
+### `__init__.mojo` Module Listing Pattern
+
+```mojo
+Modules:
+    extensor: Core tensor type (ExTensor, implements Hashable via __hash__) and creation functions
+```
+
+### `__init__.mojo` Section Comment Pattern
+
+```mojo
+# ============================================================================
+# Core Tensor Type and Creation Functions
+# ============================================================================
+# ExTensor implements the Hashable trait (__hash__), allowing tensors to be
+# used as dictionary keys or in hash-based data structures via hash(tensor).
+
+from shared.core.extensor import (
+    ExTensor,
+    ...
+)
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Searching for `__hash__` without context | Grepped for `__hash__` alone | Found the method but missed that the docstring `Example` was already present but minimal | Always read `-C 10` context to see the full docstring before editing |
+| Trying to add `__hash__` to the import list | Considered adding `__hash__` as an explicit re-export in `__init__.mojo` | Dunder methods are not importable symbols — they are trait implementations on the struct | Document dunders via comments and docstrings, not import lists |
+| Reading the full `extensor.mojo` file | Attempted `Read` on the full file | File exceeds 25K token limit, read fails | Use `Grep` with `-C` context for targeted reads; use `offset`+`limit` for specific line ranges |


### PR DESCRIPTION
## Summary

Documents the workflow for adding trait-implementing dunder method documentation
(`__hash__`, `__eq__`, etc.) to Mojo struct docstrings and package `__init__.mojo`
API surface listings.

- Two files always need updating: the method's own docstring and the package `__init__.mojo`
- Dunder methods are NOT importable symbols — document via comments/docstrings, not import lists
- Large Mojo files (>25K tokens) require `Grep` with `-C` context instead of full-file `Read`

## Key Findings

**What Worked**:
- Targeted `Grep` with `-C 10` for finding the method + surrounding context in large files
- Updating two locations in `__init__.mojo`: the `Modules:` table entry and the section comment above the import block
- Expanding the `Example:` block with equality and inequality cases communicates the hash contract clearly

**What Failed**:
- Full-file `Read` on `extensor.mojo` — file exceeds 25K token limit, use `Grep`+`offset`+`limit` instead
- Attempting to add `__hash__` to the import list — dunder methods are not re-exportable symbols

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Check skill appears under `documentation` category
- [ ] Verify SKILL.md renders correctly with all required sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
