### PR TITLE
feat(skills): add testing/mojo-hash-collision-test skill

### DIFF
--- a/skills/testing/mojo-hash-collision-test/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-hash-collision-test/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-hash-collision-test",
+  "version": "1.0.0",
+  "description": "Add hash collision resistance tests for Mojo tensors with same values but different dtypes. Use when: (1) verifying __hash__ distinguishes float32 vs float64 tensors, (2) expanding hash test coverage in test_utility.mojo.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "hash", "tensor", "dtype", "collision", "unit-test"]
+}

--- a/skills/testing/mojo-hash-collision-test/references/notes.md
+++ b/skills/testing/mojo-hash-collision-test/references/notes.md
@@ -1,0 +1,65 @@
+# Notes
+
+## Session Context
+
+Implemented as part of ProjectOdyssey GitHub issue #3379 (worktree `3379-auto-impl`, branch `3379-auto-impl`).
+
+## Objective
+
+Add `test_hash_same_values_different_dtype()` to `tests/shared/core/test_utility.mojo` asserting that
+tensors with identical numeric values but different dtypes (float32 vs float64) produce different hashes.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3379.md` to understand requirements
+2. Used Explore agent to locate `test_hash_different_values` and the `__hash__` implementation
+3. Read `tests/shared/core/test_utility.mojo` to understand existing test patterns (shape setup, hash assertion style)
+4. Searched the `main()` function to find where tests are registered
+5. Added `test_hash_same_values_different_dtype()` after `test_hash_small_values_distinguish()`
+6. Registered the new test in `main()`
+7. Committed with pre-commit hooks — all passed on first attempt
+8. Pushed branch and created PR
+
+## Environment Details
+
+- Host OS: Debian Buster (GLIBC 2.28) — too old for Mojo runtime
+- Mojo runtime requires: GLIBC_2.32, GLIBC_2.33, GLIBC_2.34
+- Local test execution: not possible; requires Docker or CI
+- `just` command: only available inside Docker container
+
+## Key Code Patterns Observed
+
+```mojo
+fn test_hash_same_values_different_dtype() raises:
+    var shape = List[Int]()
+    shape.append(1)
+    var tensor_f32 = full(shape, 1.0, DType.float32)
+    var tensor_f64 = full(shape, 1.0, DType.float64)
+    var hash_f32 = hash(tensor_f32)
+    var hash_f64 = hash(tensor_f64)
+    if hash_f32 == hash_f64:
+        raise Error(
+            "Hash collision: float32 and float64 tensors with same values should have different hashes"
+        )
+```
+
+Registration in `main()`:
+
+```mojo
+test_hash_same_values_different_dtype()
+```
+
+## Pre-commit Hooks Encountered
+
+- `mojo format` — auto-formats `.mojo` files (no changes needed; code was already correctly formatted)
+- `Validate Test Count Badge` — checks test count badge in README is consistent with actual test count
+- `trailing-whitespace` — passed
+- `end-of-file-fixer` — passed
+- `check-yaml` — passed
+
+## Commit
+
+Committed on branch `3379-auto-impl` in ProjectOdyssey worktree at
+`/home/mvillmow/Odyssey2/.worktrees/issue-3379/`.
+
+Commit hash: `45163b87` (test(utility): add hash collision resistance test for same-shape different-dtype tensors)

--- a/skills/testing/mojo-hash-collision-test/skills/mojo-hash-collision-test/SKILL.md
+++ b/skills/testing/mojo-hash-collision-test/skills/mojo-hash-collision-test/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mojo-hash-collision-test
+description: "Add hash collision resistance tests for Mojo tensors with same values but different dtypes. Use when verifying __hash__ distinguishes float32 vs float64 tensors."
+category: testing
+date: 2026-03-07
+user-invocable: true
+---
+
+# Mojo Hash Collision Test Skill
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-07 |
+| Objective | Add `test_hash_same_values_different_dtype()` asserting that tensors with identical numeric values but different dtypes (float32 vs float64) produce different hashes. |
+| Outcome | Successful — test added, pre-commit hooks passed, PR created |
+
+## When to Use
+
+- Adding hash collision resistance tests to `tests/shared/core/test_utility.mojo`
+- Verifying that `__hash__` encodes dtype information (not just values and shape)
+- Following TDD to guard against regressions in tensor hash uniqueness
+- Expanding hash test coverage alongside `test_hash_different_values` and `test_hash_small_values_distinguish`
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+fn test_hash_same_values_different_dtype() raises:
+    var shape = List[Int]()
+    shape.append(1)
+    var tensor_f32 = full(shape, 1.0, DType.float32)
+    var tensor_f64 = full(shape, 1.0, DType.float64)
+    var hash_f32 = hash(tensor_f32)
+    var hash_f64 = hash(tensor_f64)
+    if hash_f32 == hash_f64:
+        raise Error(
+            "Hash collision: float32 and float64 tensors with same values should have different hashes"
+        )
+```
+
+1. **Locate insertion point** — find `test_hash_small_values_distinguish` in `tests/shared/core/test_utility.mojo`
+2. **Add function** — insert `test_hash_same_values_different_dtype()` immediately after that function
+3. **Register in main()** — add a call to the new function in the `main()` runner at the bottom of the file
+4. **Commit** — run pre-commit hooks; the "Validate Test Count Badge" hook requires no extra action if counts are updated automatically
+5. **Push and create PR** — branch naming: `<issue-number>-<description>`
+
+### Pattern Notes
+
+- Shape setup: `var shape = List[Int](); shape.append(1)` (not a literal, append required)
+- Tensor creation: `full(shape, value, DType.float32)` (imported from `shared.core.utility`)
+- Hash assertion: use `if hash_a == hash_b: raise Error(...)` — NOT `assert_equal` or similar macros
+- Function signature: `fn test_hash_same_values_different_dtype() raises:`
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3379, worktree `3379-auto-impl` | [notes.md](../references/notes.md) |
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| `pixi run mojo test tests/shared/core/test_utility.mojo` locally | GLIBC_2.32/2.33/2.34 not found — host OS (Debian Buster) too old | Mojo tests require Docker or CI environment; do not expect local `mojo test` to work outside container |
+| `just test-mojo` locally | `just` command not found outside Docker | The `justfile` recipes are designed for use inside the container; use CI to verify test execution |
+
+## Results & Parameters
+
+- Test function name: `test_hash_same_values_different_dtype`
+- File: `tests/shared/core/test_utility.mojo`
+- Insert after: `test_hash_small_values_distinguish()`
+- Register in: `main()` at the bottom of the same file
+- Pre-commit hooks that run: `mojo format`, `Validate Test Count Badge`, `trailing-whitespace`, `end-of-file-fixer`
+- All hooks passed on first attempt when following exact existing code style
+
+## References
+
+- `tests/shared/core/test_utility.mojo` — test file containing hash tests
+- `.claude/shared/mojo-anti-patterns.md` — common Mojo test failure patterns
+- ProjectOdyssey issue #3379 — original work item


### PR DESCRIPTION
## Summary

- Adds `skills/testing/mojo-hash-collision-test/` skill documenting learnings from ProjectOdyssey issue #3379
- Captures the exact Mojo test pattern for asserting hash collision resistance between same-valued tensors of different dtypes (float32 vs float64)
- Documents the critical environment constraint: `mojo test` requires Docker/CI due to GLIBC version requirements on older host OS

## Test plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes (525 plugins, 0 failures)
- [x] `plugin.json` has all required fields: `name`, `version`, `description`, `category`, `date`, `tags`
- [x] `SKILL.md` has all required sections: Overview, When to Use, Verified Workflow, Failed Attempts (with table), Results & Parameters
- [x] Branch naming follows convention: `skill/<category>/<name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)