### PR TITLE
feat: add mojo-hash-shape-test skill

### DIFF
--- a/skills/testing/mojo-hash-shape-test/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-hash-shape-test/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-hash-shape-test",
+  "version": "1.0.0",
+  "description": "Add a Mojo test verifying that tensors with identical data but different shapes produce different hashes. Use when: (1) a hash test suite covers equal tensors and different values but not different shapes, (2) adding shape-sensitivity coverage to __hash__ in ExTensor or similar structs, (3) following up on a hash test issue referencing shape collision edge cases.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "hash", "extensor", "shape", "test-coverage", "arange", "reshape"]
+}

--- a/skills/testing/mojo-hash-shape-test/references/notes.md
+++ b/skills/testing/mojo-hash-shape-test/references/notes.md
@@ -1,0 +1,41 @@
+# Session Notes: mojo-hash-shape-test
+
+## Session Date
+
+2026-03-07
+
+## Issue
+
+GitHub Issue #3380 — "Add __hash__ test for shape-different tensors same data"
+Follow-up from #3164.
+
+## Objective
+
+Add `test_hash_different_shapes_differ` to `tests/shared/core/test_utility.mojo` verifying
+that a `[3]` tensor with values `[1,2,3]` and a `[1,3]` tensor with the same values hash
+differently.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3380.md` to understand the task.
+2. Read `tests/shared/core/test_utility.mojo` to learn existing hash test patterns.
+3. Added `test_hash_different_shapes_differ` function after `test_hash_small_values_distinguish`.
+4. Added call to `test_hash_different_shapes_differ()` in `main()`.
+5. Staged and committed — all pre-commit hooks passed on first attempt.
+6. Pushed branch and created PR #4054 with auto-merge enabled.
+
+## Key Observations
+
+- All hash tests use `raise Error(...)` pattern (not `assert_*` helpers) for inequality checks.
+- `arange(1.0, 4.0, 1.0, DType.float32)` produces `[1, 2, 3]` (3 elements).
+- `reshape` is called as `t2 = t2.reshape(shape)` (reassignment, not in-place).
+- `List[Int]` must be built with `.append()` calls — no literal syntax.
+- Mojo binary cannot run locally (GLIBC_2.32/2.33/2.34 not available on Debian 10); CI (Docker) validates.
+- Pre-commit hooks include a test-count badge validator — adding a new test updated the badge automatically.
+
+## Environment
+
+- Branch: `3380-auto-impl`
+- Working dir: `/home/mvillmow/Odyssey2/.worktrees/issue-3380`
+- OS: Linux (Debian 10, GLIBC 2.28 — too old for Mojo binary)
+- PR: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4054

--- a/skills/testing/mojo-hash-shape-test/skills/mojo-hash-shape-test/SKILL.md
+++ b/skills/testing/mojo-hash-shape-test/skills/mojo-hash-shape-test/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: mojo-hash-shape-test
+description: "Add a Mojo test verifying tensors with identical data but different shapes produce different hashes. Use when: hash test suite lacks shape-sensitivity coverage, adding __hash__ edge-case tests to ExTensor, or following up on shape collision issues."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+# Skill: Mojo Hash Shape-Sensitivity Test
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-03-07 |
+| **Category** | testing |
+| **Objective** | Add `test_hash_different_shapes_differ` to verify shape is encoded in `__hash__` |
+| **Outcome** | Successfully added test; all pre-commit hooks passed on first attempt |
+| **Context** | Issue #3380 - follow-up from #3164; `test_utility.mojo` lacked shape-collision edge case |
+
+## When to Use
+
+Use this skill when:
+
+- A hash test suite covers equal-tensor and different-value cases but **not** shape differences
+- You need to verify `__hash__` encodes shape information (not just element values)
+- A follow-up issue requests adding the `[N]` vs `[1, N]` same-data different-shape test case
+- Adding edge-case hash coverage for `ExTensor` or similar tensor types
+
+Do NOT use when:
+
+- The `__hash__` implementation is known not to encode shape (would require implementation fix first)
+- Shape-sensitivity is already tested elsewhere in the same test file
+
+## Verified Workflow
+
+### Step 1: Identify the hash test section
+
+Locate the `# Test __hash__` section in the target test file:
+
+```bash
+grep -n "__hash__" tests/shared/core/test_utility.mojo
+```
+
+### Step 2: Add the test function
+
+Insert after the last existing hash test (e.g., `test_hash_small_values_distinguish`):
+
+```mojo
+fn test_hash_different_shapes_differ() raises:
+    """Test that tensors with same data but different shapes produce different hashes."""
+    # Create [3] tensor with values [1, 2, 3]
+    var t1 = arange(1.0, 4.0, 1.0, DType.float32)
+
+    # Create [1, 3] tensor with values [1, 2, 3]
+    var shape = List[Int]()
+    shape.append(1)
+    shape.append(3)
+    var t2 = arange(1.0, 4.0, 1.0, DType.float32)
+    t2 = t2.reshape(shape)
+
+    var hash_1 = hash(t1)
+    var hash_2 = hash(t2)
+    if hash_1 == hash_2:
+        raise Error(
+            "Tensors with same data but different shapes should have different hashes"
+        )
+```
+
+### Step 3: Register in main()
+
+Add the call inside the `# __hash__` block in `main()`:
+
+```mojo
+    # __hash__
+    print("  Testing __hash__...")
+    test_hash_immutable()
+    test_hash_different_values_differ()
+    test_hash_large_values()
+    test_hash_small_values_distinguish()
+    test_hash_different_shapes_differ()   # <-- add this
+```
+
+### Step 4: Commit and push
+
+```bash
+git add tests/shared/core/test_utility.mojo
+git commit -m "test(utility): add hash test for same-data different-shape tensors"
+git push -u origin <branch>
+gh pr create --title "..." --body "Closes #NNNN"
+gh pr merge --auto --rebase <PR-number>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | First attempt succeeded | — | Following existing `arange` + `reshape` pattern directly was sufficient |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Test name | `test_hash_different_shapes_differ` |
+| Tensor shapes tested | `[3]` vs `[1, 3]` |
+| Data | `arange(1.0, 4.0, 1.0, DType.float32)` → values `[1, 2, 3]` |
+| Reshape method | `t2 = t2.reshape(shape)` with `shape = [1, 3]` |
+| Pre-commit hooks | All passed (mojo format, trailing whitespace, test count badge) |
+| Mojo test runner | Not runnable locally (GLIBC version mismatch) — CI validates |


### PR DESCRIPTION
## Summary

Documents the pattern for adding a `__hash__` shape-sensitivity test to Mojo's `ExTensor` test suite.

- Verifies that `[3]` and `[1, 3]` tensors with identical data hash differently
- Covers the gap where existing hash tests only checked equal tensors and different values
- Uses `arange` + `reshape` to construct the same-data different-shape pair

## Key Findings

**What Worked**:
- `arange(1.0, 4.0, 1.0, DType.float32)` + `t2 = t2.reshape(shape)` creates the test pair cleanly
- `raise Error(...)` pattern (not `assert_*`) is the correct style for hash inequality assertions
- Pre-commit hooks (mojo format, test-count badge) all passed on first attempt

**What Failed**:
- N/A — first attempt succeeded by following existing hash test patterns

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Confirm skill activates on "hash shape test" trigger queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
