### PR TITLE
feat: add mojo-bounds-test-pattern skill

### DIFF
--- a/skills/testing/mojo-bounds-test-pattern/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-bounds-test-pattern/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-bounds-test-pattern",
+  "version": "1.0.0",
+  "description": "Pattern for adding symmetric boundary condition tests in Mojo by mirroring existing analogous tests. Use when: (1) adding a missing bounds check test that is symmetric to an existing one, (2) implementing follow-up test coverage for __setitem__/__getitem__ boundary conditions.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "testing", "bounds-check", "boundary-conditions", "setitem", "getitem"]
+}

--- a/skills/testing/mojo-bounds-test-pattern/references/notes.md
+++ b/skills/testing/mojo-bounds-test-pattern/references/notes.md
@@ -1,0 +1,32 @@
+# Session Notes: mojo-bounds-test-pattern
+
+Date: 2026-03-07
+Issue: HomericIntelligence/ProjectOdyssey#3387
+PR: HomericIntelligence/ProjectOdyssey#4065
+
+## Raw Session Notes
+
+The __setitem__ implementation in shared/core/extensor.mojo checks:
+
+```text
+if index < 0 or index >= self._numel:
+    raise Error("Index out of bounds")
+```
+
+The existing test only covered `index >= numel` (t[5] = 1.0 on a size-3 tensor).
+Added test for `index < 0` (t[-1] = 1.0).
+
+Pattern in test_utility.mojo uses a `raised` flag with try/except:
+
+```mojo
+var raised = False
+try:
+    t[-1] = 1.0
+except:
+    raised = True
+if not raised:
+    raise Error("...")
+```
+
+GLIBC issue: The dev machine runs Debian 10 (Buster) with GLIBC 2.28.
+Mojo requires GLIBC 2.32+. All Mojo test execution happens in Docker containers.

--- a/skills/testing/mojo-bounds-test-pattern/skills/mojo-bounds-test-pattern/SKILL.md
+++ b/skills/testing/mojo-bounds-test-pattern/skills/mojo-bounds-test-pattern/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: mojo-bounds-test-pattern
+description: "Pattern for adding symmetric boundary condition tests in Mojo by mirroring existing analogous tests. Use when: (1) adding a missing bounds check test, (2) implementing follow-up coverage for __setitem__/__getitem__ boundary conditions."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Name | mojo-bounds-test-pattern |
+| Category | testing |
+| Trigger | Adding missing boundary condition test that mirrors an existing one |
+| Output | New test function + main() call following existing pattern |
+
+## When to Use
+
+- Issue asks to add a negative index test analogous to an out-of-bounds test
+- You need to cover the `index < 0` branch of a bounds check
+- An existing test covers `index >= size` and you need the symmetric `index < 0` case
+- Adding follow-up test coverage identified in code review
+
+## Verified Workflow
+
+1. **Find the analogous test first** — search for `test_setitem_out_of_bounds` or similar
+2. **Read the full test file** to understand the pattern (try/except with `raised` flag)
+3. **Copy the test function** and change only the index value and error message
+4. **Add the call in `main()`** after the analogous test
+5. **Commit** — pre-commit hooks will validate (mojo format, test count badge)
+6. **Note**: Mojo tests cannot run locally on older GLIBC systems; CI validates correctness
+
+## Pattern
+
+```mojo
+fn test_setitem_negative_index() raises:
+    """Test that __setitem__ raises error for negative index."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.float32)
+
+    var raised = False
+    try:
+        t[-1] = 1.0
+    except:
+        raised = True
+
+    if not raised:
+        raise Error("__setitem__ should raise error for negative index")
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Run mojo test locally | `pixi run mojo test tests/shared/core/test_utility.mojo` | GLIBC_2.32/2.33/2.34 not found on host OS | Mojo tests must run in Docker/CI on this dev machine |
+
+## Results & Parameters
+
+- **File modified**: `tests/shared/core/test_utility.mojo`
+- **Lines added**: 17 (function + main() call)
+- **Pre-commit hooks**: All passed (mojo format, validate-test-coverage, trailing whitespace)
+- **PR**: #4065 on ProjectOdyssey with auto-merge enabled
+- **Issue**: #3387 (follow-up from #3165)


### PR DESCRIPTION
## Summary

- Adds `skills/testing/mojo-bounds-test-pattern/` skill documenting the pattern for adding symmetric boundary condition tests in Mojo
- Documents learnings from ProjectOdyssey issue #3387 (adding `test_setitem_negative_index`)
- Key insight: find the analogous test first and copy its structure; `index < 0` and `index >= numel` checks are symmetric

## Files Added

- `skills/testing/mojo-bounds-test-pattern/.claude-plugin/plugin.json`
- `skills/testing/mojo-bounds-test-pattern/skills/mojo-bounds-test-pattern/SKILL.md`
- `skills/testing/mojo-bounds-test-pattern/references/notes.md`

## Validation

- `python3 scripts/validate_plugins.py skills/ plugins/` passes with `PASS: mojo-bounds-test-pattern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)