### PR TITLE
feat: add mojo-exception-message-assertion skill

### DIFF
--- a/skills/testing/mojo-exception-message-assertion/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-exception-message-assertion/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-exception-message-assertion",
+  "version": "1.0.0",
+  "description": "Pattern for asserting exact error message text in Mojo exception tests using 'except e:'. Use when: (1) upgrading a bare 'except:' test to assert a specific error message, (2) following up an out-of-bounds test to verify the error message string matches exactly.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "exception", "assert", "error-message", "except", "bounds-check", "test-upgrade"]
+}

--- a/skills/testing/mojo-exception-message-assertion/references/notes.md
+++ b/skills/testing/mojo-exception-message-assertion/references/notes.md
@@ -1,0 +1,60 @@
+# Session Notes: mojo-exception-message-assertion
+
+## Context
+
+- **Date**: 2026-03-07
+- **Project**: ProjectOdyssey
+- **Issue**: #3389 — Verify `__setitem__` error message text in out-of-bounds test
+- **Branch**: `3389-auto-impl`
+- **PR**: #4070
+
+## Objective
+
+Follow-up from #3165 (which added `__setitem__` tests with a bare `except:` clause).
+Issue #3389 asked to upgrade the bare clause to `except e:` and assert the exact error
+message `"Index out of bounds"`, matching the `test_bool_requires_single_element` pattern.
+
+## File Modified
+
+`tests/shared/core/test_utility.mojo` — lines 324–331
+
+## The Change
+
+```diff
+-    var raised = False
++    var error_raised = False
+     try:
+         t[5] = 1.0
+-    except:
+-        raised = True
++    except e:
++        error_raised = True
++        assert_equal(String(e), "Index out of bounds")
+
+-    if not raised:
++    if not error_raised:
+         raise Error("__setitem__ should raise error for out-of-bounds index")
+```
+
+## Import Discovery
+
+The test file imports `assert_equal` from `tests.shared.conftest`, which re-exports it
+from `shared.testing.assertions`. This is the correct helper to use — NOT `testing.assert_equal`
+(the `testing` module is not imported).
+
+## Pre-commit Results
+
+All hooks passed on first attempt:
+
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## GLIBC Note
+
+Mojo tests cannot run locally on this machine (requires GLIBC_2.32+, host has older version).
+Pre-commit hooks serve as the local quality gate; CI validates compilation and test execution.

--- a/skills/testing/mojo-exception-message-assertion/skills/mojo-exception-message-assertion/SKILL.md
+++ b/skills/testing/mojo-exception-message-assertion/skills/mojo-exception-message-assertion/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: mojo-exception-message-assertion
+description: "Pattern for asserting exact error message text in Mojo exception tests using 'except e:'. Use when: (1) upgrading bare except: clauses to assert specific error message text, (2) adding message verification to out-of-bounds or error-path tests."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+# Mojo Exception Message Assertion Pattern
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-07 |
+| **Issue** | #3389 — Verify `__setitem__` error message text in out-of-bounds test |
+| **Objective** | Replace bare `except:` with `except e:` and assert `String(e) == "Index out of bounds"` |
+| **Outcome** | ✅ Success — minimal test-only change, PR #4070 created with auto-merge enabled |
+
+## When to Use
+
+Use this skill when:
+
+- A Mojo test uses a bare `except:` clause and needs to verify the specific error message text
+- You are writing a follow-up to a test that only checks an error was raised (not what it says)
+- An issue asks to match the `except e:` pattern used in analogous tests (e.g. `test_bool_requires_single_element`)
+- You need to catch accidental changes to error message strings
+
+## Verified Workflow
+
+### 1. Identify the bare `except:` test to upgrade
+
+Find tests using the manual-flag pattern:
+
+```mojo
+var raised = False
+try:
+    t[5] = 1.0
+except:
+    raised = True
+
+if not raised:
+    raise Error("...")
+```
+
+### 2. Find the existing import for assertions
+
+Check the file's imports — prefer using already-imported helpers:
+
+```bash
+grep -n "assert_equal\|import testing" <test-file>.mojo
+```
+
+In ProjectOdyssey, `assert_equal` is re-exported from `shared.testing.assertions` via `tests/shared/conftest.mojo` and is already imported in most test files.
+
+### 3. Apply the upgrade pattern
+
+Replace the bare `except:` pattern with `except e:` + exact message assertion:
+
+**Before:**
+
+```mojo
+var raised = False
+try:
+    t[5] = 1.0
+except:
+    raised = True
+
+if not raised:
+    raise Error("__setitem__ should raise error for out-of-bounds index")
+```
+
+**After:**
+
+```mojo
+var error_raised = False
+try:
+    t[5] = 1.0
+except e:
+    error_raised = True
+    assert_equal(String(e), "Index out of bounds")
+
+if not error_raised:
+    raise Error("__setitem__ should raise error for out-of-bounds index")
+```
+
+Key changes:
+
+- `raised` → `error_raised` (clearer name matching project convention)
+- `except:` → `except e:` (binds the exception to variable `e`)
+- Add `assert_equal(String(e), "<exact message>")` inside the except block
+- The final `if not error_raised` guard stays — it still ensures the error was raised
+
+### 4. Verify the exact error message string
+
+The message must match the implementation exactly. Find it with:
+
+```bash
+grep -n "Index out of bounds\|raise Error" <package>/extensor.mojo
+```
+
+Use the literal string from the implementation (case-sensitive, exact match).
+
+### 5. Commit and create PR
+
+```bash
+git add <test-file>.mojo
+git commit -m "test(<scope>): verify error message in <test-name>
+
+Closes #<issue>"
+git push -u origin <branch>
+gh pr create --title "test(<scope>): verify error message in <test-name>" \
+  --body "Closes #<issue>" --label "testing"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Used `testing.assert_equal` directly | Called `testing.assert_equal(String(e), "...")` without importing `testing` | `testing` module not imported in the test file | Check existing imports first; use the project's `assert_equal` helper from conftest instead |
+| Run mojo test locally | `pixi run mojo test tests/shared/core/test_utility.mojo` | GLIBC_2.32/2.33/2.34 not found on host | Mojo tests must run in Docker/CI on this dev machine; pre-commit hooks are the local gate |
+
+## Results & Parameters
+
+### Pattern Summary
+
+| Component | Before | After |
+|-----------|--------|-------|
+| Exception binding | `except:` (bare) | `except e:` (named) |
+| Variable name | `raised` | `error_raised` |
+| Message assertion | None | `assert_equal(String(e), "exact message")` |
+| Error-not-raised guard | `if not raised: raise Error(...)` | `if not error_raised: raise Error(...)` |
+
+### Key Parameters
+
+- Assert helper: `assert_equal` (already imported via conftest, not `testing.assert_equal`)
+- Error message: exact string from implementation, e.g. `"Index out of bounds"`
+- Final guard: keep the `if not error_raised` block — it ensures the error path was taken
+
+### Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3389, PR #4070, follow-up from #3165 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern for upgrading bare `except:` clauses in Mojo tests to use `except e:` with exact error message assertion.

- Use `except e:` instead of bare `except:` to bind the exception
- Assert `String(e) == "exact message"` inside the except block
- Use the project's `assert_equal` helper (already imported via conftest), not `testing.assert_equal`

## Key Findings

**What Worked**:
- Replacing `except:` with `except e:` + `assert_equal(String(e), "Index out of bounds")`
- Renaming `raised` → `error_raised` to match the project's existing naming convention
- Keeping the final `if not error_raised: raise Error(...)` guard

**What Failed**:
- `testing.assert_equal` → `testing` module not imported; use `assert_equal` from conftest instead
- Running mojo tests locally → GLIBC version mismatch; CI is the verification gate

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill triggers on "upgrade bare except" or "assert error message" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
