### PR TITLE
feat: add mojo-extensor-method-from-issue skill

### DIFF
--- a/skills/tooling/mojo-extensor-method-from-issue/.claude-plugin/plugin.json
+++ b/skills/tooling/mojo-extensor-method-from-issue/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-extensor-method-from-issue",
+  "version": "1.0.0",
+  "description": "Pattern for adding stride-view methods to ExTensor and updating tests from standalone-function workarounds to method-syntax. Use when: (1) implementing a new ExTensor method that replaces a standalone function workaround, (2) updating tests that use placeholder stride-mutation hacks, (3) pre-commit hooks catch deprecated List[Int](args) syntax in docstring examples.",
+  "category": "tooling",
+  "date": "2026-03-07",
+  "tags": ["mojo", "extensor", "stride-view", "pre-commit", "deprecated-syntax", "workaround-removal"]
+}

--- a/skills/tooling/mojo-extensor-method-from-issue/references/notes.md
+++ b/skills/tooling/mojo-extensor-method-from-issue/references/notes.md
@@ -1,0 +1,37 @@
+# Session Notes: Issue #3390 - ExTensor.transpose()
+
+## Date: 2026-03-07
+
+## Objective
+
+Replace stride-mutation workaround tests with a proper `ExTensor.transpose(dim0, dim1)` method.
+Issue #3390 follow-up from #3166.
+
+## Context at Start
+
+- Branch `3390-auto-impl` was clean — already up to date with `origin/main`
+- Tests in `test_utility.mojo` already used `transpose_view(a)` (intermediate step)
+- `transpose_view()` standalone function existed in `shared/core/matrix.mojo`
+- No `transpose()` method existed on `ExTensor` itself
+- Issue plan wanted method syntax: `a.transpose(0, 1)`
+
+## Steps Taken
+
+1. Read `.claude-prompt-3390.md` to understand task
+2. Read `gh issue view 3390 --comments` — got full implementation plan
+3. Searched for `transpose_view` implementation → found in `matrix.mojo:827`
+4. Confirmed tests already imported and used `transpose_view` (better than stride mutation but not the final goal)
+5. Added `fn transpose(self, dim0, dim1)` to `ExTensor` after `slice()` method
+6. First commit attempt: `check-list-constructor` hook failed on docstring example
+7. Fixed docstring to use `append()` style instead of `List[Int](3, 4)` constructor
+8. Removed `transpose_view` import from test file
+9. Updated both test functions to use `a.transpose(0, 1)` method syntax
+10. Second commit succeeded — all hooks passed
+11. Pushed and created PR #4078
+
+## Key Observations
+
+- The `check-list-constructor` pre-commit hook scans docstring code block content, not just executable code
+- `transpose_view` is exported from `shared.core` (still needed by other callers) — only remove from this specific test import
+- Mojo cannot run locally due to GLIBC version mismatch — rely on CI for test validation
+- Pattern `self.copy(); result._is_view = True; return result^` is the established ExTensor view pattern (matches `slice()`)

--- a/skills/tooling/mojo-extensor-method-from-issue/skills/mojo-extensor-method-from-issue/SKILL.md
+++ b/skills/tooling/mojo-extensor-method-from-issue/skills/mojo-extensor-method-from-issue/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: mojo-extensor-method-from-issue
+description: "Pattern for adding stride-view methods to ExTensor and migrating tests from standalone-function workarounds to method-syntax. Use when: implementing ExTensor methods that replace workarounds, updating tests with stride-mutation hacks, or encountering deprecated List syntax in docstring examples."
+category: tooling
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #3390 - Implement transpose() to replace stride-mutation workaround |
+| **PR** | #4078 |
+| **Branch** | `3390-auto-impl` |
+| **Files Changed** | `shared/core/extensor.mojo`, `tests/shared/core/test_utility.mojo` |
+| **Result** | Success — pre-commit passed, PR created |
+
+## When to Use
+
+- Implementing a new method on `ExTensor` that creates a stride-based view (transpose, permute, etc.)
+- Removing standalone function workarounds in favor of proper method-syntax on `ExTensor`
+- Tests use `transpose_view(a)` or direct `_strides` mutation and need upgrading to `a.transpose(0, 1)`
+- Adding docstring examples to Mojo methods with `List[Int]` construction
+
+## Verified Workflow
+
+### 1. Locate insertion point after `slice()`
+
+```bash
+grep -n "fn reshape\|fn slice\|fn __getitem__" shared/core/extensor.mojo
+```
+
+Insert new method between `slice()` and `__getitem__` — consistent with existing ordering.
+
+### 2. Implement stride-view method pattern
+
+```mojo
+fn transpose(self, dim0: Int, dim1: Int) raises -> ExTensor:
+    """Return a non-contiguous view with dim0 and dim1 swapped.
+    ...
+    """
+    var ndim = self.dim()
+    if ndim < 2:
+        raise Error("transpose requires at least 2 dimensions")
+    if dim0 < 0 or dim0 >= ndim:
+        raise Error("transpose: dim0 out of range")
+    if dim1 < 0 or dim1 >= ndim:
+        raise Error("transpose: dim1 out of range")
+
+    var result = self.copy()
+    result._is_view = True
+
+    var tmp_shape = result._shape[dim0]
+    result._shape[dim0] = result._shape[dim1]
+    result._shape[dim1] = tmp_shape
+
+    var tmp_stride = result._strides[dim0]
+    result._strides[dim0] = result._strides[dim1]
+    result._strides[dim1] = tmp_stride
+
+    return result^
+```
+
+### 3. Write docstring examples with List[Int] literals (NOT deprecated constructor)
+
+**WRONG** (triggers pre-commit check-list-constructor hook):
+```mojo
+var a = ones(List[Int](3, 4), DType.float32)
+```
+
+**CORRECT**:
+```mojo
+var shape = List[Int]()
+shape.append(3)
+shape.append(4)
+var a = ones(shape, DType.float32)
+```
+
+### 4. Update tests — remove standalone function import, use method syntax
+
+In test imports: remove `transpose_view` from `from shared.core import (...)`
+
+In test bodies:
+```mojo
+# Before (workaround):
+var b = transpose_view(a)
+
+# After (proper method):
+var b = a.transpose(0, 1)
+```
+
+### 5. Commit — pre-commit will catch issues automatically
+
+```bash
+git add shared/core/extensor.mojo tests/shared/core/test_utility.mojo
+git commit -m "feat(extensor): add ExTensor.transpose(dim0, dim1) ..."
+```
+
+If `check-list-constructor` hook fails: fix docstring examples to use `append()` style.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Docstring with `List[Int](3, 4)` constructor | Used shorthand in docstring example: `var a = ones(List[Int](3, 4), DType.float32)` | `check-list-constructor` pre-commit hook scans ALL Mojo source including docstring code blocks and rejects deprecated constructor syntax | Docstring examples are scanned by pre-commit hooks — always use `append()` style even in code block examples |
+
+## Results & Parameters
+
+### Stride-view method correctness
+
+After `a = ones([3, 4], DType.float32)`:
+- `a._strides` = `[4, 1]`, `a._shape` = `[3, 4]`
+- `b = a.transpose(0, 1)` → `b._strides` = `[1, 4]`, `b._shape` = `[4, 3]`
+- `b.is_contiguous()` → `False` (stride[0]=1 ≠ expected 3)
+- `c = as_contiguous(b)` → `c.is_contiguous()` → `True`, strides `[3, 1]`
+
+### Key implementation notes
+
+- Use `self.copy()` then set `result._is_view = True` — same pattern as `slice()`
+- Return with `result^` (ownership transfer)
+- The `transpose_view()` standalone function in `matrix.mojo` handles arbitrary permutations via `Optional[List[Int]]`; the new method handles the common 2-axis case with cleaner syntax
+- `transpose_view` remains in `shared.core` exports — it is used by other callers; only remove the import from the specific test file
+
+### Pre-commit hooks that apply to Mojo edits
+
+| Hook | Trigger | Fix |
+|------|---------|-----|
+| `mojo format` | Bad formatting | Auto-fixed by hook — re-stage |
+| `check-list-constructor` | `List[Int](...)` in ANY source line | Use `append()` style everywhere including docstrings |
+| `trailing-whitespace` | Trailing spaces | Auto-fixed — re-stage |
+| `end-of-file-fixer` | Missing newline | Auto-fixed — re-stage |


### PR DESCRIPTION
## Summary

Documents the pattern for adding stride-view methods to `ExTensor` and migrating tests from standalone-function workarounds to proper method syntax.

- Pattern for implementing `ExTensor` stride-view methods (transpose, permute, etc.)
- Key gotcha: `check-list-constructor` hook scans docstring code blocks, not just executable code
- View creation pattern: `self.copy()` + `result._is_view = True` + `return result^`

## Key Findings

**What Worked**:
- Insert new method after `slice()`, before `__getitem__` for consistent ordering
- Use `self.copy()` then set `_is_view = True` — matches existing `slice()` pattern
- Use `append()` style for `List[Int]` in docstring examples to pass pre-commit hooks

**What Failed**:
- `List[Int](3, 4)` in docstring example → `check-list-constructor` pre-commit hook rejected it — hook scans all Mojo source lines including docstring code blocks

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with ExTensor method implementation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
