### PR TITLE
feat: add mojo-as-contiguous-stride-verification skill

### DIFF
--- a/skills/testing/mojo-as-contiguous-stride-verification/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-as-contiguous-stride-verification/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-as-contiguous-stride-verification",
+  "version": "1.0.0",
+  "description": "TDD pattern for verifying stride-aware memory remapping in Mojo tensor operations. Use when: (1) testing as_contiguous() or similar stride-based copy operations, (2) verifying non-contiguous tensors produce correct row-major output, (3) writing regression tests before fixing stride-indexing bugs.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "tensor", "stride", "contiguous", "tdd", "regression-test", "memory-layout"]
+}

--- a/skills/testing/mojo-as-contiguous-stride-verification/references/notes.md
+++ b/skills/testing/mojo-as-contiguous-stride-verification/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes — mojo-as-contiguous-stride-verification
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: ProjectOdyssey #3392 — "Add as_contiguous() test with stride-correct value verification"
+- **Follow-up from**: Issue #3166 (as_contiguous() stride-indexing bug)
+- **PR**: #4087
+- **Branch**: `3392-auto-impl`
+- **File modified**: `tests/shared/core/test_utility.mojo`
+
+## Objective
+
+Add a Mojo test that verifies `as_contiguous()` remaps tensor elements using
+stride-based indexing, not flat-order indexing. The existing test
+`test_contiguous_on_noncontiguous` only checked that the result was contiguous
+and had correct strides — not that values were at the correct positions.
+
+## Steps Taken
+
+1. Read the issue prompt from `.claude-prompt-3392.md`
+2. Located `tests/shared/core/test_utility.mojo` (641 lines)
+3. Observed existing `test_contiguous_on_noncontiguous` uses `transpose_view`
+   but doesn't assert value positions
+4. Checked `shared/core/extensor.mojo` for `_set_float64` API
+5. Checked `shared/core/__init__.mojo` to confirm `is_contiguous` export
+6. Designed 2×3 column-major test tensor with manually overwritten strides
+7. Hand-derived expected row-major output: `[0.0, 2.0, 4.0, 1.0, 3.0, 5.0]`
+8. Added `test_contiguous_stride_correct_values()` function
+9. Registered in `main()`
+10. Committed (pre-commit hooks passed: mojo format, test count badge, etc.)
+11. Pushed and created PR #4087 with auto-merge enabled
+
+## Key Decision: Manually Overwrite `_strides`
+
+Instead of relying on `transpose_view()` (which changes shape and makes value
+tracing complex), we directly construct a tensor and overwrite `_strides`:
+
+```mojo
+t._strides[0] = 1
+t._strides[1] = 2
+```
+
+This gives precise control over the non-contiguous layout and makes the
+expected output trivially derivable from stride arithmetic.
+
+## Why This Test Matters
+
+The bug from #3166: `as_contiguous()` calls `_get_float64(i)` which reads
+flat memory ignoring strides. The fix should use stride-based indexing to
+read `_get_float64(row * stride[0] + col * stride[1])`. The new test catches
+this difference — it will FAIL with the buggy implementation and PASS once
+the fix from #3166 is applied.
+
+## Environment Notes
+
+- Mojo toolchain cannot run locally (GLIBC_2.32/2.33/2.34 not found on Debian 10)
+- Tests run in CI via Docker (`ghcr.io/homericintelligence/projectodyssey:main`)
+- Pre-commit hooks run via `pixi run pre-commit` and passed locally

--- a/skills/testing/mojo-as-contiguous-stride-verification/skills/mojo-as-contiguous-stride-verification/SKILL.md
+++ b/skills/testing/mojo-as-contiguous-stride-verification/skills/mojo-as-contiguous-stride-verification/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: mojo-as-contiguous-stride-verification
+description: "TDD pattern for verifying stride-aware memory remapping in Mojo tensor as_contiguous(). Use when: writing regression tests for non-contiguous tensor copy operations, verifying stride-based indexing before or after a bug fix."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-as-contiguous-stride-verification |
+| **Category** | testing |
+| **Language** | Mojo |
+| **Issue** | #3392 (follow-up from #3166) |
+| **PR** | #4087 |
+
+Captures the TDD pattern for writing stride-correct value verification tests
+for `as_contiguous()` in Mojo's `ExTensor`. The key insight: pre-existing tests
+used `_get_float64(i)` which ignores strides (flat order), so bugs in
+stride-aware remapping were invisible. The fix is to construct a tensor with
+**manually overwritten strides** and assert against the expected stride-remapped
+flat output.
+
+## When to Use
+
+- Writing a test for `as_contiguous()` or any stride-based copy operation
+- Creating a regression test before fixing a stride-indexing bug (TDD-first)
+- Verifying a non-contiguous tensor (e.g. column-major, transposed) produces
+  the correct C-order (row-major) copy after `as_contiguous()`
+- Discovering that an existing contiguity test only checks flat order, not
+  stride-correct positions
+
+## Verified Workflow
+
+1. **Identify the gap**: check if existing tests use `_get_float64(i)` for value
+   assertions — if so, they ignore strides and cannot catch stride-remapping bugs.
+
+2. **Construct a minimal non-contiguous tensor** by creating a normally-shaped
+   tensor and **overwriting `_strides` directly**:
+
+   ```mojo
+   var shape = List[Int]()
+   shape.append(2)
+   shape.append(3)
+   var t = ExTensor(shape, DType.float32)
+
+   # Fill raw memory sequentially
+   for i in range(6):
+       t._set_float64(i, Float64(i))
+
+   # Overwrite to column-major strides [1, 2]
+   t._strides[0] = 1
+   t._strides[1] = 2
+   ```
+
+3. **Assert non-contiguity** using `t.is_contiguous()` before calling
+   `as_contiguous()`.
+
+4. **Derive expected output by hand** using stride arithmetic:
+
+   ```
+   Column-major strides [1, 2] for shape [2, 3]:
+     result[0,0] = mem[0*1 + 0*2] = mem[0] = 0.0
+     result[0,1] = mem[0*1 + 1*2] = mem[2] = 2.0
+     result[0,2] = mem[0*1 + 2*2] = mem[4] = 4.0
+     result[1,0] = mem[1*1 + 0*2] = mem[1] = 1.0
+     result[1,1] = mem[1*1 + 1*2] = mem[3] = 3.0
+     result[1,2] = mem[1*1 + 2*2] = mem[5] = 5.0
+
+   Expected flat row-major output: [0.0, 2.0, 4.0, 1.0, 3.0, 5.0]
+   ```
+
+5. **Assert each flat position** in the result using `assert_value_at`:
+
+   ```mojo
+   var result = as_contiguous(t)
+   assert_true(result.is_contiguous(), "result should be contiguous")
+   assert_value_at(result, 0, 0.0, 1e-6, "result[0,0] = 0.0 (mem[0])")
+   assert_value_at(result, 1, 2.0, 1e-6, "result[0,1] = 2.0 (mem[2])")
+   assert_value_at(result, 2, 4.0, 1e-6, "result[0,2] = 4.0 (mem[4])")
+   assert_value_at(result, 3, 1.0, 1e-6, "result[1,0] = 1.0 (mem[1])")
+   assert_value_at(result, 4, 3.0, 1e-6, "result[1,1] = 3.0 (mem[3])")
+   assert_value_at(result, 5, 5.0, 1e-6, "result[1,2] = 5.0 (mem[5])")
+   ```
+
+6. **Register the test in `main()`** after any existing contiguity tests.
+
+7. **Commit in TDD-first style** — the test may intentionally fail until the
+   parent bug fix lands, serving as a regression harness.
+
+## Results & Parameters
+
+- **Shape**: 2×3 is the minimum useful shape (not square, clearly shows
+  row vs column ordering)
+- **Memory fill**: sequential integers starting from 0.0 — easy to trace
+- **Stride override**: column-major `[1, 2]` for shape `[2, 3]`
+  (C-order would be `[3, 1]`)
+- **Tolerance**: `1e-6` for float32 value assertions
+- **Test file location**: `tests/shared/core/test_utility.mojo`
+- **Naming convention**: `test_contiguous_stride_correct_values`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `transpose_view()` as the non-contiguous source | Create a transposed tensor and assert specific flat positions in the result | `transpose_view` changes shape but the value mapping is harder to control precisely from raw memory | Manually overwriting `_strides` gives full control of the non-contiguous layout |
+| Using `_get_float64(i)` for assertions in the original test | Original `test_contiguous_on_noncontiguous` asserted values via `_get_float64(i)` | `_get_float64` ignores strides — it reads flat memory — so stride bugs are invisible | Always use `assert_value_at` on the result flat indices to catch stride-remapping errors |
+| Asserting only strides and contiguity, not values | Only checking `is_contiguous()` and `_strides[n]` | Does not verify that elements ended up in the correct positions | Both stride metadata AND value positions must be verified |


### PR DESCRIPTION
## Summary

Documents the TDD pattern for verifying stride-aware memory remapping in Mojo tensor `as_contiguous()` operations (ProjectOdyssey #3392, follow-up from #3166).

- Pre-existing tests only checked flat-order values via `_get_float64(i)`, which ignores strides and cannot catch stride-remapping bugs
- Pattern: manually overwrite `_strides` to create a controlled non-contiguous layout, derive expected output by hand via stride arithmetic, assert each flat position in the row-major result
- Committed as a TDD-first test that intentionally fails until the parent stride-fix lands

## Key Findings

**What Worked**:
- Manually overwriting `t._strides[0]` and `t._strides[1]` for precise control over non-contiguous layout
- Sequential `_set_float64(i, Float64(i))` fill + stride arithmetic for easily traceable expected values
- Asserting `assert_value_at(result, N, expected, 1e-6, msg)` on all 6 flat positions

**What Failed**:
- Using `transpose_view()` as the non-contiguous source → value tracing is complex (shape changes)
- Asserting only `is_contiguous()` and stride metadata → does not verify element positions
- Using `_get_float64(i)` for value assertions → ignores strides, existing bug was invisible

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with Mojo stride testing triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
