### PR TITLE
feat: add adr009-test-file-splitting skill

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-test-file-splitting/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "adr009-test-file-splitting",
-  "version": "1.0.0",
-  "description": "Workflow for splitting Mojo test files that exceed ADR-009 ≤10 fn test_ limit to prevent heap corruption in CI. Use when: (1) a test file exceeds the ADR-009 limit, (2) CI has intermittent heap corruption failures in Testing Fixtures group, (3) over-limit files need splitting while preserving all test cases.",
+  "version": "1.2.0",
+  "description": "Split Mojo test files exceeding ADR-009 limit of 10 fn test_ functions to prevent heap corruption crashes. Use when: (1) a Mojo test file has more than 10 fn test_ functions, (2) CI shows intermittent heap corruption (libKGENCompilerRTShared.so) in a test group, (3) a test file needs to be split to comply with ADR-009.",
   "category": "ci-cd",
-  "date": "2026-03-07",
+  "date": "2026-03-08",
   "tags": ["mojo", "adr-009", "heap-corruption", "test-splitting", "ci-stability"]
 }

--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -1,43 +1,416 @@
-# Session Notes: ADR-009 Test File Splitting (Issue #3397)
+# Session Notes: ADR-009 Test File Splitting (Issue #3623)
 
-## Date
+## Context
 
-2026-03-07
+- **Date**: 2026-03-08
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3623-auto-impl
+- **Issue**: #3623 — fix(ci): split test_gradient_ops.mojo (12 tests) into 2 files per ADR-009
+- **PR**: #4412
 
 ## Problem
 
-test_assertions.mojo (61 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI.
-ADR-009 mandates ≤10 fn test_ per file.
+`tests/shared/training/test_gradient_ops.mojo` had 12 `fn test_` functions, exceeding the
+ADR-009 hard limit of 10 and the ≤8 safety target. This caused intermittent heap corruption
+in the `Shared Infra & Testing` CI group (`libKGENCompilerRTShared.so` JIT fault).
 
-## Initial State (already in main)
+## Approach Taken
 
-The file had been partially split into 7 files:
+1. Read the original file to identify all 12 test functions (accumulate, scale, zero operations + workflow)
+2. Checked `comprehensive-tests.yml` — `Shared Infra & Testing` group uses `training/test_*.mojo` glob,
+   so new `_part1` and `_part2` files are auto-discovered; no workflow changes needed
+3. Checked `validate_test_coverage.py` — no explicit reference to the original filename;
+   no coverage script changes needed
+4. Created `test_gradient_ops_part1.mojo` (8 tests: accumulate + scale operations) with ADR-009 header
+5. Created `test_gradient_ops_part2.mojo` (4 tests: zero operations + workflow integration) with ADR-009 header
+6. Deleted original `test_gradient_ops.mojo`
+7. All pre-commit hooks passed on first attempt
 
-- test_assertions_bool.mojo: 5 tests
-- test_assertions_comparison.mojo: 8 tests
-- test_assertions_equality.mojo: 8 tests
-- test_assertions_float.mojo: 10 tests (AT hard limit)
-- test_assertions_shape.mojo: 9 tests
-- test_assertions_tensor_props.mojo: 8 tests
-- test_assertions_tensor_values.mojo: 11 tests (OVER hard limit)
-- test_assertions.mojo.DEPRECATED (stale artifact)
+## Files Changed
 
-## Actions Taken
+- DELETED: `tests/shared/training/test_gradient_ops.mojo`
+- CREATED: `tests/shared/training/test_gradient_ops_part1.mojo` (8 tests: accumulate + scale)
+- CREATED: `tests/shared/training/test_gradient_ops_part2.mojo` (4 tests: zero ops + workflow)
 
-1. Created test_assertions_int.mojo (2 tests) - moved assert_equal_int tests from float file
-2. Updated test_assertions_float.mojo: 10 → 8 tests
-3. Created test_assertions_tensor_type.mojo (3 tests) - moved assert_type + not_equal_fails
-4. Updated test_assertions_tensor_values.mojo: 11 → 8 tests
-5. Deleted test_assertions.mojo.DEPRECATED
+## Key Technical Observations
 
-## Final State
+- `training/test_*.mojo` glob auto-discovers `_part1` and `_part2` files — no CI changes needed
+- `validate_test_coverage.py` had no explicit list entry for this file — no changes needed
+- Simpler than #3607 (no validate_test_coverage.py exclusion list update needed)
+- Split: 8 tests in part1 (at target), 4 tests in part2 (well under limit)
 
-- 9 files, all ≤9 tests each
-- 59 total test functions preserved
-- CI glob testing/test_*.mojo covers new files automatically
-- PR #4094 created, auto-merge enabled
+## Failed Attempts
 
-## Key Insight
+None — first approach worked cleanly.
 
-The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
-grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3399)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3399-auto-impl
+- **Issue**: #3399 — fix(ci): split test_elementwise_dispatch.mojo (47 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4106
+
+## Problem
+
+`tests/shared/core/test_elementwise_dispatch.mojo` had 47 `fn test_` functions.
+ADR-009 mandates ≤10 per file to avoid Mojo v0.26.1 heap corruption from
+`libKGENCompilerRTShared.so` JIT faults under high test load.
+
+CI failure rate: 13/20 recent runs on main, rotating across groups (load-dependent).
+
+## Approach Taken
+
+1. Read original 47-test file end-to-end
+2. Identified logical groupings (unary ops by type, binary ops by type, edge cases)
+3. Created 6 split files of ≤8 tests each (target below the 10 limit for headroom)
+4. Each file: full import block + required ADR-009 header comment + own `main()`
+5. Custom structs (DoubleOp, IncrementOp, AverageOp) duplicated in files that need them
+6. Deleted original file
+7. Updated comprehensive-tests.yml pattern from old filename to 6 new filenames
+8. All pre-commit hooks passed on first attempt
+
+## Files Changed
+
+- DELETED: `tests/shared/core/test_elementwise_dispatch.mojo`
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part1.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part2.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part3.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part4.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part5.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_elementwise_dispatch_part6.mojo` (7 tests)
+- MODIFIED: `.github/workflows/comprehensive-tests.yml`
+
+## Key Technical Observations
+
+- Mojo test files cannot import from each other — each split file is fully self-contained
+- The CI `pattern:` field takes space-separated literal filenames (no glob support)
+- `validate_test_coverage.py` did not need updating (it passed automatically)
+- Pre-commit hooks include a "Validate Test Coverage" step that auto-passed
+- The `mojo format` hook took ~4 minutes for 6 new Mojo files
+
+## Time Breakdown
+
+- Reading/analyzing original file: ~1 min
+- Creating 6 split files: ~3 min
+- Updating CI workflow: ~1 min
+- Waiting for pre-commit (mojo format): ~4 min
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3429)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3429-auto-impl
+- **Issue**: #3429 — fix(ci): split test_activation_funcs.mojo (24 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4209
+
+## Problem
+
+`tests/shared/core/test_activation_funcs.mojo` had 24 `fn test_` functions (limit: 10, target: ≤8),
+causing intermittent heap corruption in the `Core Activations & Types` CI group.
+
+CI failure rate: 13/20 recent runs on main.
+
+## Approach Taken
+
+1. Read original 24-test file end-to-end
+2. Distributed into 3 logical groups (ReLU+Sigmoid, Tanh+Softmax-basic, Softmax-axis+Integration)
+3. Created 3 split files with ADR-009 header comment and full import blocks
+4. Deleted original file
+5. Updated `comprehensive-tests.yml` — the `Core Activations & Types` group uses an explicit
+   file list (not a glob), so `test_activation_funcs.mojo` had to be replaced with 3 new names
+6. All pre-commit hooks passed on first attempt
+
+## Files Changed
+
+- DELETED: `tests/shared/core/test_activation_funcs.mojo`
+- CREATED: `tests/shared/core/test_activation_funcs_part1.mojo` (9 tests: ReLU + Sigmoid)
+- CREATED: `tests/shared/core/test_activation_funcs_part2.mojo` (8 tests: Tanh + Softmax basic)
+- CREATED: `tests/shared/core/test_activation_funcs_part3.mojo` (7 tests: Softmax axis + Integration)
+- MODIFIED: `.github/workflows/comprehensive-tests.yml`
+
+## Key Difference vs Issue #3399
+
+Issue #3399 split a file in a CI group that used a glob (`test_*.mojo`), so new files were
+auto-discovered. Issue #3429's `Core Activations & Types` group used a space-separated explicit
+file list — new files are invisible to CI until the list is updated manually.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3432)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3432-auto-impl
+- **Issue**: #3432 — fix(ci): split test_logging.mojo (22 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4215
+
+## Problem
+
+`tests/shared/utils/test_logging.mojo` had 22 `fn test_` functions, causing intermittent
+heap corruption crashes (`libKGENCompilerRTShared.so`) in Mojo v0.26.1 CI.
+CI failure rate: 13/20 recent runs on `main` in the `Shared Infra` group.
+
+## Approach Taken
+
+1. Read original 22-test file end-to-end
+2. Grouped into 3 logical categories (log levels+formatters+console / file+multi+training / config+error+integration)
+3. Created 3 split files with ADR-009 header comment and full import blocks
+4. Deleted original file
+5. Checked `comprehensive-tests.yml` — the `Shared Infra` group uses `utils/test_*.mojo` glob,
+   so new `_part1/2/3` files are auto-discovered. No CI matrix changes needed.
+6. All pre-commit hooks passed on first attempt
+
+## Files Changed
+
+- DELETED: `tests/shared/utils/test_logging.mojo`
+- CREATED: `tests/shared/utils/test_logging_part1.mojo` (8 tests: log levels, formatters, console handler)
+- CREATED: `tests/shared/utils/test_logging_part2.mojo` (7 tests: file handler, multi-handler, training logging)
+- CREATED: `tests/shared/utils/test_logging_part3.mojo` (7 tests: logger config/factory, error handling, integration)
+- MODIFIED: `.github/workflows/comprehensive-tests.yml` (comment update only)
+
+## Key Technical Observations
+
+- `utils/test_*.mojo` is a glob pattern — new files with `_partN` suffix auto-discovered
+- `validate_test_coverage.py` uses `Path.rglob("test_*.mojo")` — also auto-covered
+- No CI matrix changes needed when the group uses glob-based pattern
+
+## What Failed
+
+Nothing. Approach was straightforward on first attempt. Pre-commit hooks passed immediately.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3435)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3435-auto-impl
+- **Issue**: #3435 — fix(ci): split test_arithmetic_backward.mojo (23 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4220
+
+## Problem
+
+`tests/shared/core/test_arithmetic_backward.mojo` had 23 `fn test_` functions, causing
+intermittent heap corruption in the `Core Tensors` CI group (13/20 recent runs failing).
+
+## Approach Taken
+
+1. Read original 23-test file end-to-end
+2. Grouped into 3 logical categories:
+   - Part 1 (8): element-wise + scalar backward ops (add/subtract/multiply/divide, tests 1–8)
+   - Part 2 (8): broadcasting tests + numerical gradient checking for A operand (tests 9–16)
+   - Part 3 (7): numerical gradient checking for B operand + broadcast grad checks (tests 17–23)
+3. Created 3 split files with ADR-009 header comment and full import blocks
+4. Deleted original file entirely
+5. Updated `comprehensive-tests.yml` — `Core Tensors` group uses explicit filename list;
+   replaced `test_arithmetic_backward.mojo` with the three new filenames
+6. All pre-commit hooks passed on first attempt
+
+## Files Changed
+
+- DELETED: `tests/shared/core/test_arithmetic_backward.mojo`
+- CREATED: `tests/shared/core/test_arithmetic_backward_part1.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_arithmetic_backward_part2.mojo` (8 tests)
+- CREATED: `tests/shared/core/test_arithmetic_backward_part3.mojo` (7 tests)
+- MODIFIED: `.github/workflows/comprehensive-tests.yml`
+
+## Key Technical Observations
+
+- This is the 4th application of this pattern; the explicit-vs-glob distinction was recognized immediately
+- ADR-009 header comment placed at very top of file (before docstring) — consistent with other splits
+- `validate_test_coverage.py` did not require changes (uses `Path.rglob("test_*.mojo")`)
+
+## What Failed
+
+Nothing. Pattern well-established by this point. Pre-commit hooks passed on first attempt.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3455)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3455-auto-impl
+- **Issue**: #3455 — fix(ci): split test_mobilenetv1_layers.mojo (19 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4276
+
+## Problem
+
+`tests/models/test_mobilenetv1_layers.mojo` had 19 `fn test_` functions across 6 categories
+(depthwise conv, pointwise conv, separable blocks, batchnorm, relu, pooling + channel configs),
+exceeding ADR-009 limit of ≤10 per file.
+
+## Approach Taken
+
+1. Read original 19-test file end-to-end
+2. Checked CI workflow — `Models` group uses `test_*_layers.mojo` glob pattern
+3. New files named `_part1/2/3` match this glob automatically
+4. Created 3 split files with ADR-009 header comment and full import blocks
+5. Deleted original file
+6. No CI workflow changes needed
+7. All pre-commit hooks passed on first attempt
+
+## Files Changed
+
+- DELETED: `tests/models/test_mobilenetv1_layers.mojo`
+- CREATED: `tests/models/test_mobilenetv1_layers_part1.mojo` (7 tests: depthwise + pointwise conv)
+- CREATED: `tests/models/test_mobilenetv1_layers_part2.mojo` (7 tests: separable blocks + BatchNorm + ReLU)
+- CREATED: `tests/models/test_mobilenetv1_layers_part3.mojo` (5 tests: global avgpool + channel configs)
+
+## Key Technical Observations
+
+- `test_*_layers.mojo` glob in the `Models` CI group auto-discovers `_partN` files
+- `validate_test_coverage.py` uses glob patterns — auto-discovers split files without changes
+- This is the 5th application of the pattern; glob vs explicit check is now the first step
+
+## What Failed
+
+Nothing. Approach was straightforward on first attempt. Pre-commit hooks passed immediately.
+
+---
+
+# Session #3458: test_googlenet_layers.mojo
+
+- **Issue**: #3458
+- **PR**: #4279
+- **Original**: 18 tests → 3 parts (8+6+4)
+- **Key finding**: `test_*_layers.mojo` glob does NOT match `test_googlenet_layers_part1.mojo` — explicit CI update required
+- **validate_test_coverage.py**: Caught uncovered part files, confirmed CI update was needed
+- **Pre-commit hooks**: All passed on first attempt
+
+---
+
+# Session #3462: test_advanced_activations.mojo
+
+- **Issue**: #3462
+- **PR**: #4288
+- **Original**: 17 tests → 3 parts (4+8+5)
+- **Split**: Part1=Swish/SiLU (4), Part2=Mish+ELU forward (8), Part3=ELU backward (5)
+- **CI group**: `Core Activations & Types` uses explicit space-separated filename list
+- **Workflow update**: Required — replaced `test_advanced_activations.mojo` with 3 new filenames
+- **Pre-commit hooks**: All passed on first attempt (mojo format, validate_test_coverage, YAML)
+- **Key note**: Targeting ≤8 tests per file (not just ≤10) provides a safety margin
+
+---
+
+# Session #3490: test_linear.mojo
+
+- **Issue**: #3490
+- **PR**: #4352
+- **Date**: 2026-03-08
+- **Original**: `tests/shared/core/test_linear.mojo` — 14 tests → 2 parts (8+6)
+
+## Tests in the original file
+
+1. test_linear_forward_basic
+2. test_linear_forward_batch
+3. test_linear_forward_no_bias
+4. test_linear_forward_single_feature
+5. test_linear_backward_gradients
+6. test_linear_backward_no_bias
+7. test_linear_weight_init
+8. test_linear_bias_init
+9. test_linear_backward_multi_sample
+10. test_linear_backward_accumulate_gradients
+11. test_linear_integration_forward_backward
+12. test_linear_integration_parameter_update
+13. test_linear_edge_case_single_sample
+14. test_linear_numerical_gradient_check
+
+## Split Decision
+
+- Part 1 (8 tests): tests 1–8 (forward pass + basic backward/init)
+- Part 2 (6 tests): tests 9–14 (backward multi-sample + integration + edge cases)
+- Grouping rationale: forward-facing tests first, then more complex backward/integration tests
+
+## CI Pattern Discovery
+
+The issue title mentioned "Core NN Modules" as the CI group, but the actual group was
+"Core Utilities". Found by running: `grep -r "test_linear.mojo" .github/workflows/`
+
+The "Core Utilities" group uses an explicit space-separated filename list — not a glob.
+Both the old filename removal and new filename insertion were required in the YAML.
+
+## Gotchas
+
+1. `gh pr create --label "fix"` failed — label "fix" doesn't exist in ProjectOdyssey.
+   Omit `--label` or run `gh label list` first to see available labels.
+2. Issue description said wrong CI group name. Always grep the actual workflow.
+3. `validate_test_coverage.py` runs in pre-commit — catches uncovered files automatically,
+   confirming that the CI update must be done before committing the new split files.
+
+## Pre-commit hooks
+
+All passed on first attempt: mojo format, YAML check, validate_test_coverage.py.
+
+---
+
+# Session #3607: test_mixed_precision.mojo
+
+- **Issue**: #3607
+- **PR**: #4402
+- **Date**: 2026-03-08
+- **Original**: `tests/shared/training/test_mixed_precision.mojo` — 13 tests → 2 parts (8+5)
+
+## Problem
+
+`tests/shared/training/test_mixed_precision.mojo` had 13 `fn test_` functions, exceeding the
+ADR-009 limit of 10. This caused intermittent heap corruption in the Shared Infra CI group.
+
+## Split Decision
+
+- Part 1 (8 tests): GradientScaler tests — init, loss scaling, gradient unscaling,
+  step updates, backoff, min/max limits, FP32 master conversion, model update from master
+- Part 2 (5 tests): Gradient checking — finite check (FP32), finite check (FP16),
+  clip by value, clip by norm, FP16 operations
+
+## CI Pattern Discovery
+
+The "Shared Infra & Testing" CI group in `.github/workflows/comprehensive-tests.yml` uses:
+
+```yaml
+pattern: "... training/test_*.mojo ..."
+```
+
+The `training/test_*.mojo` wildcard auto-discovers all `test_*.mojo` files under
+`tests/shared/training/`, so no workflow changes were needed.
+
+## validate_test_coverage.py Update Required
+
+Unlike previous splits where `validate_test_coverage.py` auto-discovered new files via glob,
+this file required an explicit exclusion list update. The training group in `validate_test_coverage.py`
+maintains an explicit list of training test files. Replaced `test_mixed_precision.mojo` with
+`test_mixed_precision_part1.mojo` and `test_mixed_precision_part2.mojo`.
+
+Key lesson: Always check whether the affected test group has an exclusion list in
+`validate_test_coverage.py` — not just whether the CI workflow uses a glob.
+
+## Files Changed
+
+- DELETED: `tests/shared/training/test_mixed_precision.mojo`
+- CREATED: `tests/shared/training/test_mixed_precision_part1.mojo` (8 tests)
+- CREATED: `tests/shared/training/test_mixed_precision_part2.mojo` (5 tests)
+- MODIFIED: `scripts/validate_test_coverage.py` (exclusion list update)
+
+## Failed Attempts
+
+None — the approach was straightforward once the files and CI patterns were understood.
+
+## Pre-commit hooks
+
+All passed on first attempt: mojo format, validate_test_coverage, mypy, ruff, bandit.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr009-test-file-splitting
-description: "Workflow for splitting Mojo test files that exceed ADR-009 ≤10 fn test_ limit. Use when: CI has heap corruption failures, a test file has >10 fn test_ functions, or Testing Fixtures CI group fails intermittently."
+description: "Split large Mojo test files into ≤10 fn test_ per file to fix heap corruption CI crashes. Use when: Mojo test file exceeds 10 fn test_ functions, CI shows intermittent libKGENCompilerRTShared.so crashes."
 category: ci-cd
 date: 2026-03-07
 user-invocable: false
@@ -8,120 +8,212 @@ user-invocable: false
 
 ## Overview
 
-| Field | Value |
-|-------|-------|
-| Category | ci-cd |
-| Complexity | Low |
-| Risk | Low |
-| Time | ~30 minutes |
-
-Splits Mojo test files that exceed ADR-009's ≤10 `fn test_` hard limit and ≤8 target per file,
-to prevent Mojo v0.26.1 heap corruption (`libKGENCompilerRTShared.so` JIT fault) in CI.
+| Attribute | Value |
+|-----------|-------|
+| **Problem** | Mojo v0.26.1 heap corruption when a single test file has too many `fn test_` functions |
+| **Symptom** | Intermittent CI failures: `libKGENCompilerRTShared.so` JIT fault |
+| **Fix** | Split file into multiple files with ≤10 (target ≤8) `fn test_` each |
+| **ADR** | ADR-009: Heap Corruption Workaround |
+| **CI failure rate** | 13/20 runs non-deterministically across groups |
 
 ## When to Use
 
-- A Mojo test file has more than 10 `fn test_` functions
-- CI Testing Fixtures group fails intermittently (13/20 runs is a strong signal)
-- A new large test file is being added that would exceed the limit
-- ADR-009 compliance check fails in PR review
+Trigger this skill when:
+
+1. A Mojo test file has more than 10 `fn test_` functions
+2. CI shows intermittent crashes with `libKGENCompilerRTShared.so` in the stack
+3. A CI group fails non-deterministically — not always the same test, just the same group
+4. A new large test file is being added with 10+ tests
+
+**CI Pattern note**: Some CI groups use a glob (`test_*.mojo`) that auto-discovers `_partN` files.
+Others use explicit space-separated filenames that must be updated manually. Always check which
+pattern applies before assuming no CI changes are needed.
 
 ## Verified Workflow
 
-### 1. Audit existing split state
-
-Check if splitting has already started before creating new files:
+### Step 1 — Count tests in the file
 
 ```bash
-# Count actual test functions (use [a-z] to avoid matching comments)
-grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
-
-# Check for stale deprecated artifacts
-ls tests/shared/testing/*.DEPRECATED 2>/dev/null
+grep -c "^fn test_" tests/path/to/test_file.mojo
 ```
 
-### 2. Identify over-limit files
+If count > 10, proceed. Target ≤8 per split file for headroom.
 
-Files with >10 tests violate ADR-009 hard limit. Files with >8 tests exceed the target.
-Target: ≤8 per file (buffer below the 10-test limit that triggers heap corruption).
+### Step 2 — Plan the split
 
-### 3. Group tests logically for split files
+Divide tests into logical groups (by operation category, not alphabetically).
+For N tests, use `ceil(N / 8)` files. Example: 47 tests → 6 files (8+8+8+8+8+7).
 
-Move tests that form a coherent group (e.g., `assert_equal_int` tests from a float file,
-`assert_type` tests from a tensor_values file). Prefer semantic groupings over arbitrary splits.
+### Step 3 — Create split files with ADR-009 header
 
-### 4. Create new split file with ADR-009 header
-
-Each new file must include the ADR-009 comment:
+Each split file **must** include this header comment:
 
 ```mojo
-"""Tests for <description>.
-
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
-# high test load. Split from test_assertions.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-
-Note: Split from <original_file>.mojo to satisfy ADR-009 ≤8 fn test_ target per file.
-"""
+# high test load. Split from <original_filename>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 ```
 
-### 5. Update source file
+Naming convention: `test_<original>_part1.mojo`, `test_<original>_part2.mojo`, etc.
 
-Remove moved tests from the source file:
+### Step 4 — Copy imports and shared structs to each split file
 
-- Remove the `fn test_` function definitions
-- Remove moved functions from the `main()` call list
-- Remove now-unused imports
+Each split file needs its own full import block. Custom structs/ops used across parts
+must be duplicated in each file that uses them (Mojo has no shared module within a test).
 
-### 6. Delete stale artifacts
+### Step 5 — Each split file needs its own `main()` runner
+
+```mojo
+fn main() raises:
+    """Run <original> tests - Part N."""
+    test_function_1()
+    test_function_2()
+    # ... only the tests in THIS file
+```
+
+### Step 6 — Delete the original file
 
 ```bash
-git rm tests/shared/testing/test_assertions.mojo.DEPRECATED
+rm tests/path/to/test_original.mojo
 ```
 
-### 7. Verify counts and CI coverage
+### Step 7 — Update CI workflow pattern
+
+First check whether the CI group uses a glob or explicit filenames:
 
 ```bash
-# Verify no file exceeds 10 (count actual functions, not comments)
-grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
-
-# CI glob auto-picks up new files if named test_*.mojo in the right directory
-# No workflow changes needed for testing/test_*.mojo glob pattern
+grep -A5 "<test-group-name>" .github/workflows/comprehensive-tests.yml
 ```
 
-### 8. Commit and push
+**If glob** (e.g., `test_*.mojo`): new `_partN` files are discovered automatically. No changes needed.
 
-All pre-commit hooks must pass (mojo format, test coverage validation).
+**If explicit filenames**: replace the old filename with all new filenames:
+
+```yaml
+# Before:
+pattern: "... test_original.mojo ..."
+
+# After:
+pattern: "... test_original_part1.mojo test_original_part2.mojo test_original_part3.mojo ..."
+```
+
+### Step 8 — Verify and commit
+
+```bash
+# Check no file exceeds 10 tests
+for f in tests/path/to/test_original_part*.mojo; do
+  count=$(grep -c "^fn test_" "$f")
+  echo "$f: $count tests"
+done
+
+git add tests/path/to/test_original_part*.mojo tests/path/to/test_original.mojo
+git add .github/workflows/comprehensive-tests.yml
+git commit -m "fix(ci): split test_original.mojo into N files (ADR-009)"
+```
+
+## Results & Parameters
+
+### Session Results (Issue #3399)
+
+- **Original file**: `tests/shared/core/test_elementwise_dispatch.mojo` — 47 tests
+- **Split into**: 6 files of 8/8/8/8/8/7 tests
+- **All pre-commit hooks**: Passed (mojo format, deprecated syntax check, validate test coverage, YAML)
+- **PR**: #4106
+
+### Session Results (Issue #3429)
+
+- **Original file**: `tests/shared/core/test_activation_funcs.mojo` — 24 tests
+- **Split into**: 3 files of 9/8/7 tests (ReLU+Sigmoid / Tanh+Softmax basic / Softmax axis+Integration)
+- **All pre-commit hooks**: Passed
+- **PR**: #4209
+
+### Session Results (Issue #3432)
+
+- **Original file**: `tests/shared/utils/test_logging.mojo` — 22 tests
+- **Split into**: 3 files of 8/7/7 tests (log levels+formatters+console / file+multi+training / config+error+integration)
+- **CI pattern**: `utils/test_*.mojo` glob — new files auto-discovered, no CI changes needed
+- **Coverage script**: `validate_test_coverage.py` uses `Path.rglob("test_*.mojo")` — also auto-covered
+- **All pre-commit hooks**: Passed on first attempt
+- **PR**: #4215
+
+### Session Results (Issue #3455)
+
+- **Original file**: `tests/models/test_mobilenetv1_layers.mojo` — 19 tests
+- **Split into**: 3 files of 7/7/5 tests (depthwise+pointwise conv / separable+BatchNorm+ReLU / avgpool+channel configs)
+- **CI pattern**: `test_*_layers.mojo` glob in `Models` group — `_part1/2/3` files auto-discovered, no CI changes needed
+- **validate_test_coverage.py**: No changes needed (auto-discovers split files via glob)
+- **All pre-commit hooks**: Passed on first attempt
+- **PR**: #4276
+
+### Session Results (Issue #3458)
+
+- **Original file**: `tests/models/test_googlenet_layers.mojo` — 18 tests
+- **Split into**: 3 files of 8/6/4 tests (inception module+branches / concat+avgpool+FC / backward passes)
+- **CI pattern**: `test_*_layers.mojo` glob in `Models` group does NOT match `test_googlenet_layers_part1.mojo` — explicit CI update required
+- **validate_test_coverage.py**: Flagged part files as uncovered until CI pattern was updated
+- **All pre-commit hooks**: Passed on first attempt
+- **PR**: #4279
+
+### Session Results (Issue #3607)
+
+- **Original file**: `tests/shared/training/test_mixed_precision.mojo` — 13 tests
+- **Split into**: 2 files of 8/5 tests (GradientScaler tests / gradient checking + clipping)
+- **CI pattern**: `training/test_*.mojo` glob in `Shared Infra` group — new files auto-discovered, no CI changes needed
+- **validate_test_coverage.py**: Exclusion list update required — replaced `test_mixed_precision.mojo` with `test_mixed_precision_part1.mojo` and `test_mixed_precision_part2.mojo`
+- **All pre-commit hooks**: Passed on first attempt (mojo format, validate_test_coverage, mypy, ruff, bandit)
+- **PR**: #4402
+
+### Session Results (Issue #3623)
+
+- **Original file**: `tests/shared/training/test_gradient_ops.mojo` — 12 tests
+- **Split into**: 2 files of 8/4 tests (accumulate + scale operations / zero operations + workflow)
+- **CI pattern**: `training/test_*.mojo` glob in `Shared Infra` group — new files auto-discovered, no CI changes needed
+- **validate_test_coverage.py**: No changes needed — no explicit reference to original filename
+- **All pre-commit hooks**: Passed on first attempt (mojo format, validate_test_coverage, YAML)
+- **PR**: #4412
+
+### Key Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Max tests per file (ADR-009 limit) | 10 |
+| Target tests per file (headroom) | ≤8 |
+| Naming convention | `test_<original>_partN.mojo` |
+| Header comment | ADR-009 tracking comment (required) |
+| CI workflow key | `pattern:` field in test group (glob or explicit) |
+
+### Grouping Strategy
+
+Group tests by **logical category** (operation type), not alphabetically:
+
+- Part 1: First set of unary ops (ExpOp, LogOp, SqrtOp, SinOp, CosOp)
+- Part 2: Next set of unary ops (TanhOp, AbsOp, NegateOp, SquareOp, SignOp)
+- Part 3: Custom unary + first binary ops (AddOp, SubtractOp, MultiplyOp, DivideOp, PowerOp)
+- Part 4: More binary ops (MaxOp, MinOp, comparison ops)
+- Part 5: Logical ops, custom binary, dtype preservation
+- Part 6: Error cases, 2D tensors, edge cases
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
-| Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
-
-## Results & Parameters
-
-**ADR-009 limits:**
-
-- Hard limit: ≤10 `fn test_` per file (heap corruption threshold)
-- Target: ≤8 per file (safety buffer)
-
-**CI glob pattern** (no changes needed for new files with `test_` prefix):
-
-```yaml
-pattern: "testing/test_*.mojo"
-```
-
-**Grep pattern for accurate count:**
-
-```bash
-grep -c "^fn test_[a-z]" <file>.mojo
-```
+| Share struct definitions via import | Tried to import `DoubleOp` from part1 in part3 | Mojo test files don't export symbols to other test files | Duplicate custom structs in each split file that needs them |
+| Single combined CI pattern glob | Tried `test_elementwise_dispatch_part*.mojo` wildcard | `comprehensive-tests.yml` `pattern:` field uses space-separated literal names for explicit-list groups | List all filenames explicitly when the group uses explicit filenames |
+| Keep original file + add split files | Considered keeping original for backwards compat | Would re-introduce the heap corruption bug | Delete original; replace completely |
+| Assuming glob pattern for all CI groups | Did not check CI pattern type first | Some groups use explicit filenames, some use glob | Always check CI pattern type before deciding if workflow update is needed |
+| Trusting issue description for CI group name | Issue said "Core NN Modules" | Actual CI group was "Core Utilities" — different name | Always grep the actual workflow: `grep -r "test_filename" .github/` |
+| Using label in PR creation | `gh pr create --label "fix"` | Label "fix" didn't exist in the repo | Check `gh label list` first or omit `--label` |
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
-
-**Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942
+| ProjectOdyssey | Issue #3399, PR #4106 | Split test_elementwise_dispatch.mojo (47 → 6 files) |
+| ProjectOdyssey | Issue #3429, PR #4209 | Split test_activation_funcs.mojo (24 → 3 files), explicit CI update needed |
+| ProjectOdyssey | Issue #3432, PR #4215 | Split test_logging.mojo (22 → 3 files), glob CI pattern auto-covered |
+| ProjectOdyssey | Issue #3435, PR #4220 | Split test_arithmetic_backward.mojo (23 → 3 files), explicit CI pattern update |
+| ProjectOdyssey | Issue #3455, PR #4276 | Split test_mobilenetv1_layers.mojo (19 → 3 files), glob CI pattern auto-covered |
+| ProjectOdyssey | Issue #3458, PR #4279 | Split test_googlenet_layers.mojo (18 → 3 files, 8+6+4), explicit CI pattern update required |
+| ProjectOdyssey | Issue #3490, PR #4352 | Split test_linear.mojo (14 → 2 files, 8+6), explicit CI list; issue named wrong CI group |
+| ProjectOdyssey | Issue #3607, PR #4402 | Split test_mixed_precision.mojo (13 → 2 files, 8+5), glob CI auto-discovered; validate_test_coverage.py exclusion list update required |
+| ProjectOdyssey | Issue #3623, PR #4412 | Split test_gradient_ops.mojo (12 → 2 files, 8+4), glob CI auto-discovered; no validate_test_coverage.py changes needed |


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill (v1.2.0) with learnings from Issue #3623
(ProjectOdyssey): split `test_gradient_ops.mojo` (12 tests) into 2 files per ADR-009.

**New in this update (Issue #3623)**:
- Documents the training/ glob case for a complete file deletion + split
- Confirms `validate_test_coverage.py` does not always need exclusion list updates
  (contrast with #3607 which did require it)
- Adds Issue #3623 to Verified On table and Session Results
- Bumps version to 1.2.0

**Previous sessions** (already in skill):
- Issue #3399: split test_elementwise_dispatch.mojo (47 → 6 files)
- Issue #3429: split test_activation_funcs.mojo (24 → 3 files)
- Issue #3432: split test_logging.mojo (22 → 3 files)
- Issue #3435: split test_arithmetic_backward.mojo (23 → 3 files)
- Issue #3455: split test_mobilenetv1_layers.mojo (19 → 3 files)
- Issue #3458: split test_googlenet_layers.mojo (18 → 3 files)
- Issue #3490: split test_linear.mojo (14 → 2 files)
- Issue #3607: split test_mixed_precision.mojo (13 → 2 files)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — PASSED (529/529)
- [x] New session notes added to references/notes.md
- [x] Verified On table updated with Issue #3623, PR #4412

🤖 Generated with [Claude Code](https://claude.com/claude-code)