### PR TITLE
feat: update adr009-test-file-splitting skill with new learnings

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,65 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3464)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_optimizers.mojo (16 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI
+(Shared Infra group, 13/20 recent run failures). ADR-009 mandates ≤10 fn test_ per file.
+
+## Actions Taken
+
+1. Read test_optimizers.mojo — confirmed 16 `fn test_` functions
+2. Verified CI workflow: `training/test_*.mojo` glob pattern, no workflow changes needed
+3. Confirmed `validate_test_coverage.py` references the original filename in excluded list
+4. Created test_optimizers_part1.mojo (8 tests): SGD (6 tests) + Adam init/update (2 tests)
+5. Created test_optimizers_part2.mojo (8 tests): Adam bias correction + AdamW + RMSprop +
+   property tests + PyTorch numerical validation
+6. Each file: ADR-009 `#` comment block at file top (above docstring)
+7. Deleted original test_optimizers.mojo
+8. Updated validate_test_coverage.py: replaced single entry with 2 new filenames
+9. All pre-commit hooks passed (mojo format, mypy, ruff, validate_test_coverage)
+10. PR #4291 created, auto-merge enabled
+
+## Final State
+
+- 2 files (part1, part2), each with exactly 8 tests
+- 16 total test functions preserved (all original tests present)
+- CI glob training/test_*.mojo covers new files automatically
+- No workflow changes needed
+
+## Key New Insight: ADR-009 Comment Placement
+
+The ADR-009 header comment **must be placed at the top of the file** using `#` comment syntax,
+NOT inside the module docstring (`"""..."""`). Mojo does not support `#` comments inside string
+literals.
+
+**Correct:**
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# ...
+"""Module docstring."""
+```
+
+**Wrong:**
+
+```mojo
+"""
+# ADR-009: ...  ← # is not a comment inside a string literal in Mojo
+"""
+```
+
+## Key New Insight: validate_test_coverage.py
+
+When the original file appears in the excluded files list in `scripts/validate_test_coverage.py`,
+both new split filenames must be added and the original removed, or the pre-commit
+`Validate Test Coverage` hook will fail with a "file not found" error.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr009-test-file-splitting
-description: "Workflow for splitting Mojo test files that exceed ADR-009 ≤10 fn test_ limit. Use when: CI has heap corruption failures, a test file has >10 fn test_ functions, or Testing Fixtures CI group fails intermittently."
+description: "Workflow for splitting Mojo test files that exceed ADR-009 ≤10 fn test_ limit. Use when: CI has heap corruption failures, a test file has >10 fn test_ functions, or a CI test group fails intermittently."
 category: ci-cd
 date: 2026-03-07
 user-invocable: false
@@ -21,7 +21,7 @@ to prevent Mojo v0.26.1 heap corruption (`libKGENCompilerRTShared.so` JIT fault)
 ## When to Use
 
 - A Mojo test file has more than 10 `fn test_` functions
-- CI Testing Fixtures group fails intermittently (13/20 runs is a strong signal)
+- A CI test group fails intermittently (13/20 runs is a strong signal)
 - A new large test file is being added that would exceed the limit
 - ADR-009 compliance check fails in PR review
 
@@ -33,10 +33,10 @@ Check if splitting has already started before creating new files:
 
 ```bash
 # Count actual test functions (use [a-z] to avoid matching comments)
-grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
+grep -c "^fn test_[a-z]" tests/shared/training/test_optimizers*.mojo
 
 # Check for stale deprecated artifacts
-ls tests/shared/testing/*.DEPRECATED 2>/dev/null
+ls tests/shared/training/*.DEPRECATED 2>/dev/null
 ```
 
 ### 2. Identify over-limit files
@@ -46,51 +46,58 @@ Target: ≤8 per file (buffer below the 10-test limit that triggers heap corrupt
 
 ### 3. Group tests logically for split files
 
-Move tests that form a coherent group (e.g., `assert_equal_int` tests from a float file,
-`assert_type` tests from a tensor_values file). Prefer semantic groupings over arbitrary splits.
+Group tests by optimizer/topic (e.g., SGD + Adam basics in part1, advanced Adam + RMSprop + PyTorch
+validation in part2). Prefer semantic groupings over arbitrary splits.
 
-### 4. Create new split file with ADR-009 header
+### 4. Create new split files with ADR-009 header
 
-Each new file must include the ADR-009 comment:
+Place the ADR-009 comment at the **top of the file** (before the docstring), not inside it:
 
 ```mojo
-"""Tests for <description>.
-
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
-# high test load. Split from test_assertions.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+# high test load. Split from test_optimizers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Module docstring describing what tests this file contains.
 
-Note: Split from <original_file>.mojo to satisfy ADR-009 ≤8 fn test_ target per file.
+Split from <original_file>.mojo per ADR-009 to avoid Mojo heap corruption.
 """
 ```
 
-### 5. Update source file
-
-Remove moved tests from the source file:
-
-- Remove the `fn test_` function definitions
-- Remove moved functions from the `main()` call list
-- Remove now-unused imports
-
-### 6. Delete stale artifacts
+### 5. Delete the original file
 
 ```bash
-git rm tests/shared/testing/test_assertions.mojo.DEPRECATED
+rm tests/shared/training/test_optimizers.mojo
+# Then stage the deletion
+git add tests/shared/training/test_optimizers.mojo
+```
+
+### 6. Update validate_test_coverage.py if needed
+
+If the original file was in an excluded list in `scripts/validate_test_coverage.py`,
+replace it with both new filenames:
+
+```python
+# Before:
+"tests/shared/training/test_optimizers.mojo",
+
+# After:
+"tests/shared/training/test_optimizers_part1.mojo",
+"tests/shared/training/test_optimizers_part2.mojo",
 ```
 
 ### 7. Verify counts and CI coverage
 
 ```bash
 # Verify no file exceeds 10 (count actual functions, not comments)
-grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
+grep -c "^fn test_[a-z]" tests/shared/training/test_optimizers_part*.mojo
 
 # CI glob auto-picks up new files if named test_*.mojo in the right directory
-# No workflow changes needed for testing/test_*.mojo glob pattern
+# No workflow changes needed — the pattern training/test_*.mojo covers both new files
 ```
 
 ### 8. Commit and push
 
-All pre-commit hooks must pass (mojo format, test coverage validation).
+All pre-commit hooks must pass (mojo format, test coverage validation, mypy, ruff).
 
 ## Failed Attempts
 
@@ -98,6 +105,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Placing ADR-009 comment inside docstring | Added comment block inside `"""..."""` | Mojo syntax — `#` comments are not valid inside string literals | Place ADR-009 `#` comment block above the docstring at file top |
 
 ## Results & Parameters
 
@@ -109,7 +117,8 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 **CI glob pattern** (no changes needed for new files with `test_` prefix):
 
 ```yaml
-pattern: "testing/test_*.mojo"
+# Both training/test_*.mojo and testing/test_*.mojo patterns auto-cover new files
+pattern: "training/test_*.mojo testing/test_*.mojo"
 ```
 
 **Grep pattern for accurate count:**
@@ -118,10 +127,14 @@ pattern: "testing/test_*.mojo"
 grep -c "^fn test_[a-z]" <file>.mojo
 ```
 
+**validate_test_coverage.py:** Always check if the original file is referenced in excluded lists
+and replace with both new filenames.
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 | test_assertions split (testing/ directory) |
+| ProjectOdyssey | Issue #3464, PR #4291 | test_optimizers split (training/ directory) |
 
-**Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942
+**Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issues #2942, #3397, #3464


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with two new learnings from Issue #3464
(splitting `test_optimizers.mojo` from 16 tests into 2×8 files).

- ADR-009 `#` comment block must be at file top, NOT inside the module docstring
- `validate_test_coverage.py` excluded list must be updated when splitting files
- Adds second verified instance (Issue #3464, PR #4291) to the "Verified On" table

## Key Findings

**What Worked**:
- Semantic split by optimizer type (SGD+Adam basic vs Adam advanced+RMSprop+PyTorch validation)
- `training/test_*.mojo` CI glob automatically covers new files — no workflow changes needed
- Pre-commit `Validate Test Coverage` hook caught the missing update to `validate_test_coverage.py`

**What Failed / New Lessons**:
- Placing `#` ADR-009 comment inside `"""docstring"""` → invalid Mojo syntax; must be above it
- Not updating `validate_test_coverage.py` excluded list → pre-commit hook fails with "file not found"

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
