### PR TITLE
feat: update adr009-test-file-splitting skill with complete-replacement variant

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,57 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3403)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_generic_transforms.mojo (42 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI.
+ADR-009 mandates ≤10 fn test_ per file (target ≤8). CI Data Transforms group failed 13/20 recent runs.
+
+## Approach: Complete Replacement
+
+Unlike #3397 (partial split, source file kept), this used complete replacement:
+
+- All 42 tests moved out of the original file
+- Original file deleted (`git rm`)
+- 6 brand-new `_partN.mojo` files created
+
+## Split Distribution
+
+| File | Tests | Contents |
+|------|-------|----------|
+| test_generic_transforms_part1.mojo | 7 | Identity + Lambda |
+| test_generic_transforms_part2.mojo | 7 | Conditional + Clamp (first 3) |
+| test_generic_transforms_part3.mojo | 6 | Clamp (last 3) + Debug |
+| test_generic_transforms_part4.mojo | 7 | Type conversions + Sequential (first 3) |
+| test_generic_transforms_part5.mojo | 7 | Sequential (last 2) + Batch |
+| test_generic_transforms_part6.mojo | 8 | Integration + Edge cases |
+
+## Actions Taken
+
+1. Read source file to map all 42 tests across categories
+2. Planned logical groupings (Identity+Lambda, Conditional+Clamp, etc.)
+3. Created 6 new files, each with ADR-009 header comments BEFORE the docstring
+4. Deleted original with `git rm`
+5. Verified counts: `grep -c "^fn test_" <file>` for each part
+6. Confirmed CI glob `transforms/test_*.mojo` covers new files — no workflow changes needed
+7. All pre-commit hooks passed: mojo format, validate test coverage, etc.
+
+## Key Insight
+
+ADR-009 comment must be placed BEFORE the docstring (as `#` comments at file top), not inside
+the `"""..."""` docstring. The issue template showed it inside the docstring, which is incorrect.
+
+## Final State
+
+- 6 files, all ≤8 tests each (max: 8, min: 6)
+- 42 total test functions preserved
+- CI glob transforms/test_*.mojo covers new files automatically
+- PR #4122 created, auto-merge enabled

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -98,6 +98,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Placing ADR-009 header comment inside the docstring | Issue template showed header inside `"""..."""` | Comment style `# ADR-009:` cannot appear inside docstrings; must be outside | Place ADR-009 `#` comments before the docstring, at the top of the file |
 
 ## Results & Parameters
 
@@ -122,6 +123,20 @@ grep -c "^fn test_[a-z]" <file>.mojo
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 — partial split (9 files, kept source) | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3403, PR #4122 — complete replacement (42 tests → 6 files, source deleted) | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942
+
+## Variant: Complete Replacement (Delete Source File)
+
+When ALL tests must be moved out (no tests remaining in the original file), delete the source:
+
+```bash
+# Delete original instead of editing it
+git rm tests/shared/data/transforms/test_generic_transforms.mojo
+# Create 6 new files with all tests distributed
+```
+
+The CI glob pattern (`transforms/test_*.mojo`) automatically covers new `_partN.mojo` files — no
+workflow changes needed. This variant was used for `test_generic_transforms.mojo` (42 tests → 6 files).


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with learnings from Issue #3403 (PR #4122 in ProjectOdyssey).

- Documents the **complete-replacement variant**: delete source file + create N new files (vs. partial split in #3397)
- Adds new Failed Attempt: ADR-009 header comment placement (must be `#` comments before docstring, not inside it)
- Adds second entry to Verified On table
- Adds raw session notes for Issue #3403

## Key Findings

**What Worked**:
- Complete source deletion (`git rm`) + 6 new `_partN.mojo` files for 42-test file
- CI glob `transforms/test_*.mojo` auto-covers new files — no workflow changes needed
- Logical semantic groupings: Identity+Lambda, Conditional+Clamp, Debug, Type+Sequential, Batch, Integration+Edge

**What Was Clarified**:
- ADR-009 `#` comments must go BEFORE the `"""docstring"""`, not inside it
- Issue description may show incorrect placement — always use `#` prefix outside the string

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes
- [x] No new files created in incorrect locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)