### PR TITLE
feat(ci-cd): update adr009-test-file-splitting with second verified application

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,44 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3408)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_test_models.mojo (37 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI.
+ADR-009 mandates ≤10 fn test_ per file (target ≤8). CI failure rate was 13/20 recent runs.
+
+## Split Plan
+
+Distributed 37 tests across 5 new files by semantic grouping:
+
+- test_test_models_part1.mojo: 8 tests — SimpleCNN (4) + LinearModel (4)
+- test_test_models_part2.mojo: 6 tests — SimpleMLP init (2) + forward (4)
+- test_test_models_part3.mojo: 7 tests — SimpleMLP params/state_dict/zero_grad
+- test_test_models_part4.mojo: 8 tests — MockLayer (5) + SimpleLinearModel init/forward (3)
+- test_test_models_part5.mojo: 8 tests — SimpleLinearModel (2) + Parameter (2) + factory (2) + integration (2)
+
+## Actions Taken
+
+1. Read original test_test_models.mojo (37 fn test_ functions) to enumerate all tests
+2. Created 5 new part files with semantic groupings and ADR-009 headers
+3. Deleted test_test_models.mojo
+4. Verified no CI workflow changes needed — testing/test_*.mojo wildcard covers new files
+5. All pre-commit hooks passed (mojo format, validate test coverage, deprecated syntax)
+6. PR #4138 created, auto-merge enabled
+
+## Key Observations
+
+- The `testing/test_*.mojo` wildcard pattern in comprehensive-tests.yml automatically picks up
+  `test_test_models_part*.mojo` — no workflow edits needed
+- Semantic groupings (by model type) produce more maintainable split files than arbitrary splits
+- The ADR-009 header comment must go in the module docstring area, not as a standalone comment,
+  to avoid placement issues with mojo format
+- The `mojo-format` pre-commit hook places the ADR-009 comment correctly inside the docstring

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -122,6 +122,7 @@ grep -c "^fn test_[a-z]" <file>.mojo
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 | Splitting test_assertions.mojo (61 tests → 9 files) |
+| ProjectOdyssey | Issue #3408, PR #4138 | Splitting test_test_models.mojo (37 tests → 5 files) |
 
-**Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942
+**Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issues #2942, #3397, #3408


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with a second verified application of the pattern,
from ProjectOdyssey issue #3408 (splitting `test_test_models.mojo`, 37 tests → 5 files).

- Adds issue #3408 / PR #4138 to the Verified On table
- Appends session notes for the second application to references/notes.md
- New key learnings: semantic grouping strategy, wildcard CI coverage, docstring placement

## Key Findings

**What Worked**:
- Grouping tests by model type (SimpleCNN, LinearModel, SimpleMLP, MockLayer, etc.) produces semantically coherent split files
- The existing `testing/test_*.mojo` wildcard pattern in CI auto-covers `test_test_models_part*.mojo` — no workflow edits needed
- All pre-commit hooks (mojo format, validate test coverage) passed cleanly on first attempt

**What Failed**:
- N/A — clean execution following the existing skill workflow

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)