### PR TITLE
feat: add adr009-explicit-pattern-ci-update skill

### DIFF
--- a/skills/ci-cd/adr009-explicit-pattern-ci-update/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-explicit-pattern-ci-update/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-explicit-pattern-ci-update",
+  "version": "1.0.0",
+  "description": "Workflow for splitting Mojo test files (ADR-009) when the CI group uses an explicit filename list instead of a glob pattern. Use when: (1) splitting a test file in a CI group that lists filenames explicitly (not test_*.mojo glob), (2) Core Tensors or similar fixed-pattern CI groups fail intermittently with heap corruption, (3) the new split files won't be auto-discovered by the workflow.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["mojo", "adr-009", "heap-corruption", "ci", "test-split", "explicit-pattern", "workflow-update"]
+}

--- a/skills/ci-cd/adr009-explicit-pattern-ci-update/references/notes.md
+++ b/skills/ci-cd/adr009-explicit-pattern-ci-update/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: ADR-009 Explicit Pattern CI Update
+
+## Context
+
+- **Project**: ProjectOdyssey
+- **Issue**: #3415 — fix(ci): split test_reduction_forward.mojo (30 tests)
+- **PR**: #4159
+- **Date**: 2026-03-07
+- **Branch**: 3415-auto-impl
+
+## Objective
+
+Split `tests/shared/core/test_reduction_forward.mojo` (30 `fn test_` functions) into 4 files
+of ≤8 tests each to comply with ADR-009 and fix intermittent `Core Tensors` CI group failures
+caused by Mojo v0.26.1 heap corruption (`libKGENCompilerRTShared.so` JIT fault).
+
+## Files Created
+
+| File | Tests |
+|------|-------|
+| `test_reduction_forward_part1.mojo` | 8 (sum basics + mean basics) |
+| `test_reduction_forward_part2.mojo` | 8 (mean keepdims/dtype, max_reduce start, min_reduce start) |
+| `test_reduction_forward_part3.mojo` | 8 (min_reduce, axis-specific sum/mean) |
+| `test_reduction_forward_part4.mojo` | 6 (axis-specific mean/max/min, consistency) |
+
+Total: 30 tests preserved across 4 files (8+8+8+6=30).
+
+## Key Discovery
+
+The `Core Tensors` CI group in `.github/workflows/comprehensive-tests.yml` uses an explicit
+space-separated filename list, not a glob:
+
+```yaml
+pattern: "test_tensors.mojo test_arithmetic.mojo ... test_reduction_forward.mojo ..."
+```
+
+This required updating the workflow to replace `test_reduction_forward.mojo` with the 4 new
+part filenames. The existing `adr009-test-file-splitting` skill documents the glob case
+(where new files are auto-discovered), but not the explicit list case.
+
+## Workflow Update
+
+```yaml
+# Before
+pattern: "... test_reduction_forward.mojo ..."
+
+# After
+pattern: "... test_reduction_forward_part1.mojo test_reduction_forward_part2.mojo test_reduction_forward_part3.mojo test_reduction_forward_part4.mojo ..."
+```
+
+## Pre-Commit Hook Results
+
+All hooks passed on commit:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Check YAML: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed

--- a/skills/ci-cd/adr009-explicit-pattern-ci-update/skills/adr009-explicit-pattern-ci-update/SKILL.md
+++ b/skills/ci-cd/adr009-explicit-pattern-ci-update/skills/adr009-explicit-pattern-ci-update/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: adr009-explicit-pattern-ci-update
+description: "Workflow for ADR-009 test splits where CI uses explicit filename lists (not glob). Use when: CI group lists filenames explicitly, new split files won't be auto-discovered, Core Tensors or similar fixed-pattern groups fail with heap corruption."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Category | ci-cd |
+| Complexity | Low |
+| Risk | Low |
+| Time | ~20 minutes |
+
+Extends the `adr009-test-file-splitting` skill for the case where the CI workflow group uses an
+**explicit filename list** (not a `test_*.mojo` glob). In this case, creating split files is not
+sufficient — the workflow YAML must also be updated to reference the new filenames and remove the
+original.
+
+## When to Use
+
+- A Mojo test file in a CI group with an **explicit pattern** (e.g., `"test_a.mojo test_b.mojo"`) exceeds ADR-009 limit
+- Creating new `test_*_part1.mojo` files but they don't appear in CI runs
+- CI group like `Core Tensors` uses `pattern: "file1.mojo file2.mojo ..."` (space-separated list)
+- After splitting, the original filename is still in the workflow and new ones are missing
+
+## Verified Workflow
+
+### 1. Check the CI pattern type
+
+Before splitting, check whether the CI group uses a glob or explicit list:
+
+```yaml
+# Glob pattern — new files auto-discovered (no workflow update needed)
+pattern: "test_*.mojo"
+
+# Explicit list — MUST update workflow after splitting
+pattern: "test_tensors.mojo test_arithmetic.mojo test_reduction_forward.mojo ..."
+```
+
+### 2. Split the test file per ADR-009
+
+Follow `adr009-test-file-splitting` for the split itself:
+
+- Target ≤8 `fn test_` functions per file (hard limit: ≤10)
+- Add ADR-009 header comment to each new file
+- Preserve all test function bodies exactly
+- Delete the original file
+
+### 3. Update the CI workflow
+
+Replace the original filename with the split filenames in the `pattern` field:
+
+```yaml
+# Before
+pattern: "... test_reduction_forward.mojo ..."
+
+# After
+pattern: "... test_reduction_forward_part1.mojo test_reduction_forward_part2.mojo test_reduction_forward_part3.mojo test_reduction_forward_part4.mojo ..."
+```
+
+### 4. Verify counts
+
+```bash
+for f in tests/shared/core/test_reduction_forward_part*.mojo; do
+  echo "$f: $(grep -c "^fn test_" $f) tests"
+done
+```
+
+### 5. Commit — all hooks must pass
+
+Pre-commit hooks validate: mojo format, YAML check, test coverage validation.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assuming glob auto-discovery | Expected new `part*.mojo` files to appear in CI without workflow changes | CI group used explicit space-separated filename list, not a glob | Always check the `pattern:` field type before splitting |
+| Keeping original file | Left `test_reduction_forward.mojo` alongside the part files | Would result in 30+30 duplicate test runs and still exceed ADR-009 | Delete the original file after splitting |
+
+## Results & Parameters
+
+**ADR-009 limits:**
+
+- Hard limit: ≤10 `fn test_` per file
+- Target: ≤8 per file (safety buffer)
+
+**Naming convention for splits:**
+
+```text
+test_<original_name>_part1.mojo
+test_<original_name>_part2.mojo
+...
+```
+
+**Grep count (avoiding header comment false positives):**
+
+```bash
+grep -c "^fn test_" <file>.mojo
+```
+
+**Workflow pattern update:**
+
+```yaml
+# Replace single filename with space-separated list of parts
+pattern: "... test_X_part1.mojo test_X_part2.mojo test_X_part3.mojo test_X_part4.mojo ..."
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3415, PR #4159 | [notes.md](../../references/notes.md) |
+
+**Related:** `adr009-test-file-splitting`, `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Documents the ADR-009 test split workflow variant for CI groups that use **explicit filename lists**
rather than glob patterns, which require a workflow YAML update in addition to the file split.

- Extends the existing `adr009-test-file-splitting` skill with the explicit-pattern case
- Documents the key distinction between glob-based and explicit-list CI patterns
- Captured from splitting `test_reduction_forward.mojo` (30 tests → 4 files) for the `Core Tensors` group

## Key Findings

**What Worked**:
- Check `pattern:` field type first (glob vs explicit list) to determine if workflow update is needed
- Replace single filename with all part filenames in the space-separated list
- Delete original file after splitting (don't leave both original and parts)

**What Failed**:
- Assuming new `part*.mojo` files would be auto-discovered → they weren't, because the pattern was explicit
- Keeping the original file alongside split files → would duplicate tests

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "Core Tensors", "explicit pattern", "ADR-009 CI update" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
