### PR TITLE
feat: add adr009-test-file-split skill

### DIFF
--- a/skills/ci-cd/adr009-test-file-split/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-test-file-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files to comply with ADR-009 heap corruption workaround (≤10 fn test_ per file). Use when: (1) a Mojo test file exceeds 10 fn test_ functions, (2) CI shows intermittent heap corruption crashes from libKGENCompilerRTShared.so, (3) a Testing Fixtures CI group is non-deterministically failing.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["mojo", "adr-009", "heap-corruption", "test-split", "ci-stability"]
+}

--- a/skills/ci-cd/adr009-test-file-split/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-split/references/notes.md
@@ -1,0 +1,68 @@
+# Session Notes: ADR-009 Test File Split
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: #3416 — fix(ci): split test_tensor_factory.mojo (28 tests) — Mojo heap corruption (ADR-009)
+- **Branch**: `3416-auto-impl`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4166
+
+## Problem
+
+`tests/shared/testing/test_tensor_factory.mojo` contained 28 `fn test_` functions, exceeding
+ADR-009's limit of 10 per file. This caused intermittent heap corruption crashes in Mojo v0.26.1
+(`libKGENCompilerRTShared.so` JIT fault), with a 13/20 CI failure rate on the `main` branch.
+
+## Solution
+
+Split the 28-test file into 4 files of ≤8 tests each:
+
+- `test_tensor_factory_part1.mojo`: 8 tests (zeros_tensor, ones_tensor)
+- `test_tensor_factory_part2.mojo`: 8 tests (full_tensor, random_tensor)
+- `test_tensor_factory_part3.mojo`: 8 tests (random_normal_tensor, set_tensor_value first half)
+- `test_tensor_factory_part4.mojo`: 4 tests (set_tensor_value second half, integration tests)
+
+## Key Observations
+
+1. **CI glob pattern**: The `comprehensive-tests.yml` workflow uses `testing/test_*.mojo` for the
+   "Shared Infra & Testing" group — no workflow changes were needed.
+
+2. **validate_test_coverage.py**: Had no explicit references to `test_tensor_factory.mojo`,
+   so no script updates were required.
+
+3. **Pre-commit hooks passed**: Mojo format, validate_test_coverage, and other hooks all
+   passed automatically on the split files.
+
+4. **Safety margin**: Targeting ≤8 (not just ≤10) provides buffer below the ADR-009 limit.
+
+5. **Import scoping**: Each split file only imports the functions it tests, keeping imports minimal.
+
+## Commands Used
+
+```bash
+# Count tests in original file
+grep -c "^fn test_" tests/shared/testing/test_tensor_factory.mojo
+# → 28
+
+# Verify counts in split files
+grep -c "^fn test_" tests/shared/testing/test_tensor_factory_part*.mojo
+# → 8, 8, 8, 4
+
+# Delete original
+rm tests/shared/testing/test_tensor_factory.mojo
+
+# Stage and commit
+git add tests/shared/testing/test_tensor_factory.mojo tests/shared/testing/test_tensor_factory_part*.mojo
+git commit -m "fix(ci): split test_tensor_factory.mojo into 4 files (ADR-009)"
+
+# Push and create PR
+git push -u origin 3416-auto-impl
+gh pr create --title "fix(ci): split test_tensor_factory.mojo into 4 files (ADR-009)"
+gh pr merge --auto --rebase
+```
+
+## Related
+
+- ADR-009: `docs/adr/ADR-009-heap-corruption-workaround.md`
+- Related issue: #2942
+- Sample failing CI run: `22751105525`

--- a/skills/ci-cd/adr009-test-file-split/skills/adr009-test-file-split/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-split/skills/adr009-test-file-split/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: adr009-test-file-split
+description: "Split Mojo test files to comply with ADR-009 heap corruption workaround (≤10 fn test_ per file). Use when: a Mojo test file exceeds 10 fn test_ functions, CI shows intermittent heap corruption from libKGENCompilerRTShared.so, or a CI group fails non-deterministically."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Trigger** | Mojo test file with >10 `fn test_` functions causing intermittent CI failures |
+| **Root Cause** | Mojo v0.26.1 heap corruption bug (`libKGENCompilerRTShared.so`) under high test load |
+| **Fix** | Split into multiple files of ≤8 tests each (ADR-009 mandates ≤10, target ≤8 for safety margin) |
+| **CI Impact** | Glob patterns like `testing/test_*.mojo` auto-discover split files — no workflow changes needed |
+| **Effort** | ~15 minutes for a 28-test file split into 4 parts |
+
+## When to Use
+
+- A Mojo test file has more than 10 `fn test_` functions
+- CI shows intermittent failures with `libKGENCompilerRTShared.so` JIT fault in the error log
+- A CI group (e.g., "Testing Fixtures", "Shared Infra & Testing") fails non-deterministically
+- ADR-009 compliance check flags a file as exceeding the limit
+- CI failure rate across recent runs is high (e.g., 13/20) with no single reproducible root cause
+
+## Verified Workflow
+
+### 1. Count test functions in the file
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+If count > 10, proceed with split.
+
+### 2. Plan the split
+
+Divide tests into logical groups of ≤8 per file:
+
+- Group by the function under test (e.g., `zeros_tensor`, `ones_tensor`, `full_tensor`)
+- Keep integration/workflow tests together in the last file
+- Target ≤8 (not just ≤10) for a safety margin
+
+### 3. Create split files with ADR-009 header
+
+Each new file MUST include this header comment:
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_file>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+Name files with `_part1`, `_part2`, etc. suffix:
+
+```
+test_tensor_factory.mojo → test_tensor_factory_part1.mojo
+                           test_tensor_factory_part2.mojo
+                           test_tensor_factory_part3.mojo
+                           test_tensor_factory_part4.mojo
+```
+
+### 4. Each split file needs its own `main()` function
+
+```mojo
+fn main() raises:
+    """Run all tests."""
+    test_zeros_tensor_float32()
+    test_zeros_tensor_int32()
+    # ... all tests in this file
+```
+
+### 5. Delete the original file
+
+```bash
+rm tests/path/to/test_file.mojo
+```
+
+### 6. Verify test counts
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file_part*.mojo
+# Each file should show ≤8
+```
+
+### 7. Check CI workflow glob patterns
+
+Check if CI uses glob patterns or explicit filenames:
+
+```bash
+grep -r "test_tensor_factory\|testing/test_" .github/workflows/
+```
+
+- **Glob pattern** (`testing/test_*.mojo`): No changes needed — new files auto-discovered
+- **Explicit filenames**: Update workflow to reference new `_part1`, `_part2`, etc. filenames
+
+### 8. Commit and push
+
+```bash
+git add tests/path/to/test_file.mojo tests/path/to/test_file_part*.mojo
+git commit -m "fix(ci): split test_file.mojo into N files (ADR-009)"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Updating CI workflow pattern | Checked `comprehensive-tests.yml` for explicit filename references | Not needed — workflow already used `testing/test_*.mojo` glob | Always check if CI uses globs before modifying workflow files |
+| Using `_part_1` naming | Considered underscore-number naming | Would sort inconsistently | Use `_part1`, `_part2` (no underscore before number) |
+| Keeping original file | Thought about keeping original with reduced tests | Would still trigger heap corruption for the remaining tests | Delete the original entirely and fully redistribute tests |
+
+## Results & Parameters
+
+### Split Distribution for 28-test File
+
+| File | Tests | Content |
+|------|-------|---------|
+| `*_part1.mojo` | 8 | `zeros_tensor` + `ones_tensor` tests |
+| `*_part2.mojo` | 8 | `full_tensor` + `random_tensor` tests |
+| `*_part3.mojo` | 8 | `random_normal_tensor` + `set_tensor_value` (first half) |
+| `*_part4.mojo` | 4 | `set_tensor_value` (second half) + integration tests |
+
+### ADR-009 Compliance Formula
+
+```
+files_needed = ceil(total_tests / 8)  # target ≤8 per file
+tests_per_file ≤ 8                    # safety margin below the 10-test limit
+```
+
+### Pre-commit Hook Behavior
+
+Pre-commit hooks (Mojo format, validate_test_coverage) pass automatically for split files with no extra configuration.
+
+### Key Imports per File
+
+Only import what each file needs — don't copy all imports from the original:
+
+```mojo
+from shared.testing.tensor_factory import (
+    zeros_tensor,   # only functions tested in this file
+    ones_tensor,
+)
+```


### PR DESCRIPTION
## Summary

Documents the workflow for splitting Mojo test files to comply with ADR-009
(≤10 `fn test_` functions per file) to fix intermittent heap corruption crashes
in Mojo v0.26.1 (`libKGENCompilerRTShared.so` JIT fault).

- Captures the complete split workflow from counting tests to CI verification
- Documents the safety margin recommendation (≤8, not just ≤10)
- Explains when CI workflow changes are needed vs. when glob patterns suffice

## Key Findings

**What Worked**:
- Splitting into groups of ≤8 tests per file (safety margin below 10-test limit)
- CI `testing/test_*.mojo` glob pattern auto-discovers split files — no workflow changes needed
- Each split file uses only the imports it needs (scoped imports)
- Deleting the original file entirely (not just reducing its tests)

**What Failed**:
- Checking if CI workflow needed updating → Not needed (glob pattern already covered new files)
- Keeping original file with fewer tests → Would still risk corruption; full replacement is safer

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with ADR-009 related triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
