### PR TITLE
feat: update adr009-test-file-splitting with explicit CI list learnings

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,57 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3422)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_shape.mojo (26 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI.
+ADR-009 mandates ≤10 fn test_ per file. The Core Tensors CI group was failing 13/20 runs.
+
+## Initial State
+
+Single file: test_shape.mojo with 26 fn test_ functions covering:
+reshape, squeeze, unsqueeze, expand_dims, flatten, ravel, concatenate, stack, split,
+tile, repeat, broadcast_to, permute, dtype preservation, flatten_to_2d.
+
+## Actions Taken
+
+1. Split into 4 files of ≤10 tests each:
+   - test_shape_part1.mojo (9 tests): reshape, squeeze, unsqueeze, flatten/ravel
+   - test_shape_part2.mojo (8 tests): concatenate, stack, split, tile
+   - test_shape_part3.mojo (7 tests): repeat, broadcast_to, permute, dtype, flatten_to_2d basic
+   - test_shape_part4.mojo (2 tests): flatten_to_2d additional cases
+2. Each file got ADR-009 header comment in top-level docstring
+3. Deleted test_shape.mojo
+4. Updated .github/workflows/comprehensive-tests.yml Core Tensors pattern:
+   replaced `test_shape.mojo` with 4 explicit filenames
+
+## Final State
+
+- 4 files, all ≤9 tests each (9+8+7+2=26 total)
+- All 26 original test cases preserved
+- validate_test_coverage.py passed (Core Tensors uses explicit list, but new files were added)
+- All pre-commit hooks passed
+- PR #4187 created, auto-merge enabled
+
+## Key Insight — Explicit vs. Glob CI Patterns
+
+The Core Tensors CI group uses an **explicit space-separated filename list**, not a glob:
+
+```yaml
+pattern: "test_tensors.mojo test_arithmetic.mojo ... test_shape.mojo ..."
+```
+
+This means new split files are NOT auto-discovered. The original filename must be replaced
+with all new split filenames in the pattern string. This is different from groups like
+"Testing Fixtures" that use `pattern: "testing/test_*.mojo"` (glob, auto-discovers).
+
+Always check the relevant test group's pattern before finishing to determine if a CI update
+is needed.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -83,9 +83,35 @@ git rm tests/shared/testing/test_assertions.mojo.DEPRECATED
 ```bash
 # Verify no file exceeds 10 (count actual functions, not comments)
 grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
+```
 
-# CI glob auto-picks up new files if named test_*.mojo in the right directory
-# No workflow changes needed for testing/test_*.mojo glob pattern
+**CI coverage — two cases:**
+
+**Case A: CI uses glob patterns** (e.g., `pattern: "test_*.mojo"`)
+
+New files are picked up automatically — no workflow changes needed.
+
+```yaml
+# Example: glob auto-discovers new files
+pattern: "testing/test_*.mojo"
+```
+
+**Case B: CI uses explicit filename lists** (e.g., `Core Tensors` group)
+
+Must manually update the pattern string to replace the original filename with the new split filenames:
+
+```yaml
+# Before:
+pattern: "... test_shape.mojo ..."
+
+# After (replace original with all 4 split files):
+pattern: "... test_shape_part1.mojo test_shape_part2.mojo test_shape_part3.mojo test_shape_part4.mojo ..."
+```
+
+Check which case applies by inspecting the workflow pattern for the relevant test group:
+
+```bash
+grep -A3 '"Core Tensors"' .github/workflows/comprehensive-tests.yml
 ```
 
 ### 8. Commit and push
@@ -98,6 +124,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Assuming CI auto-discovers split files | Assumed `test_shape_part*.mojo` would be found by glob | Core Tensors CI group uses explicit filename list, not a glob | Always check whether the group uses glob or explicit list before finishing |
 
 ## Results & Parameters
 
@@ -123,5 +150,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3422, PR #4187 | test_shape.mojo (26 tests) → 4 files, explicit CI list update required |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with new learnings from issue #3422
(test_shape.mojo split, ProjectOdyssey PR #4187).

- Documents the explicit CI filename list scenario (vs. glob auto-discovery)
- Adds concrete workflow guidance for the `Core Tensors` CI group pattern
- Extends Failed Attempts table with new case
- Adds second Verified On entry

## Key Findings

**What Worked**:
- Split 26-test file into 4 part files of ≤10 tests each (9+8+7+2)
- Explicit workflow pattern update: replace `test_shape.mojo` with 4 new filenames
- validate_test_coverage.py passed without modification (uses same glob coverage check)

**What Failed**:
- Initial assumption that CI would auto-discover split files → Core Tensors uses explicit list, not glob

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Verify `adr009-test-file-splitting` skill passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
