### PR TITLE
feat: update adr009-test-file-splitting skill with explicit-list CI pattern

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,37 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3423)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_arithmetic_contiguous.mojo (26 tests) was causing intermittent heap corruption in Mojo
+v0.26.1 CI. ADR-009 mandates ≤10 fn test_ per file, target ≤8.
+
+## Actions Taken
+
+1. Read original file (26 tests across 5 logical groups)
+2. Split into 4 part files (7 + 7 + 7 + 5 tests)
+3. Deleted original file with `rm` + `git rm` via staging
+4. Updated `.github/workflows/comprehensive-tests.yml` Core Tensors `pattern:` field
+   (explicit space-separated list — NOT a glob)
+5. All pre-commit hooks passed on commit
+
+## Final State
+
+- 4 files: test_arithmetic_contiguous_part1-4.mojo
+- 26 total test functions preserved (7+7+7+5)
+- PR #4188 created, auto-merge enabled
+
+## Key Insight
+
+The `comprehensive-tests.yml` Core Tensors group uses an explicit space-separated file list
+in the `pattern:` field, NOT a glob. New files must be added manually to the list.
+This is different from the testing group which uses a glob.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -83,9 +83,27 @@ git rm tests/shared/testing/test_assertions.mojo.DEPRECATED
 ```bash
 # Verify no file exceeds 10 (count actual functions, not comments)
 grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
+```
 
-# CI glob auto-picks up new files if named test_*.mojo in the right directory
-# No workflow changes needed for testing/test_*.mojo glob pattern
+**If CI uses a glob pattern** (`test_*.mojo`): New files are picked up automatically — no
+workflow changes needed.
+
+**If CI uses an explicit file list** (e.g., `comprehensive-tests.yml` `pattern:` field):
+You MUST update the workflow to reference the new filenames. Replace the original filename
+with all split filenames:
+
+```yaml
+# Before
+pattern: "... test_arithmetic_contiguous.mojo ..."
+
+# After (replace with all 4 parts)
+pattern: "... test_arithmetic_contiguous_part1.mojo test_arithmetic_contiguous_part2.mojo test_arithmetic_contiguous_part3.mojo test_arithmetic_contiguous_part4.mojo ..."
+```
+
+To check whether CI uses a glob or explicit list:
+
+```bash
+grep -A2 "Core Tensors" .github/workflows/comprehensive-tests.yml
 ```
 
 ### 8. Commit and push
@@ -98,6 +116,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Assuming CI glob auto-picks new files | Did not update `comprehensive-tests.yml` after split | CI used an explicit space-separated file list in `pattern:` field, not a glob | Check whether CI uses glob or explicit list; update explicit lists manually |
 
 ## Results & Parameters
 
@@ -123,5 +142,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3423, PR #4188 | Explicit-list CI workflow update (26-test arithmetic_contiguous split into 4 files) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates `adr009-test-file-splitting` skill with a new workflow variant: when CI uses an
**explicit space-separated file list** (not a glob) in the `pattern:` field, new split files
must be added manually to the workflow.

- Adds explicit-list detection and update steps to the Verified Workflow
- Adds a new Failed Attempts row documenting the assumption that CI always uses globs
- Adds a second "Verified On" entry (issue #3423, PR #4188)
- Updates references/notes.md with the new session context

## Key Findings

**What Worked**:
- Checking `grep -A2 "Core Tensors" .github/workflows/comprehensive-tests.yml` to detect list vs glob
- Replacing the original filename with all 4 part filenames in the explicit list

**What Failed**:
- Assuming CI glob auto-picks up new files — `comprehensive-tests.yml` Core Tensors uses an explicit list

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Check skill appears in marketplace search for "adr009" or "explicit list"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
