### PR TITLE
feat: update adr009-test-file-splitting with PR #4214 verification

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -123,5 +123,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3431, PR #4214 | `test_mxfp4_block.mojo` (24 tests) → 3 files ×8; `Core Types & Fuzz` wildcard auto-discovers new files |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill's "Verified On" table with a second
confirmed application of the workflow (Issue #3431, PR #4214 in ProjectOdyssey).

## Key Findings

**What Worked**:
- The same ADR-009 workflow (split >10 test functions into ≤8 per file) applied identically to `test_mxfp4_block.mojo` (24 tests → 3 files ×8)
- CI wildcard patterns (`test_*.mojo`) auto-discover new split files — no workflow YAML changes needed, regardless of which test group

**Additional Learning**:
- Previous verification was in "Testing Fixtures" group; this confirms the pattern holds for "Core Types & Fuzz" group too
- Wildcard auto-discovery is reliable across multiple CI test groups, not just one

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` — PASSED
- [x] Skill content unchanged except Verified On table row addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
