### PR TITLE
feat: update adr009-test-file-splitting skill with issue #3433 session

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes-3433.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes-3433.md
@@ -1,0 +1,57 @@
+# Session Notes: ADR-009 Test File Splitting (Issue #3433)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+`tests/shared/training/test_schedulers.mojo` had 23 `fn test_` functions, exceeding the
+ADR-009 ≤10 hard limit and ≤8 target per file. This caused intermittent heap corruption
+(`libKGENCompilerRTShared.so` JIT fault) in the Shared Infra CI group — 13/20 recent runs
+were failing.
+
+## Initial State
+
+Single monolithic file with 23 tests:
+
+- 9 CosineAnnealingLR tests
+- 12 ReduceLROnPlateau tests
+- 2 integration tests
+
+## Actions Taken
+
+1. Read the issue to understand the split plan (3 files, ≤8 each)
+2. Read the full original file to enumerate all 23 tests
+3. Checked CI workflow (`comprehensive-tests.yml`) — existing glob `training/test_*.mojo`
+   auto-discovers all files; no workflow changes needed
+4. Checked `validate_test_coverage.py` — needed to update the hardcoded filename list
+5. Created 3 replacement files with ADR-009 header comment:
+   - `test_schedulers_part1.mojo`: 8 CosineAnnealingLR tests
+   - `test_schedulers_part2.mojo`: 8 ReduceLROnPlateau tests
+   - `test_schedulers_part3.mojo`: 7 edge case + integration tests
+6. Deleted the original `test_schedulers.mojo`
+7. Updated `scripts/validate_test_coverage.py` to reference the 3 new filenames
+8. Committed — all pre-commit hooks passed (mojo format, mypy, ruff, validate-test-coverage)
+9. Pushed and created PR #4216
+
+## Key Difference vs Issue #3397
+
+Issue #3397 (test_assertions) was an **incremental refinement** of an already-split file —
+moving tests between existing split files that were still over the limit.
+
+Issue #3433 (test_schedulers) was a **fresh wholesale split** of a single monolithic file —
+simpler: read original, partition tests logically, create 3 new files, delete original.
+
+## Final State
+
+- 3 files, all ≤8 tests each (8 + 8 + 7 = 23 total, all preserved)
+- CI glob `training/test_*.mojo` covers new files automatically — no CI changes needed
+- `validate_test_coverage.py` updated with new filenames
+- PR #4216 created on branch `3433-auto-impl`, auto-merge enabled
+
+## Note on ADR-009 Header Placement
+
+The ADR-009 comment was placed at the very top of the file (before the docstring),
+consistent with the issue specification. This is correct — it documents the constraint
+at the file level.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -98,6 +98,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Expecting CI workflow changes needed | Assumed new files would not be auto-discovered | CI glob pattern `training/test_*.mojo` auto-discovers all matching files | Check existing glob pattern before modifying CI workflow files |
 
 ## Results & Parameters
 
@@ -122,6 +123,7 @@ grep -c "^fn test_[a-z]" <file>.mojo
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 — split test_assertions.mojo (61 tests → 9 files) | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3433, PR #4216 — split test_schedulers.mojo (23 tests → 3 files) | [notes-3433.md](../../references/notes-3433.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the existing `adr009-test-file-splitting` skill with learnings from a second
application of the pattern — splitting `test_schedulers.mojo` (23 tests) into 3 files
for ProjectOdyssey issue #3433 / PR #4216.

- New "Verified On" table row for issue #3433
- New `references/notes-3433.md` documenting the fresh wholesale-split workflow
- New Failed Attempts row: CI glob auto-discovers new test files (no CI workflow edits needed)

## Key Findings

**What Worked**:
- Partitioning by scheduler type (CosineAnnealingLR / ReduceLROnPlateau / edge cases) gives semantic groupings
- Existing CI glob `training/test_*.mojo` auto-discovers new files — no `comprehensive-tests.yml` changes needed
- `validate_test_coverage.py` requires manual update of hardcoded filename list

**What was clarified**:
- Fresh wholesale split (one large file → N new files) is simpler than incremental refinement
- ADR-009 header goes at top of file before docstring per issue spec

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in `/advise` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)