### PR TITLE
feat: update adr009-test-file-splitting with configs test split (issue #3436)

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,50 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3436)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+tests/configs/test_validation.mojo had 23 fn test_ functions, exceeding ADR-009 ≤10 limit.
+CI Configs group was failing non-deterministically (13/20 recent runs).
+
+## Initial State
+
+Single file: tests/configs/test_validation.mojo — 23 tests across 7 logical sections:
+- Required key validation (3)
+- Type validation (5)
+- Range validation (4)
+- Enum validation (3)
+- Mutual exclusivity validation (3)
+- Complex validation (3)
+- Validator builder (2)
+
+## Actions Taken
+
+1. Created test_validation_part1.mojo (8 tests) — required key + type validation
+2. Created test_validation_part2.mojo (7 tests) — range + enum validation
+3. Created test_validation_part3.mojo (8 tests) — exclusive + complex + validator builder
+4. Deleted tests/configs/test_validation.mojo
+5. Updated tests/configs/__init__.mojo to reference new filenames
+6. CI workflow uses `just test-group tests/configs "test_*.mojo"` — no changes needed
+
+## Final State
+
+- 3 files, all ≤8 tests each (8 + 7 + 8 = 23 total)
+- All original test cases preserved
+- CI glob test_*.mojo covers new files automatically
+- PR #4221 created, auto-merge enabled
+
+## Key Insight
+
+When a test file is completely replaced (not just partially split), the workflow is:
+delete original → create N new files → update any package __init__.mojo references.
+The CI pattern glob handles discovery automatically.
+No workflow YAML changes needed if the CI job already uses a test_*.mojo glob pattern.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -123,5 +123,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3436, PR #4221 — configs/test_validation.mojo (23 tests → 3 files) | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with a second verified instance:
splitting `tests/configs/test_validation.mojo` (23 tests → 3 files of ≤8) per ADR-009.

## Key Findings

**What Worked**:
- Complete file replacement pattern: delete original, create N new part files
- CI job using `test_*.mojo` glob pattern auto-discovers new files — no YAML changes needed
- Grouping tests by logical sections (required key, type, range, enum, exclusive, complex, validator)
- Updating `__init__.mojo` to reference new split filenames

**New vs Prior Instance**:
- Prior (#3397): partial split of existing split files (7 → 9 files)
- This (#3436): full replacement of a single file (1 → 3 files)

## Test Plan

- [x] Plugin validated with `python3 scripts/validate_plugins.py skills/ plugins/` — PASS
- [x] SKILL.md "Verified On" table updated with issue #3436 and PR #4221
- [x] notes.md updated with full session details

🤖 Generated with [Claude Code](https://claude.com/claude-code)