### PR TITLE
feat: update adr009-test-file-splitting with nvfp4 instance (#3440)

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes-nvfp4.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes-nvfp4.md
@@ -1,0 +1,55 @@
+# Session Notes: ADR-009 Test File Splitting (Issue #3440)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+`tests/core/types/test_nvfp4_block.mojo` had 22 `fn test_` functions (limit: 10, target: ≤8),
+causing intermittent heap corruption in Mojo v0.26.1 CI (`libKGENCompilerRTShared.so` JIT fault).
+CI failure rate: 13/20 recent runs on `main`.
+
+## Initial State
+
+Single file with all 22 tests, no prior splitting:
+
+- Block creation tests (4)
+- Round-trip conversion tests (3)
+- Scale computation tests (1)
+- Accuracy comparison (1)
+- Bit packing (1)
+- Indexing get/set (4)
+- All-negative blocks TEST-001 (3)
+- NaN/infinity handling TEST-003 (3)
+- Edge cases (2)
+
+## Split Strategy
+
+Grouped by semantic category, 3 files of ≤8 tests each:
+
+- `test_nvfp4_block_part1.mojo` (8 tests): creation + round-trip + scale
+- `test_nvfp4_block_part2.mojo` (8 tests): accuracy + bit packing + indexing + TEST-001 negatives
+- `test_nvfp4_block_part3.mojo` (6 tests): TEST-001 scale + TEST-003 NaN/inf + edge cases
+
+## Actions Taken
+
+1. Read `test_nvfp4_block.mojo` to catalog all 22 tests
+2. Verified CI workflow pattern: `test_*.mojo` glob in `tests/core/types` directory — no update needed
+3. Created 3 new files, each with ADR-009 header comment
+4. Deleted original file
+5. Committed with all pre-commit hooks passing (mojo format, validate test coverage)
+
+## Final State
+
+- 3 files: 8 + 8 + 6 = 22 tests total (all original tests preserved)
+- CI glob `pattern: "test_*.mojo"` auto-discovers new files
+- No workflow changes needed
+- PR #4230 created, auto-merge enabled
+
+## Key Insight
+
+When a `test_*.mojo` file is being replaced (not incrementally split), delete the original
+file entirely rather than leaving it with a reduced test set. The `part{N}` naming convention
+(`test_<name>_part1.mojo`, etc.) is cleaner than derived names when the original had no
+natural subgrouping names.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -98,6 +98,7 @@ All pre-commit hooks must pass (mojo format, test coverage validation).
 |---------|----------------|---------------|----------------|
 | Using `grep "^fn test_"` to count tests | Counted comment lines matching the pattern | ADR-009 header comment contained `fn test_` text at line start | Use `^fn test_[a-z]` pattern instead |
 | Expecting 61 tests in split files | Issue description said 61 tests | The actual split files in main had 59 tests (issue count was approximate) | Always verify against actual code, not issue description |
+| Checking CI workflow for glob update when splitting | Looked for explicit filename references to update | CI used `pattern: "test_*.mojo"` glob covering entire directory | Files named `test_*_part{N}.mojo` are auto-discovered; no workflow update needed |
 
 ## Results & Parameters
 
@@ -123,5 +124,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3440, PR #4230 | [notes-nvfp4.md](../../references/notes-nvfp4.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with a second verified instance:
splitting `test_nvfp4_block.mojo` (22 tests) into 3 part files for issue #3440 in ProjectOdyssey.

- Added `references/notes-nvfp4.md` with session-specific details
- Updated `Verified On` table with PR #4230 entry
- Added new `Failed Attempts` row: CI workflow glob auto-discovery (no update needed)

## Key Findings

**What Worked**:
- `part{N}` naming convention (`test_<name>_part1.mojo`) when original has no natural subgroupings
- Deleting original file entirely rather than leaving a reduced version
- CI `pattern: "test_*.mojo"` glob auto-discovers new files in the same directory

**What Was New vs Prior Session**:
- Prior session (#3397): Incremental split of partially-split file with semantic names
- This session (#3440): Clean split of un-split file using `_part{N}` naming

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Check skill appears in marketplace for adr009 queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
