### PR TITLE
feat: add mojo-adr009-test-file-split skill

### DIFF
--- a/skills/testing/mojo-adr009-test-file-split/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-adr009-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-adr009-test-file-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files exceeding the ADR-009 ≤10 fn test_ limit to prevent libKGENCompilerRTShared.so heap corruption crashes in Mojo v0.26.1. Use when: (1) a Mojo test file has >10 fn test_ functions and causes non-deterministic CI heap corruption, (2) CI shows intermittent JIT faults on a specific test group, (3) implementing ADR-009 compliance for a new or existing test file.",
+  "category": "testing",
+  "date": "2026-03-07",
+  "tags": ["mojo", "heap-corruption", "adr-009", "test-splitting", "ci", "mojo-v0.26.1", "libKGENCompilerRTShared"]
+}

--- a/skills/testing/mojo-adr009-test-file-split/references/notes.md
+++ b/skills/testing/mojo-adr009-test-file-split/references/notes.md
@@ -1,0 +1,103 @@
+# Session Notes: Mojo ADR-009 Test File Split
+
+## Session Details
+
+- **Date**: 2026-03-07
+- **Project**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3441
+- **PR**: #4233
+- **Branch**: `3441-auto-impl`
+
+## Problem
+
+`tests/shared/data/datasets/test_emnist.mojo` had 21 `fn test_` functions. ADR-009 limits
+Mojo test files to ≤10 `fn test_` functions due to a JIT heap corruption bug in Mojo v0.26.1
+(`libKGENCompilerRTShared.so`). The Data Datasets CI group was failing non-deterministically
+(13/20 recent runs on `main`).
+
+Sample failing CI run: `22755966807`
+
+## File Before Split
+
+```
+tests/shared/data/datasets/test_emnist.mojo — 21 fn test_ functions
+```
+
+Functions in order:
+1. test_emnist_init_balanced
+2. test_emnist_init_byclass
+3. test_emnist_init_digits
+4. test_emnist_init_letters
+5. test_emnist_init_invalid_split
+6. test_emnist_len
+7. test_emnist_getitem_index
+8. test_emnist_getitem_negative_index
+9. test_emnist_getitem_out_of_bounds
+10. test_emnist_shape
+11. test_emnist_num_classes_balanced
+12. test_emnist_num_classes_byclass
+13. test_emnist_num_classes_digits
+14. test_emnist_num_classes_letters
+15. test_emnist_num_classes_mnist
+16. test_emnist_get_train_data
+17. test_emnist_get_test_data
+18. test_emnist_train_vs_test_sizes
+19. test_emnist_data_label_consistency
+20. test_emnist_all_valid_splits
+21. test_emnist_performance_random_access
+
+## Files After Split
+
+- `test_emnist_part1.mojo`: tests 1–9 (init + access) — 9 fn test_
+- `test_emnist_part2.mojo`: tests 10–17 (shape + class counts + integration) — 8 fn test_
+- `test_emnist_part3.mojo`: tests 18–21 (edge cases + performance) — 4 fn test_
+
+## CI Workflow
+
+The `Data` test group in `comprehensive-tests.yml` uses:
+```
+pattern: "test_*.mojo datasets/test_*.mojo samplers/test_*.mojo ..."
+```
+
+The `datasets/test_*.mojo` wildcard automatically picks up the new `_part1/2/3` files.
+No workflow changes required.
+
+## Pre-commit Results
+
+All hooks passed on commit:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## Key Commands Used
+
+```bash
+# Verify test counts in each new file
+grep -c "^fn test_" tests/shared/data/datasets/test_emnist_part1.mojo  # → 9
+grep -c "^fn test_" tests/shared/data/datasets/test_emnist_part2.mojo  # → 8
+grep -c "^fn test_" tests/shared/data/datasets/test_emnist_part3.mojo  # → 4
+
+# Verify CI pattern covers new files
+grep -A2 "datasets" .github/workflows/comprehensive-tests.yml
+# → pattern: "test_*.mojo datasets/test_*.mojo ..."
+
+# Stage and commit
+git add tests/shared/data/datasets/test_emnist.mojo  # deleted
+git add tests/shared/data/datasets/test_emnist_part1.mojo
+git add tests/shared/data/datasets/test_emnist_part2.mojo
+git add tests/shared/data/datasets/test_emnist_part3.mojo
+```
+
+## ADR-009 Header Template
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_emnist.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+This comment is placed in the module docstring immediately after the description paragraph.

--- a/skills/testing/mojo-adr009-test-file-split/skills/mojo-adr009-test-file-split/SKILL.md
+++ b/skills/testing/mojo-adr009-test-file-split/skills/mojo-adr009-test-file-split/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: mojo-adr009-test-file-split
+description: "Split Mojo test files exceeding the ADR-009 ≤10 fn test_ limit to prevent libKGENCompilerRTShared.so heap corruption. Use when: a Mojo test file has >10 fn test_ functions and causes non-deterministic CI failures (heap corruption/JIT fault)."
+category: testing
+date: 2026-03-07
+user-invocable: false
+---
+
+# Mojo ADR-009: Split Test Files to Prevent Heap Corruption
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Date** | 2026-03-07 |
+| **Objective** | Split `test_emnist.mojo` (21 `fn test_` functions) into 3 ADR-009 compliant files |
+| **Outcome** | ✅ 21 tests preserved across 3 files; pre-commit passes; PR #4233 created |
+| **PR** | HomericIntelligence/ProjectOdyssey#4233 |
+| **ADR** | docs/adr/ADR-009-heap-corruption-workaround.md |
+
+Mojo v0.26.1 has a JIT heap corruption bug in `libKGENCompilerRTShared.so` that triggers
+when a single test file contains many `fn test_` functions. ADR-009 mandates ≤10 `fn test_`
+functions per `.mojo` test file. When a file exceeds this limit, CI for the associated test
+group fails non-deterministically.
+
+This skill documents the repeatable workflow for splitting an oversized Mojo test file into
+ADR-009 compliant parts, without losing any tests.
+
+## When to Use
+
+- A Mojo test file has >10 `fn test_` functions
+- CI shows non-deterministic heap corruption (`libKGENCompilerRTShared.so` JIT fault) for a test group
+- ADR-009 compliance review finds a file over the limit
+- A new large Mojo test file is being authored and should be pre-split
+
+## Verified Workflow
+
+### Step 1 — Count fn test_ Functions
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+If count > 10, the file must be split. Target ≤8 per file for headroom.
+
+### Step 2 — List All Test Functions in Order
+
+```bash
+grep -n "^fn test_" tests/path/to/test_file.mojo
+```
+
+Record the function names and their natural groupings (init, access, shape, class counts,
+integration, edge cases, performance, etc.).
+
+### Step 3 — Plan the Split
+
+Divide functions into groups of ≤8 tests, grouped by functional area:
+
+| Part | Tests | Functional Area |
+|------|-------|----------------|
+| `_part1.mojo` | ≤8 | Initialization, basic access |
+| `_part2.mojo` | ≤8 | Shape, class counts, integration |
+| `_part3.mojo` | ≤5 | Edge cases, performance |
+
+### Step 4 — Create Each Part File
+
+Each part file must include:
+
+1. **Module docstring** naming the part and listing what it covers
+2. **ADR-009 header comment** (exact text required):
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_filename>. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+3. **All imports** from the original file (copy exactly)
+4. **Shared helper functions** (copy to each part that uses them, or import if refactored)
+5. **The test functions** for this part
+6. **`fn main() raises`** runner calling only this part's tests
+
+### Step 5 — Delete the Original File
+
+```bash
+rm tests/path/to/test_file.mojo
+```
+
+Do NOT use `git mv` — the original file is replaced by multiple new files, not renamed.
+
+### Step 6 — Verify Test Counts
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file_part1.mojo
+grep -c "^fn test_" tests/path/to/test_file_part2.mojo
+grep -c "^fn test_" tests/path/to/test_file_part3.mojo
+```
+
+All must be ≤10. Sum must equal original count.
+
+### Step 7 — Check CI Workflow Coverage
+
+The CI workflow pattern for datasets uses wildcards like `datasets/test_*.mojo`. Verify the
+new part files will be discovered automatically:
+
+```bash
+grep -A2 "datasets" .github/workflows/comprehensive-tests.yml
+```
+
+If the wildcard `test_*.mojo` covers the new `test_*_part1.mojo` files, no workflow update
+is needed. If explicit filenames were used, update the pattern list.
+
+### Step 8 — Stage and Commit
+
+```bash
+git add tests/path/to/test_file.mojo  # deleted
+git add tests/path/to/test_file_part1.mojo
+git add tests/path/to/test_file_part2.mojo
+git add tests/path/to/test_file_part3.mojo
+
+git commit -m "fix(ci): split <test_file> into N files per ADR-009
+
+<original> had <N> fn test_ functions, exceeding the ADR-009 limit of 10.
+Split into <N> files of ≤10 tests each to prevent heap corruption.
+
+Closes #<issue>"
+```
+
+### Step 9 — Verify Pre-commit Passes
+
+Pre-commit hooks include `mojo format` and `validate_test_coverage.py`. Both must pass.
+`validate_test_coverage.py` checks that all `test_*.mojo` files are covered by CI patterns.
+The wildcard `datasets/test_*.mojo` covers part files automatically.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `git mv` for original file | Renaming original to `_part1.mojo` to preserve history | History on deleted tests in split-out parts is lost anyway; adds confusion | Just delete the original and create new files; history is in git log |
+| Updating CI workflow patterns | Explicitly listing `test_emnist_part1.mojo test_emnist_part2.mojo test_emnist_part3.mojo` | Unnecessary — the wildcard `datasets/test_*.mojo` already covers all new files | Always check existing patterns before editing the CI workflow |
+| Shared helper functions in separate file | Extracting `create_mock_idx_files` to a shared helper | No shared helper import pattern established for Mojo test files | Copy shared helpers to each part file that uses them |
+
+## Results & Parameters
+
+**Original file**: `tests/shared/data/datasets/test_emnist.mojo` — 21 `fn test_` functions
+
+**Split result**:
+
+| File | fn test_ count | Functional Area |
+|------|---------------|----------------|
+| `test_emnist_part1.mojo` | 9 | Init + access (getitem, bounds, negative index) |
+| `test_emnist_part2.mojo` | 8 | Shape + class counts + integration (get_train/test_data) |
+| `test_emnist_part3.mojo` | 4 | Train/test sizes + consistency + valid splits + perf |
+| **Total** | **21** | All original tests preserved |
+
+**CI workflow pattern**: `datasets/test_*.mojo` — no workflow update required.
+
+**Pre-commit hooks**: All pass (mojo format, validate test coverage, trailing whitespace,
+end-of-file fixer, large file check).
+
+**ADR-009 header** (copy-paste template):
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_filename>. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3441, PR #4233 | [notes.md](../references/notes.md) |
+
+## Related Skills
+
+- `split-large-test-file` — Python test splitting due to Edit tool token limits (different problem)
+- `mojo-test-runner` — Running Mojo test suites
+- `validate-mojo-patterns` — Checking Mojo code against project standards


### PR DESCRIPTION
## Summary

Documents the workflow for splitting Mojo test files that exceed the ADR-009 ≤10 `fn test_`
limit, which prevents `libKGENCompilerRTShared.so` heap corruption crashes in Mojo v0.26.1.

- Validated on ProjectOdyssey issue #3441 (splitting `test_emnist.mojo`, 21 tests → 3 files)
- Distinct from `split-large-test-file` skill (that's for Python/token limits; this is for Mojo/heap corruption)
- Covers CI wildcard pattern compatibility, ADR-009 header requirements, and correct commit strategy

## Key Findings

**What Worked**:
- Simple `rm` + create new files approach (no `git mv` needed)
- `datasets/test_*.mojo` wildcard in CI automatically covers `_part1/2/3` files — no workflow update required
- Grouping tests by functional area (init, shape, edge cases) produces clean, logical splits
- ADR-009 header comment in each part file provides traceability

**What Failed**:
- `git mv` original to `_part1` is unnecessary — when one file becomes multiple, just delete and create
- Pre-emptively editing CI workflow — check existing patterns first, wildcards often cover new files already

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` → ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in `/advise` results for Mojo heap corruption queries
- [ ] Check skill activation with tags: mojo, heap-corruption, adr-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
