### PR TITLE
feat: update adr009-test-file-splitting skill with issue #3445 session

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,47 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3445)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_callbacks.mojo (20 tests) was causing intermittent heap corruption in the Shared Infra CI
+group (13/20 recent runs failing). ADR-009 mandates ≤10 fn test_ per file, target ≤8.
+
+## Initial State
+
+Single file `tests/shared/training/test_callbacks.mojo` with 20 fn test_ functions:
+
+- 6 EarlyStopping tests
+- 6 ModelCheckpoint tests
+- 6 LoggingCallback tests
+- 2 Integration tests
+
+## Actions Taken
+
+1. Created test_callbacks_part1.mojo (6 EarlyStopping tests)
+2. Created test_callbacks_part2.mojo (6 ModelCheckpoint tests)
+3. Created test_callbacks_part3.mojo (8 LoggingCallback + integration tests)
+4. Deleted test_callbacks.mojo
+5. Updated scripts/validate_test_coverage.py: replaced test_callbacks.mojo with 3 new filenames
+   in the training exclusion list
+
+## Final State
+
+- 3 files, 6/6/8 tests each (all ≤8, well within ADR-009 limit)
+- 20 total test functions preserved
+- CI glob training/test_*.mojo covers new files automatically (no workflow change needed)
+- PR #4244 created, auto-merge enabled
+
+## Key Observation
+
+When the original file is deleted (not just updated), validate_test_coverage.py must be updated
+to remove the old filename and add the new filenames. The script uses an explicit exclusion list
+for training tests, not a glob pattern.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -88,7 +88,21 @@ grep -c "^fn test_[a-z]" tests/shared/testing/test_assertions_*.mojo
 # No workflow changes needed for testing/test_*.mojo glob pattern
 ```
 
-### 8. Commit and push
+### 8. Update validate_test_coverage.py if needed
+
+If the original file is fully deleted (not just updated), the exclusion list in
+`scripts/validate_test_coverage.py` must be updated:
+
+```python
+# Replace the old filename with the new split filenames in the exclusion list
+"tests/shared/training/test_callbacks_part1.mojo",
+"tests/shared/training/test_callbacks_part2.mojo",
+"tests/shared/training/test_callbacks_part3.mojo",
+```
+
+The pre-commit `validate-test-coverage` hook will catch this automatically if missed.
+
+### 9. Commit and push
 
 All pre-commit hooks must pass (mojo format, test coverage validation).
 
@@ -122,6 +136,7 @@ grep -c "^fn test_[a-z]" <file>.mojo
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 — split test_assertions.mojo (61 tests) in tests/shared/testing/ | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3445, PR #4244 — split test_callbacks.mojo (20 tests) in tests/shared/training/ | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with a second verified application of the
workflow, from Issue #3445 (test_callbacks.mojo split in tests/shared/training/).

- Adds Issue #3445 / PR #4244 to the Verified On table
- Documents session notes for the callbacks split in references/notes.md
- Adds a workflow step for updating `validate_test_coverage.py` exclusion lists
  when the original file is fully deleted (vs. just reduced)

## Key Findings

**What Worked**:
- Semantic split by callback type (EarlyStopping / ModelCheckpoint / LoggingCallback+integration)
- Pre-commit `validate-test-coverage` hook caught any exclusion list mismatches automatically

**New Learning**:
- When deleting (not just reducing) the original file, `validate_test_coverage.py` needs
  the old filename removed and new filenames added to the training exclusion list

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
