### PR TITLE
feat: update adr009-test-file-splitting skill with training/ session

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes.md
@@ -41,3 +41,55 @@ The file had been partially split into 7 files:
 
 The ADR-009 comment in SKILL.md headers contains the text "fn test_" which matches
 grep "^fn test_" if placed at line start. Always use "^fn test_[a-z]" for accurate counts.
+
+---
+
+# Session Notes: ADR-009 Test File Splitting (Issue #3456)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+test_training_infrastructure.mojo (18 tests) was causing intermittent heap corruption in Mojo v0.26.1 CI.
+CI group "Shared Infra & Testing" failing 13/20 recent runs on main. ADR-009 mandates ≤10 fn test_ per file.
+
+## Initial State
+
+Single file `tests/training/test_training_infrastructure.mojo` with 18 `fn test_` functions:
+
+- 2 TrainerConfig tests
+- 3 TrainingMetrics tests
+- 2 DataLoader tests
+- 1 TrainingLoop test
+- 1 ValidationLoop test
+- 7 BaseTrainer tests (init, factory, get_metrics, get_best_checkpoint, reset, databatch)
+- 2 Integration tests
+
+## Actions Taken
+
+1. Read existing file to understand all 18 tests and their logical groupings
+2. Created `test_training_infrastructure_part1.mojo` (7 tests) — TrainerConfig, TrainingMetrics, DataLoader
+3. Created `test_training_infrastructure_part2.mojo` (6 tests) — TrainingLoop, ValidationLoop, BaseTrainer init/factory
+4. Created `test_training_infrastructure_part3.mojo` (5 tests) — BaseTrainer lifecycle, DataBatch, integration
+5. Deleted original `test_training_infrastructure.mojo`
+6. Verified CI wildcard `training/test_*.mojo` picks up new files automatically — no workflow changes needed
+
+## Final State
+
+- 3 files: 7+6+5 = 18 tests total (all preserved)
+- All ≤8 tests per file (≤ target)
+- ADR-009 header in each file's docstring
+- PR #4277 created, auto-merge enabled
+
+## Key Insight for This Session
+
+When the file is a clean unsplit original (not already partially split like #3397 was),
+the split is straightforward: group by domain/responsibility. Tests in this file had
+clear logical sections already marked with `# ====` dividers, making grouping trivial.
+
+The CI workflow used `training/test_*.mojo` wildcard — confirmed by reading the workflow YAML.
+No changes to `.github/workflows/comprehensive-tests.yml` were needed.
+
+`validate_test_coverage.py` did not reference the original filename — confirmed by grep before deleting.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -122,6 +122,7 @@ grep -c "^fn test_[a-z]" <file>.mojo
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3397, PR #4094 — split test_assertions.mojo (61 tests, testing/) | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3456, PR #4277 — split test_training_infrastructure.mojo (18 tests, training/) | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the existing `adr009-test-file-splitting` skill with a second verified application of the pattern — this time splitting `tests/training/test_training_infrastructure.mojo` (18 tests) into 3 files in ProjectOdyssey issue #3456 / PR #4277.

- New entry in the "Verified On" table
- Detailed session notes added to `references/notes.md`

## Key Findings

**What Worked**:
- Splitting a clean (unsplit) original by logical domain sections is straightforward
- CI wildcard `training/test_*.mojo` picks up new files automatically — no workflow YAML changes needed
- Grep `validate_test_coverage.py` before deleting original to check for hardcoded references

**What Was Different vs. #3397**:
- #3397 had a partially-split file with stale artifacts; #3456 was a clean unsplit original
- #3397 required moving individual tests across files; #3456 was a clean 3-way split
- Both confirmed: wildcard CI patterns need no modification

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes
- [x] "Verified On" table updated in SKILL.md
- [x] Session notes appended (not overwritten) in references/notes.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)