### PR TITLE
feat: update adr009-test-file-splitting with Issue #3459 verification

### DIFF
--- a/skills/ci-cd/adr009-test-file-splitting/references/notes-3459.md
+++ b/skills/ci-cd/adr009-test-file-splitting/references/notes-3459.md
@@ -1,0 +1,50 @@
+# Session Notes: ADR-009 Test File Splitting (Issue #3459)
+
+## Date
+
+2026-03-07
+
+## Problem
+
+`tests/shared/testing/test_dtype_utils.mojo` (17 `fn test_` functions) was causing intermittent
+heap corruption in Mojo v0.26.1 CI (libKGENCompilerRTShared.so JIT fault). ADR-009 mandates
+≤10 fn test_ per file (target ≤8).
+
+## Initial State
+
+Single file with 17 test functions across these logical groups:
+
+- `get_test_dtypes` coverage (5 tests: count + each of float32/float16/bfloat16/int8)
+- `get_float_dtypes` (2 tests: count + no int8)
+- `get_precision_dtypes` (1 test: count)
+- `get_float32_only` (2 tests: single dtype + is float32)
+- `dtype_to_string` (4 tests: float16/float32/bfloat16/int8)
+- Integration/iteration (3 tests: list independence, iterate all, iterate float-only)
+
+## Actions Taken
+
+1. Split into 3 new files — original file deleted (not kept as deprecated artifact):
+   - `test_dtype_utils_part1.mojo`: 6 tests (get_test_dtypes count/dtypes + float_dtypes count)
+   - `test_dtype_utils_part2.mojo`: 8 tests (float_dtypes no-int8, precision_dtypes, float32_only, dtype_to_string)
+   - `test_dtype_utils_part3.mojo`: 3 tests (integration/iteration)
+2. Each new file has ADR-009 header comment at the top (before the docstring)
+3. No CI workflow changes needed — existing `testing/test_*.mojo` glob covers all 3 files
+
+## Final State
+
+- 3 files: 6 / 8 / 3 tests each (all ≤8, within ADR-009 limit)
+- 17 total test functions preserved (none deleted)
+- Pre-commit hooks passed: mojo format, deprecated pattern check, validate_test_coverage
+- PR #4286 created, auto-merge enabled
+
+## Key Insights
+
+- When splitting a file cleanly (no partial split already in main), deleting the original and
+  creating all 3 new files in one commit is cleaner than keeping a .DEPRECATED artifact.
+- The ADR-009 comment belongs at the very top of the file (before the docstring) so it's
+  immediately visible to reviewers.
+- Part split naming (`_part1`, `_part2`, `_part3`) works when there is no better semantic
+  grouping. Prefer semantic groupings (e.g., `_bool`, `_float`, `_int`) when tests cluster
+  meaningfully.
+- `validate_test_coverage.py` `exclude_files` list references `tests/shared/training/test_dtype_utils.mojo`
+  (a different file in the `training/` subdirectory) — no change needed there.

--- a/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-splitting/skills/adr009-test-file-splitting/SKILL.md
@@ -123,5 +123,6 @@ grep -c "^fn test_[a-z]" <file>.mojo
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3397, PR #4094 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3459, PR #4286 | [notes-3459.md](../../references/notes-3459.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issue #2942


### PR DESCRIPTION
## Summary

Updates the `adr009-test-file-splitting` skill with a second verified instance:
splitting `test_dtype_utils.mojo` (17 tests) into 3 files for ProjectOdyssey Issue #3459 / PR #4286.

- Adds `references/notes-3459.md` with full session context
- Updates "Verified On" table in SKILL.md with Issue #3459 / PR #4286

## Key Findings

**What Worked**:
- Deleting the original file + creating all 3 new files in one commit (cleaner than keeping `.DEPRECATED` artifact)
- `_part1`/`_part2`/`_part3` naming when no semantic grouping is obvious
- Placing ADR-009 comment before the docstring for immediate reviewer visibility
- `testing/test_*.mojo` CI glob auto-picks up new files — no workflow changes needed

**What Failed**:
- N/A (straightforward application of existing skill)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Verify skill appears in `/advise` for heap-corruption / ADR-009 queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
