### PR TITLE
feat: add adr009-validate-coverage-update skill

### DIFF
--- a/skills/ci-cd/adr009-validate-coverage-update/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-validate-coverage-update/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-validate-coverage-update",
+  "version": "1.0.0",
+  "description": "Update validate_test_coverage.py when splitting Mojo test files per ADR-009. Use when: (1) splitting a test file listed in validate_test_coverage.py, (2) pre-commit Validate Test Coverage hook fails after a test file split, (3) adding or removing test files that are tracked in the coverage script.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["adr009", "test-coverage", "validate-test-coverage", "mojo", "pre-commit", "heap-corruption"]
+}

--- a/skills/ci-cd/adr009-validate-coverage-update/references/notes.md
+++ b/skills/ci-cd/adr009-validate-coverage-update/references/notes.md
@@ -1,0 +1,42 @@
+# Session Notes: Issue #3465 — Split test_metrics.mojo
+
+## Session Context
+
+- **Date**: 2026-03-07
+- **Issue**: #3465 — fix(ci): split test_metrics.mojo (16 tests) — Mojo heap corruption (ADR-009)
+- **PR**: #4292
+- **Branch**: 3465-auto-impl
+
+## What Was Done
+
+Split `tests/shared/training/test_metrics.mojo` (16 `fn test_` functions) into two files:
+
+- `test_metrics_part1.mojo` — 8 tests (ComponentTracker × 5, LossTracker × 3)
+- `test_metrics_part2.mojo` — 8 tests (LossTracker reset × 1, MetricResult × 3, MetricLogger × 4)
+
+Each new file has the required ADR-009 header comment at the top.
+
+## Key Discovery
+
+`scripts/validate_test_coverage.py` explicitly lists expected test file paths. When a test
+file is deleted and replaced with two new files, this script must be updated or the pre-commit
+`Validate Test Coverage` hook fails.
+
+The CI workflow (`comprehensive-tests.yml`) uses `training/test_*.mojo` glob pattern, so it
+automatically picks up the new files — no workflow changes were needed.
+
+## Steps
+
+1. Read original `test_metrics.mojo` (16 tests identified)
+2. Grep CI workflow for `test_metrics` — no explicit reference found (glob pattern used)
+3. Created `test_metrics_part1.mojo` with 8 tests + ADR-009 header
+4. Created `test_metrics_part2.mojo` with 8 tests + ADR-009 header
+5. Deleted original `test_metrics.mojo`
+6. Grepped all `.py` files for `test_metrics` — found `validate_test_coverage.py:89`
+7. Updated `validate_test_coverage.py` to reference both new files
+8. Committed — all pre-commit hooks passed (including `Validate Test Coverage`)
+9. Pushed and created PR #4292 with auto-merge enabled
+
+## Timing
+
+Total time: ~10 minutes (very fast — well-defined task, existing ADR-009 patterns clear)

--- a/skills/ci-cd/adr009-validate-coverage-update/skills/adr009-validate-coverage-update/SKILL.md
+++ b/skills/ci-cd/adr009-validate-coverage-update/skills/adr009-validate-coverage-update/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: adr009-validate-coverage-update
+description: "Update validate_test_coverage.py when splitting Mojo test files per ADR-009. Use when: splitting a test file listed in validate_test_coverage.py, pre-commit Validate Test Coverage hook fails after a split, or adding/removing tracked test files."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Category | ci-cd |
+| Complexity | Low |
+| Risk | Low |
+| Time | ~5 minutes |
+
+When splitting a Mojo test file per ADR-009, `scripts/validate_test_coverage.py` tracks
+expected test files by exact path. Failing to update it causes the pre-commit `Validate Test
+Coverage` hook to fail with the old filename missing and new filenames unrecognized.
+
+## When to Use
+
+- Splitting a test file that appears in `scripts/validate_test_coverage.py`
+- Pre-commit `Validate Test Coverage` hook fails after an ADR-009 file split
+- Any test file is renamed, added, or deleted that is tracked in the coverage script
+
+## Verified Workflow
+
+### 1. Check if the file is tracked
+
+```bash
+grep "test_metrics" scripts/validate_test_coverage.py
+```
+
+If the file appears, it must be updated. If it doesn't appear, no change needed.
+
+### 2. Replace old entry with two new entries
+
+Use a single Edit (not sed) to replace the old filename with both new filenames:
+
+```python
+# Before
+"tests/shared/training/test_metrics.mojo",
+
+# After
+"tests/shared/training/test_metrics_part1.mojo",
+"tests/shared/training/test_metrics_part2.mojo",
+```
+
+### 3. Verify pre-commit passes
+
+```bash
+# Stage all changed files first
+git add tests/shared/training/test_metrics_part1.mojo \
+        tests/shared/training/test_metrics_part2.mojo \
+        tests/shared/training/test_metrics.mojo \
+        scripts/validate_test_coverage.py
+
+# Run pre-commit to verify (or just commit — hooks run automatically)
+```
+
+### 4. CI workflow check
+
+For CI workflows using glob patterns like `training/test_*.mojo`, new `test_*` files are
+automatically picked up — **no workflow changes needed**. Only update workflows that
+reference specific filenames explicitly.
+
+```bash
+# Verify: does the CI workflow reference the specific filename?
+grep "test_metrics" .github/workflows/comprehensive-tests.yml
+# If no output → glob picks it up automatically, no change needed
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Skipping validate_test_coverage.py update | Assumed CI workflow was the only file to update | Pre-commit `Validate Test Coverage` hook would fail with deleted filename | Always grep for the filename in `scripts/validate_test_coverage.py` before committing |
+| Updating CI workflow unnecessarily | Thought the workflow needed new filenames | CI pattern `training/test_*.mojo` auto-discovers all `test_*.mojo` files | Check if the CI pattern is a glob before editing the workflow |
+
+## Results & Parameters
+
+**Files to always check when splitting a test file:**
+
+1. `scripts/validate_test_coverage.py` — explicit file list, must be updated
+2. `.github/workflows/comprehensive-tests.yml` — check if pattern is glob or explicit
+
+**validate_test_coverage.py update pattern:**
+
+```python
+# Find the entry
+grep "test_original_name" scripts/validate_test_coverage.py
+
+# Update it (replace 1 entry with 2)
+"tests/shared/training/test_original.mojo",
+# becomes:
+"tests/shared/training/test_original_part1.mojo",
+"tests/shared/training/test_original_part2.mojo",
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3465, PR #4292 | Split test_metrics.mojo (16 tests → 8+8), updated validate_test_coverage.py |
+
+**Related:** `adr009-test-file-splitting` skill, `docs/adr/ADR-009-heap-corruption-workaround.md`


### PR DESCRIPTION
## Summary

Documents the pattern of updating `validate_test_coverage.py` when splitting Mojo test files per ADR-009 heap corruption workaround.

- Complements the existing `adr009-test-file-splitting` skill with the coverage script update step
- Captures the CI workflow glob vs explicit filename distinction
- Verified on issue #3465 (ProjectOdyssey), PR #4292

## Key Findings

**What Worked**:
- Grep all `.py` files for the old test filename to catch `validate_test_coverage.py` before committing
- CI `training/test_*.mojo` glob auto-picks up new `test_*` files — no workflow edit needed

**What Failed**:
- N/A — workflow was straightforward once the `validate_test_coverage.py` file was identified

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
