### PR TITLE
feat: add adr009-split-audit-and-recovery skill

### DIFF
--- a/skills/ci-cd/adr009-split-audit-and-recovery/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-split-audit-and-recovery/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-split-audit-and-recovery",
+  "version": "1.0.0",
+  "description": "Audit completed ADR-009 test file splits for dropped tests, missing headers, and secondary violations. Use when: (1) a split was previously done but issue is still open, (2) the post-split test count doesn't match the original, (3) other test files in the same CI group also violate ADR-009.",
+  "category": "ci-cd",
+  "date": "2026-03-07",
+  "tags": ["adr009", "mojo", "test-splitting", "heap-corruption", "audit", "recovery"]
+}

--- a/skills/ci-cd/adr009-split-audit-and-recovery/references/notes.md
+++ b/skills/ci-cd/adr009-split-audit-and-recovery/references/notes.md
@@ -1,0 +1,71 @@
+# Session Notes: ADR-009 Split Audit and Recovery
+
+**Date**: 2026-03-07
+**Issue**: #3470 — fix(ci): split test_gradient_checking.mojo (16 tests)
+**Branch**: 3470-auto-impl
+**PR**: #4305
+
+## What Happened
+
+The issue asked to split `test_gradient_checking.mojo` (16 tests) into 2 files of ≤8 tests each.
+When we started work, the split had **already been done** in commit `8a78d3aa` as part of a bulk split:
+
+- `test_gradient_checking_basic.mojo` (8 tests)
+- `test_gradient_checking_dtype.mojo` (5 tests)
+
+Total in split: **13 tests**, but original had **16 tests** → 3 were dropped silently.
+
+## Dropped Tests Found via Git History
+
+```bash
+SPLIT_COMMIT=8a78d3aa
+git show $SPLIT_COMMIT -- "tests/shared/core/test_gradient_checking.mojo" | grep "^-fn test_"
+```
+
+Output showed 16 original tests. The 3 missing:
+1. `test_relu_mixed_inputs` — tests ReLU with mixed +/- inputs
+2. `test_conv2d_gradient_fp16` — Conv2D gradient in FP16 (actually uses FP32 compute)
+3. `test_cross_entropy_gradient_fp16` — CrossEntropy gradient in FP16
+
+## Secondary Violation Found
+
+While auditing the CI group pattern in `comprehensive-tests.yml`:
+
+```
+pattern: "... test_gradient_validation.mojo ..."
+```
+
+`test_gradient_validation.mojo` had **12 tests** — violating ADR-009's ≤10 limit.
+This file was from a different commit (`9505a576`) and had never been split.
+
+It was also missing the required ADR-009 header comment entirely.
+
+## Resolution
+
+1. Added 3 dropped tests back to their respective split files
+2. Added exact ADR-009 header comment to `test_gradient_checking_basic.mojo` and `test_gradient_checking_dtype.mojo`
+3. Split `test_gradient_validation.mojo` (12 → 8 + 4):
+   - `test_gradient_validation_activations.mojo` (8 tests: ReLU x5, Sigmoid x3)
+   - `test_gradient_validation_layers.mojo` (4 tests: Tanh, GELU, Conv2D, Linear)
+4. Renamed original to `.DEPRECATED` per project convention
+5. Updated CI workflow to reference new filenames
+
+## Files Changed
+
+- `tests/shared/core/test_gradient_checking_basic.mojo` — +ADR-009 header, +test_relu_mixed_inputs (→ 9 tests)
+- `tests/shared/core/test_gradient_checking_dtype.mojo` — +ADR-009 header, +2 FP16 tests (→ 7 tests)
+- `tests/shared/core/test_gradient_validation_activations.mojo` — new (8 tests)
+- `tests/shared/core/test_gradient_validation_layers.mojo` — new (4 tests)
+- `tests/shared/core/test_gradient_validation.mojo.DEPRECATED` — renamed
+- `.github/workflows/comprehensive-tests.yml` — Core Gradient group updated
+
+## ADR-009 Header Format (Required)
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+NOT equivalent: prose docstrings like `"Note: Split from X due to ADR-009."` — the acceptance criteria
+specified the exact comment format.

--- a/skills/ci-cd/adr009-split-audit-and-recovery/skills/adr009-split-audit-and-recovery/SKILL.md
+++ b/skills/ci-cd/adr009-split-audit-and-recovery/skills/adr009-split-audit-and-recovery/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: adr009-split-audit-and-recovery
+description: "Audit completed ADR-009 test file splits for dropped tests, missing headers, and secondary violations. Use when: a split was previously done but tests are still failing or the issue remains open, the post-split test count doesn't match the original file's count, or other test files in the same CI group also violate ADR-009."
+category: ci-cd
+date: 2026-03-07
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Prior ADR-009 split may drop tests, use wrong header format, or leave other violations in the same CI group |
+| **Risk** | Test coverage gaps from dropped tests; secondary heap corruption from un-split files |
+| **Trigger** | Issue still open after split, test count mismatch, CI group still flaky |
+| **Validated On** | `test_gradient_checking.mojo` (16 → 13 tests in split; 3 dropped; `test_gradient_validation.mojo` also violated) |
+
+## When to Use
+
+- A split was completed (`.DEPRECATED` file exists, new files reference CI workflow), but the issue is still open
+- The sum of `fn test_` counts in split files is less than the original file's count
+- Other test files referenced in the same CI group also exceed 10 `fn test_` functions
+- Split files are missing the required ADR-009 header comment block
+
+## Verified Workflow
+
+### Step 1: Confirm the prior split state
+
+```bash
+# Check if DEPRECATED file exists (split was done)
+ls tests/**/*.DEPRECATED
+
+# Count tests in all split files vs original deleted file
+grep -c "^fn test_" tests/path/to/test_file_part*.mojo
+
+# Check git log for the split commit
+git log --oneline -- "tests/path/to/test_file.mojo" | head -5
+```
+
+### Step 2: Count original tests from git history
+
+The original file was deleted in the split commit. Recover the count via `git show`:
+
+```bash
+# Find the commit that deleted the original
+SPLIT_COMMIT=$(git log --oneline -- "tests/path/to/test_original.mojo" | head -1 | cut -d' ' -f1)
+
+# Count original fn test_ functions
+git show $SPLIT_COMMIT -- "tests/path/to/test_original.mojo" | grep "^-fn test_" | wc -l
+
+# List original test names
+git show $SPLIT_COMMIT -- "tests/path/to/test_original.mojo" | grep "^-fn test_"
+```
+
+### Step 3: Identify dropped tests
+
+Compare original test names against what's in the split files:
+
+```bash
+# Get all test names from split files
+grep "^fn test_" tests/path/to/test_file_*.mojo
+
+# Visually diff original list vs split list to find missing tests
+```
+
+### Step 4: Recover dropped tests from git history
+
+Get the full implementation of each missing test:
+
+```bash
+git show $SPLIT_COMMIT -- "tests/path/to/test_original.mojo" | grep -A 40 "^-fn test_missing_test_name"
+```
+
+Strip the leading `-` from each line (it's the diff prefix) and add to the appropriate split file.
+
+### Step 5: Audit the CI group for secondary violations
+
+Other files in the same CI group may also violate ADR-009:
+
+```bash
+# Get CI group pattern from workflow
+grep -A 3 '"Core Gradient"' .github/workflows/comprehensive-tests.yml
+
+# Count tests in every file referenced by the group
+for f in <files from pattern>; do
+  COUNT=$(grep -c "^fn test_" tests/path/to/$f 2>/dev/null || echo 0)
+  echo "$COUNT $f"
+done | sort -n
+```
+
+Any file with > 10 tests must be split. Files with 11-12 tests often went unnoticed.
+
+### Step 6: Verify ADR-009 header format in all split files
+
+The required header is:
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_file>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+Check if existing split files have it:
+
+```bash
+grep "^# ADR-009" tests/path/to/test_file_*.mojo
+```
+
+If missing (files may have prose docstrings instead), prepend the exact comment block before the docstring.
+
+### Step 7: Split any secondary violations
+
+For each file with > 10 tests, apply the standard split workflow:
+
+- Group tests semantically (e.g., activation functions vs layers)
+- Target ≤8 tests per file (ADR-009 hard limit is 10, target 8 for safety margin)
+- Rename original to `.DEPRECATED`
+- Create split files with ADR-009 header
+- Update CI workflow pattern
+
+### Step 8: Update CI workflow
+
+Replace the old filenames with new split filenames:
+
+```yaml
+# Before
+pattern: "... test_gradient_validation.mojo ..."
+
+# After
+pattern: "... test_gradient_validation_activations.mojo test_gradient_validation_layers.mojo ..."
+```
+
+### Step 9: Pre-commit and commit
+
+```bash
+git add <all modified files>
+pixi run pre-commit run --files <files>
+git commit -m "fix(ci): restore N missing tests and split secondary violations (ADR-009)
+
+Closes #<issue>
+..."
+```
+
+## Results & Parameters
+
+From the `test_gradient_checking.mojo` session (2026-03-07):
+
+| Metric | Value |
+|--------|-------|
+| Original test count | 16 |
+| Tests in initial split | 13 (3 dropped) |
+| Dropped test names | `test_relu_mixed_inputs`, `test_conv2d_gradient_fp16`, `test_cross_entropy_gradient_fp16` |
+| Secondary violation | `test_gradient_validation.mojo` — 12 tests (found via CI group audit) |
+| Final split result | 4 files: 9, 7, 8, 4 tests |
+| ADR-009 header format | Must use `# ADR-009:` comment (not prose docstring) |
+
+## Key Invariants
+
+- **Always audit secondary files** in the same CI group — they often have violations too
+- **Always verify test counts** from git history before closing an issue
+- **Dropped tests are silent** — no compiler or CI error warns you; only manual count comparison reveals them
+- **Header format matters** — prose docstrings mentioning ADR-009 are NOT equivalent to the required comment block
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assumed split was complete | Checked only that the original file was deleted and new files existed in CI workflow | 3 tests were silently dropped; count 13 ≠ 16 | Always compare `git show <split_commit> \| grep "^-fn test_"` count vs split file count |
+| Checked only the primary file | Audited `test_gradient_checking.mojo` split files only | `test_gradient_validation.mojo` (12 tests, same CI group) was still violating ADR-009 | Always audit ALL files referenced in the CI group pattern, not just the issue's primary file |
+| Prose docstring as ADR-009 header | Initial splits used `"Note: Split from X due to ADR-009"` in docstring | Issue spec requires exact `# ADR-009:` comment block format | Check issue acceptance criteria for exact header format requirements |


### PR DESCRIPTION
## Summary

Documents the workflow for auditing completed ADR-009 test file splits to detect silently dropped
tests, incorrect header formats, and secondary violations in the same CI group.

- Validates split test counts against original via git history
- Identifies secondary files in same CI group that also violate ADR-009
- Distinguishes required `# ADR-009:` comment blocks from informal prose docstrings

## Key Findings

**What Worked**:
- `git show <split_commit> -- <original_file> | grep "^-fn test_"` reliably recovers original test list
- Auditing all files in the CI group pattern catches secondary violations missed by issue scope
- ADR-009 header must be exact `# ADR-009:` comment block (not prose docstring) per acceptance criteria

**What Failed**:
- Assuming split was complete because original file was deleted and CI workflow was updated — 3 tests were silently dropped (count 13 ≠ 16 original)
- Checking only the primary file from the issue — `test_gradient_validation.mojo` (12 tests, same CI group) was also violating ADR-009

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant trigger patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
