### PR TITLE
feat(ci-cd): update mojo-adr009-test-split with test_conv.mojo learnings (Issue #3477)

### DIFF
--- a/skills/ci-cd/mojo-adr009-test-split/references/notes.md
+++ b/skills/ci-cd/mojo-adr009-test-split/references/notes.md
@@ -176,3 +176,75 @@ Single file `tests/shared/autograd/test_optimizer_base.mojo` containing 18 tests
 1. When the CI group uses a glob (`autograd/test_*.mojo`), new `_part1/2/3` files are picked up automatically — no workflow edit needed
 2. Equal splits (6/6/6) are simpler to reason about than asymmetric splits for 18-test files
 3. `validate_test_coverage.py` uses glob patterns, so no script changes are needed when splitting
+
+---
+
+# Session Notes: ADR-009 Conv Test Split (Issue #3477)
+
+## Context
+
+- **Date**: 2026-03-07
+- **Issue**: #3477 — `tests/shared/core/test_conv.mojo` title said 15 `fn test_` functions but actual count was 20
+- **ADR-009 limit**: ≤10 per file
+- **CI group**: Core Utilities (explicit filename pattern in workflow, not glob)
+- **Root cause**: Same Mojo v0.26.1 heap corruption bug
+
+## Key Discovery: Issue Description Undercount
+
+The issue title stated "15 tests" but `grep -c "^fn test_" tests/shared/core/test_conv.mojo`
+returned 20. A 2-way split of 20 would yield 10/10, which hits the hard limit exactly (not the
+≤8 target). This forced a 3-way split.
+
+**Lesson**: Always grep for the actual count before planning — issue descriptions can undercount.
+
+## Original file test inventory (20 tests)
+
+```text
+fn test_conv2d_initialization
+fn test_conv2d_shape_inference
+fn test_conv2d_forward_shape
+fn test_conv2d_stride_shape
+fn test_conv2d_dilation_shape
+fn test_conv2d_groups_shape
+fn test_conv2d_padding_shape
+fn test_conv2d_forward_values
+fn test_conv2d_no_bias
+fn test_conv2d_batched
+fn test_conv2d_5x5
+fn test_conv2d_backward_input_shape
+fn test_conv2d_backward_weight_shape
+fn test_conv2d_backward_bias_shape
+fn test_conv2d_backward_input_gradient
+fn test_conv2d_backward_weight_gradient
+fn test_conv2d_backward_bias_gradient
+fn test_conv2d_backward_no_bias
+fn test_conv2d_full_backward_pass
+fn test_conv2d_integration
+```
+
+## Split decision
+
+- **part1** (7): initialization and shape tests — test_conv2d_initialization through test_conv2d_padding_shape
+- **part2** (7): numerical correctness and batch tests — test_conv2d_forward_values through test_conv2d_5x5
+- **part3** (6): backward pass and integration — test_conv2d_backward_input_shape through test_conv2d_integration
+
+## CI workflow update
+
+The `comprehensive-tests.yml` Core Utilities group used an explicit filename pattern (not a glob),
+so a workflow update was required. Replaced `test_conv.mojo` with three filenames:
+`test_conv_part1.mojo test_conv_part2.mojo test_conv_part3.mojo`.
+
+## Pre-commit results
+
+All hooks passed on first attempt.
+
+## PR
+
+- PR #4322: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4322
+- Auto-merge enabled with rebase strategy
+
+## Key Gotchas (new learnings vs #3457)
+
+1. Issue descriptions can undercount tests — grep for `^fn test_[a-z]` to get accurate count before planning
+2. A 2-way split of 20 tests yields 10/10 which hits the ADR-009 hard limit; use 3-way split to meet ≤8 target
+3. Explicit filename patterns in CI workflow require manual update (unlike glob patterns that auto-match)

--- a/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
+++ b/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
@@ -138,6 +138,7 @@ grep -c "^fn test_[a-z]" <original>_part*.mojo   # should also total 18
 | `continue-on-error: true` | Marking group non-blocking in CI | Hides signal, doesn't fix root cause | Only use as temporary mitigation, not fix |
 | Reducing test complexity | Simplifying individual tests | Heap corruption is load-based, not complexity-based | Total `fn test_` count is the trigger, not test logic |
 | Assumed split was complete | Saw N split files and `.DEPRECATED`, assumed done | Tests were missing from split files — some categories of tests omitted | Always verify by comparing `fn test_` lists between original and split files, not just file existence |
+| Trusted issue description test count | Issue #3477 said 15 tests; planned a 2-way split | Actual count was 20 (issue undercounted); 2-way split would yield 10/10 which hits the limit | Always grep for `^fn test_[a-z]` to get the real count before planning the split |
 | Used `grep -c "fn test_"` to count tests | Counted lines matching pattern to verify ≤10 limit | ADR-009 header comment contains "fn test_" text, inflating count by 1 | Use `grep -n "fn test_"` or `grep -c "^fn test_[a-z]"` to see actual lines and verify count |
 | Wrong ADR-009 header format | Used docstring note: "Note: Split from... See ADR-009." | ADR-009 requires `# ADR-009:` comment block format, not a note inside the docstring | Header must be `#` comment lines at file top, before the module docstring |
 | Modifying CI workflow glob pattern | Thought new files would not be matched by existing glob | Glob `test_*.mojo` already covers `test_*_part1.mojo` | Verify existing glob before making changes; it usually already works |
@@ -166,5 +167,6 @@ grep -n "^fn test_" tests/path/to/test_<name>_*.mojo
 | ProjectOdyssey | Issue #3438, PR #4223 | test_reduction.mojo: 22 tests → 3 files |
 | ProjectOdyssey | Issue #3444, PR #4238 | test_backward.mojo: 21 tests → 3 files; found 7 missing tests + wrong header format |
 | ProjectOdyssey | Issue #3457, PR #4278 | test_optimizer_base.mojo: 18 tests → 3 files of 6/6/6; CI glob auto-covered new files |
+| ProjectOdyssey | Issue #3477, PR #4322 | test_conv.mojo: issue said 15 tests but actual count was 20 → 3 files of 7/7/6; CI workflow explicit pattern updated |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`


### PR DESCRIPTION
## Summary

- Adds verified instance from ProjectOdyssey Issue #3477 / PR #4322 to the `mojo-adr009-test-split` skill
- `test_conv.mojo` had 20 tests (issue said 15) → split into 3 files of 7/7/6
- Adds new Failed Attempts entry: trusting issue description test count leads to wrong split planning

## Changes

- `skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md`: added row to Verified On table and new Failed Attempts row
- `skills/ci-cd/mojo-adr009-test-split/references/notes.md`: appended full session notes for Issue #3477

## Key New Learning

Issue descriptions can undercount tests. The issue said 15 but `grep -c "^fn test_[a-z]"` returned 20.
A 2-way split of 20 tests would yield 10/10 (hitting the hard limit, not the ≤8 target).
Always grep for the real count before planning.

## Test plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` — 528/528 passed, 0 failed