### PR TITLE
feat: add adr009-mojo-test-file-split skill

### DIFF
--- a/skills/ci-cd/adr009-mojo-test-file-split/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-mojo-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-mojo-test-file-split",
+  "version": "1.0.0",
+  "description": "Split oversized Mojo test files to comply with ADR-009 heap-corruption workaround (≤10 fn test_ per file). Use when: (1) a .mojo test file exceeds 10 fn test_ functions, (2) CI shows intermittent libKGENCompilerRTShared.so JIT crashes in a test group, (3) implementing ADR-009 for a new test file.",
+  "category": "ci-cd",
+  "date": "2026-03-08",
+  "tags": ["mojo", "adr-009", "heap-corruption", "test-split", "ci-stability"]
+}

--- a/skills/ci-cd/adr009-mojo-test-file-split/references/notes.md
+++ b/skills/ci-cd/adr009-mojo-test-file-split/references/notes.md
@@ -1,0 +1,46 @@
+# Session Notes: ADR-009 Mojo Test File Split
+
+## Session Context
+
+- **Issue**: #3486 — fix(ci): split test_augmentations.mojo (14 tests) — Mojo heap corruption (ADR-009)
+- **Branch**: `3486-auto-impl`
+- **PR**: #4340
+- **Date**: 2026-03-08
+
+## Problem
+
+`tests/shared/data/transforms/test_augmentations.mojo` had 14 `fn test_` functions,
+exceeding ADR-009's limit of 10 per file. This caused intermittent CI crashes in the
+`Data Transforms` CI group (13/20 recent runs on main failing) due to Mojo v0.26.1
+heap corruption in `libKGENCompilerRTShared.so` JIT under high test load.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3486.md` to understand the task
+2. Read `test_augmentations.mojo` (509 lines, 14 test functions)
+3. Checked `comprehensive-tests.yml` for explicit filename references — found none
+4. Checked `validate_test_coverage.py` for explicit references — found none
+5. Created `test_augmentations_part1.mojo` (7 tests: general/rotation/crop)
+6. Created `test_augmentations_part2.mojo` (7 tests: flip/erasing/composition)
+7. Deleted original `test_augmentations.mojo`
+8. Committed — all pre-commit hooks passed on first attempt
+9. Pushed and created PR #4340
+
+## Key Decisions
+
+- Split logically by test category, not arbitrarily
+- 7+7 equal split (14 total → two files of 7, well under the 10-function limit)
+- ADR-009 header placed in module docstring (not as standalone comment) for clarity
+- No CI workflow changes needed — `transforms/test_*.mojo` glob covers new files
+- No `validate_test_coverage.py` changes needed — dynamic discovery used
+
+## Pre-Commit Results
+
+All hooks passed on first commit attempt:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed

--- a/skills/ci-cd/adr009-mojo-test-file-split/skills/adr009-mojo-test-file-split/SKILL.md
+++ b/skills/ci-cd/adr009-mojo-test-file-split/skills/adr009-mojo-test-file-split/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: adr009-mojo-test-file-split
+description: "Split oversized Mojo test files to comply with ADR-009 heap-corruption workaround (≤10 fn test_ per file). Use when: a .mojo test file exceeds 10 fn test_ functions causing intermittent CI crashes."
+category: ci-cd
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo v0.26.1 causes heap corruption (`libKGENCompilerRTShared.so` JIT fault) under high test load |
+| **Symptom** | Intermittent CI crashes in a test group, non-deterministic failures across runs |
+| **Root Cause** | Single `.mojo` test file containing >10 `fn test_` functions |
+| **Fix** | Split file into multiple files of ≤8 tests each, add ADR-009 header comment |
+| **Precedent** | ADR-009 (`docs/adr/ADR-009-heap-corruption-workaround.md`) |
+
+## When to Use
+
+- A `.mojo` test file has more than 10 `fn test_` functions
+- CI shows intermittent `libKGENCompilerRTShared.so` crashes in a test group
+- ADR-009 compliance audit flags a file as over the limit
+- Issue title contains "ADR-009" and involves splitting a test file
+
+## Verified Workflow
+
+### 1. Count fn test_ functions in the target file
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+### 2. Read the original file to plan the split
+
+Split logically by test category (e.g., rotation tests in part1, flip tests in part2).
+Target ≤8 tests per file (leaving headroom below the 10-function limit).
+
+### 3. Create part1 and part2 files
+
+Each file must:
+
+- Use the **same imports** as the original
+- Include the **ADR-009 header comment** in the module docstring:
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_filename>. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+- Have its own `fn main() raises:` that calls only its subset of tests
+- Update the final print to reflect the correct count (e.g., "All 7 augmentation tests (part 1) passed!")
+
+### 4. Delete the original file
+
+```bash
+rm tests/path/to/test_file.mojo
+```
+
+### 5. Verify CI workflow picks up new files automatically
+
+Check that the CI workflow uses a glob pattern (e.g., `transforms/test_*.mojo`) rather than
+listing filenames explicitly. If it lists filenames explicitly, update the pattern list.
+
+```bash
+grep -n "test_augmentations\|test_<filename>" .github/workflows/comprehensive-tests.yml
+```
+
+### 6. Check validate_test_coverage.py for explicit references
+
+```bash
+grep -n "<original_filename>" scripts/validate_test_coverage.py
+```
+
+If found, update the references to the two new filenames.
+
+### 7. Stage, commit, and verify pre-commit passes
+
+```bash
+git add tests/path/to/test_file_part1.mojo tests/path/to/test_file_part2.mojo tests/path/to/test_file.mojo
+git commit -m "fix(ci): split <filename> into 2 files (ADR-009)"
+```
+
+Pre-commit hooks that run: `mojo format`, `Validate Test Coverage`, `trailing-whitespace`,
+`end-of-file-fixer`.
+
+## Results & Parameters
+
+### Split ratio
+
+For a 14-test file: split 7+7 (equal halves). For a 12-test file: split 6+6 or 7+5.
+Always target ≤8 per file to leave headroom.
+
+### Naming convention
+
+```text
+test_<topic>.mojo          → original (DELETE)
+test_<topic>_part1.mojo   → first split file
+test_<topic>_part2.mojo   → second split file
+```
+
+### ADR-009 header template
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+### CI workflow check
+
+The `Data` test group and most others use glob patterns like `transforms/test_*.mojo`,
+so new `_part1`/`_part2` files are discovered automatically without workflow changes.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Checking for explicit filename in CI workflow | Searched for `augmentation` in comprehensive-tests.yml | No explicit references found — glob pattern used instead | Always check CI workflow first; glob patterns auto-discover split files |
+| Modifying validate_test_coverage.py | Searched for explicit references to the original filename | No references found — script uses dynamic discovery | validate_test_coverage.py may not need updates if it uses glob/dynamic discovery |


### PR DESCRIPTION
## Summary

Documents the workflow for splitting oversized Mojo test files to comply with ADR-009
heap-corruption workaround (≤10 `fn test_` per file in Mojo v0.26.1).

Captured from issue #3486 in ProjectOdyssey: splitting `test_augmentations.mojo`
(14 tests) into `test_augmentations_part1.mojo` + `test_augmentations_part2.mojo` (7 each).

## Key Findings

**What Worked**:
- Splitting logically by test category (rotation/crop in part1, flip/erasing/compose in part2)
- 7+7 equal split leaves headroom below the 10-function limit
- ADR-009 header comment in module docstring of each split file
- All pre-commit hooks passed on first attempt (no reformatting needed)

**What Failed**:
- N/A — straightforward execution; no failed attempts in this session

**Key Insight**: CI workflow uses `transforms/test_*.mojo` glob patterns, so split files
are auto-discovered without workflow changes. Always check this before editing CI YAML.

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with ADR-009 / test-split triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
