### PR TITLE
feat: update mojo-adr009-test-split skill with issue #3494 findings

### DIFF
--- a/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
+++ b/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
@@ -2,7 +2,7 @@
 name: mojo-adr009-test-split
 description: "Split oversized Mojo test files to comply with ADR-009 (≤10 fn test_ per file) and eliminate heap corruption CI failures. Use when: a test_*.mojo file exceeds 10 fn test_ functions, CI shows intermittent libKGENCompilerRTShared.so crashes, or a test group non-deterministically fails under high load."
 category: ci-cd
-date: 2026-03-07
+date: 2026-03-08
 user-invocable: false
 ---
 
@@ -142,7 +142,7 @@ grep -c "^fn test_[a-z]" <original>_part*.mojo   # should also total 18
 | Used `grep -c "fn test_"` to count tests | Counted lines matching pattern to verify ≤10 limit | ADR-009 header comment contains "fn test_" text, inflating count by 1 | Use `grep -n "fn test_"` or `grep -c "^fn test_[a-z]"` to see actual lines and verify count |
 | Wrong ADR-009 header format | Used docstring note: "Note: Split from... See ADR-009." | ADR-009 requires `# ADR-009:` comment block format, not a note inside the docstring | Header must be `#` comment lines at file top, before the module docstring |
 | Modifying CI workflow glob pattern | Thought new files would not be matched by existing glob | Glob `test_*.mojo` already covers `test_*_part1.mojo` | Verify existing glob before making changes; it usually already works |
-| Checking `validate_test_coverage.py` for filename refs | Searched for original filename in the script | Script uses glob patterns, not hardcoded filenames | No changes needed to coverage validation script when splitting |
+| Checking `validate_test_coverage.py` for filename refs | Assumed script uses glob patterns, so no changes needed | Script has a hardcoded filename list — original filename must be replaced with new part filenames | Always grep for the original filename in `validate_test_coverage.py`; update list if found |
 
 ## Additional Notes
 
@@ -168,5 +168,6 @@ grep -n "^fn test_" tests/path/to/test_<name>_*.mojo
 | ProjectOdyssey | Issue #3444, PR #4238 | test_backward.mojo: 21 tests → 3 files; found 7 missing tests + wrong header format |
 | ProjectOdyssey | Issue #3457, PR #4278 | test_optimizer_base.mojo: 18 tests → 3 files of 6/6/6; CI glob auto-covered new files |
 | ProjectOdyssey | Issue #3477, PR #4322 | test_conv.mojo: issue said 15 tests but actual count was 20 → 3 files of 7/7/6; CI workflow explicit pattern updated |
+| ProjectOdyssey | Issue #3494, PR #4365 | test_lars.mojo: 13 tests → 2 files of 8/5; CI glob auto-covered new files; validate_test_coverage.py had hardcoded filename — updated |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`


### PR DESCRIPTION
## Summary

Updates the `mojo-adr009-test-split` skill with a new verified-on entry and a corrected failed-attempts row.

- **New verified-on**: issue #3494, PR #4365 — `test_lars.mojo` (13 tests → 2 files of 8/5)
- **Corrected failed-attempt**: `validate_test_coverage.py` uses a **hardcoded filename list**, not globs — must be updated when splitting; previous entry incorrectly said "no changes needed"

## Key Findings

**What Worked**:
- 2-way split (8+5) for a 13-test file works cleanly within ADR-009 ≤10 limit
- CI `training/test_*.mojo` glob auto-covers new `_part1`/`_part2` files — no workflow YAML change needed
- `grep -c "^fn test_"` count (13) matched issue description exactly — no undercount this time

**What Failed / Needed Correction**:
- Previous skill entry said `validate_test_coverage.py` uses globs → it does NOT; it has a hardcoded list of filenames; must grep for the original filename and replace with part filenames

## Test Plan

- [x] Plugin validated with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] ALL VALIDATIONS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
