### PR TITLE
feat: update mojo-adr009-test-split with issue #3498 learnings

### DIFF
--- a/skills/ci-cd/mojo-adr009-test-split/references/notes.md
+++ b/skills/ci-cd/mojo-adr009-test-split/references/notes.md
@@ -248,3 +248,32 @@ All hooks passed on first attempt.
 1. Issue descriptions can undercount tests — grep for `^fn test_[a-z]` to get accurate count before planning
 2. A 2-way split of 20 tests yields 10/10 which hits the ADR-009 hard limit; use 3-way split to meet ≤8 target
 3. Explicit filename patterns in CI workflow require manual update (unlike glob patterns that auto-match)
+
+---
+
+## Session Notes: ADR-009 Test Split (Issue #3498, PR #4373)
+
+### Context
+
+- **Date**: 2026-03-08
+- **Issue**: #3498 — `tests/shared/testing/test_gradient_checker_meta.mojo` had 14 `fn test_` functions
+- **ADR-009 limit**: ≤10 per file (target ≤8)
+- **CI failure rate**: 13/20 recent runs on `main` (Testing Fixtures group)
+- **Split result**: 2 files — part1 (8 tests), part2 (6 tests)
+
+### Key Learnings vs Prior Sessions
+
+1. **ADR-009 header placement**: The `# ADR-009:` comment block must appear at the absolute top of
+   the file (line 1), before the triple-quoted module docstring. Placing it inside the docstring
+   makes it a string literal, not a source comment.
+
+2. **CI glob auto-coverage**: The `testing/test_*.mojo` glob in `comprehensive-tests.yml` already
+   covers `test_gradient_checker_meta_part1.mojo` and `test_gradient_checker_meta_part2.mojo`.
+   No workflow edits were needed. Always verify existing glob before editing CI YAML.
+
+3. **validate_test_coverage.py is glob-based**: Confirmed once more that the pre-commit hook uses
+   glob patterns (not hardcoded filenames), so no script changes needed after a split.
+
+4. **Helper functions duplicated across parts**: Both part files needed the shared helper functions
+   (`square_forward`, `square_backward_correct`, etc.) because Mojo has no intra-test imports.
+   This is expected and acceptable.

--- a/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
+++ b/skills/ci-cd/mojo-adr009-test-split/skills/mojo-adr009-test-split/SKILL.md
@@ -143,6 +143,7 @@ grep -c "^fn test_[a-z]" <original>_part*.mojo   # should also total 18
 | Wrong ADR-009 header format | Used docstring note: "Note: Split from... See ADR-009." | ADR-009 requires `# ADR-009:` comment block format, not a note inside the docstring | Header must be `#` comment lines at file top, before the module docstring |
 | Modifying CI workflow glob pattern | Thought new files would not be matched by existing glob | Glob `test_*.mojo` already covers `test_*_part1.mojo` | Verify existing glob before making changes; it usually already works |
 | Checking `validate_test_coverage.py` for filename refs | Searched for original filename in the script | Script uses glob patterns, not hardcoded filenames | No changes needed to coverage validation script when splitting |
+| ADR-009 header inside module docstring | Placed `# ADR-009:` comment block inside the triple-quoted module docstring | Mojo treats it as part of the string literal, not a source comment | ADR-009 header must be `#` comment lines at the absolute top of the file, before the `"""` docstring |
 
 ## Additional Notes
 
@@ -168,5 +169,6 @@ grep -n "^fn test_" tests/path/to/test_<name>_*.mojo
 | ProjectOdyssey | Issue #3444, PR #4238 | test_backward.mojo: 21 tests → 3 files; found 7 missing tests + wrong header format |
 | ProjectOdyssey | Issue #3457, PR #4278 | test_optimizer_base.mojo: 18 tests → 3 files of 6/6/6; CI glob auto-covered new files |
 | ProjectOdyssey | Issue #3477, PR #4322 | test_conv.mojo: issue said 15 tests but actual count was 20 → 3 files of 7/7/6; CI workflow explicit pattern updated |
+| ProjectOdyssey | Issue #3498, PR #4373 | test_gradient_checker_meta.mojo: 14 tests → 2 files of 8/6; ADR-009 header at file top (before docstring); CI glob auto-covered |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`


### PR DESCRIPTION
## Summary

Updates the `mojo-adr009-test-split` skill with learnings from ProjectOdyssey issue #3498
(splitting `test_gradient_checker_meta.mojo`, 14 tests → 2 files of 8/6).

- Adds new "Verified On" row for issue #3498 / PR #4373
- New Failed Attempts row: ADR-009 header must be `#` comment at file top, BEFORE the module docstring
- Session notes with 4 key learnings added to references/notes.md

## Key Findings

**What Worked**:
- Split 14-test file into part1 (8 tests) + part2 (6 tests) — both under ≤8 target
- CI `testing/test_*.mojo` glob auto-picked up both new files — zero workflow changes needed
- All pre-commit hooks passed without issues

**What Failed / New Learnings**:
- ADR-009 header inside module docstring → must be `#` comment lines at absolute file top, before `"""`
- Helper functions cannot be shared across part files (Mojo has no intra-test imports) — duplication is expected

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] All validations passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
