### PR TITLE
feat: add adr-test-file-split skill

### DIFF
--- a/skills/ci-cd/adr-test-file-split/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr-test-file-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files that exceed ADR-009 fn test_ function limits to prevent heap corruption CI failures. Use when: (1) a .mojo test file has more than 10 fn test_ functions, (2) CI shows intermittent heap corruption crashes (libKGENCompilerRTShared.so), (3) a test file needs to comply with ADR-009 limits.",
+  "category": "ci-cd",
+  "date": "2026-03-08",
+  "tags": ["mojo", "adr-009", "heap-corruption", "test-split", "ci-stability"]
+}

--- a/skills/ci-cd/adr-test-file-split/references/notes.md
+++ b/skills/ci-cd/adr-test-file-split/references/notes.md
@@ -1,0 +1,41 @@
+# Session Notes: ADR-009 Test File Split
+
+**Date**: 2026-03-08
+**Issue**: ProjectOdyssey #3500
+**PR**: ProjectOdyssey #4377
+
+## Context
+
+`tests/shared/integration/test_multi_precision_training.mojo` had 13 `fn test_` functions,
+exceeding ADR-009's limit of ≤10 per file. This caused intermittent heap corruption crashes
+(libKGENCompilerRTShared.so JIT fault) in Mojo v0.26.1 on CI.
+
+## What Was Done
+
+1. Counted test functions: `grep -c "^fn test_" <file>` → 13
+2. Read the original file to understand test groupings
+3. Created `test_multi_precision_training_part1.mojo` (8 tests: FP32/FP16/BF16/FP8 training,
+   overflow recovery, config parsing, dynamic scaling)
+4. Created `test_multi_precision_training_part2.mojo` (5 tests: master weights, FP16/BF16
+   accuracy, memory savings, TOML config)
+5. Both files: ADR-009 header comment, updated module docstring, updated `main()` with correct count
+6. Deleted original file
+7. Updated `tests/shared/integration/__init__.mojo` doc comment
+8. Checked CI workflow — `pattern: "test_*.mojo"` auto-discovers new files, no changes needed
+9. Committed, pushed, PR created with auto-merge enabled
+
+## Pre-commit Results
+
+All hooks passed on first attempt:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+
+## Key Insight
+
+The CI Integration Tests group used a glob pattern (`test_*.mojo`), so splitting the file
+automatically made both new files discoverable with zero workflow changes. This is a common
+pattern in the ProjectOdyssey CI setup — always check the pattern before editing workflows.

--- a/skills/ci-cd/adr-test-file-split/skills/adr-test-file-split/SKILL.md
+++ b/skills/ci-cd/adr-test-file-split/skills/adr-test-file-split/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: adr-test-file-split
+description: "Split Mojo test files exceeding ADR-009 fn test_ function limits to fix heap corruption CI failures. Use when: a .mojo test file has >10 fn test_ functions causing intermittent CI crashes."
+category: ci-cd
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so JIT fault) under high test load |
+| **ADR** | ADR-009 — ≤10 `fn test_` functions per file |
+| **Trigger** | File has >10 `fn test_` functions OR CI shows intermittent crashes in test group |
+| **Fix** | Split into multiple files of ≤8 tests each with ADR-009 header comment |
+| **CI Impact** | Glob patterns (`test_*.mojo`) auto-discover new files — no workflow changes needed |
+
+## When to Use
+
+- A `.mojo` test file has more than 10 `fn test_` functions
+- CI shows intermittent `libKGENCompilerRTShared.so` crashes in a test group
+- GitHub issue references ADR-009 heap corruption workaround
+- `grep -c "^fn test_" <file>.mojo` returns a number > 10
+
+## Verified Workflow
+
+### 1. Count test functions in the file
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+### 2. Plan the split
+
+- Target: ≤8 tests per file (below the 10 limit for safety margin)
+- Name new files: `test_<original>_part1.mojo`, `test_<original>_part2.mojo`
+- Assign tests logically (e.g., by feature area, not just sequential)
+
+### 3. Create Part 1 (first ~8 tests)
+
+Each new file needs:
+
+1. **ADR-009 header comment** (first 3 lines):
+   ```mojo
+   # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+   # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+   # high test load. Split from <original_filename>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+   ```
+
+2. **Updated module docstring** referencing "Part 1 of 2"
+
+3. **All original imports** (copy from original)
+
+4. **The assigned test functions** (full body, no modifications)
+
+5. **Updated `main()`** that only calls the tests in this file, with updated count in final print
+
+### 4. Create Part 2 (remaining tests)
+
+Same structure as Part 1 but with the remaining tests and "Part 2 of 2" labels.
+
+### 5. Delete the original file
+
+```bash
+rm tests/path/to/test_original.mojo
+```
+
+### 6. Update any `__init__.mojo` or registry files
+
+- Search for references to the original filename
+- Update doc comments and any registry lists
+
+```bash
+grep -r "test_original" tests/  # find references
+```
+
+### 7. Check CI workflow patterns
+
+```bash
+grep -A3 "Integration Tests\|<test-group-name>" .github/workflows/comprehensive-tests.yml
+```
+
+- If the group uses `pattern: "test_*.mojo"` → **no changes needed**, glob auto-discovers new files
+- If the group lists filenames explicitly → update the pattern to include both new files
+
+### 8. Stage, commit, push, PR
+
+```bash
+git add tests/path/to/test_original_part1.mojo \
+        tests/path/to/test_original_part2.mojo \
+        tests/path/to/original.mojo \          # deleted
+        tests/path/to/__init__.mojo             # if updated
+
+git commit -m "fix(ci): split test_<name>.mojo into 2 files (ADR-009)"
+git push -u origin <branch>
+gh pr create ...
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Reducing test count | Deleting some test functions | Violates acceptance criteria — all tests must be preserved | Always split, never delete tests |
+| Modifying CI workflow | Adding explicit filenames to pattern | Unnecessary — glob `test_*.mojo` auto-discovers new files | Check the existing pattern before editing workflow |
+| Creating 3 files | Splitting 13 tests into 3 files of ~4 each | Over-engineering for a 13-test file | Use 2 files targeting ≤8 each; ADR-009 limit is 10, not 4 |
+
+## Results & Parameters
+
+### ADR-009 Header Template
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <ORIGINAL_FILE>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+### Target Test Distribution
+
+| Scenario | Part 1 | Part 2 | Part 3 |
+|----------|--------|--------|--------|
+| 11-16 tests | ≤8 | remaining | — |
+| 17-24 tests | ≤8 | ≤8 | remaining |
+
+### Key Observations
+
+- CI group using `test_*.mojo` glob: **zero workflow changes needed**
+- Pre-commit hooks (mojo format, validate_test_coverage) pass automatically on split files
+- `__init__.mojo` doc comments should be updated but are non-functional
+- The split is purely mechanical — copy test functions verbatim, no logic changes


### PR DESCRIPTION
## Summary

Documents the workflow for splitting Mojo test files that exceed ADR-009's ≤10 `fn test_` function limit, fixing intermittent heap corruption CI failures in Mojo v0.26.1.

- Provides a step-by-step split workflow with the required ADR-009 header template
- Documents when CI workflow changes are needed vs. when glob patterns auto-discover new files
- Captures the failed attempt of deleting tests (vs. splitting) and of unnecessary workflow edits

## Key Findings

**What Worked**:
- Targeting ≤8 tests per file (safety margin below the 10-function limit)
- Including the ADR-009 header comment verbatim in each new file
- Checking CI group patterns first — `test_*.mojo` globs auto-discover split files with zero workflow changes
- Copying test functions verbatim (no logic changes) to keep the split purely mechanical

**What Failed**:
- Deleting tests to reduce count → violates acceptance criteria, all tests must be preserved
- Editing CI workflow unnecessarily → glob patterns already handle new files automatically
- Planning 3-way splits for 13 tests → over-engineering; 2 files of ≤8 is sufficient

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with "ADR-009", "heap corruption", "fn test_ limit" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
