### PR TITLE
feat: add mojo-heap-corruption-test-split skill

### DIFF
--- a/skills/ci-cd/mojo-heap-corruption-test-split/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mojo-heap-corruption-test-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-heap-corruption-test-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files that exceed the ADR-009 limit of 10 fn test_ functions per file to prevent heap corruption in Mojo v0.26.1. Use when: (1) a test file has more than 10 fn test_ functions, (2) CI fails intermittently with libKGENCompilerRTShared.so JIT fault, (3) implementing ADR-009 heap corruption workaround.",
+  "category": "ci-cd",
+  "date": "2026-03-08",
+  "tags": ["mojo", "heap-corruption", "test-split", "adr-009", "ci-stability", "mojo-v0.26.1"]
+}

--- a/skills/ci-cd/mojo-heap-corruption-test-split/references/notes.md
+++ b/skills/ci-cd/mojo-heap-corruption-test-split/references/notes.md
@@ -1,0 +1,71 @@
+# Session Notes: Mojo Heap Corruption Test Split
+
+## Session Context
+
+- **Date**: 2026-03-08
+- **Issue**: #3507 — fix(ci): split test_random.mojo (13 tests) — Mojo heap corruption (ADR-009)
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Branch**: 3507-auto-impl
+- **PR**: #4386
+
+## Problem
+
+`tests/shared/data/samplers/test_random.mojo` had 13 `fn test_` functions, exceeding the ADR-009
+limit of 10 per file. This caused intermittent heap corruption crashes in Mojo v0.26.1:
+- `libKGENCompilerRTShared.so` JIT fault
+- Data Samplers CI group failing 13/20 recent runs on main
+- Non-deterministic failures consistent with load-dependent heap corruption
+
+## Solution Applied
+
+Split into 2 files:
+
+**test_random_part1.mojo** (8 tests):
+- test_random_sampler_creation
+- test_random_sampler_with_seed
+- test_random_sampler_empty
+- test_random_sampler_shuffles_indices
+- test_random_sampler_deterministic_with_seed
+- test_random_sampler_varies_without_seed
+- test_random_sampler_yields_all_indices
+- test_random_sampler_no_duplicates
+
+**test_random_part2.mojo** (5 tests):
+- test_random_sampler_valid_range
+- test_random_sampler_with_replacement
+- test_random_sampler_replacement_oversampling
+- test_random_sampler_with_dataloader
+- test_random_sampler_shuffle_speed
+
+## Key Decisions
+
+1. **No CI workflow changes needed**: The existing pattern `samplers/test_*.mojo` in
+   `comprehensive-tests.yml` automatically matches `test_random_part1.mojo` and
+   `test_random_part2.mojo`. No explicit file references required.
+
+2. **No validate_test_coverage.py changes needed**: The script uses `rglob("test_*.mojo")`
+   which dynamically discovers all test files. Pre-commit hook `Validate Test Coverage` passed
+   on commit without any script changes.
+
+3. **ADR-009 header format**: Placed in the module docstring (not as a standalone comment)
+   to avoid pre-commit whitespace issues.
+
+4. **Target: ≤8 tests per file**: Conservative buffer below the 10-test limit.
+
+## Pre-commit Hook Results
+
+All hooks passed on commit:
+- Mojo Format: Passed
+- Check for deprecated List[Type](args) syntax: Passed
+- Validate Test Coverage: Passed
+- Trim Trailing Whitespace: Passed
+- Fix End of Files: Passed
+- Check for Large Files: Passed
+- Fix Mixed Line Endings: Passed
+
+## File Sizes
+
+- Original: 13 fn test_ functions
+- Part 1: 8 fn test_ functions
+- Part 2: 5 fn test_ functions
+- Total preserved: 13/13 (100% coverage)

--- a/skills/ci-cd/mojo-heap-corruption-test-split/skills/mojo-heap-corruption-test-split/SKILL.md
+++ b/skills/ci-cd/mojo-heap-corruption-test-split/skills/mojo-heap-corruption-test-split/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: mojo-heap-corruption-test-split
+description: "Split Mojo test files exceeding ADR-009 limit (10 fn test_ per file) to prevent heap corruption in Mojo v0.26.1. Use when: a .mojo test file has >10 fn test_ functions causing intermittent CI failures."
+category: ci-cd
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Problem** | Mojo v0.26.1 has a heap corruption bug (`libKGENCompilerRTShared.so` JIT fault) triggered by high test load — specifically when a single test file contains more than 10 `fn test_` functions |
+| **Solution** | Split oversized test files into smaller files of ≤8 tests each, add ADR-009 header comment, ensure CI glob patterns cover new files |
+| **ADR** | ADR-009: ≤10 `fn test_` functions per file |
+| **Target** | ≤8 tests per file (conservative buffer below the 10-test limit) |
+| **CI Impact** | Fixes non-deterministic CI failures (heap corruption triggers under load) |
+
+## When to Use
+
+- A `.mojo` test file has **more than 10 `fn test_` functions**
+- CI group fails intermittently with `libKGENCompilerRTShared.so` JIT fault
+- Implementing ADR-009 compliance for Mojo v0.26.1
+- A new test file is being created that might exceed 10 tests
+
+## Verified Workflow
+
+### Step 1: Count fn test_ functions
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+If count > 10, split is required per ADR-009.
+
+### Step 2: Plan the split
+
+Aim for ≤8 tests per file. Group tests by logical category:
+
+- Part 1: Creation + Randomization + Correctness basics (~8 tests)
+- Part 2: Remaining correctness + Replacement + Integration + Performance (~5 tests)
+
+### Step 3: Create split files with ADR-009 header
+
+Each new file must start with the ADR-009 tracking comment in its docstring:
+
+```mojo
+"""Tests for <module> (part N of M): <category1>, <category2>.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_filename>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+```
+
+### Step 4: Verify test count in each new file
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file_part1.mojo
+grep -c "^fn test_" tests/path/to/test_file_part2.mojo
+# Both must be ≤ 8
+```
+
+### Step 5: Delete the original file
+
+```bash
+rm tests/path/to/test_original.mojo
+```
+
+### Step 6: Check CI workflow coverage
+
+The CI `comprehensive-tests.yml` typically uses glob patterns like `test_*.mojo`. Verify new files are covered:
+
+```bash
+# Pattern samplers/test_*.mojo automatically covers test_foo_part1.mojo and test_foo_part2.mojo
+grep -A3 "samplers/test_" .github/workflows/comprehensive-tests.yml
+```
+
+If the CI uses explicit file lists rather than globs, update the workflow to include the new filenames.
+
+### Step 7: Verify validate_test_coverage.py still passes
+
+```bash
+python3 scripts/validate_test_coverage.py
+```
+
+The script uses glob expansion — it will automatically find new `test_*_part1.mojo` and `test_*_part2.mojo` files if the CI pattern uses wildcards.
+
+### Step 8: Commit
+
+```bash
+git add tests/path/to/test_file_part1.mojo tests/path/to/test_file_part2.mojo tests/path/to/test_original.mojo
+git commit -m "fix(ci): split test_foo.mojo into 2 files to fix heap corruption (ADR-009)"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Modifying CI workflow pattern | Considered updating `samplers/test_*.mojo` pattern to explicit filenames | Not needed — glob patterns already cover `test_*_part1.mojo` and `test_*_part2.mojo` | Always check if existing glob patterns already cover new filenames before modifying CI |
+| Updating validate_test_coverage.py | Considered adding explicit entries for new files | Not needed — script uses `rglob("test_*.mojo")` which picks up all matching files dynamically | Dynamic glob-based coverage scripts self-update when files are renamed/split |
+
+## Results & Parameters
+
+### ADR-009 Required Header Template
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original_file>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+### Naming Convention
+
+| Original | Part 1 | Part 2 |
+|----------|--------|--------|
+| `test_foo.mojo` | `test_foo_part1.mojo` | `test_foo_part2.mojo` |
+| `test_bar_sampler.mojo` | `test_bar_sampler_part1.mojo` | `test_bar_sampler_part2.mojo` |
+
+### Test Distribution Strategy
+
+- **Target**: ≤8 tests per file (buffer below 10-test ADR-009 limit)
+- **Group by category**: Keep logically related tests together
+- **Part 1**: Usually creation/basic tests
+- **Part 2**: Usually integration/edge case/performance tests
+
+### Pre-commit Hook Compatibility
+
+Mojo format pre-commit hook runs on new files automatically. No special configuration needed. The `validate_test_coverage.py` pre-commit hook uses glob patterns and will verify new files are covered by CI.


### PR DESCRIPTION
## Summary

Documents the workflow for splitting Mojo test files that exceed the ADR-009 limit
of 10 `fn test_` functions per file, which triggers heap corruption in Mojo v0.26.1
(`libKGENCompilerRTShared.so` JIT fault).

- Implemented for issue #3507 in ProjectOdyssey (split `test_random.mojo` 13→8+5 tests)
- Covers when CI workflow changes are needed vs when glob patterns handle it automatically
- Documents the ADR-009 header comment format and naming conventions

## Key Findings

**What Worked**:
- Target ≤8 tests per file (conservative buffer below ADR-009's 10-test limit)
- Existing `test_*.mojo` glob patterns in CI automatically cover `test_foo_part1.mojo` / `test_foo_part2.mojo`
- `validate_test_coverage.py` uses `rglob("test_*.mojo")` — no script changes needed
- ADR-009 header placed in module docstring to avoid pre-commit whitespace hooks

**What Failed**:
- Considered updating CI workflow to explicit filenames → Not needed, glob patterns already match
- Considered patching validate_test_coverage.py → Not needed, dynamic rglob self-updates

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers (heap corruption, ADR-009, test split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
