### PR TITLE
feat: update mojo-test-file-split skill with issue #3509 verification

### DIFF
--- a/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
+++ b/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
@@ -174,5 +174,6 @@ Total: 37 tests preserved
 | ProjectOdyssey | Issue #3409, PR #4142 — split `test_elementwise.mojo` (37 tests → 5 files) | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3424, PR #4189 — split `test_utility.mojo` (31 tests → 4 files) | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3496, PR #4372 — split `test_checkpointing.mojo` (13 tests → 2 files, 8/5); CI glob auto-covered; `validate_test_coverage.py` had explicit filename ref requiring 1-for-2 update | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3509, PR #4387 — split `test_file_dataset.mojo` (13 tests → 2 files, 7/6); CI `datasets/test_*.mojo` glob auto-covered; `validate_test_coverage.py` had no explicit ref — no changes needed | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issues #2942, #3397


### PR DESCRIPTION
## Summary

Updates the existing `mojo-test-file-split` skill with a new **Verified On** entry from
ProjectOdyssey issue #3509 / PR #4387.

## New Verification Data Point

Split `test_file_dataset.mojo` (13 tests → 7+6 across two files) per ADR-009:

- **File**: `tests/shared/data/datasets/test_file_dataset.mojo`
- **Split**: `_part1.mojo` (7 tests: creation + lazy loading) and `_part2.mojo` (6 tests: memory + labels + error handling)
- **CI pattern**: `datasets/test_*.mojo` glob — new files picked up automatically, no workflow changes needed
- **validate_test_coverage.py**: No explicit filename reference — no changes needed

## Key Learning

Both `comprehensive-tests.yml` AND `validate_test_coverage.py` independently used glob patterns
for this file — confirming that sometimes **neither** file needs updating, just the test split itself.
This contrasts with the #3496 case where `validate_test_coverage.py` had a hardcoded filename
despite the workflow using a glob.

## Test Plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes
- [x] Single-line table update to existing SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)