### PR TITLE
feat: add verified-on entry for test_progress_bar.mojo split (ADR-009)

### DIFF
--- a/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
+++ b/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
@@ -2,7 +2,7 @@
 name: mojo-test-file-split
 description: "Split large Mojo test files exceeding ADR-009 fn test_ function limits to prevent heap corruption in CI. Use when: a test file has >10 fn test_ functions causing intermittent libKGENCompilerRTShared.so JIT faults."
 category: ci-cd
-date: 2026-03-07
+date: 2026-03-08
 user-invocable: false
 ---
 
@@ -175,5 +175,6 @@ Total: 37 tests preserved
 | ProjectOdyssey | Issue #3424, PR #4189 — split `test_utility.mojo` (31 tests → 4 files) | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3496, PR #4372 — split `test_checkpointing.mojo` (13 tests → 2 files, 8/5); CI glob auto-covered; `validate_test_coverage.py` had explicit filename ref requiring 1-for-2 update | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3509, PR #4387 — split `test_file_dataset.mojo` (13 tests → 2 files, 7/6); CI `datasets/test_*.mojo` glob auto-covered; `validate_test_coverage.py` had no explicit ref — no changes needed | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3549, PR #4400 — split `test_progress_bar.mojo` (22 tests → 3 files, 8/8/6); CI `utils/test_*.mojo` glob auto-covered; `validate_test_coverage.py` had no explicit ref — no changes needed | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issues #2942, #3397


### PR DESCRIPTION
## Summary

Updates the `mojo-test-file-split` skill with a new verified-on entry documenting Issue #3549 / PR #4400: splitting `test_progress_bar.mojo` (22 tests) into 3 files per ADR-009.

- CI `utils/test_*.mojo` glob auto-discovered all 3 part files with no workflow change needed
- `validate_test_coverage.py` had no explicit filename reference — no script update needed
- All 22 original test cases preserved; pre-commit hooks passed clean on first attempt

## Key Findings

**What Worked**:
- Glob pattern `utils/test_*.mojo` in CI auto-covered new `_part1/2/3` files with zero workflow edits
- Splitting 22 tests into 8/8/6 distribution kept all files well within the ≤10 ADR-009 limit
- Logical grouping by class (ProgressBar, ProgressBarWithMetrics, ProgressBarWithETA, factory, integration) made the split natural and self-documenting

**What Was Confirmed**:
- No new failed attempts — existing skill guidance was accurate and sufficient
- This is the 5th confirmed ADR-009 split, reinforcing the pattern's reliability

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Check `mojo-test-file-split` skill appears in skill registry
- [ ] Verify "Verified On" table now has 5 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
