### PR TITLE
feat: add adr-009-test-file-split skill

### DIFF
--- a/skills/testing/adr-009-test-file-split/.claude-plugin/plugin.json
+++ b/skills/testing/adr-009-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr-009-test-file-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files to comply with ADR-009 heap corruption workaround (≤10 fn test_ per file). Use when: (1) a Mojo test file has more than 10 fn test_ functions, (2) CI shows intermittent heap corruption crashes from libKGENCompilerRTShared.so, (3) a test group is non-deterministically failing in Mojo v0.26.1.",
+  "category": "testing",
+  "date": "2026-03-08",
+  "tags": ["mojo", "adr-009", "heap-corruption", "test-split", "ci-stability"]
+}

--- a/skills/testing/adr-009-test-file-split/references/notes.md
+++ b/skills/testing/adr-009-test-file-split/references/notes.md
@@ -1,0 +1,54 @@
+# Session Notes: ADR-009 Test File Split
+
+## Session Context
+
+- **Date**: 2026-03-08
+- **Issue**: #3625 — fix(ci): split test_parallel_loader.mojo (12 tests) — Mojo heap corruption (ADR-009)
+- **Branch**: 3625-auto-impl
+- **PR**: #4416
+
+## Problem
+
+`tests/shared/data/loaders/test_parallel_loader.mojo` had 12 `fn test_` functions, exceeding
+ADR-009's limit of 10 per file. This caused intermittent heap corruption crashes in Mojo v0.26.1
+(`libKGENCompilerRTShared.so` JIT fault), making the `Data Loaders` CI group non-deterministically
+fail (13/20 recent runs on `main`).
+
+## Approach
+
+1. Read original file — confirmed 12 `fn test_` functions across 4 logical groups:
+   - Creation (3 tests)
+   - Correctness (3 tests)
+   - Performance (3 tests)
+   - Resource management (3 tests)
+
+2. Split into part1 (creation + correctness = 6 tests) and part2 (performance + resource = 6 tests)
+
+3. Each new file includes ADR-009 header comment and its own `fn main() raises:` runner
+
+4. Deleted original file
+
+5. Checked CI: `comprehensive-tests.yml` `Data` group uses `loaders/test_*.mojo` wildcard —
+   no changes needed
+
+6. `validate_test_coverage.py` pre-commit hook passed automatically
+
+## Key Observations
+
+- The `validate_test_coverage.py` pre-commit hook runs automatically and verifies coverage
+- Wildcard CI patterns (`loaders/test_*.mojo`) automatically cover new split files
+- Splitting by logical test group (creation, correctness, performance, resources) produces
+  coherent, easy-to-navigate files
+- 6 tests per file is a safe target under the 10-function limit
+
+## Pre-commit Hook Results
+
+```
+Mojo Format..............................................................Passed
+Check for deprecated List[Type](args) syntax.............................Passed
+Validate Test Coverage...................................................Passed
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Check for Large Files....................................................Passed
+Fix Mixed Line Endings...................................................Passed
+```

--- a/skills/testing/adr-009-test-file-split/skills/adr-009-test-file-split/SKILL.md
+++ b/skills/testing/adr-009-test-file-split/skills/adr-009-test-file-split/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: adr-009-test-file-split
+description: "Split Mojo test files to comply with ADR-009 heap corruption workaround (≤10 fn test_ per file). Use when: a Mojo test file exceeds 10 fn test_ functions, CI shows libKGENCompilerRTShared.so crashes, or a test group fails non-deterministically."
+category: testing
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | adr-009-test-file-split |
+| **Category** | testing |
+| **Mojo Version** | v0.26.1 |
+| **ADR** | ADR-009 (docs/adr/ADR-009-heap-corruption-workaround.md) |
+| **Limit** | ≤10 `fn test_` functions per file (target: ≤8 for headroom) |
+
+## When to Use
+
+- A Mojo test file contains more than 10 `fn test_` functions
+- CI shows intermittent `libKGENCompilerRTShared.so` JIT faults
+- A test group is non-deterministically failing (e.g., 13/20 recent CI runs)
+- A new test file is being created with many test cases (plan splits upfront)
+
+## Verified Workflow
+
+### 1. Identify the offending file
+
+```bash
+# Count fn test_ functions per file
+grep -r "^fn test_" tests/ --include="*.mojo" -l | while read f; do
+  count=$(grep -c "^fn test_" "$f")
+  echo "$count $f"
+done | sort -rn | head -20
+```
+
+### 2. Decide on split boundaries
+
+- Target ≤8 tests per file (leaves headroom under the 10-function limit)
+- Split along logical groupings: creation, correctness, performance, resource management
+- Keep the original filename removed — replace with `_part1.mojo`, `_part2.mojo`, etc.
+
+### 3. Create the split files
+
+Each new file MUST include the ADR-009 header comment:
+
+```mojo
+"""Tests for <component> - Part N: <Group Name>.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from <original_filename>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+```
+
+Each file must have its own `fn main() raises:` that calls only its subset of tests.
+
+### 4. Delete the original file
+
+```bash
+rm tests/path/to/test_original.mojo
+```
+
+### 5. Check CI workflow coverage
+
+The CI `comprehensive-tests.yml` uses wildcard patterns like `loaders/test_*.mojo`.
+If the original was covered by a wildcard, the split files are automatically covered.
+Only update the workflow if the original used explicit filename references.
+
+```bash
+# Verify wildcard covers new files
+grep "test_*.mojo" .github/workflows/comprehensive-tests.yml
+```
+
+### 6. Run validate_test_coverage.py
+
+```bash
+# Runs automatically as a pre-commit hook, or manually:
+python scripts/validate_test_coverage.py
+```
+
+If the original file was covered by a glob pattern, the split files are covered automatically.
+
+### 7. Commit
+
+```bash
+git add tests/path/to/test_original.mojo \
+        tests/path/to/test_original_part1.mojo \
+        tests/path/to/test_original_part2.mojo
+git commit -m "fix(tests): split test_original.mojo per ADR-009 (≤10 fn test_ limit)"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Update CI workflow | Assumed explicit filename references in `comprehensive-tests.yml` | CI already used `loaders/test_*.mojo` wildcard — no update needed | Always check if CI uses wildcard patterns before editing the workflow |
+| Create a "Data Loaders" explicit CI group | Considered adding a dedicated group entry for split files | Unnecessary — the existing `Data` group's wildcard already matched | Wildcard patterns like `loaders/test_*.mojo` automatically pick up new files without CI changes |
+
+## Results & Parameters
+
+### Verified Configuration (Issue #3625)
+
+- **Original file**: `tests/shared/data/loaders/test_parallel_loader.mojo` (12 tests)
+- **Split into**:
+  - `test_parallel_loader_part1.mojo` — 6 tests (creation + correctness)
+  - `test_parallel_loader_part2.mojo` — 6 tests (performance + resource management)
+- **CI group**: `Data` — pattern `loaders/test_*.mojo` covered both files automatically
+- **Pre-commit hooks**: All passed (mojo format, validate_test_coverage, trailing-whitespace)
+- **Result**: Clean commit, no CI workflow changes required
+
+### ADR-009 Header Template
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from <original>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+### Quick Count Command
+
+```bash
+# Check all test files for ADR-009 compliance
+grep -r "^fn test_" tests/ --include="*.mojo" -l | while read f; do
+  count=$(grep -c "^fn test_" "$f")
+  if [ "$count" -gt 10 ]; then
+    echo "VIOLATION ($count): $f"
+  fi
+done
+```


### PR DESCRIPTION
## Summary

Documents the workflow for splitting Mojo test files to comply with ADR-009's
heap corruption workaround (≤10 `fn test_` functions per file in Mojo v0.26.1).

- Extracted from issue #3625 in ProjectOdyssey (PR #4416)
- Covers detection, split strategy, file structure, and CI workflow impact
- Includes quick-count command to find all ADR-009 violations

## Key Findings

**What Worked**:
- Targeting ≤8 tests per file provides safe headroom under the 10-function limit
- Splitting by logical test groups (creation, correctness, performance, resources) produces coherent files
- Wildcard CI patterns (`loaders/test_*.mojo`) automatically cover split files — no workflow edits needed
- `validate_test_coverage.py` pre-commit hook verifies coverage automatically

**What Failed**:
- Assumed CI workflow needed updating → wildcard patterns already covered new filenames
- Considered creating a dedicated CI group → unnecessary given existing wildcard coverage

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with ADR-009/heap-corruption/test-split triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
