### PR TITLE
feat: update adr009-mojo-test-file-splitting with issue #3626 verification

### DIFF
--- a/skills/ci-cd/adr009-mojo-test-file-splitting/skills/adr009-mojo-test-file-splitting/SKILL.md
+++ b/skills/ci-cd/adr009-mojo-test-file-splitting/skills/adr009-mojo-test-file-splitting/SKILL.md
@@ -141,5 +141,6 @@ gh pr create --title "fix(ci): split test_file.mojo to fix ADR-009 heap corrupti
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3466, PR #4293 | `test_early_stopping.mojo`: 16 tests → 2 files of 8/8; glob CI pattern |
 | ProjectOdyssey | Issue #3475, PR #4316 | `test_reduction_edge_cases.mojo`: 15 tests → 2 files of 8/7; explicit CI filename list |
+| ProjectOdyssey | Issue #3626, PR #4417 | `test_gradient_validation.mojo`: 12 tests → 2 files of 8/4; explicit CI filename list; `validate_test_coverage.py` did not reference file (no update needed) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`


### PR DESCRIPTION
## Summary

Updates the `adr009-mojo-test-file-splitting` skill's **Verified On** table with a new
confirmed instance from ProjectOdyssey issue #3626 / PR #4417.

- `test_gradient_validation.mojo` (12 tests) → split into `_part1.mojo` (8) and `_part2.mojo` (4)
- CI group: `Core Gradient` — explicit filename list (not glob)
- `validate_test_coverage.py` did not reference the file — no update was needed

## Key Findings

**What Worked**:
- Existing skill workflow applied exactly as documented
- Splitting at the activation-function boundary (ReLU/Sigmoid in part1, Tanh/GELU/Conv2D/Linear in part2) made logical grouping clear
- Pre-commit hooks passed on first attempt (mojo format, validate-test-coverage, YAML check)

**New Learning**:
- `validate_test_coverage.py` does not always need updating — the file may not be listed there at all; always check with `grep test_original_name scripts/validate_test_coverage.py` before assuming an edit is required

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL PASSED
- [x] Only "Verified On" table extended — no structural changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)