### PR TITLE
feat: update mojo-test-file-split skill with issue #3627 session

### DIFF
--- a/skills/ci-cd/mojo-test-file-split/references/notes.md
+++ b/skills/ci-cd/mojo-test-file-split/references/notes.md
@@ -173,3 +173,75 @@ fn test_checkpoint_empty_metrics
 - `tests/shared/training/test_checkpointing_part1.mojo` — CREATED (8 tests)
 - `tests/shared/training/test_checkpointing_part2.mojo` — CREATED (5 tests)
 - `scripts/validate_test_coverage.py` — UPDATED (replaced 1 filename entry with 2)
+
+---
+
+# Session Notes: ADR-009 Test Split for test_composed_op.mojo (Issue #3627)
+
+## Session Context
+
+- **Date**: 2026-03-08
+- **Issue**: #3627 — `tests/shared/core/test_composed_op.mojo` contained 12 `fn test_` functions
+- **ADR-009 limit**: ≤10 per file
+- **Branch**: `3627-auto-impl`
+- **PR**: #4421
+
+## Problem
+
+`tests/shared/core/test_composed_op.mojo` had 12 `fn test_` functions, exceeding ADR-009's
+limit of ≤10 per file. This caused intermittent heap corruption crashes in Mojo v0.26.1
+(`libKGENCompilerRTShared.so` JIT fault), making the Core NN Modules CI group non-deterministically
+fail.
+
+## Original file test inventory (12 tests)
+
+```text
+fn test_composed_op_initialization
+fn test_composed_op_implements_differentiable
+fn test_composed_op_implements_composable
+fn test_composed_op_forward_chains_operations
+fn test_composed_op_forward_caches_intermediate
+fn test_composed_op_forward_shape_preservation
+fn test_composed_op_backward_applies_chain_rule
+fn test_composed_op_backward_shape_preservation
+fn test_composed_op_backward_multiple_passes
+fn test_composed_op_forward_backward_roundtrip
+fn test_composed_op_with_different_scales
+fn test_composed_op_identity_composition
+```
+
+## What Was Done
+
+1. Read the issue prompt and the original `test_composed_op.mojo` (366 lines, 12 tests)
+2. Checked `.github/workflows/comprehensive-tests.yml` — the `Core Utilities` group uses an
+   explicit filename list (not a glob); `test_composed_op.mojo` was directly named → workflow
+   update required
+3. Checked `scripts/validate_test_coverage.py` — no direct filename reference found; uses glob
+   patterns → no changes needed to coverage script
+4. Created `test_composed_op_part1.mojo` (7 tests): initialization, trait checks, forward pass
+5. Created `test_composed_op_part2.mojo` (5 tests): backward pass, integration tests
+6. Added ADR-009 header comment to both files
+7. Deleted the original file with `rm`
+8. Updated CI workflow pattern (replaced `test_composed_op.mojo` with
+   `test_composed_op_part1.mojo test_composed_op_part2.mojo`)
+9. All pre-commit hooks passed on first attempt: mojo format, validate_test_coverage, check-yaml
+10. Pushed and created PR #4421 with `gh pr merge --auto --rebase`
+
+## Key Observations
+
+- CI group `Core Utilities` uses an explicit filename list → workflow YAML must be updated.
+  This mirrors issue #3424 (Core Utilities) pattern.
+- `validate_test_coverage.py` had no direct reference — the grep for `test_composed_op`
+  returned no matches in that script. Glob-based discovery handled it automatically.
+- Mock structs (`ScaleMul`, `ScaleAdd`) must be duplicated in both part files since Mojo v0.26.1
+  has no `#include` mechanism. Both files also need their own full import block.
+- The issue count (12) matched the actual grep count exactly — no discrepancy this time.
+- Split grouping: part1 covers initialization + all forward pass tests + one integration-style
+  test (`test_composed_op_with_different_scales`); part2 covers backward pass + integration.
+
+## Files Changed
+
+- `tests/shared/core/test_composed_op.mojo` — DELETED
+- `tests/shared/core/test_composed_op_part1.mojo` — CREATED (7 tests)
+- `tests/shared/core/test_composed_op_part2.mojo` — CREATED (5 tests)
+- `.github/workflows/comprehensive-tests.yml` — UPDATED (Core Utilities explicit pattern)

--- a/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
+++ b/skills/ci-cd/mojo-test-file-split/skills/mojo-test-file-split/SKILL.md
@@ -175,5 +175,6 @@ Total: 37 tests preserved
 | ProjectOdyssey | Issue #3424, PR #4189 — split `test_utility.mojo` (31 tests → 4 files) | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3496, PR #4372 — split `test_checkpointing.mojo` (13 tests → 2 files, 8/5); CI glob auto-covered; `validate_test_coverage.py` had explicit filename ref requiring 1-for-2 update | [notes.md](../../references/notes.md) |
 | ProjectOdyssey | Issue #3509, PR #4387 — split `test_file_dataset.mojo` (13 tests → 2 files, 7/6); CI `datasets/test_*.mojo` glob auto-covered; `validate_test_coverage.py` had no explicit ref — no changes needed | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3627, PR #4421 — split `test_composed_op.mojo` (12 tests → 2 files, 7/5); CI `Core Utilities` explicit list required workflow update; `validate_test_coverage.py` had no explicit ref — no changes needed | [notes.md](../../references/notes.md) |
 
 **Related:** `docs/adr/ADR-009-heap-corruption-workaround.md`, issues #2942, #3397


### PR DESCRIPTION
## Summary

Updates the `mojo-test-file-split` skill with session notes from ProjectOdyssey issue #3627, PR #4421.

- Added session notes for `test_composed_op.mojo` split (12 → 7+5 tests)
- Updated "Verified On" table with issue #3627 entry

## Key Findings

**What Worked**:
- Explicit filename list in CI `Core Utilities` group — updated workflow YAML directly
- `validate_test_coverage.py` had no explicit reference (glob-based) — no script changes needed
- Mock structs duplicated in both part files per Mojo no-include pattern
- All pre-commit hooks passed on first attempt

**What was confirmed again**:
- Issue test count (12) matched actual grep count — no discrepancy this time (unlike #3424)
- Glob in CI workflow does NOT mean glob in `validate_test_coverage.py` — always check both

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — PASS
- [x] Both SKILL.md and references/notes.md updated
- [x] No new skill created (updated existing to avoid duplication per DRY principle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
