### PR TITLE
feat: add adr009-test-file-split skill (issue #3630 verification)

### DIFF
--- a/skills/ci-cd/adr009-test-file-split/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-test-file-split/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-test-file-split",
+  "version": "1.0.0",
+  "description": "Split Mojo test files exceeding ADR-009 limit of ≤10 fn test_ functions per file to prevent heap corruption CI failures. Use when: (1) a test_*.mojo file has >10 fn test_ functions, (2) CI shows intermittent libKGENCompilerRTShared.so heap corruption crashes, (3) ADR-009 compliance check flags a file.",
+  "category": "ci-cd",
+  "date": "2026-03-08",
+  "tags": ["mojo", "adr-009", "heap-corruption", "test-split", "ci-stability"]
+}

--- a/skills/ci-cd/adr009-test-file-split/references/notes.md
+++ b/skills/ci-cd/adr009-test-file-split/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: ADR-009 Test File Split
+
+## Date
+
+2026-03-08
+
+## Issue
+
+GitHub issue #3630: `tests/training/test_confusion_matrix.mojo` had 11 `fn test_` functions,
+exceeding the ADR-009 limit of ≤10 per file. This caused intermittent heap corruption crashes
+(`libKGENCompilerRTShared.so` JIT fault) in the "Shared Infra" CI group.
+
+## Context
+
+- Mojo v0.26.1 has a known heap corruption bug triggered under high test load
+- ADR-009 mandates ≤10 `fn test_` functions per file as a workaround
+- CI failure rate: 13/20 recent runs on `main` non-deterministically failing
+- File had 11 tests; target was ≤8 per split file
+
+## Approach
+
+1. Read the original `tests/training/test_confusion_matrix.mojo` (594 lines, 11 tests)
+2. Checked CI workflow `comprehensive-tests.yml` — "Misc Tests" group uses `training/test_*.mojo` wildcard
+3. Checked `validate_test_coverage.py` — original file not in any exclude list
+4. Created `test_confusion_matrix_part1.mojo` (8 tests: basic, perfect, normalize_row, normalize_column, normalize_total, precision, recall, f1_score)
+5. Created `test_confusion_matrix_part2.mojo` (3 tests: with_logits, reset, empty)
+6. Both files include ADR-009 header comment in module docstring
+7. Deleted original file
+8. Committed — all pre-commit hooks passed (including `Validate Test Coverage`)
+9. Pushed and created PR #4430
+
+## Key Insight: Wildcard CI Patterns
+
+The CI workflow uses `pattern: "training/test_*.mojo"` which automatically discovers any
+`test_*.mojo` file in that directory. This meant:
+
+- No changes to `comprehensive-tests.yml` were needed
+- No changes to `validate_test_coverage.py` were needed
+- The pre-commit `Validate Test Coverage` hook confirmed coverage automatically
+
+Always check if CI uses wildcards before editing workflows.
+
+## Files Changed
+
+- Deleted: `tests/training/test_confusion_matrix.mojo`
+- Created: `tests/training/test_confusion_matrix_part1.mojo` (8 tests)
+- Created: `tests/training/test_confusion_matrix_part2.mojo` (3 tests)
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4430

--- a/skills/ci-cd/adr009-test-file-split/skills/adr009-test-file-split/SKILL.md
+++ b/skills/ci-cd/adr009-test-file-split/skills/adr009-test-file-split/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: adr009-test-file-split
+description: "Split Mojo test files exceeding ADR-009 limit of ≤10 fn test_ functions to prevent heap corruption CI failures. Use when: test file has >10 fn test_ functions, CI shows intermittent libKGENCompilerRTShared.so crashes, or ADR-009 compliance check flags a file."
+category: ci-cd
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Trigger** | Mojo test file has >10 `fn test_` functions |
+| **Symptom** | Intermittent CI heap corruption: `libKGENCompilerRTShared.so` JIT fault |
+| **Fix** | Split into ≤8 tests per file with ADR-009 header comment |
+| **CI Impact** | Wildcard patterns auto-discover split files — usually no workflow changes needed |
+
+## When to Use
+
+- A `test_*.mojo` file has **more than 10 `fn test_`** functions (ADR-009 violation)
+- CI shows non-deterministic `libKGENCompilerRTShared.so` heap corruption crashes
+- Running `grep -c "^fn test_" <file>` returns > 10
+- ADR-009 compliance tooling flags a file as over-limit
+
+## Verified Workflow
+
+### 1. Count existing test functions
+
+```bash
+grep -c "^fn test_" tests/path/to/test_file.mojo
+```
+
+### 2. Plan the split
+
+- Target: ≤8 tests per file (buffer below the 10-function limit)
+- Name files `test_<original>_part1.mojo` and `test_<original>_part2.mojo`
+- Group logically: basic/correctness in part1, edge cases/special inputs in part2
+
+### 3. Create part1 and part2 files
+
+Each file must include the ADR-009 header comment in the module docstring:
+
+```mojo
+"""<Description> (Part N of 2).
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from <original_file>.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+```
+
+Each file needs its own `fn main() raises:` that calls only its subset of tests.
+
+### 4. Delete the original file
+
+```bash
+rm tests/path/to/test_original.mojo
+```
+
+### 5. Check CI workflow coverage
+
+Check if the CI group uses a wildcard pattern that will auto-discover the new files:
+
+```bash
+grep -A3 "path.*tests/" .github/workflows/comprehensive-tests.yml | grep pattern
+```
+
+If the pattern is `test_*.mojo` or `training/test_*.mojo`, the new files are **automatically covered** — no workflow changes needed.
+
+If the original file was listed **explicitly by name**, update the workflow to reference both new filenames.
+
+### 6. Check validate_test_coverage.py
+
+```bash
+grep "test_original" scripts/validate_test_coverage.py
+```
+
+If the original file was in an exclude list, update it to reference the new filenames (or remove if they should be in CI coverage).
+
+### 7. Commit
+
+```bash
+git add tests/path/to/test_original.mojo \
+        tests/path/to/test_original_part1.mojo \
+        tests/path/to/test_original_part2.mojo
+git commit -m "fix(ci): split test_<name>.mojo into 2 files per ADR-009"
+```
+
+Pre-commit hooks validate test coverage automatically — they will catch if the split files are not covered.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Keeping original file and adding parts | Rename original to part1, add part2 | Original still has >10 tests; ADR-009 violation remains | Must delete original; only the split files should exist |
+| Updating CI workflow explicitly | Editing `comprehensive-tests.yml` to list new filenames | Unnecessary — wildcard `test_*.mojo` patterns auto-discover split files | Check existing CI patterns before editing workflows; wildcards handle discovery |
+| Splitting at 5 tests each | Equal distribution regardless of logical grouping | Tests felt arbitrary; harder to understand what each file covers | Group logically: part1=basic/normalization, part2=edge cases/special inputs |
+
+## Results & Parameters
+
+### Key numbers
+
+- ADR-009 limit: **≤10** `fn test_` functions per file
+- Recommended target: **≤8** per file (2-function safety buffer)
+- Typical split: part1 ≈ 8 tests, part2 ≈ 3 tests
+
+### Verification commands
+
+```bash
+# Count tests in each new file
+grep -c "^fn test_" tests/path/to/test_original_part1.mojo
+grep -c "^fn test_" tests/path/to/test_original_part2.mojo
+
+# Confirm original is gone
+ls tests/path/to/test_original.mojo  # Should not exist
+
+# Verify CI discovery (wildcard must match new names)
+just test-group tests/path/to "test_*.mojo"
+```
+
+### Pre-commit hook output on success
+
+```
+Mojo Format..............................................................Passed
+Validate Test Coverage...................................................Passed
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+```
+
+### CI group that uses wildcard pattern (no changes needed)
+
+```yaml
+- name: "Misc Tests"
+  path: "tests"
+  pattern: "test_*.mojo training/test_*.mojo ..."
+```


### PR DESCRIPTION
## Summary

Documents the `adr009-test-file-split` workflow for splitting Mojo test files that exceed the ADR-009 limit of ≤10 `fn test_` functions per file.

- Verified on issue #3630: `tests/training/test_confusion_matrix.mojo` (11 tests → part1: 8, part2: 3)
- All 11 original tests preserved across both split files
- Pre-commit `Validate Test Coverage` hook confirmed coverage with no workflow changes

## Key Findings

**What Worked**:
- Wildcard CI patterns (`training/test_*.mojo`) auto-discover split files — no `comprehensive-tests.yml` edits needed
- Pre-commit `Validate Test Coverage` hook serves as automated confirmation of CI discovery
- Logical grouping (basic/normalization in part1, edge cases in part2) makes the split readable

**What Failed**:
- Trying to edit `comprehensive-tests.yml` first → Unnecessary; wildcards handle discovery automatically
- Equal-count splitting → Less readable; logical grouping is better

## Test Plan

- [x] Validated plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL PASSED
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with ADR-009 trigger conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
