### PR TITLE
feat: add adr009-glob-pattern-auto-pickup skill

### DIFF
--- a/skills/ci-cd/adr009-glob-pattern-auto-pickup/.claude-plugin/plugin.json
+++ b/skills/ci-cd/adr009-glob-pattern-auto-pickup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adr009-glob-pattern-auto-pickup",
+  "version": "1.0.0",
+  "description": "When splitting Mojo test files per ADR-009, check if the CI workflow uses a glob pattern before editing it. Use when: (1) splitting test_*.mojo files to comply with ADR-009 ≤10 fn test_ limit, (2) verifying whether CI workflow needs updating after a test file split, (3) avoiding unnecessary workflow edits.",
+  "category": "ci-cd",
+  "date": "2026-03-08",
+  "tags": ["adr-009", "mojo", "test-split", "ci-workflow", "glob-pattern", "heap-corruption"]
+}

--- a/skills/ci-cd/adr009-glob-pattern-auto-pickup/references/notes.md
+++ b/skills/ci-cd/adr009-glob-pattern-auto-pickup/references/notes.md
@@ -1,0 +1,53 @@
+# Session Notes: ADR-009 Glob Pattern Auto-Pickup
+
+**Date**: 2026-03-08
+**Issue**: #3633 — fix(ci): split test_rmsprop.mojo (11 tests) — Mojo heap corruption (ADR-009)
+**PR**: #4439
+
+## What happened
+
+The issue asked us to:
+1. Split `test_rmsprop.mojo` (11 `fn test_` functions) into 2 files of ≤8 tests each
+2. Add ADR-009 header comment to each new file
+3. Update `.github/workflows/comprehensive-tests.yml` to reference new filenames
+4. Update `validate_test_coverage.py` if needed
+
+## Key discovery
+
+When checking the CI workflow, `grep -i "test_rmsprop" .github/workflows/comprehensive-tests.yml`
+returned **no matches**. The `Shared Infra & Testing` job uses:
+
+```
+pattern: "test_imports.mojo test_data_generators.mojo test_model_utils.mojo test_serialization.mojo utils/test_*.mojo fixtures/test_*.mojo training/test_*.mojo testing/test_*.mojo"
+```
+
+The glob `training/test_*.mojo` automatically picks up `test_rmsprop_part1.mojo` and
+`test_rmsprop_part2.mojo` — no workflow edit was needed.
+
+## validate_test_coverage.py
+
+This script maintains an explicit exclusion list. `test_rmsprop.mojo` was in it (line 96).
+We replaced the single entry with two entries for the new part files.
+
+## Pre-commit validation
+
+All hooks passed cleanly on the first attempt:
+- `Mojo Format` ✅
+- `Check for deprecated List[Type](args) syntax` ✅
+- `Bandit Security Scan` ✅
+- `mypy` ✅
+- `Ruff Format Python` ✅
+- `Ruff Check Python` ✅
+- `Validate Test Coverage` ✅
+
+## Timeline
+
+1. Read `.claude-prompt-3633.md` → understood task
+2. Read `test_rmsprop.mojo` → confirmed 11 `fn test_` functions
+3. Grepped CI workflow → found glob pattern, no edit needed
+4. Grepped `validate_test_coverage.py` → found hardcoded filename, needs update
+5. Created `test_rmsprop_part1.mojo` (8 tests) with ADR-009 header
+6. Created `test_rmsprop_part2.mojo` (3 tests) with ADR-009 header
+7. Deleted original `test_rmsprop.mojo`
+8. Updated `validate_test_coverage.py`
+9. Committed, pushed, created PR #4439

--- a/skills/ci-cd/adr009-glob-pattern-auto-pickup/skills/adr009-glob-pattern-auto-pickup/SKILL.md
+++ b/skills/ci-cd/adr009-glob-pattern-auto-pickup/skills/adr009-glob-pattern-auto-pickup/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: adr009-glob-pattern-auto-pickup
+description: "When splitting Mojo test files per ADR-009, check if the CI workflow uses a glob pattern before editing it. Use when: (1) splitting test_*.mojo files, (2) verifying whether CI workflow needs updating after a split, (3) avoiding unnecessary workflow edits."
+category: ci-cd
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Problem** | ADR-009 splits produce new `test_*_part1.mojo` / `test_*_part2.mojo` files; the issue description may say "update CI workflow" but the workflow may already pick them up via glob |
+| **Solution** | Always grep the workflow for the original filename first; if only a glob pattern exists (e.g. `training/test_*.mojo`), no workflow edit is needed |
+| **ADR Reference** | ADR-009 in `docs/adr/ADR-009-heap-corruption-workaround.md` |
+| **Key Insight** | `test_rmsprop_part1.mojo` and `test_rmsprop_part2.mojo` both match `training/test_*.mojo` — the split is transparent to CI |
+
+## When to Use
+
+- Implementing an ADR-009 test file split and the issue says "update CI workflow"
+- Splitting any `test_*.mojo` file and unsure whether the CI workflow hardcodes the filename
+- Verifying whether `validate_test_coverage.py` or CI workflows need manual filename updates after a split
+
+## Verified Workflow
+
+### 1. Check if CI workflow hardcodes the filename
+
+```bash
+# Search for the exact filename in the workflow
+grep -i "test_rmsprop" .github/workflows/comprehensive-tests.yml
+# If no match → the workflow uses a glob pattern → no edit needed
+```
+
+### 2. Check if the workflow uses a glob pattern
+
+```bash
+grep -A2 "Shared Infra" .github/workflows/comprehensive-tests.yml
+# Example output:
+#   pattern: "training/test_*.mojo testing/test_*.mojo"
+# → Glob pattern: split files are automatically discovered
+```
+
+### 3. Only update validate_test_coverage.py
+
+`validate_test_coverage.py` maintains an explicit list of excluded files (dataset-dependent tests).
+If the original file is in this list, replace it with the two new part files:
+
+```python
+# Before
+"tests/shared/training/test_rmsprop.mojo",
+
+# After
+"tests/shared/training/test_rmsprop_part1.mojo",
+"tests/shared/training/test_rmsprop_part2.mojo",
+```
+
+```bash
+# Verify the file is in the exclusion list
+grep -n "test_rmsprop" scripts/validate_test_coverage.py
+```
+
+### 4. Decision tree
+
+```text
+grep the original filename in comprehensive-tests.yml
+├── Found (hardcoded) → edit workflow to reference both new files
+└── Not found → check for glob pattern covering the directory
+    ├── Glob pattern exists (training/test_*.mojo) → NO workflow edit needed
+    └── No pattern at all → add glob pattern or explicit filenames
+```
+
+### 5. Split file naming convention
+
+```text
+test_rmsprop.mojo (11 tests)
+  → test_rmsprop_part1.mojo (8 tests)   # ≤8 per ADR-009 target
+  → test_rmsprop_part2.mojo (3 tests)   # remaining tests
+```
+
+Each split file must include the ADR-009 header comment:
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_rmsprop.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Editing CI workflow | Started editing `comprehensive-tests.yml` to add new filenames to the `Shared Infra` group | Unnecessary — the workflow already uses `training/test_*.mojo` glob pattern | Always grep for the exact filename before editing the workflow |
+| Trusting issue description | Issue said "Update `.github/workflows/comprehensive-tests.yml` to reference the new filenames" | The glob pattern already covered it; the description was written defensively | Issue descriptions can be overly cautious — verify actual workflow content |
+
+## Results & Parameters
+
+**Session**: Split `test_rmsprop.mojo` (11 tests) into `test_rmsprop_part1.mojo` (8) + `test_rmsprop_part2.mojo` (3)
+
+**Files changed**:
+
+```text
+tests/shared/training/test_rmsprop.mojo          → deleted
+tests/shared/training/test_rmsprop_part1.mojo    → created (8 fn test_)
+tests/shared/training/test_rmsprop_part2.mojo    → created (3 fn test_)
+scripts/validate_test_coverage.py                → updated exclusion list
+# .github/workflows/comprehensive-tests.yml      → NOT edited (glob covers it)
+```
+
+**CI workflow pattern** (no edit needed):
+
+```yaml
+- name: "Shared Infra & Testing"
+  pattern: "test_imports.mojo test_data_generators.mojo ... training/test_*.mojo ..."
+```
+
+**Pre-commit hooks all passed**: mojo format, mypy, ruff, validate-test-coverage, trailing-whitespace, end-of-file-fixer


### PR DESCRIPTION
## Summary

Documents the insight that CI glob patterns (e.g. `training/test_*.mojo`) automatically
pick up ADR-009 split files, making explicit workflow edits unnecessary.

- Captures the decision tree: grep for filename → if not found, check for glob → skip workflow edit
- Documents that `validate_test_coverage.py` uses explicit lists and always needs updating
- Preserves the lesson that issue descriptions about "update CI workflow" can be overly cautious

## Key Findings

**What Worked**:
- Grepping `comprehensive-tests.yml` for the exact filename before editing it
- Recognizing that `training/test_*.mojo` glob covers `test_rmsprop_part1.mojo` automatically
- Updating only `validate_test_coverage.py` (explicit list) while skipping the workflow

**What Failed**:
- Starting to edit CI workflow without checking if glob already covers split files → unnecessary edit avoided by checking first
- Trusting issue description literally ("update CI workflow") → description was defensive/precautionary

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with ADR-009 split triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
