### PR TITLE
feat: add docstring-view-vs-copy-clarification skill

### DIFF
--- a/skills/documentation/docstring-view-vs-copy-clarification/.claude-plugin/plugin.json
+++ b/skills/documentation/docstring-view-vs-copy-clarification/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "docstring-view-vs-copy-clarification",
+  "version": "1.0.0",
+  "description": "Fix docstring inconsistencies where memory semantics are mislabeled (view vs copy). Use when: (1) a docstring claims 'view' but the implementation allocates new memory, (2) a flag like _is_view contradicts the description, (3) sibling methods have inconsistent return-type documentation.",
+  "category": "documentation",
+  "date": "2026-03-08",
+  "tags": ["docstring", "view-semantics", "copy-semantics", "mojo", "consistency", "documentation"]
+}

--- a/skills/documentation/docstring-view-vs-copy-clarification/references/notes.md
+++ b/skills/documentation/docstring-view-vs-copy-clarification/references/notes.md
@@ -1,0 +1,44 @@
+# Session Notes: Issue #3297
+
+## Context
+
+- **Repo**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #3297 — "Unify slice() and __getitem__(*slices) view semantics in docs"
+- **Branch**: `3297-auto-impl`
+- **File**: `shared/core/extensor.mojo`
+
+## What the Issue Said
+
+The issue reported: `__getitem__(*slices)` calls `self.copy()` then sets `_is_view = True` —
+inconsistent because the flag says "view" but the prose implied copy. Fix direction was to
+either fix the implementation or the docstring.
+
+## What We Found
+
+Reading the actual code revealed that the implementation had **already been partially fixed**
+before this session. The state at start of session:
+
+- `__getitem__(Slice)`: `Self(shape, dtype)` + bytes copied + `_is_view = False` — docstring correctly said "copy"
+- `__getitem__(*slices)`: `Self(shape, dtype)` + bytes copied + `_is_view = False` — docstring correctly said "copy"
+- `slice()`: `self.copy()` + pointer offset + `_is_view = True` — docstring said "true view (shared memory)" which is accurate but imprecise
+
+## Fix Applied
+
+Updated `slice()` docstring only:
+
+1. Changed opening line from "Creates a view sharing data" to "Creates a shallow copy of the
+   tensor struct whose `_data` pointer is offset into the original buffer"
+2. Updated Returns section to say "zero-copy view: no data bytes are allocated or copied"
+3. Added Notes cross-reference distinguishing `slice()` (view) from `__getitem__` overloads (copies)
+
+## Verification
+
+- `pixi run pre-commit run --files shared/core/extensor.mojo` — all hooks passed
+- PR #4460 created, auto-merge enabled
+
+## Key Insight
+
+`self.copy()` in Mojo calls `__copyinit__`, which for a struct containing a raw pointer
+field does a **shallow copy** (copies the pointer value, not the bytes it points to).
+This means `slice()` genuinely shares memory — the docstring "true view" was correct,
+just imprecise about the mechanism.

--- a/skills/documentation/docstring-view-vs-copy-clarification/skills/docstring-view-vs-copy-clarification/SKILL.md
+++ b/skills/documentation/docstring-view-vs-copy-clarification/skills/docstring-view-vs-copy-clarification/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: docstring-view-vs-copy-clarification
+description: "Fix docstring inconsistencies where memory semantics are mislabeled (view vs copy). Use when: a docstring claims 'view' but the implementation allocates new memory, or sibling methods have conflicting return-type documentation."
+category: documentation
+date: 2026-03-08
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Objective** | Audit and fix docstrings that claim view/shared-memory semantics but whose implementation actually copies data (or vice versa) |
+| **Scope** | Docstring-only — no implementation changes |
+| **Language** | Mojo (applicable to any language with view/copy distinction) |
+| **Trigger** | Issue flagging `_is_view` flag inconsistency or misleading "returns a view" language |
+
+## When to Use
+
+- A docstring says "returns a view" or "shares memory" but the implementation allocates fresh memory and copies bytes
+- A flag like `_is_view` is set to `True` after calling `self.copy()` (or equivalent), making the flag technically correct but the prose confusing
+- Sibling methods (e.g., `slice()` vs `__getitem__(Slice)` vs `__getitem__(*slices)`) use inconsistent language for similar concepts
+- Code review identifies that callers might misuse a method based on its documented semantics
+
+## Verified Workflow
+
+1. **Read the issue** — get the exact line numbers and method names cited
+2. **Read all sibling methods** together to understand the full semantics landscape before writing a single line of documentation
+3. **Check the implementation, not just the docstring** — run `grep` for the actual code path (`self.copy()`, `_is_view = True/False`, `Self(shape, dtype)`, etc.)
+4. **Classify each method** into one of three buckets:
+   - True view: pointer offset into original buffer, `_is_view = True`, no bytes copied
+   - Copy with view flag: `self.copy()` + `_is_view = True` (this is the bug pattern)
+   - Independent copy: fresh allocation, `_is_view = False`
+5. **Update only the docstring** — do not change any implementation logic
+6. **Use precise language** in the updated docstring:
+   - True view: "zero-copy view", "pointer offset", "`_is_view = True`", "modifying will affect original"
+   - Independent copy: "independent copy", "`_is_view = False`", "does not share memory"
+   - In Notes: cross-reference the sibling methods so callers know which to use
+7. **Run pre-commit** to confirm no formatting issues: `pixi run pre-commit run --files <path>`
+8. **Commit, push, open PR** with `Closes #<issue>`
+
+## Results & Parameters
+
+### Classification Table (from Issue #3297)
+
+| Method | Implementation | `_is_view` | Docstring Fix Needed |
+|--------|---------------|------------|----------------------|
+| `slice()` | `self.copy()` + pointer offset | `True` | Clarify "shallow pointer copy" — **yes** |
+| `__getitem__(Slice)` | Fresh `Self(shape, dtype)` + byte copy | `False` | Already said "copy" — **no** |
+| `__getitem__(*slices)` | Fresh `Self(shape, dtype)` + byte copy | `False` | Already said "copy" — **no** |
+
+### Key Docstring Patterns
+
+**For a true pointer-offset view:**
+
+```text
+Creates a shallow copy of the tensor struct whose `_data` pointer is offset
+into the original buffer. No data bytes are copied. The returned tensor has
+`_is_view = True`, and modifying its elements will affect the original tensor.
+
+Returns:
+    A new ExTensor whose `_data` pointer references the same underlying memory
+    as the original, offset to `start` along `axis`. This is a zero-copy view:
+    no data bytes are allocated or copied.
+```
+
+**For an independent copy:**
+
+```text
+Returns:
+    A new ExTensor with its own data buffer (a copy of the selected elements).
+    The `_is_view` flag is set to False. Does not share memory with original.
+```
+
+**Notes cross-reference pattern:**
+
+```text
+Notes:
+    Unlike `__getitem__(Slice)` and `__getitem__(*slices)`, which both return
+    independent copies (`_is_view = False`), this method returns a genuine view
+    that shares memory with the original tensor.
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Fixing implementation instead of docs | Considered changing `__getitem__(*slices)` to use pointer offset | Multi-dim slices produce non-contiguous data; a simple pointer offset is insufficient without stride metadata | Always check whether the "bug" is in the docs or the code first |
+| Updating only one method | Would have fixed `slice()` without updating `__getitem__` overloads | Sibling inconsistency would remain; callers still confused | Read all sibling methods before writing any fix |
+| Assuming `self.copy()` = deep copy | Initially worried `self.copy()` copied bytes | Mojo `self.copy()` calls `__copyinit__`, which for pointer-based structs is a shallow copy (pointer copy, not byte copy) | Verify what `copy()` / `__copyinit__` actually does for the specific type |


### PR DESCRIPTION
## Summary

Documents how to audit and fix Mojo docstrings that mislabel memory semantics (view vs copy),
extracted from issue #3297 in ProjectOdyssey.

- Classifies each method into: true view, copy-with-view-flag, or independent copy
- Provides precise language patterns for each category
- Cross-references sibling methods so callers know which to use

## Key Findings

**What Worked**:
- Reading all sibling methods together before writing any fix
- Using precise language: "zero-copy view", "pointer offset", explicit `_is_view` flag values
- Adding a Notes section that cross-references the contrasting sibling methods

**What Failed**:
- Considering implementation changes before confirming the bug was in the docs
- Updating only one method without checking siblings for consistency
- Assuming `self.copy()` is a deep copy (Mojo `__copyinit__` is shallow for pointer-field structs)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 530/530 pass
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
