### PR TITLE
feat(skills): Add module-decomposition-pattern

### DIFF
--- a/skills/module-decomposition-pattern/SKILL.md
+++ b/skills/module-decomposition-pattern/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: module-decomposition-pattern
+description: >
+  Decompose large Python modules (1000+ lines) into focused sub-modules while
+  preserving backward compatibility, updating all import sites, and fixing mock
+  patch targets in tests. Use when a single file has 4+ logical clusters of
+  functions with distinct responsibilities.
+category: architecture
+date: 2026-03-10
+user-invocable: false
+---
+
+# Skill: Module Decomposition Pattern
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-10 |
+| Project | ProjectScylla |
+| Objective | Decompose `scylla/e2e/llm_judge.py` (1,488 lines, 35 functions) into 4 focused modules + slimmed orchestrator |
+| Outcome | Success - 142-line orchestrator + 4 modules, all 4,788 tests pass, all pre-commit hooks pass |
+| Issue | HomericIntelligence/ProjectScylla#1446 |
+
+## When to Use
+
+Use this skill when:
+- A Python module exceeds ~500 lines with 4+ logical clusters of functions
+- Functions within the module have distinct responsibilities (e.g., pipeline execution vs. log saving)
+- Other modules use lazy imports (`from X import Y` inside function bodies) to access private functions
+- The module has a large corresponding test file with many `patch()` targets
+- You want to improve navigability without changing any behavior
+
+## Key Decisions
+
+### 1. Update import sites vs. re-export from original module
+
+**Choose "update import sites"** (Option 2) when:
+- There are a manageable number of import sites (< 20)
+- Imports are lazy (inside function bodies), making updates safe
+- You want to avoid the re-export anti-pattern
+
+**Choose "re-export from original"** (Option 1) when:
+- The module is a public API with many external consumers
+- You cannot enumerate all import sites (e.g., third-party packages)
+
+### 2. Handle circular imports with TYPE_CHECKING
+
+When decomposing, circular imports often arise (e.g., Module A defines a model, Module B returns it, Module A calls Module B). Solve with:
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from original_module import MyModel
+
+def my_function() -> MyModel:  # String annotation via __future__
+    from original_module import MyModel  # Runtime import
+    return MyModel(...)
+```
+
+### 3. Keep public API exports in the original module
+
+Models and orchestrator functions that are part of the public API (`__init__.py` exports) stay in the original module. Only move private implementation functions.
+
+## Verified Workflow
+
+### Step 1 - Map all import sites
+
+Before writing any code, find every file that imports from the target module:
+
+```bash
+grep -rn "from package.module import" --include="*.py"
+grep -rn 'patch("package.module.' --include="*.py"
+```
+
+Categorize each import into the target cluster (pipeline, context, execution, artifacts, etc.).
+
+### Step 2 - Identify clusters and cross-dependencies
+
+Group functions by responsibility. Check for cross-cluster calls:
+
+```bash
+grep -n "^def \|^class " module.py
+```
+
+Order extraction: start with modules that have no cross-cluster dependencies (leaf modules first).
+
+### Step 3 - Create new modules one at a time
+
+For each new module:
+1. Write the file with moved functions and their imports
+2. Update source import sites (`from new_module import func`)
+3. Update test import sites (both `from` imports AND `patch()` targets)
+4. Run tests: `pytest tests/unit/relevant/ -x -q`
+
+### Step 4 - Update mock patch targets (CRITICAL)
+
+`patch("old.module.func")` must change to `patch("new.module.func")`. Search for ALL occurrences:
+
+```bash
+grep -rn 'patch("package.old_module.' tests/
+```
+
+**Common mistake**: Only updating `test_old_module.py` but missing patch targets in `test_other.py` files that also mock functions from the decomposed module.
+
+### Step 5 - Fix mypy type errors
+
+Moving functions that return types defined in the original module often causes `no-any-return` errors. Fix with `TYPE_CHECKING` imports and proper return type annotations instead of `-> Any`.
+
+### Step 6 - Final verification
+
+```bash
+pre-commit run --all-files
+pytest tests/ -x -q
+wc -l original_module.py new_module_*.py
+```
+
+## Results & Parameters
+
+### Files created/modified
+
+| File | Lines | Role |
+|------|-------|------|
+| `llm_judge.py` (was 1,488) | 142 | Orchestrator: JudgeResult model + run_llm_judge() |
+| `build_pipeline.py` (new) | 548 | BuildPipelineResult + 13 pipeline functions |
+| `judge_context.py` (new) | 334 | 7 workspace context/assembly functions |
+| `judge_execution.py` (new) | 259 | 3 judge execution/parsing functions |
+| `judge_artifacts.py` (new) | 295 | 10 log/script saving functions |
+
+### Import sites updated
+
+| File | Import changed |
+|------|---------------|
+| `stages.py` | 5 lazy imports |
+| `stage_finalization.py` | 2 lazy imports |
+| `rerun_judges.py` | 1 lazy import |
+| `experiment_setup_manager.py` | 1 lazy import |
+| `regenerate.py` | 1 lazy import |
+| `judge_runner.py` | 1 TYPE_CHECKING import |
+| `subtest_executor.py` | 2 imports |
+| `__init__.py` | 0 (JudgeResult/run_llm_judge stayed) |
+
+### Test files updated
+
+| File | Changes |
+|------|---------|
+| `test_llm_judge.py` | Import block rewritten (4 source modules), 12 patch targets updated |
+| `test_stages.py` | 10 patch targets updated |
+| `test_stage_finalization.py` | 2 patch targets updated |
+| `test_experiment_setup_manager.py` | 4 patch targets updated |
+| `test_baseline_regression.py` | 1 import updated |
+| `test_subtest_executor.py` | 1 import updated |
+
+## Failed Attempts
+
+### Attempt: Only searching test_llm_judge.py for patch targets
+
+**What happened**: After updating all source imports and `test_llm_judge.py`, ran the e2e test suite. `test_stage_finalization.py` failed with `AttributeError: <module 'scylla.e2e.llm_judge'> does not have the attribute '_call_claude_judge'`.
+
+**Root cause**: Other test files (`test_stages.py`, `test_stage_finalization.py`, `test_experiment_setup_manager.py`) also mock functions from `llm_judge` via `patch()`. Initial search only covered the main test file.
+
+**Fix**: Always search ALL test files for `patch("old.module.` before declaring done:
+```bash
+grep -rn 'patch("package.old_module.' tests/
+```
+
+### Attempt: Using `-> Any` return type for functions with circular import
+
+**What happened**: `_parse_judge_response` and `_execute_judge_with_retry` in `judge_execution.py` need to return `JudgeResult` (defined in `llm_judge.py`), but `llm_judge.py` imports from `judge_execution.py`. Used `-> Any` to avoid the circular import.
+
+**Error**: mypy `no-any-return` error in `llm_judge.py` line 135 where `_execute_judge_with_retry` result is returned from `run_llm_judge() -> JudgeResult`.
+
+**Fix**: Use `TYPE_CHECKING` guard with `from __future__ import annotations`:
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scylla.e2e.llm_judge import JudgeResult
+
+def _parse_judge_response(response: str) -> JudgeResult: ...
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1446 - llm_judge.py decomposition | [notes.md](../references/notes.md) |

--- a/skills/module-decomposition-pattern/references/notes.md
+++ b/skills/module-decomposition-pattern/references/notes.md
@@ -1,0 +1,54 @@
+# Module Decomposition Pattern - Reference Notes
+
+## ProjectScylla Context
+
+### Original file
+- `scylla/e2e/llm_judge.py` - 1,488 lines, 35 functions/classes
+- Issue: HomericIntelligence/ProjectScylla#1446
+
+### Cluster mapping
+
+| Cluster | Functions | New Module |
+|---------|-----------|------------|
+| Pipeline execution | `_is_modular_repo`, `_run_mojo_build_step`, `_run_mojo_format_step`, `_run_mojo_test_step`, `_run_precommit_step`, `_run_mojo_pipeline`, `_get_pipeline_env`, `_execute_python_scripts`, `_run_python_build_step`, `_run_python_format_step`, `_run_python_test_step`, `_run_python_pipeline`, `_run_build_pipeline` + `BuildPipelineResult` | `build_pipeline.py` |
+| Workspace context | `_get_workspace_state`, `_get_patchfile`, `_get_deleted_files`, `_load_reference_patch`, `_run_and_log_pipeline`, `_format_pipeline_result`, `_gather_judge_context` | `judge_context.py` |
+| Judge execution | `_call_claude_judge`, `_parse_judge_response`, `_execute_judge_with_retry` | `judge_execution.py` |
+| Log/script saving | `_create_python_scripts`, `_create_mojo_build_script`, `_create_mojo_format_script`, `_create_mojo_test_script`, `_create_mojo_scripts`, `_create_precommit_script`, `_create_run_all_script`, `_save_pipeline_commands`, `_save_pipeline_outputs`, `_save_judge_logs` | `judge_artifacts.py` |
+| Orchestrator | `JudgeResult`, `run_llm_judge`, `_score_to_grade` | `llm_judge.py` (kept) |
+
+### Extraction order rationale
+
+1. `build_pipeline.py` - No cross-cluster deps, leaf module
+2. `judge_artifacts.py` - Only TYPE_CHECKING dep on build_pipeline + llm_judge
+3. `judge_execution.py` - Depends on judge_artifacts (lazy import for _save_judge_logs)
+4. `judge_context.py` - Depends on build_pipeline + judge_artifacts (lazy imports)
+
+### Full patch target diff
+
+```
+# test_llm_judge.py (12 changes)
+scylla.e2e.llm_judge._run_python_pipeline -> scylla.e2e.build_pipeline._run_python_pipeline
+scylla.e2e.llm_judge._run_mojo_pipeline -> scylla.e2e.build_pipeline._run_mojo_pipeline
+scylla.e2e.llm_judge._run_build_pipeline -> scylla.e2e.build_pipeline._run_build_pipeline
+scylla.e2e.llm_judge._get_workspace_state -> scylla.e2e.judge_context._get_workspace_state
+scylla.e2e.llm_judge._get_patchfile -> scylla.e2e.judge_context._get_patchfile
+scylla.e2e.llm_judge._get_deleted_files -> scylla.e2e.judge_context._get_deleted_files
+scylla.e2e.llm_judge._call_claude_judge -> scylla.e2e.judge_execution._call_claude_judge
+
+# test_stages.py (10 changes)
+scylla.e2e.llm_judge._run_build_pipeline -> scylla.e2e.build_pipeline._run_build_pipeline
+scylla.e2e.llm_judge._get_workspace_state -> scylla.e2e.judge_context._get_workspace_state
+scylla.e2e.llm_judge._get_patchfile -> scylla.e2e.judge_context._get_patchfile
+scylla.e2e.llm_judge._get_deleted_files -> scylla.e2e.judge_context._get_deleted_files
+scylla.e2e.llm_judge._save_pipeline_commands -> scylla.e2e.judge_artifacts._save_pipeline_commands
+scylla.e2e.llm_judge._save_pipeline_outputs -> scylla.e2e.judge_artifacts._save_pipeline_outputs
+scylla.e2e.llm_judge._call_claude_judge -> scylla.e2e.judge_execution._call_claude_judge
+scylla.e2e.llm_judge._parse_judge_response -> scylla.e2e.judge_execution._parse_judge_response
+scylla.e2e.llm_judge._save_judge_logs -> scylla.e2e.judge_artifacts._save_judge_logs
+
+# test_stage_finalization.py (2 changes)
+scylla.e2e.llm_judge._call_claude_judge -> scylla.e2e.judge_execution._call_claude_judge
+
+# test_experiment_setup_manager.py (4 changes)
+scylla.e2e.llm_judge._run_build_pipeline -> scylla.e2e.build_pipeline._run_build_pipeline
+```


### PR DESCRIPTION
## Summary
- Captures workflow for decomposing large Python modules (1000+ lines) into focused sub-modules
- Covers import site updates, mock patch target migration, circular import resolution with TYPE_CHECKING
- Learned from ProjectScylla#1446: llm_judge.py (1,488 lines -> 142-line orchestrator + 4 modules)

## Key Learnings
- Always search ALL test files for `patch()` targets, not just the main test file
- Use `TYPE_CHECKING` + `from __future__ import annotations` to break circular imports with proper types (not `-> Any`)
- Update import sites (Option 2) is cleaner than re-exports when import count is manageable

Generated with [Claude Code](https://claude.com/claude-code)