### PR TITLE
Add TitanSchedule CI/CD and testing skills

### DIFF
--- a/skills/ci-cd/fix-ci-failures/SKILL.md
+++ b/skills/ci-cd/fix-ci-failures/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: fix-ci-failures
+description: "Diagnose and fix CI/CD failures by analyzing logs, reproducing locally, and applying fixes. Use when CI checks fail on pull requests."
+category: ci
+---
+
+# Fix CI Failures Skill
+
+Diagnose and fix CI failures systematically.
+
+## When to Use
+
+- CI checks fail on PR
+- Workflow runs fail
+- Tests pass locally but fail in CI
+
+## Quick Reference
+
+```bash
+# View PR checks
+gh pr checks <pr-number>
+
+# View specific run details
+gh run view <run-id> --log-failed
+
+# Reproduce locally
+pixi run test
+```
+
+## Workflow
+
+1. **Check status** - View failed PR checks
+2. **Get logs** - Download or view failure details
+3. **Reproduce** - Run same commands locally
+4. **Fix issue** - Apply necessary changes
+5. **Verify** - Test passes locally with `pixi run test`
+6. **Push** - Commit and push fix
+7. **Monitor** - Check CI passes
+
+## Common Failures
+
+| Failure | Command | Fix |
+|---------|---------|-----|
+| Test failure | `pixi run test` | Fix code, re-run tests |
+| Lint error | `pixi run lint` | Fix linting issues |
+| Type error | `pixi run typecheck` | Fix type annotations |
+| Build error | Check imports/deps | Update pyproject.toml |
+
+## References
+
+- Related skill: `quality-run-linters` for linting
+- Related skill: `run-precommit` for pre-commit hooks

--- a/skills/ci-cd/gh-check-ci-status/SKILL.md
+++ b/skills/ci-cd/gh-check-ci-status/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: gh-check-ci-status
+description: "Check CI/CD status of a pull request including workflow runs and test results."
+category: github
+user-invocable: false
+---
+
+# Check CI Status
+
+Verify CI/CD status of a pull request and investigate failures.
+
+## When to Use
+
+- Verifying PR is ready to merge
+- Investigating CI failures
+- Monitoring long-running CI jobs
+
+## Quick Reference
+
+```bash
+# Check PR CI status
+gh pr checks <pr>
+
+# Watch CI in real-time
+gh pr checks <pr> --watch
+
+# View failed logs
+gh run view <run-id> --log-failed
+
+# Rerun failed checks
+gh run rerun <run-id>
+```
+
+## Status Indicators
+
+- `✓` - Passing
+- `✗` - Failed
+- `○` - Pending/In progress
+- `-` - Skipped
+
+## References
+
+- See `.github/workflows/` for CI configuration

--- a/skills/ci-cd/gh-create-pr-linked/SKILL.md
+++ b/skills/ci-cd/gh-create-pr-linked/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: gh-create-pr-linked
+description: "Create a pull request properly linked to a GitHub issue using gh pr create. Use when creating a PR that implements or addresses a specific issue."
+category: github
+---
+
+# Create PR Linked to Issue
+
+Create a pull request with automatic issue linking.
+
+## When to Use
+
+- After completing implementation work
+- Ready to submit changes for review
+- Need to link PR to GitHub issue
+
+## Quick Reference
+
+```bash
+# Create PR linked to issue (preferred)
+gh pr create --title "Title" --body "Closes #<issue-number>"
+
+# Verify link appears
+gh issue view <issue-number>  # Check Development section
+```
+
+## Workflow
+
+1. **Verify changes committed**: `git status` shows clean
+2. **Push branch**: `git push -u origin branch-name`
+3. **Create PR**: `gh pr create --title "Title" --body "Closes #<number>"`
+4. **Verify link**: Check issue's Development section on GitHub
+5. **Monitor CI**: Watch checks with `gh pr checks`
+
+## PR Requirements
+
+- PR must be linked to GitHub issue
+- All changes committed and pushed
+- Branch has upstream tracking
+- Clear, descriptive title
+- Do NOT create PR without issue link
+
+## Error Handling
+
+| Problem | Solution |
+|---------|----------|
+| No upstream branch | `git push -u origin branch-name` |
+| Issue not found | Verify issue number exists |
+| Auth failure | Run `gh auth status` |
+| Link not appearing | Add "Closes #ISSUE-NUMBER" to body |
+
+## Branch Naming Convention
+
+Format: `<issue-number>-<description>`
+
+Examples:
+
+- `42-add-bracket-parser`
+- `73-fix-graph-layout`
+
+## References
+
+- See CLAUDE.md for complete git workflow

--- a/skills/ci-cd/gh-fix-pr-feedback/SKILL.md
+++ b/skills/ci-cd/gh-fix-pr-feedback/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gh-fix-pr-feedback
+description: "Address PR review feedback by making changes and replying to comments."
+category: github
+---
+
+# Fix PR Review Feedback
+
+Address PR review comments by implementing fixes and responding to each comment.
+
+## When to Use
+
+- PR has open review comments requiring responses
+- Ready to implement reviewer's requested changes
+- PR is blocked on feedback
+
+## Quick Reference
+
+```bash
+# 1. Get all review comments
+gh api repos/OWNER/REPO/pulls/PR/comments --jq '.[] | {id: .id, path: .path, body: .body}'
+
+# 2. Make fixes to code, then test
+pixi run test
+
+# 3. Commit changes
+git add . && git commit -m "fix: address PR review feedback"
+
+# 4. Reply to EACH comment
+gh api repos/OWNER/REPO/pulls/PR/comments/COMMENT_ID/replies \
+  --method POST -f body="Fixed - [brief description]"
+
+# 5. Push and verify
+git push
+gh pr checks PR
+```
+
+## Reply Format
+
+Keep responses SHORT (1 line preferred):
+
+- `Fixed - Updated parser to handle negative IDs`
+- `Fixed - Removed duplicate test`
+- `Fixed - Added error handling for edge case`
+
+## Verification
+
+After addressing feedback:
+
+- [ ] All review comments have replies
+- [ ] Changes committed and pushed
+- [ ] CI checks passing
+- [ ] No new issues introduced
+
+## References
+
+- See CLAUDE.md for PR workflow

--- a/skills/ci-cd/github-actions-security-patterns/SKILL.md
+++ b/skills/ci-cd/github-actions-security-patterns/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: github-actions-security-patterns
+description: "Secure GitHub Actions workflows against command injection via user-controlled inputs. Use when creating or reviewing workflow files."
+category: ci-cd
+---
+
+# GitHub Actions Security Patterns
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-10 |
+| Objective | Create secure CI/CD workflows for TitanSchedule |
+| Outcome | Success — caught injection risk via pre-commit hook |
+
+## When to Use
+
+- Creating GitHub Actions workflows with `workflow_dispatch` inputs
+- Reviewing workflows that use any `github.event.*` context in `run:` commands
+- Any workflow that accepts external/user-controlled data
+
+## Verified Workflow
+
+1. Use `env:` block to pass user-controlled inputs to `run:` commands
+2. Reference via `$ENV_VAR` (shell variable) instead of `${{ }}` (template interpolation)
+
+### Safe Pattern
+
+```yaml
+- name: Run scraper
+  env:
+    SCRAPE_URL: ${{ github.event.inputs.url || vars.DEFAULT_URL }}
+  run: pixi run scrape "$SCRAPE_URL"
+```
+
+### Unsafe Pattern (AVOID)
+
+```yaml
+- run: pixi run scrape ${{ github.event.inputs.url }}
+```
+
+## Failed Attempts
+
+- **Direct interpolation in `run:`**: Used `${{ github.event.inputs.url }}` directly in `run:` command. Caught by security hook — this enables command injection if the input contains shell metacharacters.
+
+## Risky Inputs Reference
+
+All of these should use the `env:` pattern, never direct interpolation in `run:`:
+- `github.event.inputs.*` (workflow_dispatch)
+- `github.event.issue.title` / `.body`
+- `github.event.pull_request.title` / `.body` / `.head.ref`
+- `github.event.comment.body`
+- `github.event.commits.*.message`
+- `github.head_ref`
+
+## Results & Parameters
+
+- Tool: Pre-commit security hook caught the vulnerability automatically
+- Fix: One-line change — wrap in `env:` block, quote the shell variable

--- a/skills/ci-cd/run-precommit/SKILL.md
+++ b/skills/ci-cd/run-precommit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: run-precommit
+description: "Run pre-commit hooks locally to validate code quality before committing. Use to ensure commits meet quality standards."
+category: ci
+user-invocable: false
+---
+
+# Run Pre-commit Hooks Skill
+
+Validate code quality with pre-commit hooks before committing.
+
+## When to Use
+
+- Before committing code
+- Testing if CI will pass
+- Troubleshooting commit failures
+
+## Quick Reference
+
+```bash
+# Run on all files
+pixi run pre-commit run --all-files
+
+# Run on staged files
+pixi run pre-commit run
+
+# NEVER use --no-verify to bypass hooks
+```
+
+## Configured Hooks
+
+| Hook | Purpose | Auto-Fix |
+|------|---------|----------|
+| `ruff` | Python linting/formatting | Yes |
+| `trailing-whitespace` | Remove trailing spaces | Yes |
+| `end-of-file-fixer` | Add final newline | Yes |
+| `check-yaml` | Validate YAML syntax | No |
+| `check-added-large-files` | Prevent large files | No |
+
+## Hook Bypass Policy
+
+**STRICT POLICY: `--no-verify` is PROHIBITED.**
+
+**What to do when hooks fail:**
+
+1. **Read the error** - Hook output explains what's wrong
+2. **Fix your code** - Update to pass the check
+3. **Re-run hooks** - Verify the fix
+4. **Commit again** - Let hooks validate
+
+**Exception for broken hooks:**
+
+```bash
+SKIP=hook-id git commit -m "fix: skip broken hook (see issue #123)"
+```
+
+## References
+
+- [Git Commit Policy](../../shared/git-commit-policy.md)
+- Related skill: `quality-run-linters`

--- a/skills/ci-cd/verify-pr-ready/SKILL.md
+++ b/skills/ci-cd/verify-pr-ready/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: verify-pr-ready
+description: "Verify a PR is ready for merge (CI passing, approvals, no conflicts). Use before merging to ensure all requirements met."
+category: github
+---
+
+# Verify PR Ready for Merge
+
+Check that PR meets all requirements before merging.
+
+## When to Use
+
+- Before merging a PR manually
+- Checking if PR is ready for automated merge
+- Before requesting final approval
+
+## Quick Reference
+
+```bash
+# Check PR status
+gh pr view <pr>
+
+# Check CI status
+gh pr checks <pr>
+
+# View PR review status
+gh pr view <pr> --json reviews
+
+# Check for conflicts
+gh pr view <pr> --json mergeable
+```
+
+## Readiness Checklist
+
+Before merging, verify:
+
+- [ ] All CI checks passing (no failures or pending)
+- [ ] Required number of approvals received
+- [ ] No requested changes from reviewers
+- [ ] PR is linked to issue
+- [ ] No merge conflicts detected
+- [ ] Branch is up to date with main
+
+## Blocking Issues
+
+PR cannot merge if:
+
+- CI checks failing
+- Merge conflicts exist
+- Required approvals not met
+- Requested changes pending
+- Branch is stale (needs rebase on main)
+
+## References
+
+- See CLAUDE.md for PR workflow

--- a/skills/testing/quality-run-linters/SKILL.md
+++ b/skills/testing/quality-run-linters/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: quality-run-linters
+description: "Run all configured linters including ruff and mypy. Use before committing code to ensure quality standards are met."
+category: quality
+user-invocable: false
+---
+
+# Run Linters Skill
+
+Run all configured linters to ensure code quality.
+
+## When to Use
+
+- Before committing code
+- CI/CD quality checks
+- Pre-PR validation
+
+## Quick Reference
+
+```bash
+# Run Python linter
+pixi run lint
+
+# Run type checker
+pixi run typecheck
+
+# Run all checks
+pixi run lint && pixi run typecheck
+```
+
+## Configured Linters
+
+| Linter | Purpose | Auto-Fix |
+|--------|---------|----------|
+| `ruff` | Python linting and formatting | Yes (`ruff format`, `ruff check --fix`) |
+| `mypy` | Python type checking | No |
+
+## Workflow
+
+```bash
+# 1. Run linters
+pixi run lint
+
+# 2. Fix auto-fixable issues
+ruff check --fix .
+ruff format .
+
+# 3. Stage changes
+git add .
+
+# 4. Commit
+git commit -m "fix: address linting issues"
+```
+
+## Common Issues
+
+| Error | Linter | Fix |
+|-------|--------|-----|
+| Import sorting | ruff | `ruff check --fix --select I .` |
+| Unused import | ruff | Remove the import |
+| Type error | mypy | Add/fix type annotations |
+| Formatting | ruff | `ruff format .` |
+
+## References
+
+- Related skill: `run-precommit` for pre-commit hooks

--- a/skills/testing/review-pr-changes/SKILL.md
+++ b/skills/testing/review-pr-changes/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: review-pr-changes
+description: "Review PR changes with structured checklist for Python/JS quality and standards compliance."
+category: review
+user-invocable: false
+---
+
+# Review PR Changes
+
+Perform structured review of PR changes against project quality standards.
+
+## When to Use
+
+- Code review before approving PR
+- Checking standards compliance (Python, JavaScript)
+- Verifying test coverage
+
+## Quick Reference
+
+```bash
+# Get PR files changed
+gh pr diff <pr> --name-only
+
+# View full diff
+gh pr diff <pr>
+
+# Get PR review status
+gh pr view <pr> --json reviews
+```
+
+## Review Checklist
+
+**Code Quality**:
+
+- [ ] Code is readable and well-structured
+- [ ] Functions have clear purposes
+- [ ] Variable names are descriptive
+- [ ] No code duplication (DRY principle)
+
+**Python-Specific**:
+
+- [ ] Type hints on function signatures
+- [ ] Docstrings for public APIs
+- [ ] No `[] or DEFAULT` pattern (use `if X is None`)
+- [ ] AES negative IDs handled correctly
+
+**JavaScript-Specific**:
+
+- [ ] CDN-only (no npm imports, no build tools)
+- [ ] All 4 game status values handled (final/in_progress/scheduled/conditional)
+- [ ] Conditional game rendering correct (opponent_text, dashed border)
+- [ ] Mobile-first responsive design maintained
+
+**Testing**:
+
+- [ ] Tests present for new functionality
+- [ ] Tests passing (CI green)
+- [ ] Edge cases covered
+- [ ] Inline fixtures used (no external fixture files for unit tests)
+
+**Security**:
+
+- [ ] No hardcoded secrets/tokens
+- [ ] Input validation present
+- [ ] API calls use proper headers
+
+**Git**:
+
+- [ ] PR linked to issue
+- [ ] Conventional commit messages
+- [ ] No unintended files included
+
+## Output Format
+
+1. **Summary** - Overall assessment
+2. **Issues Found** - Problems that must be fixed
+3. **Suggestions** - Optional improvements
+4. **Verdict** - Approve/Request Changes/Comment
+
+## References
+
+- See CLAUDE.md for project standards
+- See verify-pr-ready for merge readiness


### PR DESCRIPTION
## Summary
- 8 existing skills from TitanSchedule project (CI/CD and testing categories)
- 1 new retrospective skill: `github-actions-security-patterns` — secure workflow_dispatch inputs against command injection

## Skills Added
**ci-cd/**: fix-ci-failures, gh-check-ci-status, gh-create-pr-linked, gh-fix-pr-feedback, github-actions-security-patterns, run-precommit, verify-pr-ready
**testing/**: quality-run-linters, review-pr-changes

## Test plan
- [ ] Verify SKILL.md files have valid frontmatter
- [ ] Confirm no duplicate skill names with existing registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)