### PR TITLE
feat(skills): Add auto-init-py-generation skill

### DIFF
--- a/skills/auto-init-py-generation/SKILL.md
+++ b/skills/auto-init-py-generation/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: auto-init-py-generation
+description: "TRIGGER CONDITIONS: Auto-generating __init__.py files with __all__ exports for Python packages. Use when creating or updating package-level exports, especially with mypy implicit_reexport=false compliance."
+user-invocable: false
+category: tooling
+date: 2026-03-11
+---
+
+# auto-init-py-generation
+
+How to auto-generate `__init__.py` files with proper `__all__` exports for Python packages, handling mypy strict mode (`implicit_reexport=false`) and re-export patterns.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-11 |
+| Objective | Generate `__init__.py` with `__all__` for all subpackages in `scylla/` |
+| Outcome | Success — 17 `__init__.py` files generated, all pre-commit hooks pass |
+| Issues | HomericIntelligence/ProjectScylla#1359 |
+| PRs | HomericIntelligence/ProjectScylla#1472 |
+
+## When to Use
+
+- Creating `__init__.py` files with `__all__` for a Python package tree
+- Updating exports after adding/removing/renaming public symbols
+- Ensuring mypy `implicit_reexport=false` compliance (requires `import X as X` pattern)
+- Migrating from implicit to explicit exports in an existing codebase
+
+## Verified Workflow
+
+### 1. AST-Based Export Discovery
+
+Use Python's `ast` module to parse each `.py` file and extract public symbols:
+
+```python
+import ast
+
+def get_public_names(filepath: Path) -> list[str]:
+    tree = ast.parse(filepath.read_text())
+    names = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                names.append(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    names.append(target.id)
+    return sorted(set(names))
+```
+
+### 2. Generate `__init__.py` with `__all__`
+
+For each subpackage directory:
+1. Collect all `.py` files (excluding `__init__.py`)
+2. Extract public names from each module
+3. Generate imports using `from .module import name as name` (the `as name` pattern satisfies `implicit_reexport=false`)
+4. Build `__all__` list from all exported names
+
+### 3. Key Pattern: Re-export for mypy
+
+With `implicit_reexport=false`, bare `from .module import name` does NOT re-export. Must use:
+
+```python
+from .module import MyClass as MyClass  # explicitly re-exported
+```
+
+### 4. Handle Subpackage Re-exports
+
+For packages with nested subpackages, also re-export the subpackage's public API:
+
+```python
+from .subpkg import SubClass as SubClass
+```
+
+### 5. Pre-commit Validation
+
+Always run after generation:
+```bash
+pre-commit run --all-files  # ruff will sort imports, fix formatting
+pixi run python -m pytest tests/ -x  # verify no import breakage
+```
+
+## Failed Attempts
+
+### Manual `__init__.py` Writing
+- Writing `__init__.py` by hand for 17+ subpackages is error-prone and tedious
+- Easy to miss new symbols or include private ones
+- Script-based generation is much more reliable
+
+### Bare Imports Without `as` Alias
+- `from .module import Name` does NOT re-export under `implicit_reexport=false`
+- mypy will report errors when downstream code imports from the package
+- Must use `from .module import Name as Name` pattern
+
+### Including `__all__` Constants
+- Variables like `__all__` itself, `__version__`, etc. from submodules should be excluded
+- Filter out dunder names from the collected exports
+
+## Results & Parameters
+
+- **17 `__init__.py` files** generated across `scylla/` subpackages
+- **~400 symbols** exported in total
+- **Zero test failures** after generation
+- **All pre-commit hooks pass** (ruff, mypy, black)
+
+## Key Insights
+
+1. **AST parsing > regex**: AST correctly handles multiline definitions, decorators, and nested scopes
+2. **Sort exports alphabetically**: Makes diffs clean and review easy
+3. **One import per line**: Easier to review and produces cleaner git diffs
+4. **Run ruff after generation**: Let ruff handle import sorting (isort) rather than doing it manually
+5. **Test immediately**: Import cycles or shadowing can surface — run tests right after generation

--- a/skills/auto-init-py-generation/plugin.json
+++ b/skills/auto-init-py-generation/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "auto-init-py-generation",
+  "version": "1.0.0",
+  "description": "Auto-generate __init__.py files with __all__ exports for Python packages with mypy implicit_reexport=false compliance",
+  "category": "tooling",
+  "tags": ["python", "mypy", "init", "exports", "ast", "code-generation"],
+  "date_created": "2026-03-11",
+  "source_project": "ProjectScylla",
+  "source_issues": ["#1359"],
+  "source_prs": ["#1472"]
+}


### PR DESCRIPTION
## Summary
- Captures workflow for auto-generating `__init__.py` files with `__all__` exports
- Covers AST-based symbol discovery, mypy `implicit_reexport=false` compliance, and re-export patterns
- Source: ProjectScylla#1359, PR#1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)