### PR TITLE
feat(ci-cd): CI matrix continue-on-error pattern

### DIFF
--- a/plugins/tooling/ci-matrix-continue-on-error-pattern.json
+++ b/plugins/tooling/ci-matrix-continue-on-error-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "ci-matrix-continue-on-error-pattern",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: GitHub Actions matrix with some jobs non-blocking. Use when: (1) adding continue-on-error to specific matrix entries for flaky tests (JIT crashes, heap corruption), (2) resolving merge conflicts between hardcoded name matching vs matrix-field approaches. Fix: use matrix-level continue-on-error boolean field instead of hardcoding group names in step conditions.",
+  "category": "ci-cd",
+  "date": "2026-03-12",
+  "tags": ["ci-cd", "github-actions", "matrix", "continue-on-error", "merge-conflicts", "mojo", "jit-crashes", "odyssey"]
+}

--- a/references/ci-matrix-continue-on-error-pattern-notes.md
+++ b/references/ci-matrix-continue-on-error-pattern-notes.md
@@ -1,0 +1,33 @@
+# CI Matrix continue-on-error Pattern - Session Notes
+
+## Context
+
+ProjectOdyssey branch `fix-main-ci-failures` had a merge conflict in
+`.github/workflows/comprehensive-tests.yml` after rebasing onto main.
+
+## Conflict Details
+
+**HEAD (main)** used matrix-field approach:
+
+```yaml
+continue-on-error: ${{ matrix.test-group.continue-on-error == true }}
+```
+
+**Incoming commit** hardcoded group names:
+
+```yaml
+continue-on-error: ${{ matrix.test-group.name == 'Integration Tests' || matrix.test-group.name == 'Core Tensors' || matrix.test-group.name == 'Benchmarking' || matrix.test-group.name == 'Models' || matrix.test-group.name == 'Shared Infra & Testing' }}
+```
+
+## Resolution
+
+Kept main's matrix-field approach. The relevant matrix entries already had
+`continue-on-error: true` set, making the hardcoded names redundant.
+
+## Key Insight
+
+The `== true` comparison is necessary because GitHub Actions evaluates missing
+matrix fields as empty string, not `false`. Using just
+`${{ matrix.test-group.continue-on-error }}` would evaluate to empty string
+(falsy) for entries without the field, which happens to work — but `== true`
+is explicit and safer.

--- a/skills/ci-matrix-continue-on-error-pattern/SKILL.md
+++ b/skills/ci-matrix-continue-on-error-pattern/SKILL.md
@@ -1,0 +1,80 @@
+# Skill: CI Matrix continue-on-error Pattern
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-12 |
+| Category | ci-cd |
+| Outcome | Success |
+| Project | ProjectOdyssey |
+
+## Overview
+
+When GitHub Actions matrix jobs need `continue-on-error` for specific entries (e.g., flaky JIT tests), use a matrix-level boolean field rather than hardcoding group names in the step. This avoids merge conflicts and keeps the workflow DRY.
+
+## When to Use
+
+- GitHub Actions workflow has a matrix strategy with some jobs that should be non-blocking
+- Resolving merge conflicts between branches that modified `continue-on-error` logic differently
+- Adding new test groups that may be flaky (JIT crashes, heap corruption, etc.)
+
+## Verified Workflow
+
+### Pattern: Matrix-level continue-on-error field
+
+Add `continue-on-error: true` as a field on each matrix entry that should be non-blocking:
+
+```yaml
+strategy:
+  matrix:
+    test-group:
+      - name: "Core Tensors"
+        path: "tests/shared/core"
+        pattern: "test_tensors*.mojo"
+        # No continue-on-error field = blocking (defaults to false)
+
+      - name: "Models"
+        path: "tests/models"
+        pattern: "test_*.mojo"
+        continue-on-error: true  # Non-blocking due to JIT crashes
+```
+
+Then reference it in steps:
+
+```yaml
+steps:
+  - name: Run tests
+    continue-on-error: ${{ matrix.test-group.continue-on-error == true }}
+    run: just test-group "${{ matrix.test-group.path }}" "${{ matrix.test-group.pattern }}"
+```
+
+### Why this is better than hardcoding names
+
+The anti-pattern hardcodes group names in the step:
+
+```yaml
+# BAD - causes merge conflicts, hard to maintain
+continue-on-error: ${{ matrix.test-group.name == 'Models' || matrix.test-group.name == 'Shared Infra' }}
+```
+
+Problems with hardcoded names:
+
+1. Adding a new non-blocking group requires editing the step AND the matrix entry
+2. Merge conflicts when two branches add different groups to the condition
+3. The `||` chain grows unbounded and becomes unreadable
+
+### Conflict resolution preference
+
+When rebasing produces a conflict between these two approaches, **always keep the matrix-field approach** (the one using `matrix.test-group.continue-on-error == true`).
+
+## Failed Attempts
+
+### Hardcoded group name matching in continue-on-error
+
+- **What happened**: A branch added `|| matrix.test-group.name == 'Models' || matrix.test-group.name == 'Shared Infra & Testing'` to the step-level `continue-on-error`
+- **Why it failed**: Conflicted with main which had already migrated to the matrix-field pattern
+- **Fix**: Resolved by keeping main's matrix-field approach, since the relevant matrix entries already had `continue-on-error: true` set
+
+## Parameters
+
+- `continue-on-error: true` on matrix entry = non-blocking job
+- `== true` comparison required (not just `${{ matrix.test-group.continue-on-error }}`) because missing field returns empty string, not `false`


### PR DESCRIPTION
## Summary

- Adds skill capturing the pattern of using matrix-level `continue-on-error` boolean fields instead of hardcoding group names in GitHub Actions workflow steps
- Learned from resolving a rebase conflict on ProjectOdyssey's `fix-main-ci-failures` branch

## Files

- `skills/ci-matrix-continue-on-error-pattern/SKILL.md` - Full skill documentation
- `plugins/tooling/ci-matrix-continue-on-error-pattern.json` - Plugin metadata
- `references/ci-matrix-continue-on-error-pattern-notes.md` - Raw session notes

## Test plan

- [x] Skill follows standard SKILL.md format
- [x] Plugin JSON has required fields
- [x] References notes capture session context

🤖 Generated with [Claude Code](https://claude.com/claude-code)