### PR TITLE
feat(skills): Add checkpoint-save-guard-bug

### DIFF
--- a/skills/checkpoint-save-guard-bug/SKILL.md
+++ b/skills/checkpoint-save-guard-bug/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: checkpoint-save-guard-bug
+description: Fix for --retry-errors not persisting checkpoint when only intermediate-state runs exist
+category: debugging
+date: 2026-03-13
+user-invocable: false
+---
+
+# Checkpoint Save Guard Bug
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-13 |
+| Objective | Fix `--retry-errors` not working for runs stuck in intermediate states |
+| Outcome | Success - one-line fix, all 4774 tests pass |
+
+## When to Use
+
+- `--retry-errors` appears to do nothing when runs are stuck in intermediate states (e.g., `judge_prompt_built`, `replay_generated`, `config_committed`)
+- Checkpoint file on disk does not reflect in-memory state changes after retry-errors reset
+- Return value of a reset/count function is used as a save guard but only counts a subset of affected items
+
+## Verified Workflow
+
+1. Identified that `_reset_non_completed_runs()` returned count of only terminal (failed/rate_limited) resets
+2. Callers at two sites gated `save_checkpoint()` on `if reset_count > 0:`
+3. For intermediate-only cases, tier/subtest states were cascaded to `pending` in memory but `reset_count=0` meant checkpoint was never saved
+4. Fix: moved `reset_count += 1` to count ALL non-completed runs (before the terminal-state check), not just terminal resets
+5. Updated two test assertions to match new semantics (2->4, 0->4)
+
+## Failed Attempts
+
+| Attempt | Why It Failed |
+|---------|---------------|
+| N/A | Bug was straightforward once identified; no failed approaches |
+
+## Results & Parameters
+
+**Root cause pattern**: Function return value counts only a subset of affected items, but caller uses it as a "did anything change?" guard for persistence. The fix is to count all affected items, not just the subset that was mutated.
+
+**Files changed**:
+- `scripts/manage_experiment.py:351` - moved `reset_count += 1` before terminal-state check
+- `scripts/manage_experiment.py:337` - updated docstring
+- Two caller sites (lines 649 and 1038) required no changes - the guard `if reset_count > 0:` now works correctly
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #1474 - dryrun3 intermediate state fix | 4774 tests pass, 76.45% unit coverage |

--- a/skills/checkpoint-save-guard-bug/plugin.json
+++ b/skills/checkpoint-save-guard-bug/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "checkpoint-save-guard-bug",
+  "version": "1.0.0",
+  "description": "Fix for --retry-errors not saving checkpoint when only intermediate-state runs exist. Trigger: retry-errors finds stuck runs but checkpoint is not updated on disk.",
+  "category": "debugging",
+  "created": "2026-03-13",
+  "project": "ProjectScylla",
+  "pr": "HomericIntelligence/ProjectScylla#1474",
+  "outcome": "success"
+}


### PR DESCRIPTION
## Summary
- Captures debugging skill for --retry-errors checkpoint save guard bug in ProjectScylla
- Root cause: return value counted only terminal resets, but was used as save guard for all state changes
- Related: HomericIntelligence/ProjectScylla#1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)