### PR TITLE
feat(skills): add xterm-plan-mode-fix skill

### DIFF
--- a/skills/architecture/xterm-plan-mode-fix/.claude-plugin/plugin.json
+++ b/skills/architecture/xterm-plan-mode-fix/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "xterm-plan-mode-fix",
+  "version": "1.0.0",
+  "category": "architecture",
+  "created": "2026-03-13",
+  "updated": "2026-03-13",
+  "description": "Fix xterm.js TUI rendering for Claude Code /plan mode in browser terminals: Unicode11 addon for box-drawing/emoji, binary WebSocket handling for PTY data, resize timing to avoid layout corruption, and layout toggle to replace unreliable auto-detection.",
+  "trigger_patterns": [
+    "xterm.*plan.*mode.*render",
+    "xterm.*unicode.*box.drawing",
+    "xterm.*tui.*corrupt",
+    "pty.*resize.*timing",
+    "websocket.*binary.*arraybuffer",
+    "xterm.*wide.*character",
+    "terminal.*layout.*auto.detect",
+    "browser.*terminal.*plan.*mode"
+  ]
+}

--- a/skills/architecture/xterm-plan-mode-fix/references/notes.md
+++ b/skills/architecture/xterm-plan-mode-fix/references/notes.md
@@ -1,0 +1,65 @@
+# xterm-plan-mode-fix — Session Notes
+
+## Project Context
+
+- **Project:** AI Maestro (Claude Code Dashboard)
+- **Repository:** 23blocks-OS/ai-maestro
+- **Issues Filed:** #279 (xterm /plan fix), #280 (navigation buttons), #281 (layout toggle)
+- **Date:** 2026-03-13
+
+## Problem Statement
+
+Claude Code's `/plan` mode renders correctly in the native CLI terminal but displays with corrupted layout in the browser-based xterm.js terminal. The raw PTY data is sent unfiltered through the WebSocket pipeline (server.mjs → WebSocket → xterm.js), so no data loss occurs. The corruption manifests as:
+
+- Box-drawing characters rendered at wrong widths
+- Emoji/wide characters causing column misalignment
+- TUI layout shifted/broken on initial render
+
+A secondary problem discovered during the session: the dashboard auto-detected the user's WSL/touch-capable laptop as a "tablet," forcing a mobile-style layout that hid the desktop navigation header entirely.
+
+## Root Cause Analysis
+
+### Rendering Corruption (3 causes)
+
+1. **Missing Unicode11 addon** — xterm.js defaults to Unicode 6 character width tables. Claude Code `/plan` uses Unicode box-drawing, emojis, and wide characters that need Unicode 11+ width calculations.
+
+2. **Binary WebSocket data dropped** — PTY can emit binary frames. Without `ws.binaryType = 'arraybuffer'`, the browser delivers a Blob object that the existing JSON parser silently drops.
+
+3. **Resize timing gap** — PTY spawns at hardcoded 80x24. The client only sends a resize after the `history-complete` event (with delays). If `/plan` renders before resize arrives, it uses wrong dimensions.
+
+### Layout Misdetection (1 cause)
+
+4. **`useDeviceType` hook** classifies devices by screen width + touch capability. On WSL with a touch-capable display, it returns "tablet" even on a desktop. This loads `TabletDashboard` instead of the desktop `Header`, hiding all navigation buttons.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `package.json` | Added `@xterm/addon-unicode11: ^0.9.0` |
+| `hooks/useTerminal.ts` | Load Unicode11Addon, set activeVersion to '11' |
+| `hooks/useWebSocket.ts` | Set binaryType='arraybuffer', handle ArrayBuffer in onmessage, pass cols/rows in URL |
+| `components/TerminalView.tsx` | Track terminal dims in ref, pass to useWebSocket, send resize on open |
+| `server.mjs` | Read cols/rows from query params for PTY spawn |
+| `app/page.tsx` | Added layoutOverride state with localStorage, toggleLayout function |
+| `components/Header.tsx` | Added Settings link, Tablet toggle button, onSwitchLayout prop |
+| `components/TabletDashboard.tsx` | Added Monitor toggle button, onSwitchLayout prop |
+| `app/settings/page.tsx` | Added useSearchParams for ?section= deep-linking, Suspense boundary, dynamic import for OnboardingSection |
+
+## Iteration History
+
+1. Implemented the 3-part xterm fix (Unicode11, binary WS, resize timing)
+2. User couldn't see navigation buttons → discovered they were on TabletDashboard
+3. Added buttons to TabletDashboard → worked but wrong UX (inline create form)
+4. Tried linking + button to /zoom → wrong destination
+5. Linked to /settings?section=onboarding → hydration error (localStorage in SSR)
+6. Fixed hydration with dynamic() import and Suspense
+7. User realized the real problem was auto-detection → implemented layout toggle
+8. Removed the + button entirely, kept Settings and layout toggle
+
+## Key Learnings
+
+- **Always check which layout component is active** before adding UI elements. Auto-detection can route to unexpected components.
+- **`dynamic(() => import(...), { ssr: false })`** is the correct fix for components that read localStorage/sessionStorage during render.
+- **`useSearchParams()` requires a Suspense boundary** in Next.js App Router.
+- **xterm.js Unicode version must be explicitly activated** — loading the addon alone is not enough.
+- **Layout auto-detection is unreliable** on hybrid devices (WSL, touch laptops, Chromebooks). Prefer user-controlled toggles with auto-detection as a default.

--- a/skills/architecture/xterm-plan-mode-fix/skills/xterm-plan-mode-fix/SKILL.md
+++ b/skills/architecture/xterm-plan-mode-fix/skills/xterm-plan-mode-fix/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: xterm-plan-mode-fix
+description: Fix xterm.js rendering of TUI modes (Claude Code /plan) in browser-based terminals with Unicode11 addon, binary WebSocket handling, and resize timing
+category: architecture
+date: 2026-03-13
+user-invocable: false
+---
+
+# xterm.js /plan Mode Rendering Fix
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-13 |
+| **Objective** | Fix Claude Code `/plan` mode rendering in browser-based xterm.js terminal (box-drawing characters, emojis, and TUI layout corruption) |
+| **Outcome** | Successful — 3-layer fix (Unicode11 addon + binary WebSocket + resize timing) resolves all rendering issues |
+
+## When to Use
+
+- xterm.js renders TUI apps (Claude Code `/plan`, vim, htop) with corrupted layout
+- Box-drawing characters (Unicode) display as `?` or wrong-width glyphs
+- Emojis and wide characters cause column misalignment
+- Terminal dimensions are wrong on initial connection (80x24 default instead of actual size)
+- WebSocket drops binary PTY data silently
+- Auto-detected device type forces wrong UI layout on touch-capable laptops/WSL
+
+## Verified Workflow
+
+### Step 1: Add `@xterm/addon-unicode11`
+
+The Unicode11 addon fixes wide character width calculations. Without it, xterm.js uses Unicode 6 tables which miscalculate widths for box-drawing, emojis, and CJK characters.
+
+```bash
+yarn add @xterm/addon-unicode11
+```
+
+```typescript
+// hooks/useTerminal.ts — load after fit/weblinks, before clipboard
+try {
+  const { Unicode11Addon } = await import('@xterm/addon-unicode11')
+  const unicode11Addon = new Unicode11Addon()
+  terminal.loadAddon(unicode11Addon)
+  terminal.unicode.activeVersion = '11'
+} catch (e) {
+  console.warn('[Terminal] Unicode11Addon not available:', e)
+}
+```
+
+**Key detail:** Must set `terminal.unicode.activeVersion = '11'` after loading — loading alone doesn't activate it.
+
+### Step 2: Handle binary WebSocket data
+
+PTY can send binary frames. Without explicit handling, `event.data` may be a Blob that xterm.js silently drops.
+
+```typescript
+// hooks/useWebSocket.ts
+ws.binaryType = 'arraybuffer'
+
+ws.onmessage = (event) => {
+  if (event.data instanceof ArrayBuffer) {
+    onMessageRef.current?.(new TextDecoder().decode(event.data))
+    return
+  }
+  // ... existing JSON parsing
+}
+```
+
+### Step 3: Fix resize timing
+
+PTY spawns with hardcoded 80x24. If `/plan` renders before resize arrives, layout is wrong.
+
+**Client side** — pass dimensions in WebSocket URL and send resize on open:
+
+```typescript
+// hooks/useWebSocket.ts — add cols/rows to URL
+const url = `ws://host/term?name=${session}&cols=${cols}&rows=${rows}`
+
+// components/TerminalView.tsx — send resize immediately on open
+onOpen: () => {
+  const term = terminalInstanceRef.current
+  if (term) {
+    const resizeMsg = createResizeMessage(term.cols, term.rows)
+    setTimeout(() => sendMessage(resizeMsg), 0)
+  }
+}
+```
+
+**Server side** — use client dimensions for PTY spawn:
+
+```javascript
+// server.mjs
+const initialCols = parseInt(query.cols, 10) || 80
+const initialRows = parseInt(query.rows, 10) || 24
+ptyProcess = pty.spawn(cmd, args, {
+  name: 'xterm-256color',
+  cols: initialCols,
+  rows: initialRows,
+  // ...
+})
+```
+
+### Step 4: Layout toggle (bonus discovery)
+
+Auto-detection of device type (`useDeviceType` hook) can misclassify touch-capable laptops and WSL environments as tablets, forcing a mobile-style layout that hides navigation. Replace auto-detection with a user-controlled toggle persisted in localStorage.
+
+```typescript
+const [layoutOverride, setLayoutOverride] = useState<'tablet' | 'desktop' | null>(() => {
+  const saved = localStorage.getItem('aimaestro-layout-mode')
+  return saved === 'tablet' || saved === 'desktop' ? saved : null
+})
+const effectiveLayout = isMobile ? 'phone' : (layoutOverride || deviceType)
+```
+
+## Failed Attempts
+
+| Attempt | Why It Failed |
+|---------|---------------|
+| Adding navigation buttons only to `Header.tsx` (desktop layout) | User was on TabletDashboard (auto-detected as tablet on WSL/touch laptop). Buttons never appeared. |
+| Inline agent creation form in sidebar | Too complex for the sidebar UI; user just wanted navigation to the setup wizard |
+| Linking `+` button to `/zoom` page | Wrong destination — user wanted the agent creation/setup wizard, not the zoom view |
+| Linking `+` button to `/settings?section=onboarding` | Correct destination but caused hydration error (OnboardingSection reads localStorage on render). Fixed with `dynamic(() => import(...), { ssr: false })` |
+| Auto-detecting tablet vs desktop via `useDeviceType` | Unreliable on WSL, touch-capable laptops, and hybrid devices. Root cause of the entire navigation issue. |
+
+## Results & Parameters
+
+### Dependencies
+
+```json
+{
+  "@xterm/addon-unicode11": "^0.9.0"
+}
+```
+
+### Terminal Configuration
+
+```typescript
+// Critical xterm.js settings for PTY/tmux
+{
+  convertEol: false,           // PTY handles line endings
+  unicode: { activeVersion: '11' },  // After loading Unicode11Addon
+  windowOptions: { setWinLines: true }  // Alternate buffer support
+}
+```
+
+### WebSocket Configuration
+
+```typescript
+{
+  binaryType: 'arraybuffer',   // Handle binary PTY frames
+  // Pass initial dimensions in URL: ?cols=X&rows=Y
+}
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| AI Maestro | Issue #279 (xterm fix), #280 (nav buttons), #281 (layout toggle) | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

- Adds `architecture/xterm-plan-mode-fix` skill capturing learnings from fixing Claude Code `/plan` mode rendering in browser-based xterm.js terminals
- Documents 3-layer fix: Unicode11 addon, binary WebSocket handling, resize timing
- Includes bonus finding on layout auto-detection pitfalls (WSL/touch devices misclassified as tablets)
- Failed attempts table documents 5 iterations before finding root cause

## Files Added

- `skills/architecture/xterm-plan-mode-fix/.claude-plugin/plugin.json` — metadata + trigger patterns
- `skills/architecture/xterm-plan-mode-fix/skills/xterm-plan-mode-fix/SKILL.md` — full skill document
- `skills/architecture/xterm-plan-mode-fix/references/notes.md` — raw session details

## Test plan

- [ ] Verify plugin.json has valid JSON and required fields
- [ ] Verify SKILL.md has all required sections (Overview, When to Use, Verified Workflow, Failed Attempts, Results)
- [ ] Verify trigger patterns match relevant search queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)