### PR TITLE
feat: add fix-ci-compilation-and-lint skill

### DIFF
--- a/skills/ci-cd/fix-ci-compilation-and-lint/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-ci-compilation-and-lint/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-ci-compilation-and-lint",
+  "version": "1.0.0",
+  "description": "Fix CI failures caused by missing function declarations and markdown lint errors. Use when: (1) Mojo compilation fails with 'unknown declaration' after renaming/moving functions, (2) markdownlint MD051/MD037/MD031/MD040 errors block pre-commit.",
+  "category": "ci-cd",
+  "date": "2026-03-13"
+}

--- a/skills/ci-cd/fix-ci-compilation-and-lint/references/notes.md
+++ b/skills/ci-cd/fix-ci-compilation-and-lint/references/notes.md
@@ -1,0 +1,55 @@
+# Session Notes: Fix CI Compilation and Lint Failures
+
+## Date: 2026-03-13
+
+## Context
+
+The `main` branch CI was failing on two workflows:
+
+1. **Comprehensive Tests** — blocked by `shared/core/extensor.mojo:3737:13: error: use of unknown declaration 'dtype_to_string'`
+2. **Pre-commit Checks** — markdown lint failures in 3 files
+
+## Root Cause Analysis
+
+### Compilation Error
+
+Commit `4318de3c` changed `String(dtype)` to `dtype_to_string(dtype)` in `extensor.mojo` without
+adding an import. The function exists in `shared/utils/serialization.mojo:683` and
+`shared/training/dtype_utils.mojo:192`, but importing from either would create a wrong-direction
+dependency (core → utils).
+
+The fix followed the pattern already established in `shared/core/validation.mojo:695` which has
+its own local `_dtype_to_string()` function.
+
+### Markdown Lint Errors
+
+- `.github/workflows/README.md`: 3 MD051 errors — links to `#validate-workflows`,
+  `#precommit-benchmark`, `#workflow-smoke-test` pointed to headings that don't exist
+  (those workflows don't have dedicated sections in the detailed docs)
+- `docs/dev/backward-pass-catalog.md`: 3 MD013 (line length) + 1 MD037 (spaces in emphasis)
+  — the `*` characters in math expressions like `grad_output * alpha` were being parsed as
+  emphasis markers
+- `scripts/README.md`: 2 MD040 (missing code block language), 6 MD031 (missing blank lines
+  around code blocks), 1 MD026 (trailing colon in heading)
+
+## Mistakes Made During Fix
+
+1. **Wrong anchor suffix**: Changed `#pre-commit` to `#pre-commit-1` assuming GitHub's
+   auto-dedup suffix was needed. But `#### pre-commit` only appears once in the file,
+   so `#pre-commit` was already correct. Had to check with `grep` to confirm.
+
+2. **Wrong emphasis fix**: First attempt at fixing MD037 removed spaces around `*` operators
+   (`grad_output *alpha`), which created emphasis markers. Correct fix was escaping with `\*`.
+
+## Verification Commands
+
+```bash
+# Compilation
+pixi run mojo package -I . shared -o /tmp/shared.mojopkg
+
+# Pre-commit (targeted)
+SKIP=mojo-format pixi run pre-commit run --files <files>
+
+# Pre-commit (full)
+SKIP=mojo-format pixi run pre-commit run --all-files
+```

--- a/skills/ci-cd/fix-ci-compilation-and-lint/skills/fix-ci-compilation-and-lint/SKILL.md
+++ b/skills/ci-cd/fix-ci-compilation-and-lint/skills/fix-ci-compilation-and-lint/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: fix-ci-compilation-and-lint
+description: "Fix CI failures from missing declarations and markdown lint errors. Use when: Mojo compilation fails with unknown declaration, or markdownlint blocks pre-commit."
+category: ci-cd
+date: 2026-03-13
+user-invocable: false
+---
+
+# Fix CI Compilation and Lint Errors
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | CI blocked by Mojo compilation error + markdown lint failures |
+| **Root Cause** | Function renamed without adding import/local definition; markdown formatting violations |
+| **Fix Strategy** | Add local helper functions to avoid cross-module dependencies; fix markdown lint rules |
+| **Verification** | `mojo package` compilation + `pre-commit run --all-files` |
+
+## When to Use
+
+- Mojo compilation fails with `use of unknown declaration '<function_name>'` after a refactor
+- `markdownlint-cli2` reports MD051 (broken link fragments), MD037 (spaces in emphasis), MD031 (blank lines around code blocks), MD040 (missing language tags), or MD026 (trailing punctuation in headings)
+- CI is blocked on both comprehensive tests (compilation) and pre-commit (lint)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Verify compilation fix
+pixi run mojo package -I . shared -o /tmp/shared.mojopkg
+
+# Verify lint fixes on specific files
+SKIP=mojo-format pixi run pre-commit run --files <file1> <file2>
+
+# Full pre-commit validation
+SKIP=mojo-format pixi run pre-commit run --all-files
+```
+
+### Step 1: Fix Mojo Compilation Errors
+
+When a function reference is broken after renaming:
+
+1. **Find the pattern** in a sibling module that already has a local copy:
+
+   ```bash
+   grep -rn '_dtype_to_string' shared/core/
+   ```
+
+2. **Add a local private function** rather than importing from another module — this avoids creating wrong-direction dependencies (e.g., `core` should not depend on `utils`):
+
+   ```mojo
+   fn _dtype_to_string(dtype: DType) -> String:
+       if dtype == DType.float32:
+           return "float32"
+       # ... etc
+       else:
+           return "unknown"
+   ```
+
+3. **Update the call site** to use the local function name (prefixed with `_`).
+
+### Step 2: Fix Deprecated Mojo Syntax
+
+| Deprecation | Old | New |
+|-------------|-----|-----|
+| Pointer offset | `ptr.offset(n)` | `ptr + n` |
+| Type alias | `alias X = Y` | `comptime X = Y` |
+| Docstring format | Missing period in Returns | Add `.` at end |
+
+### Step 3: Fix Markdown Lint Errors
+
+| Rule | Issue | Fix |
+|------|-------|-----|
+| MD051 | Link fragment points to non-existent heading | Remove link or fix anchor |
+| MD037 | Spaces inside emphasis markers (`* text*`) | Escape asterisks with `\*` if used as math operators |
+| MD031 | Missing blank line before/after code block | Add blank line between closing ``` and `---` |
+| MD040 | Fenced code block without language | Add `text`, `bash`, `yaml`, etc. |
+| MD026 | Trailing punctuation in heading | Remove colon from heading text |
+| MD013 | Line exceeds 120 characters | Break line at natural boundary |
+
+### Step 4: Verify
+
+1. Run `mojo package` to confirm compilation passes (warnings OK, errors not)
+2. Run pre-commit on changed files first (fast feedback)
+3. Run pre-commit on all files (full validation)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Fix MD051 by changing `#pre-commit` to `#pre-commit-1` | Assumed GitHub auto-dedup suffix for duplicate anchors | The heading wasn't duplicated — `#pre-commit` was the correct anchor | Always check actual heading count before guessing dedup suffixes |
+| Fix MD037 by removing spaces around `*` | Changed `grad_output * alpha` to `grad_output *alpha` | This created emphasis markers wrapping `alpha, ...` | Use `\*` to escape asterisks used as math multiplication operators |
+
+## Results & Parameters
+
+### Environment
+
+- **Mojo version**: 0.26.1 (pinned in pixi.toml)
+- **markdownlint-cli2**: v0.12.1 (markdownlint v0.33.0)
+- **Pre-commit**: Configured in `.pre-commit-config.yaml`
+
+### Key Architectural Decision
+
+When a function exists in `shared/utils/` but is needed in `shared/core/`, create a local private copy prefixed with `_` rather than importing. The `core` module is foundational — it should not depend on higher-level modules like `utils`.
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `shared/core/extensor.mojo` | Added `_dtype_to_string()`, fixed `.offset()` → `+`, fixed docstring |
+| `shared/__init__.mojo` | `alias` → `comptime` |
+| `.github/workflows/README.md` | Removed 3 broken link fragments |
+| `docs/dev/backward-pass-catalog.md` | Fixed line lengths, escaped `*` operators |
+| `scripts/README.md` | Added language tags, blank lines, fixed heading punctuation |


### PR DESCRIPTION
## Summary

Documents fixing CI failures caused by missing Mojo function declarations and markdown lint errors across multiple documentation files.

- Mojo compilation error from `dtype_to_string` → local `_dtype_to_string()` pattern
- Markdown lint fixes for MD051, MD037, MD031, MD040, MD026, MD013
- Deprecated Mojo syntax fixes (`.offset()` → `+`, `alias` → `comptime`)

## Key Findings

**What Worked**:
- Adding local private helper functions to avoid wrong-direction module dependencies (core should not import from utils)
- Escaping `*` with `\*` in markdown when used as math multiplication operators
- Running targeted pre-commit on changed files first for fast feedback, then full validation

**What Failed**:
- Guessing `#pre-commit-1` as anchor suffix → heading wasn't duplicated, `#pre-commit` was correct
- Removing spaces around `*` to fix MD037 → created emphasis markers instead of fixing them

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
