### PR TITLE
feat: add mojo-test-failure-fixes skill

### DIFF
--- a/skills/testing/mojo-test-failure-fixes/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-test-failure-fixes/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-test-failure-fixes",
+  "version": "1.0.0",
+  "description": "Diagnose and fix Mojo test suite failures: compilation errors, missing main functions, wrong API usage, and JIT crashes. Use when: (1) Mojo tests fail with compilation errors after API changes, (2) test files lack main() entrypoints, (3) VGG/deep model tests crash with libKGENCompilerRTShared.so, (4) batch-fixing multiple test files across a repo.",
+  "category": "testing",
+  "date": "2026-03-13"
+}

--- a/skills/testing/mojo-test-failure-fixes/references/notes.md
+++ b/skills/testing/mojo-test-failure-fixes/references/notes.md
@@ -1,0 +1,101 @@
+# Session Notes: Mojo Test Failure Fixes
+
+**Date**: 2026-03-13
+**Branch**: batch/low-complexity-fixes
+**PR**: HomericIntelligence/ProjectOdyssey#4512
+
+## Context
+
+Ran `just test-mojo` on ~498 Mojo test files. Found 17 failures. Fixed 16 of them.
+
+## Failures Found and Fixed
+
+### 1. `__init__.mojo` files — no `main` function
+**Files**: `tests/configs/__init__.mojo`, `tests/helpers/__init__.mojo`, `tests/models/__init__.mojo`, `tests/shared/__init__.mojo`
+**Error**: `module does not define a 'main' function`
+**Fix**: Skip in justfile test runner
+
+### 2. Library files without `main`
+**Files**: `tests/helpers/fixtures.mojo`, `tests/helpers/utils.mojo`, `tests/shared/conftest.mojo`
+**Error**: No main / import errors
+**Fix**: Skip in justfile
+
+### 3. Relative import error
+**File**: `tests/helpers/__init__.mojo`
+**Error**: `cannot import relative to a top-level package`
+**Fix**: Skip (it's a package init)
+
+### 4. String character indexing
+**Files**: `tests/shared/test_imports.mojo`, `tests/shared/test_imports_part3.mojo`
+**Error**: `no matching method in call to '__getitem__'` on String with Int
+**Fix**: `str[j]` → `str.as_bytes()[j]`, compare with `Int` against ASCII values
+
+### 5. `full()` Float32 fill value
+**File**: `tests/shared/conftest.mojo`
+**Error**: `cannot be converted from 'Float32' to 'Float64'`
+**Fix**: `Float32(0.1)` → `Float64(0.1)` in `full()` calls
+
+### 6. `assert_close_float` wrong arg order
+**Files**: `tests/models/test_lenet5_e2e_part1.mojo`, `test_lenet5_e2e_part2.mojo`
+**Error**: `value passed to 'atol' cannot be converted from 'StringLiteral'`
+**Signature**: `(a, b, rtol=1e-5, atol=1e-8, message="")`
+**Fix**: Add 4th positional `atol` param before message
+
+### 7. `List.size()` → `len()`
+**Files**: `test_lenet5_e2e_part1.mojo`, `test_lenet5_e2e_part2.mojo`
+**Error**: `'List[ExTensor]' value has no attribute 'size'`
+**Fix**: `params.size()` → `len(params)`
+
+### 8. Wrong import names
+**Files**: `test_resnet18_e2e.mojo`, `test_vgg16_e2e.mojo`, `test_mobilenetv1_e2e_part1/2.mojo`
+**Errors**:
+- `module 'loss' does not contain 'cross_entropy_loss'` → use `cross_entropy`
+- `module 'pooling' does not contain 'max_pool2d'` → use `maxpool2d`
+- `module 'linear' does not contain 'Linear'` → use `linear` function
+
+### 9. Duplicate variable declarations
+**File**: `test_resnet18_e2e.mojo`
+**Error**: `invalid redefinition of '__'`
+**Fix**: Remove duplicate `var _:` / `var __:` in second batch_norm block (same function scope)
+
+### 10. Reshape needed after global_avgpool2d
+**Files**: `test_resnet18_e2e.mojo`, `test_vgg16_e2e.mojo`, `test_googlenet_e2e_part1/2.mojo`
+**Error**: `Incompatible dimensions for matmul: 1 != N`
+**Root cause**: `global_avgpool2d` returns `(B, C, 1, 1)` but `linear` expects `(B, C)`
+**Fix**: `pooled.reshape([batch_size, C])` before calling `linear`
+
+### 11. Missing `main()` entrypoints
+**Files**: `test_googlenet_e2e_part1/2.mojo`, `test_mobilenetv1_e2e_part1/2.mojo`
+**Error**: `module does not define a 'main' function`
+**Fix**: Added `fn main() raises:` calling all test functions
+
+### 12. VGG16 JIT crash
+**File**: `tests/models/test_vgg16_e2e.mojo`
+**Error**: `execution crashed` / `libKGENCompilerRTShared.so`
+**Pattern**: Crashes on 4th call to `vgg16_forward()` (batch_size=2, 32x32 input)
+**Individual run**: PASSES
+**Full suite**: CRASHES at 4th
+**Status**: Filed as issue #4511, skipped in test runner
+
+## Key API Changes (Mojo v0.26.1)
+
+| Old | New |
+|-----|-----|
+| `str[i]` | `str.as_bytes()[i]` |
+| `list.size()` | `len(list)` |
+| `cross_entropy_loss` | `cross_entropy` |
+| `max_pool2d` | `maxpool2d` |
+| `Linear` (class) | `linear` (function) |
+
+## Maxpool2d Empty Tensor Fix
+
+Added to `shared/core/pooling.mojo`:
+- Mojo `//` is floor division: `(-1) // 2 = -1`
+- `pool_output_shape(1, 1, kernel=2, stride=2, padding=0)` → `out_h = 0`
+- Added guard: if `out_height <= 0 or out_width <= 0`, return empty zeros tensor
+
+## PR
+
+- Branch: `batch/low-complexity-fixes`
+- PR: HomericIntelligence/ProjectOdyssey#4512
+- VGG16 issue: HomericIntelligence/ProjectOdyssey#4511

--- a/skills/testing/mojo-test-failure-fixes/skills/mojo-test-failure-fixes/SKILL.md
+++ b/skills/testing/mojo-test-failure-fixes/skills/mojo-test-failure-fixes/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: mojo-test-failure-fixes
+description: "Diagnose and fix Mojo test suite failures: compilation errors, missing main functions, wrong API usage, and JIT crashes. Use when: running just test-mojo reveals failures, Mojo API version changes break tests, or deep-network tests crash with libKGENCompilerRTShared.so."
+category: testing
+date: 2026-03-13
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Language | Mojo v0.26.1+ |
+| Test runner | `just test-mojo` (retries 3x per file) |
+| Scope | Batch-fix multiple test files across a repo (~498 files) |
+| PR strategy | Single PR on a feature branch |
+
+## When to Use
+
+- `just test-mojo` exits non-zero with `❌ FAILED after 3 attempts: ...`
+- After a Mojo version upgrade that changes stdlib APIs
+- After adding new test files without `main()` entrypoints
+- Deep model e2e tests crash with `libKGENCompilerRTShared.so`
+- Need to update test runner to skip non-test library files
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Run full test suite, capture output
+just test-mojo 2>&1 | tee /tmp/test-all-output.log
+
+# 2. Extract failures
+grep "^❌ FAILED" /tmp/test-all-output.log
+
+# 3. Get error details for each failure
+grep -A10 "tests/path/to/file.mojo" /tmp/test-all-output.log | head -20
+
+# 4. Fix, verify individually, then re-run suite
+pixi run mojo -I . tests/path/to/file.mojo
+just test-mojo
+```
+
+### Step 1: Run and Capture
+
+Run `just test-mojo` with output captured. The runner retries each file 3× to distinguish JIT flakes from real failures.
+
+```bash
+just test-mojo 2>&1 | tee /tmp/test-all-output.log
+```
+
+### Step 2: Triage Failures
+
+Categorize each `❌ FAILED after 3 attempts:` entry:
+
+| Category | Error Pattern | Fix |
+|----------|--------------|-----|
+| No main | `module does not define a 'main' function` | Add `fn main() raises:` calling all test functions |
+| Relative import | `cannot import relative to a top-level package` | Skip file in test runner (library file) |
+| Missing module | `unable to locate module 'X'` | Skip file (stale/wrong import path) |
+| String indexing | `no matching method in call to '__getitem__'` | Use `.as_bytes()[j]` instead of `str[j]` |
+| Float type | `cannot be converted from 'Float32' to 'Float64'` | Change `Float32(x)` → `Float64(x)` in `full()` calls |
+| Wrong import name | `module 'X' does not contain 'Y'` | Check actual function names in source module |
+| Wrong arg order | `value passed to 'atol' cannot be converted from StringLiteral` | Fix positional arg order — add missing param |
+| `List.size()` | `'List[T]' value has no attribute 'size'` | Use `len(list)` instead |
+| Duplicate var | `invalid redefinition of '__'` | Remove duplicate `var _:` / `var __:` declarations |
+| Reshape needed | `Incompatible dimensions for matmul: 1 != N` | Flatten 4D→2D after `global_avgpool2d` before `linear` |
+| JIT crash | `execution crashed` / `libKGENCompilerRTShared.so` | File GitHub issue, skip in test runner |
+
+### Step 3: Apply Fixes
+
+**Fix: Skip non-test files in justfile**
+
+`__init__.mojo`, `conftest.mojo`, and library files (no `main`) should be skipped:
+
+```bash
+# In justfile test-mojo recipe, before the test loop body:
+if [[ "$(basename "$test_file")" == "__init__.mojo" ]] || \
+   [[ "$(basename "$test_file")" == "conftest.mojo" ]] || \
+   [[ "$test_file" == "tests/helpers/fixtures.mojo" ]] || \
+   [[ "$test_file" == "tests/helpers/utils.mojo" ]]; then
+    continue
+fi
+```
+
+**Fix: String character indexing (Mojo API change)**
+
+```mojo
+# ❌ Old (broken in newer Mojo)
+var ch = part[j]
+if ch < "0" or ch > "9":
+
+# ✅ New
+var part_bytes = part.as_bytes()
+var ch = Int(part_bytes[j])
+if ch < 48 or ch > 57:  # ord("0")==48, ord("9")==57
+```
+
+**Fix: `full()` fill value type**
+
+```mojo
+# ❌ Wrong
+return full(shape, Float32(0.1), DType.float32)
+
+# ✅ Correct — full() always takes Float64
+return full(shape, Float64(0.1), DType.float32)
+```
+
+**Fix: `assert_close_float` signature**
+
+```mojo
+# Signature: (a, b, rtol, atol, message)
+# ❌ Wrong — 4th arg becomes atol, not message
+assert_close_float(val1, val2, 0.0, "message")
+
+# ✅ Correct — pass all 5 positional args
+assert_close_float(val1, val2, 0.0, 0.0, "message")
+```
+
+**Fix: `List.size()` → `len()`**
+
+```mojo
+# ❌ Old
+assert_true(params.size() == 10, "count mismatch")
+for i in range(params.size()):
+
+# ✅ New
+assert_true(len(params) == 10, "count mismatch")
+for i in range(len(params)):
+```
+
+**Fix: Duplicate variable declarations**
+
+```mojo
+# ❌ Wrong — second block redeclares _ and __ from outer scope
+var bn2_out: ExTensor
+var _: ExTensor   # redeclaration error
+var __: ExTensor  # redeclaration error
+(bn2_out, _, __) = batch_norm2d(...)
+
+# ✅ Correct — reuse existing vars declared in same function scope
+var bn2_out: ExTensor
+(bn2_out, _, __) = batch_norm2d(...)
+# OR use unique names for nested scope:
+var _bn2_rm: ExTensor
+var _bn2_rv: ExTensor
+(bn2_out, _bn2_rm, _bn2_rv) = batch_norm2d(...)
+```
+
+**Fix: Flatten 4D→2D after global avgpool**
+
+```mojo
+# global_avgpool2d returns (batch, C, 1, 1) NOT (batch, C)
+# linear() requires 2D input (batch, features)
+
+# ❌ Wrong
+var output = global_avgpool2d(features)
+var logits = linear(output, fc_weights, fc_bias)  # crash: 1 != C
+
+# ✅ Correct
+var pooled = global_avgpool2d(features)   # (batch, C, 1, 1)
+var batch_size = pooled.shape()[0]
+var flat_shape = List[Int]()
+flat_shape.append(batch_size)
+flat_shape.append(C)  # known channel count
+var flat = pooled.reshape(flat_shape)     # (batch, C)
+var logits = linear(flat, fc_weights, fc_bias)
+```
+
+**Fix: Add `main()` to test files**
+
+Test files without `main()` fail with "module does not define a 'main' function". Pattern:
+
+```mojo
+fn main() raises:
+    print("Starting <Model> Tests...")
+    print("  test_foo...", end="")
+    test_foo()
+    print(" OK")
+    print("  test_bar...", end="")
+    test_bar()
+    print(" OK")
+    print("All <Model> Tests passed!")
+```
+
+**Fix: Import name mismatches**
+
+Check actual function names in the source module:
+```bash
+grep -n "^fn " shared/core/loss.mojo | head -10
+# cross_entropy (NOT cross_entropy_loss)
+
+grep -n "^fn \|^struct " shared/core/linear.mojo | head -10
+# linear, linear_no_bias (NOT Linear class)
+
+grep -n "^fn maxpool" shared/core/pooling.mojo | head -5
+# maxpool2d, maxpool2d_backward (NOT max_pool2d)
+```
+
+**Fix: `maxpool2d` empty output guard**
+
+When kernel > input spatial dims, output would be 0-sized. Add guard:
+
+```mojo
+# In maxpool2d, after computing out_height/out_width:
+if out_height <= 0 or out_width <= 0:
+    var empty_shape = List[Int](capacity=4)
+    empty_shape.append(batch)
+    empty_shape.append(channels)
+    empty_shape.append(0)
+    empty_shape.append(0)
+    return zeros(empty_shape, x.dtype())
+```
+
+**Handle: JIT crash (libKGENCompilerRTShared.so)**
+
+When a test crashes with stack trace pointing to `libKGENCompilerRTShared.so`, it's a JIT heap corruption. Occurs with very deep networks (VGG16: 13 conv + 3 FC layers) when running 4+ sequential forward passes in one JIT session.
+
+- Individual test runs pass: `pixi run mojo -I . tests/models/test_file.mojo` ✅
+- Full suite fails on the 4th+ call ❌
+
+Options (in order of preference):
+1. File a GitHub issue and skip in test runner with a reference
+2. Reduce tensor sizes (FC 4096→256) to reduce memory pressure
+3. Split test file into parts (≤3 forward passes each)
+
+```bash
+# Skip in justfile with issue reference:
+if [[ "$test_file" == "tests/models/test_vgg16_e2e.mojo" ]]; then
+    echo "⚠️  Skipping $test_file (issue #NNNN - JIT heap corruption)"
+    continue
+fi
+```
+
+### Step 4: Verify Individually Then Full Suite
+
+```bash
+# Verify each fixed file individually first
+pixi run mojo -I . tests/models/test_lenet5_e2e_part1.mojo 2>&1 | tail -5
+
+# Then run full suite
+just test-mojo 2>&1 | tail -5
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Splitting VGG16 main() to run only 3 tests | Reduced tests in main() to avoid 4th JIT crash | User rejected — ADR-009 was wrong explanation; real fix is in maxpool2d | Always investigate root cause before applying ADR workarounds |
+| Using `Float32` in `full()` calls | Original code passed `Float32(0.1)` as fill value | `full()` signature requires `Float64` fill_value | Check function signatures before assuming type compatibility |
+| `var x_flat = x` (no reshape) | Original VGG16 code skipped reshape after global_avgpool2d | Passed 4D tensor `(B,C,1,1)` to `linear()` which expects 2D | `global_avgpool2d` always returns 4D; always reshape to 2D before FC layers |
+| Reusing `var _:` and `var __:` in nested blocks | Second batch_norm call redeclared `_` and `__` vars | Mojo treats `_` and `__` as named variables, not wildcards | Use unique names `_bn2_rm`, `_bn2_rv` for subsequent batch norm outputs |
+| `assert_close_float(a, b, rtol, "msg")` | Passed 4 positional args | 4th positional is `atol: Float64`, not `message: String` | Always check full function signatures — message is the 5th arg |
+
+## Results & Parameters
+
+**Session outcome**: Fixed 16 failing test files, reduced failures from 17 to 1 (VGG16 tracked as issue #4511).
+
+**Test runner skip pattern** (copy-paste for justfile):
+```bash
+if [[ "$(basename "$test_file")" == "__init__.mojo" ]] || \
+   [[ "$(basename "$test_file")" == "conftest.mojo" ]] || \
+   [[ "$test_file" == "tests/helpers/fixtures.mojo" ]] || \
+   [[ "$test_file" == "tests/helpers/utils.mojo" ]]; then
+    continue
+fi
+```
+
+**Mojo integer division gotcha** (pool output shape):
+```
+(1 + 0 - 2) // 2 + 1 = (-1) // 2 + 1 = -1 + 1 = 0  # empty output!
+```
+This means `maxpool2d(kernel=2, stride=2)` on a 1×1 input produces 0×0 output.
+Always guard: `if out_height <= 0 or out_width <= 0: return empty tensor`.
+
+**API name changes (Mojo v0.26.1)**:
+- `String[int]` → `String.as_bytes()[int]`
+- `List.size()` → `len(List)`
+- `cross_entropy_loss` → `cross_entropy` (in `shared.core.loss`)
+- `max_pool2d` → `maxpool2d` (in `shared.core.pooling`)
+- `Linear` class → `linear` function (in `shared.core.linear`)


### PR DESCRIPTION
## Summary

Documents batch-fixing Mojo test suite failures from a session that fixed 16 of 17 failing test files (~498 total).

- API name changes (String indexing, List.size, cross_entropy_loss, max_pool2d, Linear)
- Missing main() entrypoints in e2e test files
- global_avgpool2d returns 4D — must reshape before linear()
- maxpool2d empty output guard (Mojo floor division gotcha)

## Key Findings

**What Worked**:
- Running `just test-mojo` and capturing output to triage all failures at once
- Verifying each fix individually with `pixi run mojo -I . <file>` before re-running suite
- Skipping non-test library files (`__init__.mojo`, `conftest.mojo`) in justfile
- Adding `main()` entrypoints that call all test functions in sequence

**What Failed**:
- Splitting VGG16 main() to 3 tests (ADR-009 workaround) → user rejected; root cause is deeper
- `Float32` fill value in `full()` → needs `Float64`
- Passing 4D tensor directly to `linear()` after `global_avgpool2d` → needs reshape
- Reusing `var _:` / `var __:` across blocks in same function → Mojo treats them as named vars

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under testing category
- [ ] Confirm `## Failed Attempts` table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
