### PR TITLE
feat: add fix-ruff-pre-commit-failures skill

### DIFF
--- a/skills/ci-cd/fix-ruff-pre-commit-failures/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-ruff-pre-commit-failures/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-ruff-pre-commit-failures",
+  "version": "1.0.0",
+  "description": "Systematically fix ruff pre-commit CI failures (N806, E501, format) on a PR branch. Use when: (1) pre-commit CI is failing with ruff errors on a PR, (2) you need to fix N806 uppercase variables inside functions, E501 line-too-long in docstrings, or ruff-format auto-collapse issues.",
+  "category": "ci-cd",
+  "date": "2026-03-13"
+}

--- a/skills/ci-cd/fix-ruff-pre-commit-failures/references/notes.md
+++ b/skills/ci-cd/fix-ruff-pre-commit-failures/references/notes.md
@@ -1,0 +1,77 @@
+# Session Notes: fix-ruff-pre-commit-failures
+
+**Date**: 2026-03-13
+**Project**: HomericIntelligence/ProjectScylla
+**PR**: #1480 (`reconcile-checkpoint-retry-errors`)
+
+## Context
+
+PR #1480 adds `_reconcile_checkpoint_with_disk()` to fix stale checkpoint states before
+`--retry-errors` runs. The logic and tests were correct (unit + integration pass, 76.62%
+coverage), but pre-commit CI was failing with 3 ruff issues.
+
+## Failures Observed
+
+### N806 — Uppercase variables inside a function
+
+File: `scripts/manage_experiment.py` lines ~403, 419
+
+```
+N806 Variable `_STATE_ORDER` in function should be lowercase
+N806 Variable `_STATE_RANK` in function should be lowercase
+```
+
+Root cause: `_STATE_ORDER` and `_STATE_RANK` look like module-level constants but are defined
+inside `_reconcile_checkpoint_with_disk()`. Ruff N806 flags this pattern.
+
+### E501 — Line too long
+
+File: `tests/unit/e2e/test_manage_experiment_run.py` line 1800
+
+```
+E501 Line too long (106 > 100 characters)
+```
+
+Root cause: Single-line docstring in test function was 106 chars.
+
+### ruff-format — Un-formatted code
+
+File: `scripts/manage_experiment.py` line ~1158
+
+```
+Would reformat scripts/manage_experiment.py
+```
+
+Root cause: `logger.info(...)` was split across 3 lines but fit within 100 chars — ruff-format
+collapses it to 1 line.
+
+## Fixes Applied
+
+1. **N806**: Renamed `_STATE_ORDER` → `state_order`, `_STATE_RANK` → `state_rank` (definition +
+   2 usage sites in the same function)
+
+2. **ruff-format**: Collapsed `logger.info(f"...")` from 3 lines to 1 line
+
+3. **E501**: Wrapped 106-char docstring to a multi-line docstring
+
+## Execution Details
+
+- Checkout branch: `git fetch origin reconcile-checkpoint-retry-errors && git checkout reconcile-checkpoint-retry-errors`
+- Observed branch had diverged (local had 2 commits, remote had 1 different commit)
+- Made edits with Edit tool
+- Ran `pixi run --environment lint pre-commit run --all-files` — all ruff checks passed
+- First push rejected (non-fast-forward) — branch had diverged
+- Fixed with `git pull --rebase origin reconcile-checkpoint-retry-errors`
+- Second push succeeded after ~138s (test suite ran in push hook)
+- CI checks confirmed pending after push
+
+## Files Modified
+
+- `scripts/manage_experiment.py` — N806 fix + ruff-format fix
+- `tests/unit/e2e/test_manage_experiment_run.py` — E501 fix
+
+## Key Lesson
+
+The push hook runs the entire test suite (~135s). Don't assume the push failed if there's no
+immediate output — wait for the test suite to complete. Always check for branch divergence
+(`git status`) before pushing to avoid the rebase round-trip.

--- a/skills/ci-cd/fix-ruff-pre-commit-failures/skills/fix-ruff-pre-commit-failures/SKILL.md
+++ b/skills/ci-cd/fix-ruff-pre-commit-failures/skills/fix-ruff-pre-commit-failures/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: fix-ruff-pre-commit-failures
+description: "Systematically fix ruff pre-commit CI failures (N806, E501, format) on a PR branch. Use when: pre-commit CI is failing with ruff N806/E501/format errors on a PR branch."
+category: ci-cd
+date: 2026-03-13
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Fix ruff pre-commit CI failures without changing logic |
+| **Trigger** | Pre-commit CI red on a PR with ruff N806, E501, or format errors |
+| **Output** | Clean commit pushed to PR branch; CI goes green |
+| **Risk** | Low — purely cosmetic/style changes, no logic modified |
+
+## When to Use
+
+- Pre-commit CI is failing with `ruff check` or `ruff format` errors on a PR
+- Errors are one or more of: N806 (uppercase variable in function), E501 (line too long), format (un-formatted code)
+- The PR logic and tests are already correct; only style is blocking CI
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Checkout branch
+git fetch origin <branch> && git checkout <branch>
+
+# 2. Grep for offending variables/lines
+grep -n "_STATE_ORDER\|_STATE_RANK\|UPPERCASE_VAR" scripts/manage_experiment.py
+
+# 3. Apply fixes (see per-error steps below)
+
+# 4. Verify locally
+pixi run --environment lint pre-commit run --all-files
+
+# 5. Commit and push
+git add <files>
+git commit -m "fix(<scope>): fix ruff N806/E501/format pre-commit failures"
+git push origin <branch>
+```
+
+### Step 1 — Checkout the PR branch
+
+```bash
+git fetch origin <branch-name> && git checkout <branch-name>
+git log --oneline -5   # confirm you're on the right branch
+```
+
+Check if branch has diverged from remote before starting:
+
+```bash
+git status   # look for "have diverged"
+```
+
+If diverged, pull first: `git pull --rebase origin <branch-name>`
+
+### Step 2 — Fix N806: Uppercase variable inside function
+
+Ruff N806 flags `UPPER_CASE` variables defined inside a function body (they look like module-level
+constants but aren't).
+
+**Find offenders:**
+
+```bash
+grep -n "^    [A-Z_]\{2,\} = " scripts/manage_experiment.py
+```
+
+**Fix pattern** — rename to lowercase snake_case:
+
+```python
+# BEFORE (triggers N806)
+def _reconcile_checkpoint_with_disk(...):
+    _STATE_ORDER = ["pending", "dir_structure_created", ...]
+    _STATE_RANK = {s: i for i, s in enumerate(_STATE_ORDER)}
+    ...
+    current_rank = _STATE_RANK.get(current_state, 0)
+    inferred_rank = _STATE_RANK.get(inferred_state, 0)
+
+# AFTER (N806 resolved)
+def _reconcile_checkpoint_with_disk(...):
+    state_order = ["pending", "dir_structure_created", ...]
+    state_rank = {s: i for i, s in enumerate(state_order)}
+    ...
+    current_rank = state_rank.get(current_state, 0)
+    inferred_rank = state_rank.get(inferred_state, 0)
+```
+
+**Important**: Update ALL references — definition + every usage site.
+
+### Step 3 — Fix E501: Line too long in docstrings
+
+Ruff E501 flags lines exceeding the configured limit (commonly 100 chars). Docstrings are the
+most common offender because they aren't auto-collapsed by ruff-format.
+
+**Find offenders:**
+
+```bash
+grep -n ".\{101\}" tests/unit/e2e/test_manage_experiment_run.py | head -20
+```
+
+**Fix pattern** — wrap the docstring to multiple lines:
+
+```python
+# BEFORE (106 chars — triggers E501)
+"""_checkpoint_has_retryable_runs returns True for judge-failed runs (worktree_cleaned+failed)."""
+
+# AFTER (wrapped)
+"""_checkpoint_has_retryable_runs returns True for judge-failed runs.
+
+worktree_cleaned state with completed_runs status == "failed".
+"""
+```
+
+### Step 4 — Fix ruff-format: Un-formatted code
+
+Ruff-format auto-collapses multi-line expressions that fit within the line limit. The CI diff
+shows exactly what collapsed form is expected.
+
+**Common pattern** — multi-line `logger.info(...)` collapsed to one line:
+
+```python
+# BEFORE (un-formatted — triggers ruff-format)
+if reconcile_count > 0:
+    logger.info(
+        f"--retry-errors: reconciled {reconcile_count} run state(s) with disk"
+    )
+
+# AFTER (ruff-format collapses since it fits in 100 chars)
+if reconcile_count > 0:
+    logger.info(f"--retry-errors: reconciled {reconcile_count} run state(s) with disk")
+```
+
+**How to identify**: Run `pixi run --environment lint pre-commit run ruff-format --all-files`
+and read the diff output — it shows exactly what reformatting is needed.
+
+### Step 5 — Verify locally before pushing
+
+```bash
+pixi run --environment lint pre-commit run --all-files 2>&1 | grep -E "^(Ruff|Failed|Passed)"
+```
+
+Expected output (all Passed):
+```
+Ruff Format Python.......................................................Passed
+Ruff Check Python........................................................Passed
+Ruff Complexity Check (C901).............................................Passed
+```
+
+Ignore failures in `ProjectMnemosyne/` subdirectory — those are pre-existing unrelated issues.
+
+### Step 6 — Commit and push
+
+```bash
+git add <modified-files>
+git commit -m "fix(<scope>): fix ruff N806/E501/format pre-commit failures"
+git push origin <branch-name>
+```
+
+**If push rejected** (branch diverged):
+
+```bash
+git pull --rebase origin <branch-name>
+git push origin <branch-name>
+```
+
+The push hook runs the full test suite (~135s) before pushing. Wait for it to complete.
+
+### Step 7 — Verify CI
+
+```bash
+gh pr checks <PR-number> --repo <owner>/<repo>
+```
+
+All checks should transition from `pending` → `passing` within a few minutes.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| First push | `git push origin <branch>` after committing fixes | Branch had diverged (remote had 1 commit not in local) — rejected with non-fast-forward error | Always check `git status` for divergence before pushing; use `git pull --rebase` to reconcile |
+| Ignoring ProjectMnemosyne tier-label failures | Pre-commit output included many tier-label check failures | Those failures are pre-existing in `ProjectMnemosyne/` subdirectory, not caused by our changes | Filter pre-commit output with `grep -E "^(Ruff|Failed|Passed)"` to see only relevant checks |
+
+## Results & Parameters
+
+### Environment
+
+```toml
+# pixi.toml — lint environment used for pre-commit
+[feature.lint.dependencies]
+pre-commit = "*"
+ruff = "*"
+```
+
+### Ruff Configuration (pyproject.toml)
+
+```toml
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "N", "C901", ...]
+
+[tool.ruff.format]
+# ruff-format collapses expressions that fit within line-length
+```
+
+### Key Commands
+
+```bash
+# Run only ruff checks (fast)
+pixi run --environment lint pre-commit run ruff --all-files
+pixi run --environment lint pre-commit run ruff-format --all-files
+
+# Run all pre-commit hooks
+pixi run --environment lint pre-commit run --all-files
+
+# Find N806 candidates
+grep -n "^    [A-Z_][A-Z_]* = " scripts/*.py
+
+# Find E501 candidates
+grep -n ".\{101\}" tests/**/*.py | head -30
+```
+
+### Timing
+
+- Local pre-commit run: ~10s (ruff only), ~30s (all hooks)
+- Push hook (full test suite): ~135s
+- CI checks: ~5 min for all checks to complete


### PR DESCRIPTION
## Summary

Documents a systematic workflow for fixing ruff pre-commit CI failures (N806, E501, format) on a PR branch without changing any logic.

- N806: rename UPPER_CASE vars inside functions to snake_case (update all references)
- E501: wrap long docstrings to multiple lines (ruff-format won't auto-wrap them)
- ruff-format: collapse multi-line expressions that fit within line-length limit

## Key Findings

**What Worked**:
- Grepping for uppercase variable patterns to locate N806 offenders quickly
- Running `pixi run --environment lint pre-commit run --all-files` locally before pushing
- Filtering pre-commit output with `grep -E "^(Ruff|Failed|Passed)"` to ignore unrelated failures
- Using `git pull --rebase` to reconcile diverged branch before retrying push

**What Failed**:
- First push attempt → rejected (non-fast-forward): branch had diverged; fixed with `git pull --rebase`
- Ignoring ProjectMnemosyne tier-label failures in pre-commit output → those are pre-existing, not caused by our changes

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with ruff pre-commit failure triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
