### PR TITLE
fix(ci): update marketplace workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -39,11 +40,21 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push
+      - name: Commit and open PR
         if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/update-marketplace-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH"
           git add .claude-plugin/marketplace.json
           git commit -m "chore: update marketplace.json [skip ci]"
-          git push
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: update marketplace.json" \
+            --body "Auto-generated: regenerate marketplace.json after skills change." \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge --auto --rebase


### PR DESCRIPTION
## Summary
- The `Update Marketplace` workflow was failing with `GH006: Protected branch update failed` because it was pushing directly to `main`
- Main branch requires all changes go through PRs
- Fix: create a timestamped branch, commit, push, open PR, enable auto-merge with rebase

## Test plan
- [ ] Merge a skill PR and verify the workflow creates a `chore/update-marketplace-*` PR automatically
- [ ] Verify the auto-generated PR passes `validate` and auto-merges