### PR TITLE
fix(ci): remove path filters from validate workflow so it runs on every PR commit

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -2,18 +2,9 @@ name: Validate Plugins
 
 on:
   pull_request:
-    paths:
-      - 'skills/**'
-      - 'plugins/**'
-      - 'templates/**'
-      - 'scripts/validate_plugins.py'
   push:
     branches:
       - main
-    paths:
-      - 'skills/**'
-      - 'plugins/**'
-      - 'templates/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- `validate` is a required check for merging to main
- It was only triggered when `skills/**`, `plugins/**`, `templates/**`, or `scripts/validate_plugins.py` changed
- PRs touching only workflow files, docs, or other paths never got the required check → permanently BLOCKED
- Fix: remove all `paths:` filters so `validate` runs on every `pull_request` event

## Test plan
- [ ] Merge this PR and verify that all currently-BLOCKED PRs get a `validate` run triggered after rebase