### PR TITLE
feat: add pr-ci-failure-triage skill

### DIFF
--- a/skills/ci-cd/pr-ci-failure-triage/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pr-ci-failure-triage/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "pr-ci-failure-triage",
+  "version": "1.0.0",
+  "description": "Triage and fix CI failures blocking PR merges in Mojo/GitHub Actions projects. Use when: (1) multiple PRs are stuck with CI failures, (2) pre-commit markdownlint or action SHA errors appear, (3) Mojo --Werror unused return value errors block builds.",
+  "category": "ci-cd",
+  "date": "2026-03-14"
+}

--- a/skills/ci-cd/pr-ci-failure-triage/references/notes.md
+++ b/skills/ci-cd/pr-ci-failure-triage/references/notes.md
@@ -1,0 +1,57 @@
+# Session Notes: PR CI Failure Triage
+
+**Date**: 2026-03-14
+**Project**: ProjectOdyssey (Mojo-based ML research platform)
+**Session type**: Multi-PR CI unblocking
+
+## Context
+
+Multiple PRs (4498, 4500, 4507, 4518) were stuck and not auto-merging due to CI failures.
+Used `/pr-cleanup` skill to identify and fix each.
+
+## PRs Fixed
+
+| PR | Root Cause | Fix Applied |
+|----|-----------|-------------|
+| 4500 | Invalid action SHAs in workflow files | Replaced with valid SHAs from other workflows |
+| 4500 | run_all_tests.mojo importing split test modules by old names | Updated imports to _part1/_part2 variants |
+| 4500 | test-data-utilities.yml referencing test_sequential.mojo | Updated to test_sequential_part1.mojo + part2 |
+| 4498 | pre-commit markdownlint failing on .claude/plugins/ files | Added .claude/plugins/ to exclude: regex in .pre-commit-config.yaml |
+| 4507 | Mojo --Werror: unused return from sgd_step/adam_step | Added `_ =` prefix to 16 bare calls in bench_optimizers.mojo |
+| 4518 | comprehensive-tests.yml missing test_unsigned_part2/part3 | Added to matrix pattern |
+
+## Key Learnings
+
+### 1. .markdownlintignore has no effect on pre-commit hooks
+The pre-commit hook for markdownlint-cli2 uses its own `args:` and `exclude:` config.
+The `.markdownlintignore` file is only read when running markdownlint-cli2 directly.
+Solution: Always edit `.pre-commit-config.yaml` `exclude:` regex.
+
+### 2. ADR-009 split files require updates in 3 places
+When test files are split into _part1/_part2:
+- CI workflow `.yml` files must update `just test-group` arguments
+- `run_all_tests.mojo` must update its `from ... import` statements
+- `comprehensive-tests.yml` matrix patterns must include new filenames
+
+### 3. Pinned action SHAs must match actual action versions
+The comment `# v4` next to a SHA doesn't guarantee the SHA is correct.
+Cross-reference with other workflow files that use the same action and are known to work.
+
+### 4. Mojo --Werror makes unused returns into compile errors
+Any function returning Tuple, ExTensor, or other non-trivial types must have return
+explicitly discarded with `_ =` syntax when called for side effects only.
+
+### 5. Safety Net blocks certain git commands
+- `git checkout <branch>` for switching: use `git switch <branch>` instead
+- `git branch -D`: use `git branch -d` instead
+
+### 6. Always check main CI status before fixing PRs
+Baseline failures on `main` propagate to all PRs. Don't attempt to fix inherited failures
+in PR branches — they'll resolve when main is fixed.
+
+## Environment
+
+- Mojo version: 0.26.1
+- GitHub Actions runner: ubuntu-latest
+- Required checks: pre-commit, security-report, Mojo Package Compilation, Code Quality Analysis, secret-scan
+- Optional (non-blocking): Benchmarks, performance tests

--- a/skills/ci-cd/pr-ci-failure-triage/skills/pr-ci-failure-triage/SKILL.md
+++ b/skills/ci-cd/pr-ci-failure-triage/skills/pr-ci-failure-triage/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: pr-ci-failure-triage
+description: "Triage and fix CI failures blocking PR merges in Mojo/GitHub Actions projects. Use when: multiple PRs stuck with CI failures, pre-commit markdownlint or action SHA errors, Mojo --Werror unused return value errors."
+category: ci-cd
+date: 2026-03-14
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Category** | ci-cd |
+| **Complexity** | Medium-High |
+| **Time** | 30–90 min for multiple PRs |
+| **Prerequisites** | `gh` CLI auth, git access to repo |
+
+Systematic approach to unblock multiple stuck PRs by diagnosing CI failures, applying targeted
+fixes, and rebasing branches. Key insight: distinguish between PR-specific failures vs baseline
+failures that exist on `main` itself (don't fix what main already has broken).
+
+## When to Use
+
+- Multiple open PRs all showing CI failures preventing auto-merge
+- `pre-commit` checks fail on markdown or workflow files
+- GitHub Actions workflows fail with "invalid SHA" or "unknown action" errors
+- Mojo compilation fails with `unused return value` under `--Werror`
+- Test files were split (ADR-009 pattern) but CI workflows still reference old monolithic filenames
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Check all open PRs
+gh pr list --state open
+
+# Check CI status for a specific PR
+gh pr checks <pr-number>
+
+# Check required vs optional checks
+gh api repos/<owner>/<repo>/branches/main/protection/required_status_checks
+
+# Rebase PR branch onto main
+git fetch origin && git rebase origin/main <branch-name>
+git push --force-with-lease origin <branch-name>
+```
+
+### Step 1: Identify Required Checks
+
+Before fixing anything, determine which CI checks are *required* for merge vs optional.
+
+```bash
+gh api repos/<owner>/<repo>/branches/main/protection/required_status_checks \
+  --jq '.contexts[]'
+```
+
+**Critical insight**: Only fix failures in required checks. Optional checks (e.g., benchmarks,
+performance tests) will not block merging even if they fail.
+
+### Step 2: Triage Each PR
+
+For each blocked PR, run:
+
+```bash
+gh pr checks <pr-number> --watch
+```
+
+Categorize each failure as:
+
+- **PR-specific** — only fails on this branch, not on `main`
+- **Baseline failure** — also fails on `main`; skip fixing (not this PR's problem)
+- **Infrastructure** — invalid action SHAs, missing files, workflow syntax errors
+
+### Step 3: Fix Pattern — pre-commit markdownlint Exclusions
+
+**Symptom**: `markdownlint-cli2` fails on files that should be excluded (e.g., `.claude/plugins/`).
+
+**Wrong fix**: Adding paths to `.markdownlintignore` — pre-commit hooks do NOT read this file.
+
+**Correct fix**: Edit the `exclude:` regex in `.pre-commit-config.yaml` for the
+`markdownlint-cli2` hook:
+
+```yaml
+# Before
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  hooks:
+    - id: markdownlint-cli2
+      exclude: ^notes/(plan|issues|review|blog)/
+
+# After
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  hooks:
+    - id: markdownlint-cli2
+      exclude: ^(notes/(plan|issues|review|blog)|\.claude/plugins)/
+```
+
+### Step 4: Fix Pattern — Invalid Pinned Action SHAs
+
+**Symptom**: GitHub Actions workflow fails with `Error: Could not find actions/checkout@<sha>`.
+
+**Cause**: SHA used for a pinned action doesn't correspond to the stated version comment.
+
+**Fix**: Cross-reference valid SHAs from other workflow files in the repo:
+
+```bash
+grep -r "actions/checkout@" .github/
+grep -r "actions/cache@" .github/
+```
+
+Use the SHA that appears most frequently (or is confirmed correct by other passing workflows).
+
+| Action | Version | Confirmed SHA |
+|--------|---------|---------------|
+| `actions/checkout` | v4 | `8e8c483db84b4bee98b60c0593521ed34d9990e8` |
+| `actions/cache` | v5 | `cdf6c1fa76f9f475f3d7449005a359c84ca0f306` |
+
+### Step 5: Fix Pattern — Split Test Files (ADR-009)
+
+**Symptom**: CI workflow runs `just test-group "path" "test_foo.mojo"` but the file was split
+into `test_foo_part1.mojo` and `test_foo_part2.mojo`.
+
+**Cause**: ADR-009 pattern splits test files exceeding 10 `fn test_` functions. CI workflows
+and `run_all_tests.mojo` import collectors must be updated together.
+
+**Fix locations** (must update all three):
+
+1. GitHub Actions workflow file (`.github/workflows/test-*.yml`):
+
+   ```yaml
+   # Before
+   just test-group "tests/path/samplers" "test_sequential.mojo"
+   # After
+   just test-group "tests/path/samplers" "test_sequential_part1.mojo test_sequential_part2.mojo"
+   ```
+
+2. `run_all_tests.mojo` imports:
+
+   ```mojo
+   # Before
+   from tests.shared.data.samplers.test_sequential import (...)
+   # After
+   from tests.shared.data.samplers.test_sequential_part1 import (...)
+   ```
+
+3. `comprehensive-tests.yml` matrix (if applicable):
+
+   ```yaml
+   # Before
+   test_unsigned.mojo
+   # After
+   test_unsigned_part2.mojo test_unsigned_part3.mojo
+   ```
+
+### Step 6: Fix Pattern — Mojo `--Werror` Unused Return Values
+
+**Symptom**: `error: unused return value` in benchmark or test files.
+
+**Cause**: Mojo functions returning `Tuple` or `ExTensor` — even benchmark `step` functions —
+must have their return value explicitly discarded when `--Werror` is enabled.
+
+**Fix**: Prefix bare calls with `_ =`:
+
+```mojo
+# Before (compile error under --Werror)
+sgd_step(model, grads, lr)
+adam_step(model, grads, lr, m, v, t)
+
+# After
+_ = sgd_step(model, grads, lr)
+_ = adam_step(model, grads, lr, m, v, t)
+```
+
+**Detection**: Search for functions that return `Tuple` and are called without assignment:
+
+```bash
+grep -n "sgd_step\|adam_step\|fn.*-> Tuple" tests/shared/benchmarks/
+```
+
+### Step 7: Rebase and Force Push
+
+After fixes are committed on the feature branch:
+
+```bash
+git fetch origin
+git rebase origin/main
+git push --force-with-lease origin <branch-name>
+```
+
+If rebase has conflicts from cherry-picked commits already in main:
+
+```bash
+git rebase --reapply-cherry-picks origin/main
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Added paths to `.markdownlintignore` | Expected pre-commit hook to read the ignore file | pre-commit's markdownlint-cli2 hook uses `args:` config, not `.markdownlintignore` | Always use `exclude:` regex in `.pre-commit-config.yaml` to exclude files from hooks |
+| Used `git checkout <branch>` to switch branches | Expected standard git checkout | Safety Net hook blocked `git checkout` for branch switching | Use `git switch <branch>` instead of `git checkout <branch>` for switching |
+| Used `git branch -D <branch>` to delete merged branch | Standard force-delete | Safety Net blocked `-D` (force delete) | Use `git branch -d <branch>` (safe delete that requires merge) |
+| Fixed PR #4510 by rebasing with new commits | Branch had commits already squash-merged into main | Rebase produced diverged history with duplicate content | Check if branch content already exists in main via `git log origin/main..<branch>` before rebasing; close as superseded if already merged |
+| Tried to fix baseline failures on PRs | Failures appeared on PR CI | Same failures existed on `main` — not PR-specific | Always check `main` CI status first; don't attempt to fix inherited baseline failures in PR branches |
+
+## Results & Parameters
+
+### Required CI Checks (ProjectOdyssey)
+
+```text
+- pre-commit
+- security-report
+- Mojo Package Compilation
+- Code Quality Analysis
+- secret-scan
+```
+
+Benchmark and performance checks are NOT required — failures there don't block merge.
+
+### Rebase Command for Cherry-Pick Conflicts
+
+```bash
+git rebase --reapply-cherry-picks origin/main
+```
+
+### pre-commit Config Exclusion Pattern
+
+```yaml
+# Exclude multiple directory patterns
+exclude: ^(notes/(plan|issues|review|blog)|\.claude/plugins)/
+```
+
+### Mojo Unused Return Fix Template
+
+```bash
+# Find all bare calls to functions returning Tuple
+grep -n "^\s*sgd_step\|^\s*adam_step\|^\s*<fn_name>" <file>
+# Add "_ = " prefix to each
+sed -i 's/^    sgd_step/    _ = sgd_step/g' <file>
+```


### PR DESCRIPTION
## Summary

Documents systematic approach to triaging and fixing CI failures blocking PR merges in
Mojo/GitHub Actions projects.

- Covers 4 distinct failure patterns encountered when unblocking multiple stuck PRs
- Key insight: distinguish PR-specific vs baseline failures on `main` before fixing
- Documents pre-commit `exclude:` regex as the correct way to exclude files (not `.markdownlintignore`)

## Key Findings

**What Worked**:
- Using `exclude:` regex in `.pre-commit-config.yaml` to exclude files from markdownlint-cli2 hook
- Cross-referencing valid pinned action SHAs from other passing workflow files
- Adding `_ =` prefix to discard unused Tuple/ExTensor return values under Mojo `--Werror`
- Updating CI workflows, `run_all_tests.mojo`, and comprehensive-tests matrix when test files are split

**What Failed**:
- Adding paths to `.markdownlintignore` → pre-commit hooks don't read this file
- Using `git checkout` for branch switching → Safety Net blocks it; use `git switch` instead
- Force-deleting branches → Safety Net blocks force flags; use safe delete instead
- Trying to fix baseline failures on PRs → same failures exist on `main`; not PR-specific

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with PR CI failure triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
