### PR TITLE
feat: add always-retry-infra-failures skill

### DIFF
--- a/skills/debugging/always-retry-infra-failures/.claude-plugin/plugin.json
+++ b/skills/debugging/always-retry-infra-failures/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "always-retry-infra-failures",
+  "version": "1.0.0",
+  "description": "Fix retry logic bugs where a flag-gated retry failed to distinguish infra crashes from bad-grade results, causing valid judge results to be discarded. Use when: (1) removing a feature flag and making its behavior unconditional, (2) fixing retry/reset logic that incorrectly targets completed runs with bad scores, (3) debugging state machine checkpoint semantics where terminal states have different meanings.",
+  "category": "debugging",
+  "date": "2026-03-14"
+}

--- a/skills/debugging/always-retry-infra-failures/references/notes.md
+++ b/skills/debugging/always-retry-infra-failures/references/notes.md
@@ -1,0 +1,59 @@
+# Session Notes: always-retry-infra-failures
+
+## Date
+2026-03-14
+
+## Repository
+HomericIntelligence/ProjectScylla
+
+## Context
+ProjectScylla is an AI agent testing framework. It runs experiments with multiple tiers (T0-T6),
+subtests, and runs. Experiment state is persisted in checkpoint.json with a 4-level state machine:
+experiment → tier → subtest → run.
+
+The `--retry-errors` flag had failed to work correctly across multiple attempts. The goal was to
+remove it entirely and replace with always-on behavior.
+
+## Bugs Fixed
+
+### Bug 1: _checkpoint_has_retryable_runs() second pass (manage_experiment.py:319-324)
+The function had a second loop over `completed_runs` that returned True if any entry was "failed".
+But `completed_runs["failed"]` means judge_passed=False (bad grade) — a VALID result, not an
+infra crash. This caused the batch runner to re-queue tests that had completed with low scores,
+wasting compute and corrupting results.
+
+Fix: Delete the entire second pass over completed_runs.
+
+### Bug 2: _reset_non_completed_runs() worktree_cleaned second-pass (manage_experiment.py:354-363)
+When resetting runs for retry, there was a block that checked worktree_cleaned runs and reset them
+if their completed_runs status was "failed". This conflated the two meanings of "failed" again —
+get_run_status() returns completed_runs status, so "failed" = bad grade, not infra crash.
+
+Fix: Replace the entire worktree_cleaned block with `continue`. Completed runs (any grade) are never reset.
+
+### Bug 3: Retry gated behind --retry-errors flag
+The reconcile+reset logic in run_one_test() (batch mode) and cmd_run() (single mode) was wrapped
+in `if args.retry_errors:`. This meant infra failures were silently skipped by default.
+
+Fix: Remove the flag entirely; make both blocks unconditional.
+
+## Key Invariant (confirmed from full code read)
+- `run_states="FAILED"` → ALWAYS an unhandled exception (infra crash) → retry
+- `run_states="RATE_LIMITED"` → ALWAYS a RateLimitError → retry
+- `run_states="WORKTREE_CLEANED"` → ALWAYS completed (workspace removed) → never retry
+- `run_states="WORKTREE_CLEANED"` + `completed_runs="failed"` → bad judge grade → valid result, NEVER retry
+
+## Changes Made
+- Removed --retry-errors from argument parser
+- Fixed _checkpoint_has_retryable_runs(): removed completed_runs second pass
+- Fixed _reset_non_completed_runs(): replaced worktree_cleaned block with continue
+- Made batch skip logic unconditional (lines 816-822)
+- Made run_one_test() reconcile+reset unconditional (lines 748-774)
+- Made single-test mode reconcile+reset unconditional (~line 1151)
+- Updated tests in test_manage_experiment_run.py and test_manage_experiment_cli.py
+
+## Test Results
+- 4761 tests passing
+- 78.3% unit coverage (above 75% threshold)
+- Pre-commit hooks passed
+- PR #1491 created with auto-merge enabled

--- a/skills/debugging/always-retry-infra-failures/skills/always-retry-infra-failures/SKILL.md
+++ b/skills/debugging/always-retry-infra-failures/skills/always-retry-infra-failures/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: always-retry-infra-failures
+description: "Fix retry logic bugs where a flag-gated retry conflates infra crashes with bad-grade results, discarding valid judge results. Use when: removing a retry flag to make behavior unconditional, fixing state machine reset logic that incorrectly resets completed runs, or debugging checkpoint semantics with multiple terminal state meanings."
+category: debugging
+date: 2026-03-14
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `--retry-errors` flag incorrectly retried bad-grade runs (valid results) AND gated all retry behavior behind a flag |
+| **Root cause** | Three bugs: (1) second pass over `completed_runs` used `"failed"` ambiguously, (2) `worktree_cleaned` second-pass discarded valid judge results, (3) all retry logic was flag-gated |
+| **Fix** | Remove flag; make retry unconditional; distinguish `run_states="failed"` (infra crash) from `completed_runs="failed"` (bad grade) |
+| **Language** | Python 3.10+ |
+| **Files changed** | `scripts/manage_experiment.py`, `tests/unit/e2e/test_manage_experiment_run.py`, `tests/unit/e2e/test_manage_experiment_cli.py` |
+
+## When to Use
+
+Apply this skill when:
+
+1. A feature flag controls retry/resume behavior that should always run
+2. Reset logic is incorrectly resetting completed runs (bad scores, not crashes)
+3. A state machine has terminal states with multiple meanings that are being conflated
+4. Test failures show valid results being overwritten on retry
+
+## Verified Workflow
+
+### Quick Reference
+
+```
+Bug 1: _checkpoint_has_retryable_runs() second pass
+  completed_runs["failed"] = bad grade (NOT a crash) → delete second pass
+
+Bug 2: _reset_non_completed_runs() worktree_cleaned block
+  run_states="worktree_cleaned" + completed_runs="failed" = valid result → never reset
+  Fix: replace block with `continue`
+
+Bug 3: Retry gated behind --retry-errors flag
+  Fix: remove flag, make reconcile+reset run unconditionally
+
+The invariant:
+  run_states="FAILED"          → infra crash → always reset to pending
+  run_states="WORKTREE_CLEANED" → completed (any grade) → never reset
+```
+
+### Step 1: Identify the state model invariants
+
+Before fixing, read the full state machine to establish invariants:
+
+- `run_states` = pipeline execution state (e.g. `FAILED`, `RATE_LIMITED`, `WORKTREE_CLEANED`)
+- `completed_runs` = backward-compat field set by finalization stage (`"passed"`, `"failed"`, `"agent_complete"`)
+- **Critical invariant**: `run_states="FAILED"` is ALWAYS an infra crash (unhandled exception)
+- **Critical invariant**: `run_states="WORKTREE_CLEANED"` + `completed_runs="failed"` is ALWAYS a bad judge grade, NEVER an infra crash
+
+### Step 2: Fix `_checkpoint_has_retryable_runs()`
+
+Delete the second pass over `completed_runs` — `"failed"` there means bad grade, not retryable:
+
+```python
+# BEFORE (buggy): falsely triggers retry for bad-grade runs
+def _checkpoint_has_retryable_runs(checkpoint_path):
+    ...
+    for subtests in data.get("run_states", {}).values():
+        for runs in subtests.values():
+            for state in runs.values():
+                if state != "worktree_cleaned":
+                    return True
+    # DELETE THIS ENTIRE BLOCK:
+    for subtests in data.get("completed_runs", {}).values():
+        for runs in subtests.values():
+            for status in runs.values():
+                if status == "failed":   # "failed" here = bad grade, NOT crash
+                    return True
+    return False
+
+# AFTER (correct): only run_states non-worktree_cleaned = retryable
+def _checkpoint_has_retryable_runs(checkpoint_path):
+    """Return True if checkpoint contains any non-completed runs (infra failures or
+    mid-pipeline crashes). Runs in worktree_cleaned state (even with bad grades) are
+    NOT considered retryable."""
+    ...
+    for subtests in data.get("run_states", {}).values():
+        for runs in subtests.values():
+            for state in runs.values():
+                if state != "worktree_cleaned":
+                    return True
+    return False
+```
+
+### Step 3: Fix `_reset_non_completed_runs()`
+
+Delete the `worktree_cleaned` second-pass block that discards valid results:
+
+```python
+# BEFORE (buggy): resets bad-grade runs to pending, erasing valid results
+for run_num_str, state in list(runs.items()):
+    if state == "worktree_cleaned":
+        run_status = checkpoint.get_run_status(tier_id, subtest_id, int(run_num_str))
+        if run_status == "failed":      # "failed" here = bad grade
+            runs[run_num_str] = "pending"   # BUG: discards valid judge result
+            checkpoint.unmark_run_completed(...)
+            ...
+        continue
+    ...
+
+# AFTER (correct): simple skip — completed runs (any grade) are never reset
+for run_num_str, state in list(runs.items()):
+    if state == "worktree_cleaned":
+        continue  # Completed run (passed or bad grade) — never reset
+    ...
+```
+
+### Step 4: Make retry unconditional (remove the flag)
+
+Remove the `--retry-errors` argument from the parser and all `if args.retry_errors:` guards:
+
+```python
+# BEFORE: gated behind flag
+parser.add_argument("--retry-errors", action="store_true", ...)
+
+# In run_one_test():
+if args.retry_errors:
+    _cp_path = _find_checkpoint_path(...)
+    if _cp_path is not None:
+        ...reconcile...
+        ...reset...
+
+# AFTER: unconditional
+# (no --retry-errors argument)
+
+# In run_one_test():
+_cp_path = _find_checkpoint_path(...)
+if _cp_path is not None:
+    ...reconcile...
+    ...reset...
+```
+
+Apply the same pattern to:
+- Batch skip logic (`for test_id, r in last_by_test.items()`)
+- Single-test mode reconcile+reset block
+
+### Step 5: Update tests
+
+Update tests in three files:
+
+1. `test_manage_experiment_cli.py`: Remove `test_run_accepts_retry_errors` test and `assert not args.retry_errors` from defaults test
+2. `test_manage_experiment_run.py`: Rename classes (`TestRetryErrorsInBatch` → `TestRetryInfraFailuresInBatch`), remove `--retry-errors` from all `parse_args` calls, fix the bad-grade retryable test (was `True`, now `False`), fix the bad-grade reset test (was expecting reset, now not)
+
+Key new tests to add:
+```python
+def test_checkpoint_has_retryable_runs_false_for_worktree_cleaned_bad_grade():
+    # run_states=worktree_cleaned + completed_runs=failed → False
+    assert _checkpoint_has_retryable_runs(cp) is False
+
+def test_reset_does_not_touch_bad_grade_worktree_cleaned():
+    # reset_count=0, state stays worktree_cleaned, grade stays "failed"
+    reset_count = _reset_non_completed_runs(checkpoint)
+    assert reset_count == 0
+    assert checkpoint.run_states["T0"]["00"]["1"] == "worktree_cleaned"
+
+def test_batch_skips_test_with_only_bad_grades():
+    # All worktree_cleaned + bad grades → test NOT re-queued
+    assert "test-001" not in executed_ids
+
+def test_batch_reruns_test_with_failed_run_state():
+    # Any FAILED run_state → test IS re-queued
+    assert "test-001" in executed_ids
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Previous `--retry-errors` implementations | Added flag to make retry opt-in, with second pass over `completed_runs` to catch judge failures | `completed_runs="failed"` means bad grade (valid result), not an infra crash — the flag was retrying valid completed runs | Always distinguish state machine terminal states: `run_states` vs `completed_runs` encode different semantics |
+| Keeping `worktree_cleaned` second-pass | Tried to reset only some `worktree_cleaned` runs (those with bad grades) | Valid results were being discarded; also broke the invariant that `worktree_cleaned` = completed | Once a run reaches `worktree_cleaned`, it is done regardless of grade — never reset it |
+| Flag-gated unconditional behavior | Kept retry behind `--retry-errors` flag as default-off | Infrastructure failures were silently skipped when flag was absent, causing wasted runs and misleading "completed" status | Infra failures should always be retried — there is no valid reason to preserve a FAILED run state |
+
+## Results & Parameters
+
+**PR**: `HomericIntelligence/ProjectScylla#1491`
+**Issue**: `HomericIntelligence/ProjectScylla#1490`
+**Branch**: `1490-always-retry-infra-failures`
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `scripts/manage_experiment.py` | Remove `--retry-errors` arg; fix `_checkpoint_has_retryable_runs`; fix `_reset_non_completed_runs`; make batch + single-test retry unconditional |
+| `tests/unit/e2e/test_manage_experiment_run.py` | Rename classes, remove flag from tests, fix bad-grade test expectations, add new unit tests |
+| `tests/unit/e2e/test_manage_experiment_cli.py` | Remove `test_run_accepts_retry_errors` and `retry_errors` default assertion |
+
+### State machine semantics (ProjectScylla-specific)
+
+```
+run_states values:
+  "failed"           → unhandled exception (infra crash) → ALWAYS retry
+  "rate_limited"     → RateLimitError → ALWAYS retry
+  "worktree_cleaned" → pipeline completed (workspace removed) → NEVER retry
+  <intermediate>     → crashed mid-pipeline → cascade tier/subtest to pending, resume from state
+
+completed_runs values:
+  "passed"          → judge_passed=True → valid result
+  "failed"          → judge_passed=False (BAD GRADE) → valid result, NEVER retry
+  "agent_complete"  → agent ran, judge never ran → treat as in-progress
+```
+
+### Test coverage after fix
+
+- Unit coverage: 78.3% (above 75% threshold)
+- Tests: 4761 passing
+- Key assertions: `worktree_cleaned + bad grade → retryable=False`, `FAILED run_state → reset to pending`


### PR DESCRIPTION
## Summary

Documents how to remove a flag-gated retry mechanism and fix three inter-related bugs where infra crashes and bad-grade judge results were conflated in state machine checkpoint logic.

- `completed_runs="failed"` means bad judge grade (valid result) — not an infra crash
- `run_states="WORKTREE_CLEANED"` + bad grade is always a valid completed run — never reset it
- Making retry unconditional eliminates a silent failure mode where FAILED runs were skipped

## Key Findings

**What Worked**:
- Deleting the second pass over `completed_runs` in `_checkpoint_has_retryable_runs()` — only `run_states` non-`worktree_cleaned` entries are retryable
- Replacing the `worktree_cleaned` second-pass block in `_reset_non_completed_runs()` with `continue` — completed runs (any grade) are never reset
- Removing the `--retry-errors` flag entirely and making reconcile+reset unconditional

**What Failed**:
- Previous `--retry-errors` implementation → used `completed_runs="failed"` as retry trigger, conflating bad grades with infra crashes
- Keeping `worktree_cleaned` second-pass → discarded valid (if poor) judge results on every resume

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with retry/reset logic triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
