### PR TITLE
feat: add multi-domain-audit-remediation skill

### DIFF
--- a/skills/architecture/multi-domain-audit-remediation/.claude-plugin/plugin.json
+++ b/skills/architecture/multi-domain-audit-remediation/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "multi-domain-audit-remediation",
+  "version": "1.0.0",
+  "description": "Workflow for implementing a multi-domain production-grade audit remediation plan touching exception handling, logging hygiene, DRY violations, CI alignment, and documentation. Use when: (1) an audit report surfaces critical/major/minor issues across several independent dimensions simultaneously, (2) converting f-string logging anti-patterns and print() calls to structured logger calls across a library codebase, (3) consolidating duplicated file discovery logic into a shared utility, (4) aligning CI coverage thresholds with pyproject.toml.",
+  "category": "architecture",
+  "date": "2026-03-14"
+}

--- a/skills/architecture/multi-domain-audit-remediation/references/notes.md
+++ b/skills/architecture/multi-domain-audit-remediation/references/notes.md
@@ -1,0 +1,107 @@
+# Session Notes: multi-domain-audit-remediation
+
+## Session Context
+
+**Date**: 2026-03-14
+**Repository**: ProjectHephaestus (branch: `hephaestus-audit-remediation-v2`, based on `hephaestus-full-remediation`)
+**Trigger**: Audit report grading 15 sections with B average (82%), identifying critical/major/minor issues
+
+## Audit Scorecard
+
+| Section | Grade | Score | Status |
+|---------|-------|-------|--------|
+| Project Structure & Organization | B+ | 87% | Healthy |
+| Documentation | C+ | 75% | Needs attention |
+| Architecture & Design | B | 83% | Healthy |
+| Source Code Quality | B- | 78% | Needs attention |
+| Testing | B+ | 85% | Healthy |
+| CI/CD & Build Pipeline | B | 82% | Healthy |
+| Dependency & Package Management | B+ | 86% | Healthy |
+| Security | B+ | 85% | Healthy |
+| Safety & Reliability | C+ | 76% | Needs attention |
+| **OVERALL** | **B** | **82%** | **Conditional GO** |
+
+## Issues Fixed
+
+### Critical
+1. **35 f-string logging anti-patterns** — converted to lazy `%s` format across 4 files
+2. **21 broad `except Exception` clauses** — narrowed to specific types or documented with justifying comments
+
+### Major
+3. **44 `print()` calls in library code** — replaced with `logger.info/warning/error`
+4. **CI coverage threshold mismatch** — CI was 75%, pyproject.toml was 80%; aligned to 80%
+5. **README.md missing 6 of 13 subpackages** — updated directory structure section
+6. **scripts/README.md severely outdated** — referenced 4 non-existent scripts, omitted 5 real ones
+7. **CONTRIBUTING.md references non-existent CODE_OF_CONDUCT.md** — created the file
+8. **DRY: markdown file discovery in 3 locations** — extracted to `hephaestus/markdown/utils.py`
+
+### Minor
+9. **Typo in pyproject.toml keywords** — `"homercintelligence"` → `"homericintelligence"`
+10. **Patch files at repo root** — added `*.patch` to .gitignore
+11. **`__all__` vs `_LAZY_IMPORTS` gap undocumented** — added comment to `__init__.py`
+
+## Key Technical Details
+
+### The PyGithub Exception Problem
+Tests in `test_github_utils.py` used `mock.side_effect = Exception("API error")` for API failure
+scenarios. Narrowing to `(OSError, KeyError)` caused 3 test failures. Solution: keep broad
+`Exception` for all PyGithub API calls (4 locations) with justifying comments. The API library's
+exception hierarchy is not well-documented.
+
+### The noqa BLE001 Problem
+Attempted to use `# noqa: BLE001` on intentional broad except clauses. ruff returned `RUF100`
+(unused noqa directive). `BLE` rule group is not in ProjectHephaestus's ruff `select` list
+(`["E", "F", "W", "I", "N", "D", "UP", "S101", "S102", "S105", "S106", "B", "SIM", "C4", "C901", "RUF"]`).
+Use plain comments instead.
+
+### The frozenset Type Signature Problem
+The new `find_markdown_files()` utility initially had `exclude_dirs: set[str] | None`. mypy
+failed immediately because `MarkdownFixer.exclude_patterns` is typed as `set[str] | frozenset[str]`
+(comes from `DEFAULT_EXCLUDE_DIRS` which can be a frozenset). Fixed by widening the parameter type.
+
+### sys Import Cleanup
+After replacing all `print(..., file=sys.stderr)` in `link_fixer.py`, the `sys` import appeared
+removable. However, `sys` was NOT needed at all in that file (no `sys.exit()` either — `main()`
+was not present). Safe to remove. In `fixer.py`, `sys.exit(0)` remains in `main()`, so `sys` stays.
+
+### Version Manager print() Pattern
+`version/manager.py` had 15 `print()` calls using emoji characters (`✓`, `⚠️`, `✗`). These were
+replaced with `logger.info/warning/error`. The emoji characters were dropped from the log messages
+since they add little value in a log context.
+
+## File Change Summary
+
+| File | Change Type | Key Change |
+|------|------------|------------|
+| `hephaestus/github/pr_merge.py` | Exception narrowing + f-string logging | 7 broad excepts → commented; 16 f-strings → %s |
+| `hephaestus/validation/config_lint.py` | Exception narrowing + f-string logging | OSError for IO; yaml keeps Exception; 7 f-strings → %s |
+| `hephaestus/validation/structure.py` | F-string logging | 10 f-strings → %s |
+| `hephaestus/validation/readme_commands.py` | Exception narrowing | (OSError, ValueError) for subprocess |
+| `hephaestus/validation/markdown.py` | F-string logging + DRY | 1 f-string; removed duplicate find_markdown_files() |
+| `hephaestus/markdown/fixer.py` | Exception narrowing + print→logger + DRY | OSError; 8 prints → logger; uses shared utility |
+| `hephaestus/markdown/link_fixer.py` | Exception narrowing + print→logger + DRY | (OSError, UnicodeDecodeError); 8 prints → logger; removed sys import |
+| `hephaestus/datasets/downloader.py` | Exception narrowing + print→logger | OSError/(OSError,EOFError); 7 prints → logger |
+| `hephaestus/utils/helpers.py` | Print→logger | Added logger; 4 prints → logger |
+| `hephaestus/version/manager.py` | Print→logger | Added logger; 15 prints → logger |
+| `hephaestus/io/utils.py` | Exception narrowing | OSError for backup |
+| `hephaestus/utils/retry.py` | Documentation | Added justifying comment |
+| `hephaestus/markdown/utils.py` | NEW | Shared find_markdown_files() |
+| `hephaestus/markdown/__init__.py` | Export | Added find_markdown_files to __all__ |
+| `hephaestus/__init__.py` | Documentation | Design comment for __all__ vs _LAZY_IMPORTS |
+| `README.md` | Documentation | Added 6 missing subpackages |
+| `scripts/README.md` | Documentation | Full rewrite matching actual scripts |
+| `CONTRIBUTING.md` | Documentation | CODE_OF_CONDUCT.md now resolves |
+| `CODE_OF_CONDUCT.md` | NEW | Contributor Covenant v2.1 |
+| `pyproject.toml` | Typo fix | homercintelligence → homericintelligence |
+| `.github/workflows/test.yml` | CI alignment | --cov-fail-under=75 → 80 |
+| `.gitignore` | Hygiene | Added *.patch |
+
+## Test Results
+
+```
+358 passed in 2.33s
+Coverage: 81.66% (threshold: 80%)
+All 19 pre-commit hooks: PASSED
+```
+
+New tests added: `tests/unit/markdown/test_utils.py` (7 tests for `find_markdown_files`)

--- a/skills/architecture/multi-domain-audit-remediation/skills/multi-domain-audit-remediation/SKILL.md
+++ b/skills/architecture/multi-domain-audit-remediation/skills/multi-domain-audit-remediation/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: multi-domain-audit-remediation
+description: "Workflow for implementing a multi-domain production-grade audit remediation plan touching exception handling, logging hygiene, DRY violations, CI alignment, and documentation. Use when: (1) an audit report surfaces critical/major/minor issues across several independent dimensions simultaneously, (2) converting f-string logging anti-patterns and print() calls to structured logger calls across a library codebase, (3) consolidating duplicated file discovery logic into a shared utility."
+category: architecture
+date: 2026-03-14
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | multi-domain-audit-remediation |
+| **Category** | architecture |
+| **Source** | ProjectHephaestus 2026-03-14 post-audit remediation v2 |
+| **Trigger** | Audit report with critical/major/minor issues across multiple independent domains |
+
+This skill captures the verified workflow for implementing a multi-domain audit remediation plan
+in a Python library codebase. It covers the exact sequence for: narrowing broad `except Exception`
+clauses, converting f-string logging anti-patterns to lazy `%s` format, replacing library-level
+`print()` with `logger`, extracting a shared markdown file discovery utility to eliminate DRY
+violations, aligning CI coverage thresholds, and updating documentation to match actual code.
+
+## When to Use
+
+- An audit scorecard surfaces findings across exception handling, logging, DRY, CI/CD, and docs
+  simultaneously and you need to work through them in a safe order
+- You have `logger.info(f"Found {count} files")` patterns across many files and need to convert
+  them to `logger.info("Found %d files", count)` without breaking tests
+- Library modules use `print()` for status output that should go through the logging framework
+- The same file discovery loop is implemented in 3+ modules; you want to extract a shared utility
+- CI `--cov-fail-under` threshold doesn't match `pyproject.toml`'s `fail_under` value
+- README/scripts docs reference non-existent files or omit real ones
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Check for f-string logging anti-patterns
+grep -rn 'logger\.\(info\|warning\|error\|debug\)(f"' hephaestus/
+
+# Check for print() in library code (not cli/utils.py or main())
+grep -rn '^    print(' hephaestus/ | grep -v cli/utils | grep -v 'def main'
+
+# Check broad except clauses
+grep -rn 'except Exception' hephaestus/
+
+# After changes: verify ruff noqa comments don't reference un-selected rules
+pixi run ruff check hephaestus/ --select=BLE 2>&1 | head -5
+# If BLE is not in pyproject.toml select list → don't add # noqa: BLE001
+
+# Run full suite
+pixi run pytest tests/unit -v
+pre-commit run --all-files
+```
+
+### Step 1: Read all files before changing anything
+
+Read every file in the audit's "Files to Modify" list before writing any edits. This prevents
+mid-implementation surprises (circular imports, type mismatches, existing logger setup).
+
+Key things to check in each file:
+- Does it already import a logger? (If not, add `from hephaestus.logging.utils import get_logger` and `logger = get_logger(__name__)`)
+- Does `sys` only appear for `sys.stderr` prints? (If yes, remove `import sys` when replacing those prints with logger)
+- Is the file a CLI entry point (`main()` function)? (Keep `print()` in `main()` — those are user-facing)
+
+### Step 2: Convert f-string logging (critical priority)
+
+**Pattern to replace**:
+```python
+# BEFORE — deferred string interpolation bypassed; extra allocation per call
+logger.info(f"Found {count} files in {path}")
+logger.warning(f"  ✗ {message}")
+logger.error(f"Error accessing repo {repo_name}: {e}")
+```
+
+**Pattern to use**:
+```python
+# AFTER — lazy evaluation, only interpolates if log level is active
+logger.info("Found %d files in %s", count, path)
+logger.warning("  ✗ %s", message)
+logger.error("Error accessing repo %s: %s", repo_name, e)
+```
+
+Rules:
+- Integer format: `%d`, float: `%.2f`, everything else: `%s`
+- Never use `%s` for integers that need formatting (e.g. counts) — use `%d`
+- When logging exceptions, always pass `e` as the last argument, not `str(e)`
+
+### Step 3: Replace print() in library code
+
+Distinguish three classes of `print()` calls:
+
+| Class | Action |
+|-------|--------|
+| Library internal status (inside a class method or non-`main()` function) | Replace with `logger.info/warning/error` |
+| CLI output in `main()` or `process_path()` | Replace with `logger.info/warning/error` if it's operational, keep as `print()` only for truly interactive terminal prompts |
+| Progress bar (`print("\r...", end="", flush=True)`) | Keep as `print()` — this is a terminal UI pattern |
+
+After removing `print()` from a file, check if `sys` is still used:
+```python
+# Only keep `import sys` if sys.exit() or sys.executable or sys.argv is still present
+grep -n 'sys\.' hephaestus/markdown/link_fixer.py
+```
+
+### Step 4: Narrow broad except clauses
+
+**Strategy by module type**:
+
+| Module | Recommended exceptions |
+|--------|----------------------|
+| File I/O (`open`, `read_text`, `write_text`) | `OSError` |
+| YAML parsing | Keep `Exception` + add comment (yaml raises undocumented subtypes) |
+| Subprocess | `subprocess.CalledProcessError`, `OSError` |
+| GitHub API (PyGithub) | Keep `Exception` + comment (PyGithub raises many subtypes) |
+| Retry utilities | Keep `Exception` + comment (intentional generic retry) |
+| Gzip decompression | `(OSError, EOFError)` |
+| Unicode file reads | `(OSError, UnicodeDecodeError)` |
+| Path resolution | `(OSError, ValueError)` |
+
+**Critical**: Before narrowing, check what the existing tests raise. Tests often use
+`mock.side_effect = Exception("error message")`. If tests use bare `Exception`, either:
+- Update the tests to raise the specific type you're narrowing to, OR
+- Keep `Exception` with a justifying comment if the actual runtime exceptions are unpredictable
+
+**`# noqa: BLE001` pattern**: Only works if `BLE` is in your ruff `select` list. Check first:
+```bash
+grep "select" pyproject.toml | grep BLE
+```
+If `BLE` is not selected, use a plain comment instead:
+```python
+except Exception as e:  # broad catch intentional: yaml has undocumented exception subtypes
+```
+
+### Step 5: Extract shared utilities (DRY fix)
+
+When the same pattern appears in 3+ places, create a shared module:
+
+```python
+# hephaestus/markdown/utils.py
+from pathlib import Path
+from hephaestus.constants import DEFAULT_EXCLUDE_DIRS
+
+def find_markdown_files(
+    directory: Path, exclude_dirs: set[str] | frozenset[str] | None = None
+) -> list[Path]:
+    """Find all markdown files in a directory recursively."""
+    if exclude_dirs is None:
+        exclude_dirs = set(DEFAULT_EXCLUDE_DIRS)
+    return sorted(
+        f for f in directory.rglob("*.md")
+        if not any(part in exclude_dirs for part in f.parts)
+    )
+```
+
+**Type signature gotcha**: If callers can pass `frozenset[str]` (common when the value comes
+from a dataclass default), the signature must accept `set[str] | frozenset[str] | None`, not
+just `set[str] | None`. mypy will catch this immediately.
+
+Update `__init__.py` to export the new utility, then update all 3 callers.
+
+### Step 6: Align CI coverage threshold
+
+Check for threshold mismatches:
+```bash
+# pyproject.toml
+grep "fail-under\|fail_under" pyproject.toml
+
+# CI workflow
+grep "cov-fail-under" .github/workflows/test.yml
+```
+
+If they differ, set both to the higher value (the pyproject.toml value is authoritative).
+
+### Step 7: Update documentation
+
+For README.md subpackage listings: list ALL subpackages in the directory tree section.
+
+For scripts/README.md: list the ACTUAL files in the scripts/ directory, not what was there
+originally. Verify with `ls scripts/*.py`.
+
+For CONTRIBUTING.md references to non-existent files: either create the file or remove the
+reference. Creating a minimal `CODE_OF_CONDUCT.md` using Contributor Covenant v2.1 is the
+preferred approach.
+
+### Step 8: Verify end-to-end
+
+```bash
+pixi run ruff check hephaestus/ tests/
+pixi run ruff format --check hephaestus/ tests/
+pixi run mypy hephaestus/
+pixi run pytest tests/unit -v --tb=short
+pre-commit run --all-files
+```
+
+All must pass before committing.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Added `# noqa: BLE001` to intentional broad except clauses | Used `except Exception as e: # noqa: BLE001` to suppress ruff warnings | `BLE` is not in the ruff `select` list — ruff flagged `RUF100` (unused noqa directive) | Always check `pyproject.toml` select list before adding noqa comments |
+| Narrowed PyGithub API exceptions to `(OSError, KeyError)` | Changed `except Exception` to `(OSError, KeyError)` in pr_merge.py | 3 tests failed — tests use `mock.side_effect = Exception("API error")` which doesn't match the narrow type | When narrowing exceptions in GitHub API code, keep `Exception` with comment; API libraries raise unpredictable subtypes |
+| Added `# noqa: BLE001` comment that was too long | `except Exception as e: # broad catch intentional: yaml raises undocumented exception subtypes` | Line exceeded 100-character limit → ruff E501 error | Keep inline comments short; truncate to stay within line length |
+| Removed `sys` import from fixer.py after replacing stderr prints | Deleted `import sys` when `print()` calls to `sys.stderr` were replaced | `sys.exit(0)` in `main()` still requires `sys` | Always grep for all `sys.` usages before removing the import |
+| Used `set[str] | None` type for shared find_markdown_files | `def find_markdown_files(directory, exclude_dirs: set[str] | None = None)` | mypy error: callers pass `frozenset[str]` from dataclass defaults | Use `set[str] | frozenset[str] | None` for exclude_dirs parameters |
+
+## Results & Parameters
+
+**Session outcome**: 24 files modified, 358 tests pass (7 new), 81.66% coverage, all pre-commit hooks green.
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Tests passing | 351 | 358 |
+| Coverage | 81.65% | 81.66% |
+| Broad `except Exception` (unjustified) | 21 | 0 |
+| F-string logging instances | 35 | 0 |
+| `print()` in library code | 44 | 0 |
+| Duplicated markdown discovery | 3 locations | 1 shared utility |
+
+**Files modified** (summary):
+- Source: `pr_merge.py`, `config_lint.py`, `structure.py`, `readme_commands.py`, `validation/markdown.py`, `fixer.py`, `link_fixer.py`, `downloader.py`, `helpers.py`, `system/info.py`, `version/manager.py`, `git/changelog.py`, `io/utils.py`, `utils/retry.py`
+- New: `hephaestus/markdown/utils.py`, `CODE_OF_CONDUCT.md`
+- Docs: `README.md`, `scripts/README.md`, `CONTRIBUTING.md`
+- Config: `pyproject.toml` (typo fix), `.github/workflows/test.yml` (threshold), `.gitignore`
+- `hephaestus/__init__.py` (design doc comment), `hephaestus/markdown/__init__.py` (export)
+
+**CI threshold alignment**:
+```yaml
+# .github/workflows/test.yml — was 75, now matches pyproject.toml
+--cov-fail-under=80
+```
+
+**Logging migration pattern** (copy-paste):
+```python
+# Add to any module that needs logger
+from hephaestus.logging.utils import get_logger
+logger = get_logger(__name__)
+
+# F-string → lazy format
+# BEFORE: logger.info(f"Processing {count} files in {path}")
+# AFTER:  logger.info("Processing %d files in %s", count, path)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Post-audit remediation v2 branch, 2026-03-14 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the verified workflow for implementing a multi-domain production-grade audit remediation
plan in a Python library codebase — covering exception handling, logging hygiene, DRY violations,
CI alignment, and documentation simultaneously.

- Converts 35 f-string logging anti-patterns to lazy `%s` format across 4+ files
- Replaces 44 library-level `print()` calls with structured logger calls
- Narrows 21 broad `except Exception` clauses with a decision matrix by module type
- Extracts shared `find_markdown_files()` utility to eliminate DRY violation across 3 modules
- Aligns CI `--cov-fail-under` with `pyproject.toml` authoritative value

## Key Findings

**What Worked**:
- Reading all target files before writing any edits prevents mid-implementation surprises (circular imports, type mismatches)
- PyGithub API exceptions must stay broad — check existing test mocks before narrowing
- `frozenset[str] | set[str] | None` union type for shared utility parameters catches mypy errors immediately
- Plain justifying comments work better than `# noqa` when the rule isn't in the select list

**What Failed**:
- `# noqa: BLE001` on intentional broad excepts → `RUF100` unused directive error (BLE not in select list)
- Narrowing PyGithub API exceptions to `(OSError, KeyError)` → 3 test failures (mocks raise bare `Exception`)
- Inline justifying comment exceeded 100-char line limit → ruff E501

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `architecture` category
- [ ] Check skill activation with audit remediation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
