### PR TITLE
feat: add just-recipe-heredoc-fix skill

### DIFF
--- a/skills/ci-cd/just-recipe-heredoc-fix/.claude-plugin/plugin.json
+++ b/skills/ci-cd/just-recipe-heredoc-fix/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "just-recipe-heredoc-fix",
+  "version": "1.0.0",
+  "description": "Fix heredoc-in-just-recipe whitespace errors by replacing with printf. Use when: (1) a just recipe uses a heredoc (<<EOF) that causes 'inconsistent leading whitespace' parse errors, (2) you need to emit multi-field structured text (e.g., JSON lines) inside a just shell recipe body.",
+  "category": "ci-cd",
+  "date": "2026-03-14"
+}

--- a/skills/ci-cd/just-recipe-heredoc-fix/references/notes.md
+++ b/skills/ci-cd/just-recipe-heredoc-fix/references/notes.md
@@ -1,0 +1,75 @@
+# Session Notes: just-recipe-heredoc-fix
+
+## Session Date
+2026-03-14
+
+## What Was Being Implemented
+
+CI/CD speedup post-implementation fixes for ProjectOdyssey, specifically a new `just test-timing`
+recipe that runs all Mojo tests with per-file wall-clock timing and writes structured JSON output.
+
+## The Bug
+
+While adding `just test-timing` to `ProjectOdyssey/justfile`, the recipe used a heredoc to write
+JSON lines to the output file:
+
+```just
+        cat >> "$OUTPUT" <<ENTRY
+  {"file": "$test_file", "duration_s": $duration, "status": "$status", "attempts": $attempts_used}
+ENTRY
+```
+
+This caused `just --list` to fail with:
+
+```text
+error: Recipe line has inconsistent leading whitespace. Recipe started with `    ` but found line with `  `
+   ——▶ justfile:709:1
+    │
+709 │   {"file": "$test_file", "duration_s": $duration, "status": "$status", "attempts": $attempts_used}
+    │ ^^
+```
+
+## Root Cause Analysis
+
+`just` requires all lines in a recipe body (for `#!/usr/bin/env bash` shebang recipes) to share
+the same leading whitespace. The recipe body used 4-space indentation throughout, but:
+
+1. The heredoc content line had 2-space indent (for aesthetic JSON formatting)
+2. The heredoc terminator `ENTRY` was at column 0 (required by bash for unquoted terminators)
+
+Both violated `just`'s whitespace consistency requirement.
+
+## Fix Applied
+
+Replaced the heredoc with `printf`:
+
+```just
+        printf '  {"file": "%s", "duration_s": %s, "status": "%s", "attempts": %s}\n' \
+            "$test_file" "$duration" "$status" "$attempts_used" >> "$OUTPUT"
+```
+
+This keeps all lines at 4-space indent (the recipe standard) while producing identical output.
+
+## Other Items Implemented in Same Session
+
+1. **`validate_test_coverage.py` bug fix**: Replaced hardcoded `jobs.get("test-mojo-comprehensive", {})`
+   with a scan over all jobs for any with `strategy.matrix.test-group` — fixes false positives
+   when nightly workflow uses job key `test-mojo-nightly`.
+
+2. **`precommit-benchmark.yml` concurrency group**: Added standard `concurrency:` block after
+   the `on:` section to cancel in-progress runs on new pushes.
+
+## Verification
+
+```bash
+# Coverage script passes
+python scripts/validate_test_coverage.py; echo "Exit: $?"
+# Exit: 0
+
+# Concurrency block present
+grep -A3 "concurrency" .github/workflows/precommit-benchmark.yml
+
+# Recipe appears in just listing
+just --list | grep test-timing
+# test-timing output="test-timing.json" # Run all Mojo tests with per-file timing, output JSON report
+```

--- a/skills/ci-cd/just-recipe-heredoc-fix/skills/just-recipe-heredoc-fix/SKILL.md
+++ b/skills/ci-cd/just-recipe-heredoc-fix/skills/just-recipe-heredoc-fix/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: just-recipe-heredoc-fix
+description: "Fix heredoc-in-just-recipe whitespace errors by replacing with printf. Use when: just recipe uses <<EOF heredoc and fails with 'inconsistent leading whitespace'."
+category: ci-cd
+date: 2026-03-14
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `just` parse error: "Recipe line has inconsistent leading whitespace" when a `#!/usr/bin/env bash` recipe contains a heredoc (`<<EOF`) whose body lines have different indentation than the recipe body |
+| **Root Cause** | `just` requires all lines in a recipe body to share the same leading whitespace prefix. Heredoc body lines (e.g., 2-space indent) conflict with the recipe's 4-space indent, and the heredoc terminator (e.g., `ENTRY`) at column 0 triggers the error |
+| **Fix** | Replace the heredoc with `printf` using format strings and argument lists |
+| **Context** | Discovered while adding `just test-timing` recipe that writes JSON lines per test file |
+
+## When to Use
+
+- Adding a `#!/usr/bin/env bash` just recipe that needs to emit structured multi-field text (JSON, CSV, etc.)
+- Encountering `"Recipe line has inconsistent leading whitespace"` from `just --list` or `just <recipe>`
+- The heredoc body lines have 2-space indent but the surrounding recipe uses 4-space indent
+- The heredoc terminator appears at column 0 (bare `EOF` or `ENTRY`)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Diagnose: run just --list to see the error
+just --list 2>&1 | head -10
+# Output: error: Recipe line has inconsistent leading whitespace...
+
+# After fix: verify recipe appears
+just --list | grep <recipe-name>
+```
+
+### Step 1 — Identify the Heredoc Pattern
+
+Look for this pattern in the justfile recipe:
+
+```just
+        cat >> "$OUTPUT" <<ENTRY
+  {"field": "$var1", "field2": $var2}
+ENTRY
+```
+
+The problem: recipe body is indented 4 spaces, heredoc content is 2 spaces, terminator `ENTRY` is at column 0.
+
+### Step 2 — Replace with printf
+
+Replace the entire `cat >> ... <<ENTRY ... ENTRY` block with a `printf` call:
+
+```just
+        printf '  {"field": "%s", "field2": %s}\n' \
+            "$var1" "$var2" >> "$OUTPUT"
+```
+
+Key points:
+- Keep the same leading whitespace (4 spaces) as the rest of the recipe
+- Use `printf` format string for the fixed text skeleton
+- Use `%s` placeholders for variable values, passed as positional args
+- Append `>> "$OUTPUT"` at the end of the `printf` line (or on the continuation)
+- Use `\` line continuation — `just` handles this correctly
+
+### Step 3 — Verify Fix
+
+```bash
+just --list | grep <recipe-name>
+# Should now show the recipe without errors
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Heredoc with `ENTRY` terminator at column 0 | `cat >> "$OUTPUT" <<ENTRY\n  {...}\nENTRY` | `just` "inconsistent leading whitespace" — terminator at column 0 doesn't match recipe's 4-space indent | `just` validates whitespace of ALL lines in recipe body, including heredoc terminators |
+| Indented heredoc terminator (`    ENTRY`) | Tried indenting the `ENTRY` terminator to match recipe indent | bash heredoc terminators must be at column 0 (or use `<<-` with tab-only indent) — mixing bash and just constraints makes this impossible cleanly | bash and just have conflicting whitespace requirements for heredoc terminators |
+| `<<-ENTRY` with tabs | Considered using `<<-` (strip leading tabs) with tab-indented body | Recipe already uses spaces throughout; mixing tabs only for the heredoc body creates a maintenance hazard | `printf` is simpler and avoids the bash/just whitespace conflict entirely |
+
+## Results & Parameters
+
+### Before (broken)
+
+```just
+# Run all Mojo tests with per-file timing, output JSON report
+test-timing output="test-timing.json":
+    #!/usr/bin/env bash
+    set -e
+    # ...
+        cat >> "$OUTPUT" <<ENTRY
+  {"file": "$test_file", "duration_s": $duration, "status": "$status", "attempts": $attempts_used}
+ENTRY
+    done
+```
+
+Error output:
+```text
+error: Recipe line has inconsistent leading whitespace. Recipe started with `    ` but found line with `  `
+   ——▶ justfile:709:1
+    │
+709 │   {"file": "$test_file", ...}
+    │ ^^
+```
+
+### After (working)
+
+```just
+# Run all Mojo tests with per-file timing, output JSON report
+test-timing output="test-timing.json":
+    #!/usr/bin/env bash
+    set -e
+    # ...
+        printf '  {"file": "%s", "duration_s": %s, "status": "%s", "attempts": %s}\n' \
+            "$test_file" "$duration" "$status" "$attempts_used" >> "$OUTPUT"
+    done
+```
+
+Verification:
+```bash
+just --list | grep test-timing
+# test-timing output="test-timing.json" # Run all Mojo tests with per-file timing, output JSON report
+```
+
+### General printf Template
+
+For any JSON-line output in a just recipe:
+
+```just
+        printf '  {"<key1>": "%s", "<key2>": %s, "<key3>": "%s"}\n' \
+            "$string_var" "$numeric_var" "$another_string_var" >> "$OUTPUT"
+```
+
+- Use `"%s"` (with quotes) for string JSON values
+- Use `%s` (without quotes) for numeric JSON values
+- Append to output file with `>> "$OUTPUT"` on the last line of the `printf` call


### PR DESCRIPTION
## Summary

Documents the fix for `just` recipe heredoc whitespace errors: replace `cat <<HEREDOC` with `printf` when emitting structured multi-field text inside shebang recipes.

- `just` requires all recipe body lines to share the same leading whitespace
- Bash heredoc terminators must be at column 0, conflicting with just's 4-space indent
- `printf` with `%s` placeholders is the clean, portable replacement

## Key Findings

**What Worked**:
- `printf '  {"field": "%s", "value": %s}\n' "$var1" "$var2" >> "$OUTPUT"` — all at consistent 4-space indent
- Line continuation (`\`) works correctly inside just recipe bodies

**What Failed**:
- `cat >> "$OUTPUT" <<ENTRY ... ENTRY` — terminator at column 0 fails just's whitespace check
- Indented heredoc terminator (`    ENTRY`) — bash requires terminators at column 0
- `<<-ENTRY` with tabs — conflicts with spaces-only recipe indentation

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (just heredoc errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
