### PR TITLE
feat: add claude-md-token-trim skill

### DIFF
--- a/skills/documentation/claude-md-token-trim/.claude-plugin/plugin.json
+++ b/skills/documentation/claude-md-token-trim/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "claude-md-token-trim",
+  "version": "1.0.0",
+  "description": "Reduce CLAUDE.md token consumption by replacing verbose/duplicate sections with concise summaries and links. Use when: (1) CLAUDE.md exceeds a line/token budget, (2) sections duplicate content already in shared docs, (3) pre-commit markdownlint MD060 table errors need fixing alongside trimming.",
+  "category": "documentation",
+  "date": "2026-03-15"
+}

--- a/skills/documentation/claude-md-token-trim/references/notes.md
+++ b/skills/documentation/claude-md-token-trim/references/notes.md
@@ -1,0 +1,45 @@
+# Session Notes: claude-md-token-trim
+
+## Date
+
+2026-03-15
+
+## Objective
+
+Implement GitHub issue #3158: trim CLAUDE.md from 1,786 lines (original target) / 1,257 lines
+(actual at start) to ≤1,200 lines to reduce token consumption on every Claude Code interaction.
+
+## Context
+
+- Working directory: `/home/mvillmow/ProjectOdyssey/.worktrees/issue-3158`
+- Branch: `3158-auto-impl`
+- Issue: [P3-4] Trim CLAUDE.md length to reduce token consumption
+
+## Approach Taken
+
+1. Read CLAUDE.md in sections (it was 49KB, too large for single read)
+2. Identified sections with highest trimming potential (duplication with shared docs)
+3. Applied edits using the `Edit` tool
+4. Validated with `pixi run npx markdownlint-cli2 CLAUDE.md`
+5. Committed and created PR #4763
+
+## Key Decisions
+
+- **Never remove CRITICAL RULES**: Issue explicitly said to keep this section prominent
+- **Replace, don't move**: Instead of moving content to new files, replaced verbose sections
+  with 1-2 line summaries + links to existing shared docs
+- **Fix pre-existing MD060 errors**: Found 3 tables with compact separator rows; fixed them
+  as a bonus since we were already touching the file
+- **Target: ≤1,012 lines** (issue target was ≤1,200; we beat it significantly)
+
+## Validation Pitfall
+
+`just pre-commit-all` exits with code 1 due to unrelated pixi environment issues
+("Text file busy" errors on python3.14 binary linking). This is a pre-existing CI
+infrastructure issue not related to file content. All individual hooks (including
+markdownlint) PASS. Workaround: run `pixi run npx markdownlint-cli2 CLAUDE.md` directly.
+
+## PR
+
+- PR #4763: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4763
+- Auto-merge enabled

--- a/skills/documentation/claude-md-token-trim/skills/claude-md-token-trim/SKILL.md
+++ b/skills/documentation/claude-md-token-trim/skills/claude-md-token-trim/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: claude-md-token-trim
+description: "Reduce CLAUDE.md token consumption by replacing verbose/duplicate sections with concise summaries and links. Use when: (1) CLAUDE.md exceeds a line/token budget, (2) sections duplicate content already in shared docs, (3) pre-commit markdownlint MD060 table errors need fixing alongside trimming."
+category: documentation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+| --------- | ----- |
+| **Goal** | Reduce CLAUDE.md from N lines to ≤ target without losing critical information |
+| **Trigger** | CLAUDE.md too large, token budget concerns, sections duplicating shared docs |
+| **Output** | Trimmed CLAUDE.md + passing markdownlint + PR |
+| **Risk** | Low — structural edits only, no logic changes |
+
+## When to Use
+
+- CLAUDE.md has grown beyond a line/token budget (e.g., >1,200 lines)
+- Sections exist that fully duplicate content in `.claude/shared/` docs
+- Pre-commit `markdownlint-cli2` reports MD060 table column style errors in existing tables
+- A PR/issue requests "reduce CLAUDE.md" or "trim token consumption"
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Count lines
+wc -l CLAUDE.md
+
+# 2. Run markdownlint before editing (baseline)
+pixi run npx markdownlint-cli2 CLAUDE.md
+
+# 3. After edits, verify
+wc -l CLAUDE.md
+pixi run npx markdownlint-cli2 CLAUDE.md  # must be 0 errors
+
+# 4. Commit + PR
+git add CLAUDE.md
+git commit -m "docs(claude-md): trim CLAUDE.md from X to Y lines"
+gh pr create ...
+```
+
+### Step 1 — Baseline measurement
+
+Count lines and capture markdownlint errors before touching anything:
+
+```bash
+wc -l CLAUDE.md
+pixi run npx markdownlint-cli2 CLAUDE.md 2>&1 | tee /tmp/baseline-lint.txt
+```
+
+Note which errors are pre-existing vs. introduced by your edits. Use `git stash` + re-run
+to confirm baseline:
+
+```bash
+git stash
+pixi run npx markdownlint-cli2 CLAUDE.md 2>&1 > /tmp/before.txt
+git stash pop
+pixi run npx markdownlint-cli2 CLAUDE.md 2>&1 > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt
+```
+
+### Step 2 — Identify high-value trim targets
+
+Read the full file and look for:
+
+| Pattern | Typical Size | Action |
+| ------- | ------------ | ------ |
+| Section fully duplicates a `/.claude/shared/` doc | 30–120 lines | Replace with 1-line pointer + link |
+| Correct/Incorrect example pairs illustrating a rule already stated | 20–60 lines | Delete examples, keep rule statement |
+| Multi-step CLI block already in a dedicated workflow doc | 15–40 lines | Collapse to 2–4 key commands |
+| "Why this rule exists" rationale after rule already stated at top | 10–30 lines | Delete (rule stated at top is enough) |
+| Verbose table that could be a condensed table | 5–20 lines | Condense or remove low-value columns |
+
+**Never trim:**
+
+- CRITICAL RULES section (branch protection, PR workflow)
+- Any section with no corresponding link destination
+- Mojo-specific critical patterns (out self, mut, ^, etc.)
+
+### Step 3 — Apply edits with Edit tool
+
+Use the `Edit` tool (not sed/awk) for all edits so changes are reviewable.
+
+**Pattern: Replace verbose section with pointer**
+
+```markdown
+<!-- BEFORE: 65 lines of duplicate "Never Push to Main" instructions -->
+
+### 🚫 Never Push Directly to Main
+
+**⚠️ CRITICAL:** See [CRITICAL RULES section](#️-critical-rules---read-first) at the top of this document.
+
+**This rule has NO EXCEPTIONS - not even for emergencies.** Always use the PR workflow described there.
+
+<!-- AFTER: 3 lines -->
+```
+
+**Pattern: Condense verbose examples to key rules**
+
+```markdown
+<!-- BEFORE: 119 lines with correct/incorrect markdown examples -->
+
+## Markdown Standards
+
+All markdown files must follow these standards to pass `markdownlint-cli2` linting:
+
+- **MD031/MD040**: Fenced code blocks must have blank lines before/after and a language tag
+- **MD032**: Lists must be surrounded by blank lines
+- **MD022**: Headings must be surrounded by blank lines
+- **MD013**: Lines must not exceed 120 characters (code blocks and URLs exempt)
+
+**Quick check before committing**: blank lines around all code blocks, lists, and headings;
+language on all code fences; no lines >120 chars; file ends with newline.
+
+```bash
+pixi run npx markdownlint-cli2 path/to/file.md
+```
+
+<!-- AFTER: ~12 lines -->
+```
+
+**Pattern: Collapse verbose CLI blocks**
+
+```markdown
+<!-- BEFORE: Detailed table + pull/run/build sections = 41 lines -->
+
+### Docker Registry (GHCR)
+
+Images published to GHCR: `ghcr.io/homericintelligence/projectodyssey:{main,main-ci,main-prod}`.
+
+```bash
+docker pull ghcr.io/homericintelligence/projectodyssey:main  # ~2GB runtime
+just docker-up    # Start dev environment
+just docker-shell # Open shell in container
+just docker-build-ci runtime  # Build locally
+```
+
+<!-- AFTER: ~8 lines -->
+```
+
+### Step 4 — Fix MD060 table column style errors
+
+MD060 errors occur when table separator rows use compact notation (`|---|---|`) instead of
+spaced notation (`| --- | --- |`). Fix all tables in the file:
+
+```markdown
+<!-- BEFORE (triggers MD060) -->
+| Task Type | Budget | Examples | Rationale |
+|-----------|--------|----------|-----------|
+
+<!-- AFTER (passes MD060) -->
+| Task Type | Budget | Examples | Rationale |
+| --------- | ------ | -------- | --------- |
+```
+
+Run markdownlint after each batch of table fixes to confirm:
+
+```bash
+pixi run npx markdownlint-cli2 CLAUDE.md 2>&1 | grep MD060
+```
+
+### Step 5 — Verify and commit
+
+```bash
+# Final line count
+wc -l CLAUDE.md
+
+# Must be 0 errors
+pixi run npx markdownlint-cli2 CLAUDE.md 2>&1
+
+# Commit
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(claude-md): trim CLAUDE.md from X to Y lines
+
+Reduce token consumption by removing verbose/duplicate content:
+
+- <Section>: <brief description of what was removed>
+- Fixed pre-existing MD060 table column style lint errors
+
+All critical information preserved via links to existing shared docs.
+No content from CRITICAL RULES section was removed.
+
+Closes #<issue>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Running `just pre-commit-all` to validate | Used `just pre-commit-all` as the validation step | Fails with unrelated pixi environment "Text file busy" errors — exit code 1 even when all hooks pass | Run `pixi run npx markdownlint-cli2 CLAUDE.md` directly instead of `just pre-commit-all`; the individual hooks pass even when the recipe itself errors |
+| Assuming MD060 errors were introduced by edits | Saw MD060 in post-edit lint output | Errors existed before edits (confirmed with `git stash` + re-run) | Always baseline lint before editing so you know which errors you introduced vs. which are pre-existing |
+| Editing with Bash sed | Considered `sed -i` for bulk replacements | sed is not the preferred tool per project conventions; edits are not reviewable | Always use the `Edit` tool for file modifications — it shows clear diffs and is tool-auditable |
+
+## Results & Parameters
+
+**Session result** (2026-03-15):
+
+- File: `CLAUDE.md`
+- Before: 1,257 lines
+- After: 1,012 lines
+- Reduction: 245 lines (19%)
+- Target was ≤1,200 lines — achieved ≤1,012
+- Markdownlint: 0 errors after fixing MD060 in 3 tables
+
+**Sections trimmed and savings:**
+
+| Section | Lines Saved | Technique |
+| ------- | ----------- | --------- |
+| Git Workflow duplicate "Never Push to Main" | ~62 | Replace 65-line duplicate with 3-line pointer |
+| Markdown Standards correct/incorrect examples | ~107 | Replace 119-line verbose section with 12-line summary |
+| Documentation Org GitHub issue code blocks | ~28 | Replace with single-line link to shared doc |
+| Docker Registry detailed table + sections | ~33 | Collapse to 8-line summary |
+| Agent Testing per-script commands | ~28 | Collapse to single loop + one-line summary |
+| MD060 table fixes (3 tables) | -3 | Spacing fixes added 3 lines |


### PR DESCRIPTION
## Summary

Documents the workflow for reducing `CLAUDE.md` token consumption by replacing verbose/duplicate
sections with concise summaries and links to existing shared docs.

- Baseline lint before editing to distinguish pre-existing vs. introduced errors
- Replace duplicate sections with pointers — saves 60+ lines per section
- Fix MD060 table errors (compact `|---|---|` → spaced `| --- | --- |`)
- Validate with `pixi run npx markdownlint-cli2` directly (not `just pre-commit-all`)

## Key Findings

**What Worked**:

- Identifying sections that fully duplicate `.claude/shared/` docs as highest-value targets
- Using `git stash` + re-run to baseline lint errors before attributing them to edits
- Running markdownlint directly on the file rather than through `just pre-commit-all`
- Replacing verbose correct/incorrect example pairs with concise rule summaries

**What Failed**:

- `just pre-commit-all` → exits code 1 due to pixi "Text file busy" environment issue, even when
  all individual hooks pass; this is a pre-existing infra issue, not a content problem
- Assuming MD060 table errors were introduced by edits → they were pre-existing; always baseline

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with CLAUDE.md trimming or token reduction triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
