### PR TITLE
feat(testing): update mojo-narrowing-cast-tests with UInt16/UInt32 learnings

### DIFF
--- a/skills/testing/mojo-narrowing-cast-tests/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-narrowing-cast-tests/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "mojo-narrowing-cast-tests",
-  "version": "1.0.0",
-  "description": "Add narrowing conversion tests to Mojo test files documenting truncation semantics of .cast[DType.uint8]() on values > 255. Use when: (1) a Mojo test file covers widening conversions but not narrowing, (2) an issue asks to document truncation/modulo semantics of integer casts, (3) you need to add boundary value tests for UInt64 -> UInt8 cast behavior.",
+  "version": "1.1.0",
+  "description": "Documents how to add narrowing conversion tests in Mojo following the if/raise pattern. Use when: (1) adding UInt narrowing tests for a new target type (UInt8/UInt16/UInt32), (2) extending test_unsigned.mojo with new cast coverage, (3) documenting modular arithmetic truncation semantics for unsigned integer casts.",
   "category": "testing",
-  "date": "2026-03-07",
-  "tags": ["mojo", "testing", "narrowing-conversion", "cast", "uint8", "uint64", "truncation", "boundary-values"]
+  "date": "2026-03-15",
+  "tags": ["mojo", "testing", "narrowing-conversion", "cast", "uint8", "uint16", "uint32", "uint64", "truncation", "boundary-values"]
 }

--- a/skills/testing/mojo-narrowing-cast-tests/references/notes-3675.md
+++ b/skills/testing/mojo-narrowing-cast-tests/references/notes-3675.md
@@ -1,0 +1,69 @@
+# Session Notes: Issue #3675 — UInt16 and UInt32 Narrowing Tests
+
+## Date
+
+2026-03-15
+
+## Issue
+
+GitHub #3675: Add narrowing conversion tests for UInt16 and UInt32 targets
+
+## Context
+
+Follow-up to issue #3179 (PR #3672) which added UInt8 narrowing tests. This session
+extended `test_unsigned.mojo` with two additional narrowing test functions for UInt16
+and UInt32 targets, following the same `if/raise` pattern already established.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3675.md` for task context
+2. `gh issue view 3675 --comments` — retrieved detailed implementation plan from issue comments
+3. Read `test_unsigned.mojo` around line 392 to confirm insertion point
+4. Grepped for `test_uint_narrowing_conversion` to find both function definition and `main()` call sites
+5. Added `test_uint_narrowing_to_uint16()` and `test_uint_narrowing_to_uint32()` after `test_uint_narrowing_conversion()`
+6. Added two `try/except` blocks in `main()`
+7. `git add tests/shared/core/test_unsigned.mojo && just pre-commit` — all hooks passed
+8. Committed, pushed, created PR #4765, enabled auto-merge
+
+## Implementation Details
+
+### UInt16 boundary values tested (modulo 65536)
+
+| Input (UInt64) | Expected UInt16 | Rationale |
+|----------------|-----------------|-----------|
+| 65536 | 0 | 65536 mod 65536 = 0 |
+| 65537 | 1 | 65537 mod 65536 = 1 |
+| 65535 | 65535 | Fits exactly, no truncation |
+| 0 | 0 | No-op passthrough |
+
+### UInt32 boundary values tested (modulo 4294967296)
+
+| Input (UInt64) | Expected UInt32 | Rationale |
+|----------------|-----------------|-----------|
+| 4294967296 | 0 | 2^32 mod 2^32 = 0 |
+| 4294967297 | 1 | (2^32+1) mod 2^32 = 1 |
+| 4294967295 | 4294967295 | Fits exactly, no truncation |
+| 0 | 0 | No-op passthrough |
+
+## Key Observations
+
+- The issue had a complete implementation plan with exact line numbers and value tables —
+  trusting it saved significant exploration time
+- Variable naming: used `v0_16` and `v0_32` for the zero-case variables to avoid potential
+  confusion with `v0` used in the UInt8 function (different scope, but good practice)
+- `just precommit` → error; correct recipe is `just pre-commit`
+- Mojo format ran clean with no formatting changes needed
+- All pre-commit hooks passed without `SKIP=`
+
+## Files Modified
+
+- `tests/shared/core/test_unsigned.mojo`: +74 lines (two new test functions + two main()
+  wiring blocks)
+
+## Environment Notes
+
+- Branch: `3675-auto-impl`
+- Repo: `HomericIntelligence/ProjectOdyssey`
+- Mojo cannot run on host (GLIBC mismatch) — CI validates the actual test execution
+- `just` available on this host (unlike the prior session)
+- Skill tool was in deny mode; used raw git/gh commands instead

--- a/skills/testing/mojo-narrowing-cast-tests/skills/mojo-narrowing-cast-tests/SKILL.md
+++ b/skills/testing/mojo-narrowing-cast-tests/skills/mojo-narrowing-cast-tests/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mojo-narrowing-cast-tests
-description: "Add narrowing conversion tests to Mojo test files documenting truncation semantics. Use when: a test file covers widening but not narrowing casts, or an issue asks to document truncation behavior of .cast[DType.uint8]() on UInt64 values > 255."
+description: "Documents how to add narrowing conversion tests in Mojo following the if/raise pattern. Use when: (1) adding UInt narrowing tests for a new target type, (2) extending test_unsigned.mojo with new cast coverage."
 category: testing
-date: 2026-03-07
+date: 2026-03-15
 user-invocable: false
 ---
 
@@ -10,22 +10,38 @@ user-invocable: false
 
 | Field | Value |
 |-------|-------|
-| **Skill** | mojo-narrowing-cast-tests |
-| **Category** | testing |
-| **Complexity** | Low |
+| **Pattern** | `if/raise` narrowing cast tests |
+| **File** | `tests/shared/core/test_unsigned.mojo` |
+| **Trigger** | New UInt narrowing path needs test coverage |
+| **Mojo version** | 0.26.1 |
 | **Mojo runs locally** | No (GLIBC mismatch on host — Docker/CI only) |
-| **Key pattern** | `if v.cast[DType.uint8]() != expected: raise Error(...)` |
 
 This skill documents how to add narrowing conversion tests to an existing Mojo test file.
-Narrowing casts (e.g. `UInt64 -> UInt8`) truncate to the low N bits, equivalent to
-`value % 256` for uint8. Tests document this behavior at key boundary values.
+Narrowing casts (e.g. `UInt64 -> UInt8`, `UInt64 -> UInt16`, `UInt64 -> UInt32`) truncate
+to the low N bits, equivalent to `value % M` where M = 2^N. Tests document this behavior
+at key boundary values.
 
 ## When to Use
 
-- A Mojo test file covers widening conversions (UInt8 -> UInt16 -> UInt64) but not narrowing
-- An issue asks to document `.cast[DType.uint8]()` truncation semantics on values > 255
-- You need boundary value tests for integer narrowing casts
-- A follow-up issue on an existing unsigned integer test file requests truncation documentation
+- Adding a new `test_uint_narrowing_to_uintN()` function for a target type not yet covered
+- Extending `test_unsigned.mojo` with additional cast coverage following issue follow-ups
+- Verifying modular arithmetic (truncation) semantics for unsigned integer narrowing casts
+- A Mojo test file covers widening conversions but not narrowing
+- An issue asks to document `.cast[DType.uintN]()` truncation semantics
+
+## Boundary Values Quick Reference
+
+| Target | Modulus (M) | Boundary value | Expected result | Rationale |
+|--------|-------------|----------------|-----------------|-----------|
+| UInt8  | 256         | 256            | 0               | M % M = 0 |
+| UInt8  | 256         | 257            | 1               | (M+1) % M = 1 |
+| UInt8  | 256         | 255            | 255             | M-1 fits exactly |
+| UInt16 | 65536       | 65536          | 0               | M % M = 0 |
+| UInt16 | 65536       | 65537          | 1               | (M+1) % M = 1 |
+| UInt16 | 65536       | 65535          | 65535           | M-1 fits exactly |
+| UInt32 | 4294967296  | 4294967296     | 0               | M % M = 0 |
+| UInt32 | 4294967296  | 4294967297     | 1               | (M+1) % M = 1 |
+| UInt32 | 4294967296  | 4294967295     | 4294967295      | M-1 fits exactly |
 
 ## Verified Workflow
 
@@ -40,143 +56,110 @@ if actual != expected:
 
 NOT `assert_equal` — the unsigned test files use raw `if/raise` style.
 
-### 2. Identify the boundary values to test
+### 2. Find the insertion point
 
-For `UInt64 -> UInt8` (modulo 256):
+Grep for the most recently added narrowing test function to find where to insert the next:
 
-| Input (UInt64) | `.cast[DType.uint8]()` | Expected | Rationale |
-|----------------|------------------------|----------|-----------|
-| 0 | -> uint8 | 0 | No-op passthrough |
-| 255 | -> uint8 | 255 | Fits exactly, no truncation |
-| 256 | -> uint8 | 0 | 256 mod 256 = 0 |
-| 257 | -> uint8 | 1 | 257 mod 256 = 1 |
-| 511 | -> uint8 | 255 | 511 mod 256 = 255 |
-| 512 | -> uint8 | 0 | 512 mod 256 = 0 |
-
-### 3. Add the test function before `main()`
-
-```mojo
-fn test_uint_narrowing_conversion() raises:
-    """Test narrowing conversions that truncate via modulo 2^N semantics.
-
-    When casting a UInt64 value > 255 to UInt8, the result is the low 8 bits
-    of the original value, equivalent to value % 256.
-    """
-    # 256 % 256 = 0
-    var v256: UInt64 = 256
-    if v256.cast[DType.uint8]() != 0:
-        raise Error("UInt64(256).cast[DType.uint8]() should be 0")
-
-    # 257 % 256 = 1
-    var v257: UInt64 = 257
-    if v257.cast[DType.uint8]() != 1:
-        raise Error("UInt64(257).cast[DType.uint8]() should be 1")
-
-    # 511 % 256 = 255
-    var v511: UInt64 = 511
-    if v511.cast[DType.uint8]() != 255:
-        raise Error("UInt64(511).cast[DType.uint8]() should be 255")
-
-    # 512 % 256 = 0
-    var v512: UInt64 = 512
-    if v512.cast[DType.uint8]() != 0:
-        raise Error("UInt64(512).cast[DType.uint8]() should be 0")
-
-    # 255 fits exactly — no truncation
-    var v255: UInt64 = 255
-    if v255.cast[DType.uint8]() != 255:
-        raise Error("UInt64(255).cast[DType.uint8]() should be 255")
-
-    # 0 is a no-op
-    var v0: UInt64 = 0
-    if v0.cast[DType.uint8]() != 0:
-        raise Error("UInt64(0).cast[DType.uint8]() should be 0")
+```bash
+grep -n "test_uint_narrowing" tests/shared/core/test_unsigned.mojo
 ```
 
-### 4. Wire into `main()` after the widening conversion test
+Insert new functions immediately after the last existing narrowing function.
+
+### 3. Write the new function using this template
+
+```mojo
+fn test_uint_narrowing_to_uintN() raises:
+    """Test narrowing conversions from UInt64 to UIntN via modulo M semantics.
+
+    When casting a UInt64 value > (M-1) to UIntN, the result is the low N bits
+    of the original value, equivalent to value % M.
+    """
+    # M % M = 0
+    var vM: UInt64 = M
+    if vM.cast[DType.uintN]() != 0:
+        raise Error("UInt64(M).cast[DType.uintN]() should be 0")
+
+    # (M+1) % M = 1
+    var vM1: UInt64 = M + 1
+    if vM1.cast[DType.uintN]() != 1:
+        raise Error("UInt64(M+1).cast[DType.uintN]() should be 1")
+
+    # (M-1) fits exactly — no truncation
+    var vMax: UInt64 = M - 1
+    if vMax.cast[DType.uintN]() != (M - 1):
+        raise Error("UInt64(M-1).cast[DType.uintN]() should be M-1")
+
+    # 0 is a no-op
+    var v0_N: UInt64 = 0
+    if v0_N.cast[DType.uintN]() != 0:
+        raise Error("UInt64(0).cast[DType.uintN]() should be 0")
+```
+
+### 4. Avoid variable name collisions
+
+Use `v0_16`, `v0_32` (not `v0`) to avoid potential confusion with variables in nearby
+functions, even though they're different scopes. Match the naming style of existing
+functions (e.g., `v65536`, `v65537` for UInt16 boundaries).
+
+### 5. Wire into `main()` after the previous narrowing test block
 
 ```mojo
     try:
-        test_uint_narrowing_conversion()
-        print("OK test_uint_narrowing_conversion")
+        test_uint_narrowing_to_uintN()
+        print("OK test_uint_narrowing_to_uintN")
     except e:
-        print("FAIL test_uint_narrowing_conversion:", e)
+        print("FAIL test_uint_narrowing_to_uintN:", e)
 ```
 
-### 5. Commit — pre-commit hooks pass without SKIP
-
-Unlike some Mojo test work, this change is pure `.mojo` formatting that `mojo format`
-handles cleanly. All pre-commit hooks pass without needing `SKIP=`:
+### 6. Verify with pre-commit hooks
 
 ```bash
-git add tests/shared/core/test_unsigned.mojo
-git commit -m "test(unsigned): add narrowing conversion tests (UInt64 -> UInt8 truncation)
-
-Add test_uint_narrowing_conversion() to document the truncation semantics
-of .cast[DType.uint8]() on UInt64 values > 255. Tests boundary values:
-- 256 -> 0 (256 mod 256 = 0)
-- 257 -> 1 (257 mod 256 = 1)
-- 511 -> 255 (511 mod 256 = 255)
-- 512 -> 0 (512 mod 256 = 0)
-- 255 -> 255 (fits exactly, no truncation)
-- 0 -> 0 (no-op)
-
-Closes #<issue-number>"
+just pre-commit
 ```
 
-### 6. Create PR with auto-merge
+Note: `just precommit` (no hyphen) does NOT exist. Always use `just pre-commit`.
+
+### 7. Create PR with auto-merge
 
 ```bash
 git push -u origin <branch>
-gh pr create --title "test(unsigned): add narrowing conversion tests" \
-  --body "Closes #<issue-number>"
-gh pr merge --auto --rebase
+gh pr create --title "test(unsigned): add UIntN narrowing conversion tests" \
+  --body "Closes #<issue-number>" \
+  --label "testing"
+gh pr merge --auto --rebase <PR-number>
 ```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Run `pixi run mojo -I . tests/shared/core/test_unsigned.mojo` locally | Executed mojo on host | GLIBC_2.32/2.33/2.34 not found — Mojo requires newer libc | Mojo tests can only be verified in CI (Docker). Trust correct boundary math and submit to CI. |
-| Use `assert_equal` from `testing` module | Considered importing `from testing import assert_equal` | The existing file uses raw `if/raise` pattern, not `assert_equal` | Match the existing test file's assertion style. Read the file before deciding on pattern. |
+| Run mojo locally | `pixi run mojo -I . tests/shared/core/test_unsigned.mojo` | GLIBC_2.32/2.33/2.34 not found — Mojo requires newer libc | Use CI (Docker) for test verification, not local host |
+| Use `assert_equal` | Considered `from testing import assert_equal` | The existing file uses raw `if/raise` pattern | Match the existing test file's assertion style |
+| Wrong just recipe | Ran `just precommit` | Recipe doesn't exist; correct name is `just pre-commit` | Check `just --list` if a recipe name is uncertain |
+| Skill tool for commit | Tried `/commit-commands:commit` via Skill tool | Denied in don't-ask permission mode | Fall back to raw git/gh commands when Skill tool is denied |
 
 ## Results & Parameters
 
-### Truncation math for common narrowing casts
+### Commit format
 
-| Target | Modulus | Key boundary |
-|--------|---------|-------------|
-| uint8 | 256 | 256->0, 257->1, 511->255, 512->0 |
-| uint16 | 65536 | 65536->0, 65537->1 |
-| uint32 | 2^32 | 2^32->0, 2^32+1->1 |
+```bash
+git commit -m "test(unsigned): add UInt16 and UInt32 narrowing conversion tests"
+```
 
-### Complete function template
+### PR creation
 
-```mojo
-fn test_uint_narrowing_conversion() raises:
-    """Test narrowing conversions that truncate via modulo 2^N semantics."""
-    var v256: UInt64 = 256
-    if v256.cast[DType.uint8]() != 0:
-        raise Error("UInt64(256).cast[DType.uint8]() should be 0")
-    var v257: UInt64 = 257
-    if v257.cast[DType.uint8]() != 1:
-        raise Error("UInt64(257).cast[DType.uint8]() should be 1")
-    var v511: UInt64 = 511
-    if v511.cast[DType.uint8]() != 255:
-        raise Error("UInt64(511).cast[DType.uint8]() should be 255")
-    var v512: UInt64 = 512
-    if v512.cast[DType.uint8]() != 0:
-        raise Error("UInt64(512).cast[DType.uint8]() should be 0")
-    var v255: UInt64 = 255
-    if v255.cast[DType.uint8]() != 255:
-        raise Error("UInt64(255).cast[DType.uint8]() should be 255")
-    var v0: UInt64 = 0
-    if v0.cast[DType.uint8]() != 0:
-        raise Error("UInt64(0).cast[DType.uint8]() should be 0")
+```bash
+gh pr create \
+  --title "test(unsigned): add UInt16 and UInt32 narrowing conversion tests" \
+  --body "Closes #N" \
+  --label "testing"
+gh pr merge --auto --rebase <PR-number>
 ```
 
 ## Verified On
 
-| Project | Context | Details |
-|---------|---------|---------|
-| ProjectOdyssey | PR #3672 (Issue #3179) | [notes.md](../references/notes.md) |
+| Project | Issue | PR | Target types | Details |
+|---------|-------|----|--------------|---------|
+| ProjectOdyssey | #3179 | #3672 | UInt8 | [notes.md v1](../references/notes.md) |
+| ProjectOdyssey | #3675 | #4765 | UInt16, UInt32 | [notes.md v2](../references/notes-3675.md) |


### PR DESCRIPTION
## Summary

- Extends the `mojo-narrowing-cast-tests` skill (v1.0.0 → v1.1.0) with UInt16 and UInt32 narrowing target coverage
- Adds a generalized function template applicable to any `UIntN` target type
- Updates boundary value table to cover all three targets (UInt8, UInt16, UInt32)
- Adds new failed-attempts entry: `just precommit` vs `just pre-commit` (hyphen required)
- Adds session notes file `references/notes-3675.md` documenting issue #3675 / PR #4765 in ProjectOdyssey

## Test plan

- [x] `python3 scripts/validate_plugins.py skills/ plugins/` passes with `PASS: mojo-narrowing-cast-tests` (no warnings)
- [x] All 699 plugins validate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)