### PR TITLE
feat: add fix-validation-accuracy-placeholder skill

### DIFF
--- a/skills/evaluation/fix-validation-accuracy-placeholder/.claude-plugin/plugin.json
+++ b/skills/evaluation/fix-validation-accuracy-placeholder/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-validation-accuracy-placeholder",
+  "version": "1.0.0",
+  "description": "Fix hardcoded 0.0 accuracy placeholders in validation loop methods by wiring real AccuracyMetric accumulation per batch. Use when: (1) a validation/evaluation loop calls update_val_metrics with a literal 0.0 for accuracy, (2) a subset validation method lacks AccuracyMetric accumulation while the full validation method already has it, (3) a follow-up bug mirrors a previously fixed bug in a sibling method.",
+  "category": "evaluation",
+  "date": "2026-03-15"
+}

--- a/skills/evaluation/fix-validation-accuracy-placeholder/references/notes.md
+++ b/skills/evaluation/fix-validation-accuracy-placeholder/references/notes.md
@@ -1,0 +1,36 @@
+# Session Notes — fix-validation-accuracy-placeholder
+
+## Date
+2026-03-15
+
+## Issue
+GitHub issue #3680 — "Fix run_subset() accuracy placeholder in ValidationLoop"
+
+Follow-up from #3183, which fixed the same bug in `run()`.
+
+## Objective
+Replace `metrics.update_val_metrics(avg_loss, 0.0)` in `ValidationLoop.run_subset()` with
+a real accuracy value computed via `AccuracyMetric`.
+
+## Files Changed
+- `shared/training/loops/validation_loop.mojo` — added AccuracyMetric accumulation in `run_subset()`
+- `tests/shared/training/test_validation_loop.mojo` — added `test_validation_loop_run_subset_updates_val_accuracy()`
+
+## Key Observations
+
+1. The `run()` method already had the correct pattern (AccuracyMetric before loop, accumulate
+   per batch, compute after loop). `run_subset()` was a copy-paste that never got the accuracy fix.
+
+2. The issue description explicitly said "analogous to test_validation_loop_run_updates_val_accuracy()".
+   The existing test was found in `tests/training/test_training_infrastructure.mojo` (not in the
+   validation loop test file), but the new test was added to the validation loop test file where
+   all other `run_subset` tests live.
+
+3. `SKIP=mojo-format` was used in the commit because the local Mojo version differs from the
+   pixi.toml pin — this is the documented workaround for this repo.
+
+4. The accuracy accumulation is inside the existing capped `while` loop (not a second pass),
+   so `max_batches` is respected automatically.
+
+## PR
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4767

--- a/skills/evaluation/fix-validation-accuracy-placeholder/skills/fix-validation-accuracy-placeholder/SKILL.md
+++ b/skills/evaluation/fix-validation-accuracy-placeholder/skills/fix-validation-accuracy-placeholder/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fix-validation-accuracy-placeholder
+description: "Fix hardcoded 0.0 accuracy placeholders in validation loop methods by wiring real AccuracyMetric accumulation per batch. Use when: a validation method passes a literal 0.0 for accuracy to a metrics update call instead of computing it."
+category: evaluation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `run_subset()` passed `0.0` as accuracy to `metrics.update_val_metrics()` — a hardcoded placeholder |
+| **Root cause** | Method was written before accuracy tracking was required; the sibling `run()` method had already been fixed (#3183) but `run_subset()` was missed |
+| **Fix pattern** | Add `AccuracyMetric` variable before the batch loop; accumulate predictions per batch inside the loop when `self.compute_accuracy=True`; compute final value after loop; pass to `update_val_metrics()` instead of `0.0` |
+| **Test pattern** | Assert `metrics.val_accuracy > 0.0` after calling the fixed method with a non-trivial dataset |
+| **Language** | Mojo (applies equally to Python equivalents) |
+
+## When to Use
+
+- A validation or evaluation loop calls `update_val_metrics(loss, 0.0)` with a literal `0.0` for accuracy
+- A `run_subset()` / `evaluate_subset()` method lacks AccuracyMetric tracking while the corresponding `run()` / `evaluate()` already has it
+- A follow-up issue says "mirrors the same bug fixed in `run()` by #NNNN"
+- `metrics.val_accuracy` is always `0.0` after calling a subset validation method even when predictions are correct
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+1. Read validation_loop.mojo — find update_val_metrics(avg_loss, 0.0) in run_subset()
+2. Add AccuracyMetric variable before the batch loop
+3. Inside loop: if self.compute_accuracy → call model_forward again, accuracy_metric.update(preds, labels)
+4. After loop: compute val_accuracy = accuracy_metric.compute() when self.compute_accuracy
+5. Replace update_val_metrics(avg_loss, 0.0) with update_val_metrics(avg_loss, val_accuracy)
+6. Add test: assert metrics.val_accuracy > 0.0 after run_subset()
+7. Commit with "Closes #NNNN"
+```
+
+### Step 1 — Locate the placeholder
+
+Search for `update_val_metrics` calls with a literal `0.0` as the second argument:
+
+```bash
+grep -n "update_val_metrics.*0\.0" shared/training/loops/validation_loop.mojo
+```
+
+### Step 2 — Read the fixed sibling method for the pattern
+
+The `run()` method already had the correct pattern. Read it to understand:
+
+- Where `AccuracyMetric()` is instantiated (before the loop)
+- How `accuracy_metric.update(predictions, batch.labels)` is called inside the loop
+- How `val_accuracy = accuracy_metric.compute()` is called after the loop
+- How the result is guarded by `if self.compute_accuracy:`
+
+### Step 3 — Apply the same pattern to `run_subset()`
+
+Before the batch loop, add:
+
+```mojo
+var accuracy_metric = AccuracyMetric()
+```
+
+Inside the loop, after incrementing `num_batches`, add:
+
+```mojo
+if self.compute_accuracy:
+    var predictions = model_forward(batch.data)
+    accuracy_metric.update(predictions, batch.labels)
+```
+
+After the loop, replace the placeholder:
+
+```mojo
+# Before (bug):
+metrics.update_val_metrics(avg_loss, 0.0)
+
+# After (fix):
+var val_accuracy = Float64(0.0)
+if self.compute_accuracy:
+    val_accuracy = accuracy_metric.compute()
+metrics.update_val_metrics(avg_loss, val_accuracy)
+```
+
+### Step 4 — Add the follow-up test
+
+In the test file, add a test that mirrors `test_validation_loop_run_updates_val_accuracy()`:
+
+```mojo
+fn test_validation_loop_run_subset_updates_val_accuracy() raises:
+    """Test run_subset() computes real accuracy via AccuracyMetric, not 0.0 placeholder.
+
+    Follow-up to #3183 which fixed the same bug in run().
+    Uses a 3-batch loader with max_batches=2 to verify the limit is respected
+    and accuracy is non-zero after the call.
+    """
+    var vloop = ValidationLoop()
+    var loader = create_val_loader(n_batches=3)
+    var metrics = TrainingMetrics()
+    _ = vloop.run_subset(simple_forward, simple_loss, loader, 2, metrics)
+    assert_true(metrics.val_accuracy > 0.0)
+    print("  test_validation_loop_run_subset_updates_val_accuracy: PASSED")
+```
+
+Register the test in `main()` alongside the other `run_subset` tests.
+
+### Step 5 — Commit and PR
+
+```bash
+git add shared/training/loops/validation_loop.mojo \
+        tests/shared/training/test_validation_loop.mojo
+SKIP=mojo-format git commit -m "fix(validation): compute real accuracy in ValidationLoop.run_subset()
+
+Replace the hardcoded 0.0 accuracy placeholder in run_subset() with
+AccuracyMetric accumulation inside the batch loop, guarded by
+self.compute_accuracy (mirroring the existing run() fix from #3183).
+
+Closes #NNNN"
+git push -u origin <branch>
+gh pr create --title "fix(validation): ..." --body "Closes #NNNN"
+gh pr merge --auto --rebase <pr-number>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using a separate reset+loop for accuracy | Re-iterate the entire loader after the loss loop to compute accuracy (same pattern as `run()`) | Would process up to `max_batches` again from reset, ignoring the already-completed subset iteration | In `run_subset()`, accumulate accuracy inside the existing capped loop — do not add a second loop |
+| Passing `0.0` unchanged | Leave `update_val_metrics(avg_loss, 0.0)` and only add a comment | Issue explicitly requires computing real accuracy; comment does not fix the bug | The fix must replace the literal `0.0` with a computed value |
+
+## Results & Parameters
+
+### Key configuration
+
+```mojo
+# AccuracyMetric is already imported at the top of validation_loop.mojo
+from shared.training.metrics import AccuracyMetric, LossTracker, ConfusionMatrix
+
+# No new imports needed — AccuracyMetric is already in scope
+```
+
+### mojo-format compatibility
+
+If local Mojo version differs from pixi.toml pin, skip the mojo-format hook:
+
+```bash
+SKIP=mojo-format git commit -m "..."
+```
+
+### Test assertion pattern
+
+Use `assert_true(metrics.val_accuracy > 0.0)` rather than `assert_almost_equal`
+because the exact value depends on `simple_forward` returning ones — any positive
+value proves the placeholder was replaced with a real computation.


### PR DESCRIPTION
## Summary

Documents the pattern for fixing hardcoded `0.0` accuracy placeholders in validation loop
subset methods where the sibling full-validation method already has the correct fix.

- Accumulate `AccuracyMetric` inside the existing capped batch loop (not a second pass)
- Guard with `if self.compute_accuracy:` to mirror the full-validation pattern
- Assert `metrics.val_accuracy > 0.0` in the follow-up test

## Key Findings

**What Worked**:
- Reusing the same `AccuracyMetric` pattern from `run()` directly inside `run_subset()`'s existing loop
- Single-assertion test (`val_accuracy > 0.0`) that proves the placeholder was replaced without being brittle about the exact value

**What Failed**:
- Adding a second reset+loop for accuracy (would re-process batches ignoring `max_batches` cap)
- Leaving the `0.0` literal with just a comment (doesn't fix the bug)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `evaluation` category
- [ ] Check skill activation with trigger: "validation loop passes 0.0 for accuracy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
