### PR TITLE
feat: add pre-commit-pygrep-hook skill

### DIFF
--- a/skills/ci-cd/pre-commit-pygrep-hook/.claude-plugin/plugin.json
+++ b/skills/ci-cd/pre-commit-pygrep-hook/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "pre-commit-pygrep-hook",
+  "version": "1.0.0",
+  "description": "Add a regex-based pre-commit hook using language: pygrep to detect forbidden code patterns in specific directories. Use when: (1) automating a manual grep audit as a commit-time check, (2) banning debug artifacts (NOTE/TODO/FIXME in print calls), (3) preventing deprecated syntax patterns from being re-introduced.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/pre-commit-pygrep-hook/references/notes.md
+++ b/skills/ci-cd/pre-commit-pygrep-hook/references/notes.md
@@ -1,0 +1,48 @@
+# Session Notes — pre-commit-pygrep-hook
+
+## Context
+
+**Issue**: ProjectOdyssey #3703 — "Add pre-commit hook to catch runtime NOTE/TODO/FIXME prints"
+
+**Follow-up from**: #3194 (manual grep audit)
+
+**Branch**: `3703-auto-impl`
+
+**PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4774
+
+## Objective
+
+Convert a manual audit step (`grep -rn 'print.*NOTE\|print.*TODO\|print.*FIXME' examples/`) into
+an automated pre-commit hook so debug artifacts are caught at commit time instead of during
+periodic audits.
+
+## Steps Taken
+
+1. Read `.pre-commit-config.yaml` to understand existing hook patterns (pygrep, system, script hooks).
+2. Added `check-print-debug-artifacts` hook using `language: pygrep` — minimal, zero-dependency.
+3. Scoped hook to `^examples/` matching the original audit scope.
+4. Created `tests/test_check_print_debug_artifacts.py` with 12 parametrized pytest cases.
+5. Discovered pygrep matches commented-out lines — adjusted test expectations accordingly.
+6. Validated hook: `SKIP=mojo-format,mypy pixi run pre-commit run check-print-debug-artifacts --all-files` → Passed.
+7. All 12 tests pass.
+
+## Key Decisions
+
+- **pygrep vs system language**: pygrep is preferred for simple pattern matching — no shell
+  subprocess needed, no platform differences, pre-commit handles file iteration.
+- **Placement**: Added to the first `repo: local` block alongside `check-list-constructor`
+  (another pygrep hook) for consistency.
+- **Commented-out lines are flagged**: This is correct — `# print("NOTE: ...")` in source
+  suggests code that was commented out rather than deleted, which is itself a code smell.
+
+## Regex Translation
+
+Grep syntax: `print.*NOTE\|print.*TODO\|print.*FIXME`
+
+Python re syntax: `print.*(NOTE|TODO|FIXME)`
+
+## Test Failure & Fix
+
+Initial test included `# print("NOTE: commented out")` in NEGATIVE_CASES. Failed because
+pygrep applies the regex to the raw file line including the `#` prefix. Fixed by moving
+to POSITIVE_CASES with description "commented-out print still flagged".

--- a/skills/ci-cd/pre-commit-pygrep-hook/skills/pre-commit-pygrep-hook/SKILL.md
+++ b/skills/ci-cd/pre-commit-pygrep-hook/skills/pre-commit-pygrep-hook/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: pre-commit-pygrep-hook
+description: "Add a regex-based pre-commit hook using language: pygrep to detect forbidden code patterns. Use when: automating manual grep audits as commit-time checks, banning debug artifacts in specific directories, or preventing deprecated syntax from being re-introduced."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Category** | ci-cd |
+| **Complexity** | Low |
+| **Time** | < 5 min |
+| **Dependencies** | pre-commit installed, `.pre-commit-config.yaml` exists |
+
+Adds a `language: pygrep` hook to `.pre-commit-config.yaml` that runs a regex against
+staged files with zero external dependencies. Also adds pytest tests that validate the
+regex pattern directly, ensuring the hook behaviour is documented and regression-tested
+without requiring the full pre-commit runtime.
+
+## When to Use
+
+- A periodic manual `grep` audit was done and should be automated
+- Debug artifact patterns (`print("NOTE/TODO/FIXME")`) must be caught at commit time
+- Deprecated or banned syntax patterns must be prevented from re-appearing
+- Zero-dependency guardrail needed that works with `language: pygrep`
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# Minimal hook stanza
+- id: check-print-debug-artifacts
+  name: Check for NOTE/TODO/FIXME in print statements
+  description: >-
+    Fail if examples/ contains print() calls with NOTE, TODO, or FIXME.
+  entry: 'print.*(NOTE|TODO|FIXME)'
+  language: pygrep
+  files: ^examples/
+```
+
+### Step 1 — Identify the pattern
+
+Convert the manual grep command to a regex:
+
+```bash
+# Original manual audit command (from issue #3194)
+grep -rn 'print.*NOTE\|print.*TODO\|print.*FIXME' examples/
+```
+
+Translated to pygrep regex: `print.*(NOTE|TODO|FIXME)`
+
+**Key difference**: pygrep uses Python `re` syntax (use `|` inside a group, not `\|`).
+
+### Step 2 — Add the hook stanza
+
+Insert into the appropriate `local` repo block in `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: check-print-debug-artifacts
+      name: Check for NOTE/TODO/FIXME in print statements
+      description: >-
+        Fail if examples/ contains print() calls with NOTE, TODO, or FIXME
+        left over from development/debugging.
+      entry: 'print.*(NOTE|TODO|FIXME)'
+      language: pygrep
+      files: ^examples/
+```
+
+**Placement tip**: Add new hooks alongside similar hooks in the same `repo: local` block.
+Avoid creating a new `- repo: local` block for every hook.
+
+### Step 3 — Write pytest tests for the regex
+
+```python
+import re
+PATTERN = re.compile(r"print.*(NOTE|TODO|FIXME)")
+
+def matches(line: str) -> bool:
+    return bool(PATTERN.search(line))
+```
+
+Parametrize positive cases (must match) and negative cases (must not match):
+
+```python
+POSITIVE_CASES = [
+    ('print("NOTE: fix this")', "bare NOTE"),
+    ('print("TODO: remove")', "bare TODO"),
+    ('# print("NOTE: commented")', "commented-out print still flagged"),
+]
+
+NEGATIVE_CASES = [
+    ('print("hello world")', "no keyword"),
+    ('log("TODO: ignored")', "non-print call"),
+    ('print("noted")', "partial word match — not flagged"),
+]
+```
+
+**Important**: `language: pygrep` matches the raw line content including `#`-prefixed
+comments. Commented-out prints that contain NOTE/TODO/FIXME **will** be flagged. This is
+correct and expected — document it in the positive cases.
+
+### Step 4 — Validate baseline
+
+Run the hook against all files before committing to confirm the codebase is clean:
+
+```bash
+SKIP=mojo-format,mypy pixi run pre-commit run check-print-debug-artifacts --all-files
+```
+
+### Step 5 — Run tests
+
+```bash
+pixi run python -m pytest tests/test_check_print_debug_artifacts.py -v
+```
+
+### Step 6 — Commit and PR
+
+```bash
+git add .pre-commit-config.yaml tests/test_check_<hook-name>.py
+git commit -m "feat(pre-commit): add hook to catch <pattern>"
+git push -u origin <branch>
+gh pr create --title "feat(pre-commit): ..." --body "Closes #<issue>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Test: commented-out print as negative case | Added `# print("NOTE: ...")` to NEGATIVE_CASES expecting it would not match | `pygrep` matches the raw line — `# print(...)` still contains `print.*NOTE` | Move commented-out prints to POSITIVE_CASES; pygrep does not understand comments |
+| Using `\|` alternation in pygrep entry | Wrote `print.*NOTE\|print.*TODO\|print.*FIXME` (grep syntax) | pygrep uses Python `re` syntax; `\|` is a literal pipe | Use `(NOTE\|TODO\|FIXME)` or `(NOTE|TODO|FIXME)` group syntax |
+
+## Results & Parameters
+
+### Hook parameters
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| `language` | `pygrep` | Zero external deps; pattern matched via Python `re` |
+| `entry` | `'print.*(NOTE\|TODO\|FIXME)'` | Quoted to prevent shell expansion |
+| `files` | `^examples/` | Scope to one directory; adjust as needed |
+| `types` | (omitted) | Defaults to all text files; add `[python]` to restrict |
+| `pass_filenames` | (omitted) | pygrep handles file iteration automatically |
+
+### Test file template
+
+```python
+#!/usr/bin/env python3
+"""Unit tests for the <hook-id> pre-commit hook."""
+
+import re
+from typing import List, Tuple
+import pytest
+
+PATTERN = re.compile(r"<entry-regex>")
+
+def matches(line: str) -> bool:
+    """Return True if *line* would be flagged by the hook."""
+    return bool(PATTERN.search(line))
+
+POSITIVE_CASES: List[Tuple[str, str]] = [
+    ("<flagged line>", "<description>"),
+]
+
+NEGATIVE_CASES: List[Tuple[str, str]] = [
+    ("<clean line>", "<description>"),
+]
+
+@pytest.mark.parametrize("line,description", POSITIVE_CASES)
+def test_positive_match(line: str, description: str) -> None:
+    assert matches(line), f"Expected match for {description!r}: {line!r}"
+
+@pytest.mark.parametrize("line,description", NEGATIVE_CASES)
+def test_negative_no_match(line: str, description: str) -> None:
+    assert not matches(line), f"Unexpected match for {description!r}: {line!r}"
+```


### PR DESCRIPTION
## Summary

Documents how to convert a manual grep audit into a zero-dependency `pygrep`-based
pre-commit hook with companion pytest tests.

- Captured from ProjectOdyssey issue #3703 implementation
- Covers regex syntax translation (grep → Python re)
- Includes a reusable pytest test file template

## Key Findings

**What Worked**:
- `language: pygrep` requires no external deps and handles file iteration automatically
- Placing the new hook in an existing `repo: local` block (next to similar hooks) keeps config tidy
- Writing pytest tests against the raw regex documents and regression-tests hook behaviour

**What Failed**:
- `# print("NOTE: ...")` placed in NEGATIVE_CASES → pygrep matches raw lines including comment prefix, so it IS flagged; moved to POSITIVE_CASES
- Grep alternation syntax `NOTE\|TODO\|FIXME` in the `entry` field → must use Python re group `(NOTE|TODO|FIXME)`

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
