### PR TITLE
feat: add mojo-runtime-output-pattern-audit skill

### DIFF
--- a/skills/tooling/mojo-runtime-output-pattern-audit/.claude-plugin/plugin.json
+++ b/skills/tooling/mojo-runtime-output-pattern-audit/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-runtime-output-pattern-audit",
+  "version": "1.0.0",
+  "description": "Audit Mojo source files for misleading runtime output patterns and add CI enforcement. Use when: (1) a codebase audit series is extended to cover print() patterns beyond NOTE/TODO/FIXME (e.g. WARNING:, HACK:, XXX:, Not implemented), (2) a grep audit script modeled on an existing checker needs to be added for new pattern categories, (3) CI enforcement for runtime output cleanliness is needed in a Mojo project.",
+  "category": "tooling",
+  "date": "2026-03-15"
+}

--- a/skills/tooling/mojo-runtime-output-pattern-audit/references/notes.md
+++ b/skills/tooling/mojo-runtime-output-pattern-audit/references/notes.md
@@ -1,0 +1,69 @@
+# Session Notes: Mojo Runtime Output Pattern Audit
+
+## Context
+
+- **Repository**: ProjectOdyssey
+- **Issue**: #3704 — Audit examples/ for other misleading runtime output patterns
+- **PR**: #4776
+- **Follow-up from**: #3084 / #3194 (NOTE/TODO/FIXME audit series)
+- **Date**: 2026-03-15
+- **Branch**: `3704-auto-impl`
+
+## Objective
+
+Extend the existing comment-annotation audit series to cover runtime (print-time) misleading
+patterns: `WARNING:`, `HACK:`, `XXX:`, and `Not implemented` inside `print()` calls in Mojo source.
+
+## Steps Taken
+
+1. Read the existing `scripts/check_note_format.py` to understand the structural template
+   (argparse, `EXCLUDED_DIRS`, `SOURCE_DIRS`, `find_violations`, `scan_source_dirs`, `main()`).
+2. Read `tests/scripts/test_check_note_format.py` to understand the expected test class structure.
+3. Grepped `examples/` for all four banned patterns — found one violation:
+   `examples/lenet-emnist/run_train.mojo:302` (`print("WARNING: Gradient overflow...")`).
+4. Fixed the violation by removing only the `WARNING: ` prefix (message is legitimate).
+5. Created `scripts/check_runtime_output_patterns.py` following the same interface as the NOTE checker.
+6. Created `tests/scripts/test_check_runtime_output_patterns.py` with 44 unit tests covering all paths.
+7. Updated `.github/workflows/script-validation.yml`:
+   - Added `examples/**/*.mojo` to path triggers.
+   - Added enforcement step after "Check for common issues".
+   - Added the new check to the Summary step.
+8. Updated `scripts/README.md` with the new script entry.
+9. All 44 tests passed (0.39s). Script returned exit 0 on `examples/`.
+
+## Key Design Decisions
+
+- **Pattern scope**: Required `print\(` prefix in regex to avoid false positives on comment lines.
+  Added `is_comment_line()` as a secondary guard for lines starting with `#`.
+- **Single-line matching**: Real-world violations are single-line print calls; no need for multiline.
+- **Dedup**: `break` after first matching pattern prevents double-reporting multi-pattern lines.
+- **Shared interface**: Reused exact same `is_excluded`, `EXCLUDED_DIRS`, `SOURCE_DIRS`, and
+  exit-code contract as `check_note_format.py` — zero learning curve for future maintainers.
+
+## Files Changed
+
+```text
+examples/lenet-emnist/run_train.mojo          # Fix: remove WARNING: prefix (line 302)
+scripts/check_runtime_output_patterns.py      # New: enforcement script
+tests/scripts/test_check_runtime_output_patterns.py  # New: 44 unit tests
+.github/workflows/script-validation.yml       # Updated: CI step + path triggers
+scripts/README.md                             # Updated: directory tree entry
+```
+
+## Commit Message Used
+
+```
+feat(scripts): add runtime output pattern audit for examples/
+
+Completes the #3084/#3194 audit series by covering additional misleading
+print() patterns: WARNING:, HACK:, XXX:, and 'Not implemented'.
+
+Changes:
+- Fix examples/lenet-emnist/run_train.mojo:302: remove WARNING: prefix
+- Add scripts/check_runtime_output_patterns.py: enforcement script
+- Add tests/scripts/test_check_runtime_output_patterns.py: 44 unit tests
+- Update .github/workflows/script-validation.yml: CI step + path triggers
+- Update scripts/README.md: add entry for new script
+
+Closes #3704
+```

--- a/skills/tooling/mojo-runtime-output-pattern-audit/skills/mojo-runtime-output-pattern-audit/SKILL.md
+++ b/skills/tooling/mojo-runtime-output-pattern-audit/skills/mojo-runtime-output-pattern-audit/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: mojo-runtime-output-pattern-audit
+description: "Audit Mojo source files for misleading runtime print() patterns and wire CI enforcement. Use when: extending an existing audit series to cover WARNING:, HACK:, XXX:, or Not implemented in print() calls; adding a grep-style checker script modeled on an existing one; or enforcing runtime output cleanliness in a Mojo project."
+category: tooling
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Category** | tooling |
+| **Complexity** | Low |
+| **Risk** | Low (audit + one-line source fix + new enforcement script) |
+| **Repo** | Any Mojo project with a `scripts/` audit pattern (e.g. ProjectOdyssey) |
+
+Extends an in-progress comment/annotation audit series (like the #3084/#3194 NOTE/TODO/FIXME series)
+to also cover misleading runtime output: `print()` calls containing `WARNING:`, `HACK:`, `XXX:`,
+or placeholder messages like `Not implemented`. The pattern is: grep to find violations → fix them
+→ add enforcement script modeled on the existing checker → add CI step → add tests.
+
+## When to Use
+
+- An audit issue requests follow-up coverage for `print('WARNING: ...')`, `print('HACK: ...')`,
+  `print('XXX: ...')`, or `print('Not implemented')` patterns
+- A project already has a `check_note_format.py`-style script and needs a companion for runtime output
+- You need a CI step in `script-validation.yml` (or equivalent) to block new violations
+- The existing checker script can serve as a structural template (same `argparse`, `SOURCE_DIRS`,
+  `is_excluded`, `find_violations`, `scan_source_dirs`, `main()` exit-code interface)
+
+## Verified Workflow
+
+### Step 1 — Grep the full source tree for violations
+
+```bash
+# Find all banned patterns in .mojo files
+grep -rn 'print.*WARNING\s*:' examples/ shared/ papers/ tests/ --include="*.mojo"
+grep -rn 'print.*HACK\s*:'    examples/ shared/ papers/ tests/ --include="*.mojo"
+grep -rn 'print.*XXX\s*:'     examples/ shared/ papers/ tests/ --include="*.mojo"
+grep -rn -i 'print.*Not implemented' examples/ shared/ papers/ tests/ --include="*.mojo"
+```
+
+Record every hit (file + line number) before touching anything.
+
+### Step 2 — Fix existing violations
+
+For each violation, evaluate whether the message is legitimate:
+
+- **Legitimate message with misleading prefix** (most common): remove only the prefix.
+
+  ```mojo
+  # Before
+  print("WARNING: Gradient overflow detected, skipping parameter update")
+  # After
+  print("Gradient overflow detected, skipping parameter update")
+  ```
+
+- **Placeholder/stub**: replace with an appropriate message or raise an error.
+
+### Step 3 — Create `scripts/check_runtime_output_patterns.py`
+
+Model the script on the existing `check_note_format.py`. Required interface:
+
+```python
+BANNED_PATTERNS = [
+    re.compile(r'print\([^)]*WARNING\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*HACK\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*XXX\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*Not\s+implemented', re.IGNORECASE),
+]
+
+def is_comment_line(line: str) -> bool: ...
+def is_excluded(path: Path) -> bool: ...          # same EXCLUDED_DIRS as existing checker
+def find_violations(search_path: Path) -> List[Tuple[Path, int, str]]: ...
+def scan_source_dirs(repo_root: Path) -> List[Tuple[Path, int, str]]: ...
+def main() -> int: ...  # exit 0 = clean, exit 1 = violations
+```
+
+Key detail: skip comment lines (`line.lstrip().startswith("#")`) before pattern matching,
+and report each line only once (break after first matching pattern).
+
+### Step 4 — Write tests
+
+Create `tests/scripts/test_check_runtime_output_patterns.py` with classes:
+
+| Test class | Coverage |
+|------------|----------|
+| `TestBannedPatterns` | Each banned pattern; case-insensitivity; clean print not flagged; comment line not flagged |
+| `TestIsCommentLine` | Hash prefix detection; code lines; empty/blank lines |
+| `TestIsExcluded` | Each excluded dir; valid source dirs |
+| `TestFindViolations` | Each pattern type; comment exclusion; multi-violation; subdirs; excluded dirs; non-.mojo files; dedup |
+| `TestScanSourceDirs` | Multi-dir aggregation; missing dirs |
+| `TestMainExitCodes` | Exit 0 / 1 for each pattern; comment not flagged; stdout/stderr content; nonexistent dir |
+
+Run with: `pixi run python -m pytest tests/scripts/test_check_runtime_output_patterns.py -v`
+
+### Step 5 — Wire CI enforcement
+
+In `.github/workflows/script-validation.yml`:
+
+1. Add `examples/**/*.mojo` (and other source dirs) to `paths:` triggers under both `pull_request`
+   and `push`.
+2. Add a new step after the existing "Check for common issues" step:
+
+```yaml
+- name: Check for misleading runtime output patterns
+  run: |
+    python scripts/check_runtime_output_patterns.py examples/ || {
+      echo "❌ Misleading runtime output patterns found"
+      echo "Remove WARNING:, HACK:, XXX:, or 'Not implemented' prefixes from print() calls."
+      exit 1
+    }
+    echo "✅ No misleading runtime output patterns found"
+```
+
+3. Add the new step to the Summary step's checklist.
+
+### Step 6 — Update `scripts/README.md`
+
+Add the new script entry in alphabetical order in the directory tree section:
+
+```text
+├── check_runtime_output_patterns.py    # Audit for misleading print() patterns (WARNING:, HACK:, XXX:, Not implemented)
+```
+
+### Step 7 — Verify and commit
+
+```bash
+# Verify script is clean on source dirs
+python scripts/check_runtime_output_patterns.py examples/
+
+# Run all tests
+pixi run python -m pytest tests/scripts/test_check_runtime_output_patterns.py -v
+
+# Commit
+git add .github/workflows/script-validation.yml \
+        examples/path/to/fixed.mojo \
+        scripts/check_runtime_output_patterns.py \
+        scripts/README.md \
+        tests/scripts/test_check_runtime_output_patterns.py
+
+git commit -m "feat(scripts): add runtime output pattern audit for examples/
+
+Completes the #NNNN/#MMMM audit series by covering additional misleading
+print() patterns: WARNING:, HACK:, XXX:, and 'Not implemented'.
+
+Closes #NNNN
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Matching `WARNING:` anywhere on the line (not just in print calls) | Initial regex `r'WARNING\s*:'` without requiring `print\(` prefix | Would flag comment lines like `# WARNING: this is fine` as violations | Scope pattern to `print\([^)]*WARNING\s*:` and add an explicit `is_comment_line` check |
+| Using a multiline regex to catch print() calls spanning lines | `re.compile(r'print\(.*WARNING.*\)', re.MULTILINE)` | Mojo print calls with banned prefixes are always single-line in practice; adds complexity for no gain | Keep patterns single-line — real-world violations are never multi-line print calls |
+| Reporting the same line multiple times when it matches multiple patterns | No dedup inside `find_violations` | A line like `print("WARNING: HACK: ...")` would appear twice | `break` after the first matching pattern; one violation entry per line |
+
+## Results & Parameters
+
+**Issue**: ProjectOdyssey #3704 (follow-up to #3084/#3194 audit series)
+
+**Violations found and fixed** (1 file):
+
+```text
+examples/lenet-emnist/run_train.mojo:302
+  Before: print("WARNING: Gradient overflow detected, skipping parameter update")
+  After:  print("Gradient overflow detected, skipping parameter update")
+```
+
+**Test count**: 44 unit tests, all passing in 0.39s.
+
+**Script exit-code contract**:
+
+- Exit 0 → no violations in scanned directory
+- Exit 1 → one or more violations (details to stdout, count to stderr)
+
+**Regex patterns (copy-paste ready)**:
+
+```python
+BANNED_PATTERNS = [
+    re.compile(r'print\([^)]*WARNING\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*HACK\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*XXX\s*:', re.IGNORECASE),
+    re.compile(r'print\([^)]*Not\s+implemented', re.IGNORECASE),
+]
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4776, issue #3704 | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the workflow for extending a Mojo comment-annotation audit series
(NOTE/TODO/FIXME) to also cover misleading runtime `print()` patterns:
`WARNING:`, `HACK:`, `XXX:`, and `Not implemented`.

- Regex must be scoped to `print\(` prefix to avoid false-positive matches on comment lines
- A secondary `is_comment_line()` guard handles edge cases
- Model new checker scripts on existing audit scripts for consistency
- Wire CI with `examples/**/*.mojo` path trigger so PR checks fire when Mojo source changes

## Key Findings

**What Worked**:

- Requiring `print\(` in the pattern eliminated all false positives
- Copying the `is_excluded` / `SOURCE_DIRS` / exit-code interface from `check_note_format.py`
  gave 44 passing tests with no design decisions needed
- Fixing violations before adding the CI step ensured the new step was green on day 1

**What Failed**:

- Plain `WARNING\s*:` regex without `print\(` prefix → flagged comment lines → added `is_comment_line`
- Multiline regex → unnecessary complexity for single-line print calls → kept patterns single-line
- No dedup in `find_violations` → multi-pattern lines reported twice → added `break` after first match

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with "runtime output", "WARNING:", "print audit" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
