### PR TITLE
feat: add batchnorm-backward-gradient-checking skill

### DIFF
--- a/skills/testing/batchnorm-backward-gradient-checking/.claude-plugin/plugin.json
+++ b/skills/testing/batchnorm-backward-gradient-checking/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "batchnorm-backward-gradient-checking",
+  "version": "1.0.0",
+  "description": "Implements gradient checking for BatchNorm backward pass in Mojo using finite differences and non-uniform grad_output to avoid pathological cancellation. Use when: (1) adding gradient checking to a normalization layer backward tester, (2) debugging BatchNorm backward pass correctness, (3) validating that analytical and numerical gradients agree for layers with zero-mean outputs.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/batchnorm-backward-gradient-checking/references/notes.md
+++ b/skills/testing/batchnorm-backward-gradient-checking/references/notes.md
@@ -1,0 +1,72 @@
+# Session Notes: BatchNorm Backward Gradient Checking
+
+## Date
+
+2026-03-15
+
+## Issue
+
+GitHub Issue [#3719](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3719):
+"Implement BatchNorm backward gradient checking"
+
+Follow-up from [#3208](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3208).
+
+## Objective
+
+Replace the stub in `test_batchnorm_layer_backward` (in
+`shared/testing/layer_testers.mojo`) with actual gradient checking. The stub
+only validated NaN/Inf in inputs. The task was to implement finite-difference
+gradient checking following the pattern of `test_conv_layer_backward`.
+
+## File Modified
+
+`shared/testing/layer_testers.mojo`
+
+## Key Design Decisions
+
+### Non-uniform grad_output
+
+BatchNorm normalizes its output to zero mean per channel. When
+`grad_output = ones_like(output)`, the analytical gradient formula computes
+`gamma * sum(x_norm) / N ≈ 0` (since `x_norm` is zero-mean). Meanwhile,
+numerical finite differences give ~0.009 because perturbing a single input
+element breaks the zero-mean property locally. This mismatch is a false failure
+caused by the symmetric upstream gradient.
+
+Fix: use a non-uniform `grad_output` with pattern `i%4 * 0.25 - 0.3`:
+`[-0.3, -0.05, 0.2, 0.45]` cycling. This ensures `sum(x_norm * grad_output) ≠ 0`.
+
+### Scalar Loss
+
+The `forward_for_grad` closure must return a scalar so that numerical and
+analytical gradients correspond to the same loss function:
+
+```
+loss = sum(output * grad_output)
+dloss/dinput = batch_norm2d_backward(grad_output, input, gamma, ...)
+```
+
+`compute_numerical_gradient` handles both scalar outputs (direct) and
+non-scalar outputs (sums all elements), but for BatchNorm we compute the
+scalar explicitly via `tensor_sum(out * grad_output)`.
+
+### Imports Added
+
+```mojo
+from shared.core.normalization import batch_norm2d, batch_norm2d_backward
+from shared.core.reduction import sum as tensor_sum
+```
+
+`tensor_sum` alias follows the pattern used in `activation.mojo`,
+`autograd/functional.mojo`, and others.
+
+## Constants Used
+
+- `GRADIENT_CHECK_EPSILON_FLOAT32 = 3e-4` — documented in issue #2704
+- `GRADIENT_CHECK_EPSILON_OTHER = 1e-3` — for other dtypes
+- `tolerance = 1e-1` — 10%, same as conv2d backward (issue #3090)
+
+## PR
+
+[#4780](https://github.com/HomericIntelligence/ProjectOdyssey/pull/4780)
+Branch: `3719-auto-impl`

--- a/skills/testing/batchnorm-backward-gradient-checking/skills/batchnorm-backward-gradient-checking/SKILL.md
+++ b/skills/testing/batchnorm-backward-gradient-checking/skills/batchnorm-backward-gradient-checking/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: batchnorm-backward-gradient-checking
+description: "Implements gradient checking for BatchNorm backward pass using finite differences with non-uniform grad_output to avoid pathological cancellation. Use when: adding gradient checking to normalization layer testers, validating batch norm backward correctness, or debugging zero-gradient false failures in gradient checks."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Language | Mojo |
+| Layer Type | Batch Normalization (2D) |
+| Pattern | Finite-difference gradient checking |
+| Key Insight | Non-uniform `grad_output` prevents zero-gradient false failures |
+
+Gradient checking for BatchNorm requires care because the normalized output
+`x_norm = (x - mean) / std` always sums to zero per channel. Using
+`grad_output = ones_like(output)` causes `sum(x_norm * ones) ≈ 0`, making the
+analytical gradient nearly zero while numerical finite differences give ~0.009,
+producing a spurious test failure.
+
+The fix: use a non-uniform `grad_output` pattern so the inner product
+`sum(x_norm * grad_output)` is nonzero, and define the loss as
+`sum(output * grad_output)` in both the numerical and analytical paths.
+
+## When to Use
+
+1. Implementing `test_<layer>_backward` for any normalization layer
+2. Gradient checking fails with "analytical ≈ 0 but numerical ≈ 0.009" errors
+3. Adding backward testing to a layer whose output has zero mean (LayerNorm, InstanceNorm, GroupNorm)
+4. Validating a newly implemented backward pass before shipping
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+# 1. Build non-uniform grad_output (cycling pattern avoids zero-sum)
+var grad_output = zeros_like(output)
+for i in range(grad_output.numel()):
+    grad_output._set_float64(i, Float64(i % 4) * Float64(0.25) - Float64(0.3))
+
+# 2. Forward closure uses sum(output * grad_output) as scalar loss
+fn forward_for_grad(x: ExTensor) raises escaping -> ExTensor:
+    var (out, _, _) = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=True
+    )
+    return tensor_sum(out * grad_output)
+
+# 3. Numerical gradient via finite differences
+var numerical_grad = compute_numerical_gradient(forward_for_grad, input, epsilon)
+
+# 4. Analytical gradient via backward pass (same grad_output)
+var (grad_input, _, _) = batch_norm2d_backward(
+    grad_output, input, gamma, running_mean, running_var, training=True
+)
+
+# 5. Compare
+assert_gradients_close(grad_input, numerical_grad, rtol=tolerance, atol=tolerance, ...)
+```
+
+### Full Implementation Steps
+
+1. **Add imports** to `layer_testers.mojo`:
+
+   ```mojo
+   from shared.core.normalization import batch_norm2d, batch_norm2d_backward
+   from shared.core.reduction import sum as tensor_sum
+   ```
+
+2. **Run forward pass** and verify output shape matches input shape:
+
+   ```mojo
+   var (output, _, _) = batch_norm2d(
+       input, gamma, beta, running_mean, running_var, training=True
+   )
+   assert_shape(output, input_shape, "BatchNorm backward: output shape mismatch")
+   ```
+
+3. **Set epsilon and tolerance** using documented constants:
+
+   ```mojo
+   var epsilon = (
+       GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32
+       else GRADIENT_CHECK_EPSILON_OTHER
+   )
+   var tolerance = 1e-1  # 10% — same as conv2d backward
+   ```
+
+4. **Build non-uniform grad_output** to break the zero-sum symmetry:
+
+   ```mojo
+   var grad_output = zeros_like(output)
+   for i in range(grad_output.numel()):
+       grad_output._set_float64(i, Float64(i % 4) * Float64(0.25) - Float64(0.3))
+   # Pattern: [-0.3, -0.05, 0.2, 0.45] cycling — nonzero mean and varied signs
+   ```
+
+5. **Define forward closure** computing scalar loss `sum(output * grad_output)`:
+
+   ```mojo
+   fn forward_for_grad(x: ExTensor) raises escaping -> ExTensor:
+       var (out, _, _) = batch_norm2d(
+           x, gamma, beta, running_mean, running_var, training=True
+       )
+       return tensor_sum(out * grad_output)
+   ```
+
+6. **Run exhaustive numerical gradient check**:
+
+   ```mojo
+   var numerical_grad = compute_numerical_gradient(forward_for_grad, input, epsilon)
+   assert_shape(numerical_grad, input_shape, "...")
+   # NaN/Inf check on numerical_grad
+   ```
+
+7. **Compute analytical gradient** and compare:
+
+   ```mojo
+   var (grad_input, _, _) = batch_norm2d_backward(
+       grad_output, input, gamma, running_mean, running_var, training=True
+   )
+   assert_gradients_close(grad_input, numerical_grad, rtol=tolerance, atol=tolerance, ...)
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `ones_like(output)` as grad_output | Used `var grad_output = ones_like(output)` identical to conv2d pattern | BatchNorm normalizes so `sum(x_norm) ≈ 0` per channel; `dot(ones, x_norm) ≈ 0`; analytical grad ≈ 0 but numerical gives ~0.009 | Any layer with zero-mean output requires non-uniform grad_output |
+| Reusing conv2d forward closure directly | `fn forward(x): return batch_norm2d(x, ...)` returning full tensor | `compute_numerical_gradient` sums all output elements when output is non-scalar, which is equivalent to `ones` upstream — same cancellation problem | The closure must compute the scalar loss explicitly |
+| `tolerance=1e-2` (1%) | Tried tighter tolerance matching linear layer | BatchNorm accumulates normalization errors across N×H×W elements; 6-7% errors are common in practice (same finding as conv2d, issue #3090) | Always use 10% tolerance for normalization layers |
+| Skipping non-uniform pattern for small inputs | Assumed small tensors (shape [2,4,4,4]) would avoid cancellation | Even small inputs have the zero-sum property since it's structural, not statistical | The cancellation is inherent to batch norm math, not input size |
+
+## Results & Parameters
+
+### Verified Constants
+
+```mojo
+# Epsilon (finite difference step size)
+GRADIENT_CHECK_EPSILON_FLOAT32 = 3e-4   # float32 (see issue #2704)
+GRADIENT_CHECK_EPSILON_OTHER    = 1e-3   # other dtypes
+
+# Tolerance for gradient agreement
+tolerance = 1e-1  # 10% for all dtypes (same as conv2d backward, issue #3090)
+```
+
+### grad_output Cycling Pattern
+
+```
+i % 4 == 0: -0.3
+i % 4 == 1: -0.05
+i % 4 == 2:  0.2
+i % 4 == 3:  0.45
+```
+
+Mean ≈ 0.075, nonzero — sufficient to break symmetry.
+
+### PR Reference
+
+- PR: [#4780](https://github.com/HomericIntelligence/ProjectOdyssey/pull/4780)
+- Issue: [#3719](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3719)
+- Follow-up from: [#3208](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3208)


### PR DESCRIPTION
## Summary

Documents the non-uniform `grad_output` pattern required for correct gradient
checking in normalization layers (BatchNorm, LayerNorm, etc.) whose outputs
have zero mean per channel.

- Core insight: `ones_like(output)` as upstream gradient causes false failures
- Solution: cycling pattern `i%4*0.25-0.3` breaks zero-sum symmetry
- Loss function: `sum(output * grad_output)` must be used consistently in both numerical and analytical paths

## Key Findings

**What Worked**:
- Non-uniform `grad_output` with pattern `[-0.3, -0.05, 0.2, 0.45]` cycling
- Scalar loss `tensor_sum(out * grad_output)` in forward closure for numerical gradient
- `epsilon=3e-4` (float32), `1e-3` (other), `tolerance=10%` — matches conv2d backward

**What Failed**:
- `ones_like(output)` → analytical grad≈0, numerical grad≈0.009 (false failure due to zero-mean normalization)
- Returning full tensor from forward closure without explicit dot product → same cancellation as ones_like
- `tolerance=1e-2` → too tight; normalization accumulates N×H×W rounding errors

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with triggers: "gradient checking", "batchnorm backward", "zero-mean layer"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
