### PR TITLE
feat: add hook-grep-chain-unit-tests skill

### DIFF
--- a/skills/testing/hook-grep-chain-unit-tests/.claude-plugin/plugin.json
+++ b/skills/testing/hook-grep-chain-unit-tests/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "hook-grep-chain-unit-tests",
+  "version": "1.0.0",
+  "description": "Write pure-Python pytest tests that replicate a pre-commit hook's bash grep chain as a Python predicate. Use when: (1) a pre-commit hook uses a grep pipe with exclusion patterns and has no unit tests, (2) you need regression coverage for hook logic without invoking pre-commit, (3) you want to document known hook limitations (e.g. string literal false positives).",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/hook-grep-chain-unit-tests/references/notes.md
+++ b/skills/testing/hook-grep-chain-unit-tests/references/notes.md
@@ -1,0 +1,95 @@
+# Session Notes: hook-grep-chain-unit-tests
+
+## Context
+
+- **Project**: ProjectOdyssey
+- **Issue**: #3734 — Add unit tests for `no-matmul-call-sites` hook pattern
+- **PR**: #4783
+- **Branch**: `3734-auto-impl`
+- **Date**: 2026-03-15
+
+## Objective
+
+Add pytest regression tests for the `no-matmul-call-sites` pre-commit hook. The hook uses a
+bash grep chain to ban `.__matmul__()` call sites in Mojo files. It had no unit tests, creating
+a risk that the exclusion patterns could silently break without detection.
+
+The issue asked to follow the pattern of `check-list-constructor` tests (which don't exist in
+the codebase yet — the instruction pointed to `tests/` as the location and to the `test_audit_shared_links.py`
+style as reference).
+
+## Exact Hook Entry (from `.pre-commit-config.yaml`)
+
+```bash
+bash -c 'violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --include="*.🔥" \
+  --exclude-dir=".pixi" --exclude-dir=".git" \
+  | grep -v "fn __matmul__(" \
+  | grep -v "# __matmul__" \
+  | grep -v "__matmul__.*deprecated"); \
+  if [ -n "$violations" ]; then echo "Found .__matmul__() call sites (use matmul(A, B) instead):"; \
+  echo "$violations"; exit 1; fi'
+```
+
+## Implementation Details
+
+### File created
+
+`tests/test_no_matmul_call_sites.py` — 138 lines
+
+### Predicate function
+
+```python
+def is_violation(line: str) -> bool:
+    if not re.search(r"\.__matmul__\(", line):
+        return False
+    if re.search(r"fn __matmul__\(", line):
+        return False
+    if re.search(r"#\s*__matmul__", line):
+        return False
+    if re.search(r"__matmul__.*deprecated", line):
+        return False
+    return True
+```
+
+### Test breakdown
+
+- `TestPositiveCases`: 4 parametrized call site patterns → all `is_violation() == True`
+- `TestNegativeCases`: 5 tests (fn def, comment, indented comment, 2x deprecated comment)
+- `TestEdgeCases`: 4 tests (string literal, single-line fn+body, no-dot call, no-call at all)
+
+### Total: 13 tests, 0.02s
+
+## Issues Encountered
+
+### SyntaxWarning from backslash in docstring
+
+Initial module docstring contained:
+
+```python
+"""
+  grep -rn "\.__matmul__(" . ... |
+"""
+```
+
+Python 3.14 (test runner) emitted:
+`SyntaxWarning: "\." is an invalid escape sequence. Did you mean "\\."?`
+
+**Fix**: Changed docstring to use single quotes for the bash pattern and a RST
+`.. code-block:: bash` block, eliminating the escape sequence issue entirely.
+
+### Edge case framing
+
+The string literal case (`'var msg = ".__matmul__( is a call site"'`) initially seemed like
+it should be a negative (not caught). But bash grep has no AST awareness — `.__matmul__(` in
+a string literal WILL be caught. The test asserts `is_violation() == True` and documents this
+as a known limitation.
+
+## Key Learnings
+
+1. **Pure `re` predicate > subprocess**: Running 13 tests in 0.02s vs. ~2s for subprocess
+2. **Docstring escape sequences**: Python 3.12+ warns on `"\."` in non-raw strings; use single
+   quotes in docstrings when showing bash grep patterns
+3. **Edge case framing matters**: Document hook limitations as "known false positives" in tests
+   rather than treating them as negative cases — this reflects actual hook behavior
+4. **`#\s*__matmul__`**: The comment exclusion pattern should use `\s*` not a literal space, to
+   catch both `# __matmul__` and `#__matmul__` (indented or not)

--- a/skills/testing/hook-grep-chain-unit-tests/skills/hook-grep-chain-unit-tests/SKILL.md
+++ b/skills/testing/hook-grep-chain-unit-tests/skills/hook-grep-chain-unit-tests/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: hook-grep-chain-unit-tests
+description: "Write pure-Python pytest tests that replicate a pre-commit hook's bash grep chain as a Python predicate. Use when: a pre-commit hook uses grep with exclusion patterns and has no unit tests, you need fast regression coverage without invoking pre-commit, or you want to document known hook limitations."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Skill** | hook-grep-chain-unit-tests |
+| **Category** | testing |
+| **Language** | Python / pytest |
+| **Primary file** | `.pre-commit-config.yaml` |
+| **Test target** | Hook grep chain logic (replicated as Python `re` predicate) |
+
+A pre-commit hook that uses a bash grep pipe (`grep pattern | grep -v exclusion1 | grep -v exclusion2`)
+can be regression-tested directly as a Python predicate — no subprocess, no pre-commit invocation,
+no binary required. The predicate runs in milliseconds and makes positive/negative/edge cases explicit.
+
+## When to Use
+
+- A pre-commit hook bans a code pattern via `grep pattern | grep -v ...` and has no unit tests
+- You need to add tests for: positive cases (caught), negative cases (excluded), and edge cases
+- The issue asks you to follow the pattern of an existing similar test file
+- You want to document known hook limitations (e.g. grep cannot distinguish string literals)
+
+## Verified Workflow
+
+### Quick Reference
+
+| Step | Action |
+|------|--------|
+| 1 | Read exact hook `entry:` from `.pre-commit-config.yaml` |
+| 2 | Translate each grep step to a Python `re.search()` call |
+| 3 | Compose into an `is_violation(line: str) -> bool` predicate |
+| 4 | Write `TestPositiveCases`, `TestNegativeCases`, `TestEdgeCases` |
+| 5 | Use `@pytest.mark.parametrize` for multiple similar inputs |
+| 6 | Run and verify — no warnings, no failures |
+
+### Step 1 — Extract the exact hook entry
+
+```bash
+grep -A5 "id: <hook-id>" .pre-commit-config.yaml
+```
+
+For a hook like:
+
+```bash
+grep -rn "\.__matmul__(" . --include="*.mojo" |
+  grep -v "fn __matmul__(" |
+  grep -v "# __matmul__" |
+  grep -v "__matmul__.*deprecated"
+```
+
+### Step 2 — Map grep steps to Python re
+
+| Bash grep step | Python equivalent |
+|----------------|-------------------|
+| `grep 'PATTERN'` | `re.search(r'PATTERN', line)` |
+| `grep -v 'EXCL'` | `not re.search(r'EXCL', line)` |
+
+Translate ALL exclusion steps. A line is a violation when the positive match holds
+AND all exclusions are absent.
+
+### Step 3 — Write the predicate
+
+```python
+import re
+
+
+def is_violation(line: str) -> bool:
+    """Return True if *line* would be flagged by the <hook-name> hook.
+
+    Replicates the bash grep chain::
+
+        grep 'PATTERN'
+        grep -v 'EXCL1'
+        grep -v 'EXCL2'
+    """
+    if not re.search(r'PATTERN', line):
+        return False
+    if re.search(r'EXCL1', line):
+        return False
+    if re.search(r'EXCL2', line):
+        return False
+    return True
+```
+
+### Step 4 — Write test classes
+
+```python
+class TestPositiveCases:
+    @pytest.mark.parametrize("line", [
+        "    result = a.__matmul__(b)",
+        "    c = self.__matmul__(other)",
+    ])
+    def test_call_site_is_violation(self, line: str) -> None:
+        """Direct call sites must be flagged."""
+        assert is_violation(line), f"Expected violation for: {line!r}"
+
+
+class TestNegativeCases:
+    def test_function_definition_excluded(self) -> None:
+        """Method definition is not a call site."""
+        assert not is_violation("fn __matmul__(self, rhs: Self) -> Self:")
+
+    def test_comment_line_excluded(self) -> None:
+        assert not is_violation("# __matmul__ is deprecated")
+
+
+class TestEdgeCases:
+    def test_string_literal_is_caught(self) -> None:
+        """Grep has no AST awareness — string contents are flagged.
+        This test documents the known limitation rather than ideal behaviour."""
+        line = 'var msg = ".__matmul__( is a call site"'
+        assert is_violation(line)  # false positive — documented limitation
+```
+
+### Step 5 — Run and verify
+
+```bash
+pixi run python -m pytest tests/test_<hook_name>.py -v
+# 13 passed in 0.02s — no warnings
+```
+
+### Step 6 — Ensure docstrings use single quotes or raw strings for bash patterns
+
+Python 3.12+ emits `SyntaxWarning` for unrecognised escape sequences in regular string literals
+(e.g. `"\."` in a docstring). Use single quotes or raw strings in module/function docstrings
+when quoting bash grep patterns to avoid these warnings:
+
+```python
+# ✅ Safe — no escape sequence warning
+"""
+    grep '.__matmul__('
+"""
+
+# ❌ Triggers SyntaxWarning in Python 3.12+
+"""
+    grep "\.__matmul__("
+"""
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Backslash escape in docstring | Used `"\.__matmul__("` in module docstring to show the bash grep command | Python 3.12+ `SyntaxWarning: "\." is an invalid escape sequence` (docstrings are regular strings) | Use single quotes `'.\__matmul__('` or a `.. code-block:: bash` RST block in docstrings; backslashes in re patterns belong in raw strings `r"..."`, not docstrings |
+| Treating string literal edge case as a negative | Initially expected `".__matmul__("` inside a string to NOT be a violation | Bash grep has no AST awareness — the pattern fires regardless of syntactic context | The test should assert `is_violation(...) == True` and add a comment documenting the known false-positive limitation |
+
+## Results & Parameters
+
+### Final test structure (13 tests, 0.02s)
+
+```text
+TestPositiveCases  (4 tests) — call sites caught via @pytest.mark.parametrize
+TestNegativeCases  (5 tests) — fn definitions, comment lines, deprecated variants excluded
+TestEdgeCases      (4 tests) — string literal false-positive, single-line fn+body, no-dot, no-call
+```
+
+### Key imports (minimal)
+
+```python
+import re
+import pytest
+```
+
+No `subprocess`, no `yaml`, no `pathlib` — pure logic tests.
+
+### Predicate template
+
+```python
+def is_violation(line: str) -> bool:
+    """Return True if *line* would be flagged by the <hook-id> hook.
+
+    Replicates the bash grep chain::
+
+        grep 'POSITIVE_PATTERN'
+        grep -v 'EXCL1'
+        grep -v 'EXCL2'
+        grep -v 'EXCL3'
+    """
+    if not re.search(r'POSITIVE_PATTERN', line):
+        return False
+    if re.search(r'EXCL1', line):
+        return False
+    if re.search(r'EXCL2', line):
+        return False
+    if re.search(r'EXCL3', line):
+        return False
+    return True
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4783 — `no-matmul-call-sites` hook | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents how to write pure-Python pytest tests that replicate a pre-commit hook's bash grep chain
as an `is_violation()` predicate — no subprocess, no pre-commit invocation needed.

- Covers positive cases (caught), negative cases (excluded), and edge cases (documented limitations)
- Tests run in ~0.02s with zero external dependencies
- Captures the SyntaxWarning gotcha for backslash escapes in docstrings (Python 3.12+)

## Key Findings

**What Worked**:
- Translating each `grep` / `grep -v` step into a `re.search()` call
- Using `@pytest.mark.parametrize` for multiple similar positive/negative inputs
- Asserting that string-literal false positives ARE violations (documents known hook limitation)

**What Failed**:
- Using `"\.__matmul__("` in a module docstring → `SyntaxWarning: "\." is an invalid escape sequence` on Python 3.12+. Fix: use single quotes in docstrings for bash patterns.
- Treating string literal edge case as a negative test → grep has no AST awareness; the hook fires regardless of syntactic context.

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation when user asks about testing pre-commit hook grep patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
