### PR TITLE
feat: update mojo-package-level-reexports skill with AdaGrad/RMSprop learnings

### DIFF
--- a/skills/architecture/mojo-package-level-reexports/references/notes.md
+++ b/skills/architecture/mojo-package-level-reexports/references/notes.md
@@ -77,3 +77,26 @@ shared/autograd/optimizers.mojo | 295 ++++++++++++++++++++++++++++++++++++++++
 tests/shared/test_imports.mojo  |   8 ++
 3 files changed, 304 insertions(+), 1 deletion(-)
 ```
+
+---
+
+## Session 2: Issue #3745 — AdaGrad and RMSprop (2026-03-15)
+
+**Issue**: HomericIntelligence/ProjectOdyssey#3745
+**PR**: HomericIntelligence/ProjectOdyssey#4785
+
+### Key Discovery
+
+`shared/__init__.mojo` line 66 had `# from .training.optimizers import SGD, Adam, AdamW` (commented).
+This was NEVER the active import. The real active import was added in PR #3738:
+`from shared.autograd.optimizers import SGD, Adam, AdamW`.
+
+The issue description said "extend the existing re-export line" — but there was no single
+"existing line" visible in the comment; required auditing `grep -n "^from" shared/__init__.mojo`
+to find the active one.
+
+### Changes Made
+
+- Extended line 85: `from shared.autograd.optimizers import SGD, Adam, AdamW, AdaGrad, RMSprop`
+- Added `tests/shared/autograd/test_top_level_optimizer_imports.mojo` (5 test functions)
+- Updated `tests/shared/test_imports.mojo::test_shared_optimizer_imports` to use `from shared import`

--- a/skills/architecture/mojo-package-level-reexports/skills/mojo-package-level-reexports/SKILL.md
+++ b/skills/architecture/mojo-package-level-reexports/skills/mojo-package-level-reexports/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mojo-package-level-reexports
-description: "Add convenience top-level re-exports to a Mojo package __init__.mojo. Use when: enabling `from shared import SGD` style imports, activating commented-out import lines after implementation is ready, or adding a new optimizer struct that mirrors an existing one with decoupled behavior."
+description: "Add convenience top-level re-exports to a Mojo package __init__.mojo. Use when: enabling `from shared import X` style imports, activating commented-out import lines after implementation is ready, adding optimizer structs (AdaGrad/RMSprop/AdamW), or extending an existing re-export group with new symbols."
 category: architecture
 date: 2026-03-07
 user-invocable: false
@@ -10,131 +10,146 @@ user-invocable: false
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-07 |
-| **Objective** | Enable `from shared import SGD, Adam, AdamW`; implement AdamW with decoupled weight decay |
-| **Outcome** | Activated re-export line in `shared/__init__.mojo`, added AdamW struct (295 lines), added import test; PR #3738 created |
-| **PRs** | [#3738](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3738) |
+| **Date** | 2026-03-07 (updated 2026-03-15) |
+| **Objective** | Enable `from shared import SGD, Adam, AdamW, AdaGrad, RMSprop` at top-level package |
+| **Outcome** | Activated/extended re-export line in `shared/__init__.mojo`; all 5 optimizers exposed |
+| **PRs** | [#3738](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3738) (SGD/Adam/AdamW), [#4785](https://github.com/HomericIntelligence/ProjectOdyssey/pull/4785) (AdaGrad/RMSprop) |
 
 ## Overview
 
-ProjectOdyssey's `shared/__init__.mojo` had commented-out re-export lines for optimizers. The issue
-asked to: (1) uncomment/activate re-exports for SGD and Adam, (2) implement AdamW (Issue #49
-follow-up), and (3) add AdamW to the re-exports. The pattern is straightforward but requires
-care about which module path to import from (`shared.autograd.optimizers` vs
-`shared.training.optimizers`).
+ProjectOdyssey's `shared/__init__.mojo` had commented-out re-export lines for optimizers. Two
+sequential issues activated and extended these:
+
+- **Issue #3219 / PR #3738**: Activate re-exports for SGD, Adam; implement and add AdamW
+- **Issue #3745 / PR #4785**: Add AdaGrad and RMSprop to the same re-export line
+
+The pattern is straightforward but requires care: (1) identify the canonical defining module,
+(2) use an absolute import path, (3) add all symbols from a group in one line, (4) verify
+commented-out blocks don't point to the wrong submodule.
 
 ## When to Use
 
 1. A Mojo package has commented-out re-export lines waiting for implementation to be ready
-2. You need to add a new optimizer struct that is an Adam variant (decouple weight decay from gradient)
-3. You want `from <package> import <Symbol>` to work at the top level, sourcing from a submodule
-4. You need to trace where a symbol actually lives before exposing it at the package level
+2. You need to add a new optimizer struct (AdamW, AdaGrad, RMSprop) to the top-level API
+3. You want `from shared import X` to work at the top level, sourcing from a submodule
+4. A follow-up issue asks to extend an existing optimizer re-export with additional symbols
+5. You need to trace where a symbol actually lives before exposing it at the package level
 
 ## Verified Workflow
+
+### Quick Reference
+
+| Step | Action | Command |
+|------|--------|---------|
+| 1 | Find defining module | `grep -rn "^struct AdaGrad" shared/` |
+| 2 | Check intermediate `__init__` | `grep -n "AdaGrad" shared/autograd/__init__.mojo` |
+| 3 | Audit active imports in top-level | `grep -n "^from" shared/__init__.mojo` |
+| 4 | Check commented blocks point to right module | `grep -n "# from" shared/__init__.mojo` |
+| 5 | Add/extend active import | Edit `shared/__init__.mojo` |
+| 6 | Update API table comment | Update `# Public API Table` block |
+| 7 | Write test | `tests/shared/autograd/test_top_level_optimizer_imports.mojo` |
+| 8 | Verify with grep | `grep -n "AdaGrad\|RMSprop" shared/__init__.mojo` |
 
 ### Phase 1: Find where symbols are actually defined
 
 Before activating any re-export, confirm the canonical definition location:
 
 ```bash
-grep -rn "struct SGD\|struct Adam\b\|struct AdamW" shared/
+grep -rn "^struct SGD\|^struct Adam\b\|^struct AdaGrad\|^struct RMSprop" shared/
 ```
 
-In this session:
-- `SGD` and `Adam` are in `shared/autograd/optimizers.mojo`
-- `shared/training/__init__.mojo` re-exports `SGD` from `shared.training.optimizers.sgd`
-- Use the autograd path for the shared package re-export to avoid ambiguity
+In this project:
+- All 5 optimizers (`SGD`, `Adam`, `AdamW`, `AdaGrad`, `RMSprop`) live in `shared/autograd/optimizers.mojo`
+- `shared/autograd/__init__.mojo` already re-exports them (line 143)
+- `shared/training/__init__.mojo` re-exports only `SGD` from a different path
 
-### Phase 2: Activate the re-export in `shared/__init__.mojo`
+### Phase 2: Audit `shared/__init__.mojo` BEFORE making changes
 
-Find the commented line and uncomment it, pointing at the correct module:
+```bash
+grep -n "^from" shared/__init__.mojo    # active imports
+grep -n "# from" shared/__init__.mojo   # commented-out (may be stale/wrong)
+```
+
+**Critical lesson (Issue #3745)**: The commented-out block:
 
 ```mojo
-# Before (commented out):
 # from .training.optimizers import SGD, Adam, AdamW
-
-# After (activated, using actual source path):
-from shared.autograd.optimizers import SGD, Adam, AdamW
 ```
 
-Key: Use the absolute module path (`shared.autograd.optimizers`), not relative (`.training.optimizers`),
-because the symbol lives in autograd, not training.
+looks like the prior re-export. But it points to `training.optimizers`, NOT to
+`shared.autograd.optimizers` where the symbols actually live. Do not extend this block.
 
-### Phase 3: Implement AdamW by mirroring Adam
+**Always check which submodule actually defines the symbol** before extending a commented block.
+
+### Phase 3: Add or extend the active import
+
+If no active optimizer import exists (Issue #3745 case), add one:
+
+```mojo
+# Training optimizers - available at top-level shared package
+from shared.autograd.optimizers import SGD, Adam, AdamW, AdaGrad, RMSprop
+```
+
+If an active import already exists (prior PR had activated it), extend it to add missing symbols:
+
+```mojo
+# Before:
+from shared.autograd.optimizers import SGD, Adam, AdamW
+# After:
+from shared.autograd.optimizers import SGD, Adam, AdamW, AdaGrad, RMSprop
+```
+
+**Key rules**:
+
+- Use the **absolute module path** (`shared.autograd.optimizers`), not relative (`.autograd.optimizers`)
+- Import ALL symbols from the group in a single line for consistency
+- Do NOT import from the intermediate `__init__.mojo` (`from shared.autograd import AdaGrad`) —
+  this triggers the Mojo v0.26.1 re-export chain limitation
+
+### Phase 4: Update the Public API table comment
+
+Find the `# Public API Table` block in `shared/__init__.mojo` and add a row:
+
+```mojo
+# │ SGD, Adam, AdamW, AdaGrad,      │ shared.autograd.optimizers             │
+# │   RMSprop                       │                                        │
+```
+
+Also update the prose comment:
+
+```mojo
+# Training - Optimizers: SGD, Adam, AdamW, AdaGrad, RMSprop (via autograd)
+```
+
+### Phase 5: Add import test
+
+Create `tests/shared/autograd/test_top_level_optimizer_imports.mojo`
+(or update `tests/shared/test_imports.mojo`):
+
+```mojo
+# ADR-009: ≤10 fn test_ functions per file (heap corruption workaround)
+from shared import AdaGrad, RMSprop, SGD, Adam, AdamW
+
+fn test_adagrad_top_level_import() raises:
+    var opt = AdaGrad(learning_rate=0.01)
+    assert_almost_equal(opt.get_lr(), 0.01, tolerance=1e-10)
+    print("✓ AdaGrad top-level import test passed")
+
+fn test_rmsprop_top_level_import() raises:
+    var opt = RMSprop(learning_rate=0.001)
+    assert_almost_equal(opt.get_lr(), 0.001, tolerance=1e-10)
+    print("✓ RMSprop top-level import test passed")
+```
+
+Pattern: Import at module top-level then instantiate and call `get_lr()` to prove the import
+is functional, not just parseable at compile time.
+
+### Phase 6: Implement AdamW (if needed) by mirroring Adam
 
 AdamW is Adam with **decoupled** weight decay. The only algorithmic difference:
 
 - Adam: adds `weight_decay * param` to the gradient before the adaptive update
 - AdamW: applies `learning_rate * weight_decay * param` directly to the parameter after the Adam update
-
-Copy the Adam struct, rename to AdamW, change `weight_decay` default from `0.0` to `0.01`, and replace
-the update kernel:
-
-```mojo
-# Adam (L2 regularization folded into gradient):
-var weight_decay_update = multiply_scalar(parameters[i].data, self.learning_rate * self.weight_decay)
-param_update = scaled_grad + weight_decay_update  # adds to gradient update
-
-# AdamW (decoupled - applied directly to parameter):
-var decay_val = self.learning_rate * self.weight_decay * param_val
-new_data._set_float64(j, param_val - update_val - decay_val)  # subtract from param directly
-```
-
-### Phase 4: Add import test
-
-Add a dedicated test function for the new top-level imports:
-
-```mojo
-fn test_shared_optimizer_imports() raises:
-    """Test that SGD, Adam, AdamW are importable directly from shared package."""
-    from shared import SGD, Adam, AdamW
-
-    print("✓ Shared optimizer imports test passed")
-```
-
-Wire it into `main()` after `test_training_optimizers_imports()`.
-
-### Phase 5: Run pre-commit before committing
-
-```bash
-git add <files>
-pixi run pre-commit run --files <files>
-```
-
-Mojo's pre-commit hook auto-formats. If it reformats files, they'll be unstaged — re-add and commit.
-
-## Failed Attempts
-
-| Attempt | What Was Tried | Why It Failed | Lesson Learned |
-|---------|----------------|---------------|----------------|
-| Running `mojo test` locally | Tried `pixi run mojo test tests/shared/test_imports.mojo` | GLIBC version mismatch on host (requires 2.32+, host has 2.31) | Local mojo execution not available on this host; CI is the test oracle |
-| Running tests via Docker | `docker run ghcr.io/homericintelligence/projectodyssey:main ...` | Docker image not locally available (denied, not cached) | CI must run tests; verify by reviewing code structure and running pre-commit |
-| Using relative import in `__init__.mojo` | Considered `from .autograd.optimizers import ...` | Relative imports from `shared/__init__.mojo` in Mojo use absolute-style paths | Use `from shared.autograd.optimizers import ...` (absolute module path) |
-
-## Results & Parameters
-
-**Files modified**:
-
-| File | Change |
-|------|--------|
-| `shared/autograd/optimizers.mojo` | +295 lines: AdamW struct with decoupled weight decay |
-| `shared/__init__.mojo` | Activated re-export: `from shared.autograd.optimizers import SGD, Adam, AdamW` |
-| `tests/shared/test_imports.mojo` | +8 lines: `test_shared_optimizer_imports()` + wired to `main()` |
-
-**AdamW default parameters**:
-
-```mojo
-fn __init__(
-    out self,
-    learning_rate: Float64 = 0.001,
-    beta1: Float64 = 0.9,
-    beta2: Float64 = 0.999,
-    epsilon: Float64 = 1e-8,
-    weight_decay: Float64 = 0.01,   # Note: 0.01 default, not 0.0 like Adam
-):
-```
-
-**Key algorithmic distinction** (decoupled weight decay):
 
 ```mojo
 # Per-element update in AdamW.step():
@@ -144,8 +159,64 @@ var decay_val = self.learning_rate * self.weight_decay * param_val
 new_data._set_float64(j, param_val - update_val - decay_val)
 ```
 
+## Mojo v0.26.1 Re-Export Chain Limitation
+
+This is the critical constraint driving this entire pattern:
+
+```
+shared/autograd/optimizers.mojo    → defines AdaGrad
+shared/autograd/__init__.mojo      → imports AdaGrad from optimizers  ✓
+shared/__init__.mojo               → does NOT import AdaGrad           ✗
+```
+
+Result: `from shared import AdaGrad` **fails** even though `from shared.autograd import AdaGrad` works.
+
+**Fix**: `shared/__init__.mojo` must import directly from the defining module:
+
+```mojo
+from shared.autograd.optimizers import AdaGrad  # ✓ works
+# NOT: from shared.autograd import AdaGrad       # ✗ re-export chain fails
+```
+
+This limitation is documented in `shared/__init__.mojo` under "Re-export Chain Limitation (#3754)".
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running `mojo test` locally | Tried `pixi run mojo test tests/shared/test_imports.mojo` | GLIBC version mismatch on host (requires 2.32+, host has 2.31) | Local mojo execution not available on this host; CI is the test oracle |
+| Running tests via Docker | `docker run ghcr.io/homericintelligence/projectodyssey:main ...` | Docker image not locally available (denied, not cached) | CI must run tests; verify by reviewing code structure and running pre-commit |
+| Using relative import in `__init__.mojo` | Considered `from .autograd.optimizers import ...` | Relative imports from `shared/__init__.mojo` in Mojo use absolute-style paths | Use `from shared.autograd.optimizers import ...` (absolute module path) |
+| Importing via intermediate `__init__.mojo` | `from shared.autograd import AdaGrad` in `shared/__init__.mojo` | Triggers re-export chain limitation — Mojo v0.26.1 cannot chain re-exports through multiple `__init__.mojo` layers | Always import from the canonical defining module (`shared.autograd.optimizers`), not via an intermediate package |
+| Extending the commented-out training import | Adding AdaGrad to `# from .training.optimizers import SGD, Adam, AdamW` | This references `training.optimizers` (wrong module for AdaGrad/RMSprop); also uses relative path syntax | Check which submodule actually defines the symbol with `grep -rn "^struct AdaGrad" shared/`; commented blocks may point to stale/wrong modules |
+| Assuming commented-out block was the prior active import | Treating `# from .training.optimizers import SGD, Adam, AdamW` as the source of SGD/Adam/AdamW | That line was never active; the actual active import was `from shared.autograd.optimizers import SGD, Adam, AdamW` added in PR #3738 | Always audit with `grep -n "^from" shared/__init__.mojo` to find ACTIVE imports; commented lines are aspirational/stale |
+
+## Results & Parameters
+
+### Files Modified
+
+| Session | File | Change |
+|---------|------|--------|
+| PR #3738 | `shared/autograd/optimizers.mojo` | +295 lines: AdamW struct |
+| PR #3738 | `shared/__init__.mojo` | Activated: `from shared.autograd.optimizers import SGD, Adam, AdamW` |
+| PR #3738 | `tests/shared/test_imports.mojo` | +8 lines: `test_shared_optimizer_imports()` |
+| PR #4785 | `shared/__init__.mojo` | Extended: added `AdaGrad, RMSprop` to re-export line |
+| PR #4785 | `tests/shared/autograd/test_top_level_optimizer_imports.mojo` | New: 5 test functions for all 5 optimizers |
+| PR #4785 | `tests/shared/test_imports.mojo` | Updated to import from `shared` directly |
+
+### Key Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Mojo version | 0.26.1 (pinned in pixi.toml) |
+| Import path | `shared.autograd.optimizers` (absolute, direct to defining module) |
+| Test assertion | `assert_almost_equal(opt.get_lr(), expected, tolerance=1e-10)` |
+| Test functions per file | ≤10 (ADR-009 heap corruption workaround) |
+| AdamW weight_decay default | `0.01` (not `0.0` like Adam) |
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3219, PR #3738 | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3219, PR #3738 — SGD/Adam/AdamW | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #3745, PR #4785 — AdaGrad/RMSprop | [notes.md](../../references/notes.md) |


### PR DESCRIPTION
## Summary

Updates the `mojo-package-level-reexports` skill with learnings from Issue #3745 / PR #4785
(exposing `AdaGrad` and `RMSprop` as top-level shared imports).

- Extended Failed Attempts table with 3 new entries from this session
- Added session 2 notes to references/notes.md
- Updated SKILL.md with the critical "audit commented blocks for wrong module" warning
- Added Quick Reference table to Verified Workflow

## Key Findings

**What Worked**:

- Importing directly from `shared.autograd.optimizers` (the canonical defining module)
- Adding all 5 optimizers in one `from shared.autograd.optimizers import SGD, Adam, AdamW, AdaGrad, RMSprop` line
- Writing test functions that instantiate optimizers and call `get_lr()` to prove functional import

**What Failed**:

- Importing via intermediate `__init__.mojo` (`from shared.autograd import AdaGrad`) → re-export chain limitation
- Extending commented-out block `# from .training.optimizers import ...` → wrong module for AdaGrad/RMSprop
- Assuming the commented-out training import was the prior active re-export → it was never activated

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 699 plugins, 0 failures
- [x] Plugin PASS confirmed for `mojo-package-level-reexports`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
