### PR TITLE
feat: add mojo-init-export-uncomment skill

### DIFF
--- a/skills/tooling/mojo-init-export-uncomment/.claude-plugin/plugin.json
+++ b/skills/tooling/mojo-init-export-uncomment/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-init-export-uncomment",
+  "version": "1.0.0",
+  "description": "Activate commented-out exports in a Mojo __init__.mojo by verifying leaf-module implementations exist and using absolute paths + comptime aliases to work around the Mojo v0.26.1 re-export chain limitation. Use when: (1) __init__.mojo has commented-out imports pending implementation, (2) layer/module structs have been implemented and need to be exposed at package level, (3) API name mismatches need bridging with comptime aliases.",
+  "category": "tooling",
+  "date": "2026-03-15"
+}

--- a/skills/tooling/mojo-init-export-uncomment/references/notes.md
+++ b/skills/tooling/mojo-init-export-uncomment/references/notes.md
@@ -1,0 +1,75 @@
+# Session Notes: mojo-init-export-uncomment
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #3759 — Uncomment root-level exports in shared/__init__.mojo
+- **Branch**: 3759-auto-impl
+- **PR**: HomericIntelligence/ProjectOdyssey#4788
+
+## Objective
+
+`shared/__init__.mojo` had ~10 blocks of commented-out imports with the note
+"pending full layer implementation". Issue #3759 asked us to evaluate each one
+and activate those whose underlying modules were now ready.
+
+## Key Discovery: Mojo v0.26.1 Re-export Chain Limitation
+
+The existing comment in the file explained this, but it's critical:
+
+> Mojo v0.26.1 does not support re-export chains where an intermediate
+> `__init__.mojo` re-exports a symbol and a consumer imports it from the
+> top-level package.
+
+This means even though `shared/core/__init__.mojo` already exports `Linear`,
+doing `from shared.core import Linear` inside `shared/__init__.mojo` and expecting
+`from shared import Linear` to work **fails**.
+
+The only workaround: use absolute leaf-module paths directly in `shared/__init__.mojo`:
+
+```mojo
+from shared.core.layers.linear import Linear  # works
+```
+
+## What Was Activated vs Skipped
+
+### Activated
+
+| Symbol | Why Ready |
+|--------|-----------|
+| `Linear` | `struct Linear` in `shared/core/layers/linear.mojo` |
+| `Conv2dLayer` + `Conv2D` alias | `struct Conv2dLayer` in `shared/core/layers/conv2d.mojo` |
+| `ReLULayer` + `ReLU` alias | `struct ReLULayer` in `shared/core/layers/relu.mojo` |
+| `DropoutLayer` + `Dropout` alias | `struct DropoutLayer` in `shared/core/layers/dropout.mojo` |
+| `BatchNorm2dLayer` + `BatchNorm2d` alias | `struct BatchNorm2dLayer` in `shared/core/layers/batchnorm.mojo` |
+| `relu, sigmoid, tanh, softmax` | `fn relu/sigmoid/tanh/softmax` in `shared/core/activation.mojo` |
+| `Module` | `trait Module` in `shared/core/module.mojo` |
+| `ExTensor` + `Tensor` alias | `struct ExTensor` in `shared/core/extensor.mojo` |
+| `zeros, ones, randn` | `fn zeros/ones/randn` in `shared/core/extensor.mojo` |
+| `StepLR, CosineAnnealingLR` | structs in `shared/training/schedulers/lr_schedulers.mojo` |
+| `EarlyStopping, ModelCheckpoint` | structs in `shared/training/callbacks.mojo` |
+| `Logger` | `struct Logger` in `shared/utils/logging.mojo` |
+| `plot_training_curves` | `fn plot_training_curves` in `shared/utils/visualization.mojo` |
+
+### Not Activated
+
+| Symbol | Reason |
+|--------|--------|
+| `SGD, Adam, AdamW` | Only step-functions exist (`sgd_step`, `adam_step`), no struct classes |
+| `Sequential` | Only `Sequential2/3/4/5` (parametric), no single `Sequential` |
+| `TensorDataset, ImageDataset` | Only `ExTensorDataset` exists |
+| `DataLoader` | Not implemented as a struct |
+| `train_epoch, validate_epoch` | Functions named `train_one_epoch` and `validate` instead |
+| `MaxPool2D, Flatten` | Not yet in `shared/core/layers/` |
+
+## Test Added
+
+`test_layer_root_level_imports()` in `tests/shared/integration/test_packaging.mojo`:
+- Imports all newly activated symbols from `shared`
+- Smoke-tests `Linear` with a real forward pass
+- Verifies `Conv2D`/`ReLU` aliases resolve without error
+
+## Files Changed
+
+- `shared/__init__.mojo` — activated imports + comptime aliases + updated API table
+- `tests/shared/integration/test_packaging.mojo` — added test function + registered in main()

--- a/skills/tooling/mojo-init-export-uncomment/skills/mojo-init-export-uncomment/SKILL.md
+++ b/skills/tooling/mojo-init-export-uncomment/skills/mojo-init-export-uncomment/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: mojo-init-export-uncomment
+description: "Activate commented-out exports in Mojo __init__.mojo by verifying leaf-module implementations and using absolute import paths + comptime aliases to work around the v0.26.1 re-export chain limitation. Use when: (1) __init__.mojo has pending commented-out imports, (2) layer structs are confirmed implemented, (3) API name mismatches need bridging."
+category: tooling
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-init-export-uncomment |
+| **Category** | tooling |
+| **Context** | Mojo v0.26.1 packages, `__init__.mojo` export management |
+| **Trigger** | Issue requesting activation of commented-out `__init__.mojo` imports after underlying modules are ready |
+| **Output** | Updated `__init__.mojo` with active imports, `comptime` aliases, updated API table, and new packaging test |
+
+## When to Use
+
+Use this skill when:
+
+1. A Mojo package `__init__.mojo` has blocks of commented-out imports with notes like "pending full implementation"
+2. Some or all of the underlying modules have since been implemented
+3. You need to expose symbols at the package top-level (e.g. `from shared import Linear`)
+4. There are API name mismatches between documented names and actual struct names (e.g. `Conv2D` vs `Conv2dLayer`)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Verify which struct/fn names actually exist
+grep -rn "^struct\|^fn\|^trait" shared/core/layers/ | grep -v "__"
+
+# 2. Check if re-export chains would work (they don't in v0.26.1)
+# Use absolute leaf-module paths instead of re-exported names
+
+# 3. Import directly from leaf modules
+from shared.core.layers.linear import Linear
+
+# 4. Add comptime aliases for API name mismatches
+comptime Conv2D = Conv2dLayer
+```
+
+### Step 1 — Inventory the commented-out imports
+
+Read the `__init__.mojo` file and list every commented-out import. For each one, note:
+
+- The documented symbol name (e.g. `Conv2D`, `SGD`, `train_epoch`)
+- The claimed source module (e.g. `.core.layers`, `.training.optimizers`)
+
+### Step 2 — Verify leaf-module implementations
+
+For each symbol, check if the actual struct/fn/trait exists:
+
+```bash
+# Check layers
+grep -rn "^struct\|^fn\|^trait" shared/core/layers/ | grep -v "__"
+
+# Check specific module
+grep -rn "^struct SGD\|^struct Adam" shared/training/optimizers/
+```
+
+Categorize each import as:
+- **Ready**: Implementation exists, can activate
+- **Name mismatch**: Exists under a different name — use `comptime` alias
+- **Not yet implemented**: Struct doesn't exist — leave commented out with note
+
+### Step 3 — Determine if re-export chains work
+
+In Mojo v0.26.1, re-export chains **do not work**. If `shared/core/__init__.mojo`
+re-exports `Linear` from `shared/core/layers/linear.mojo`, you **cannot** then do:
+
+```mojo
+# shared/__init__.mojo — THIS FAILS in v0.26.1
+from shared.core import Linear  # chain re-export — broken
+```
+
+You MUST use the absolute leaf-module path:
+
+```mojo
+# shared/__init__.mojo — THIS WORKS
+from shared.core.layers.linear import Linear  # absolute path — works
+```
+
+### Step 4 — Write the activated imports
+
+Replace the commented block with activated imports using absolute leaf-module paths:
+
+```mojo
+# Core layers — activated; absolute paths required due to #3754 re-export limitation
+from shared.core.layers.linear import Linear
+from shared.core.layers.conv2d import Conv2dLayer
+from shared.core.layers.relu import ReLULayer
+
+# comptime aliases bridge documented API names to actual struct names
+comptime Conv2D = Conv2dLayer
+comptime ReLU = ReLULayer
+
+# MaxPool2D, Flatten — NOT YET IMPLEMENTED in shared/core/layers/
+```
+
+Keep comments for items that are NOT yet implemented so future contributors know
+they're still pending.
+
+### Step 5 — Update the Public API Table in the docstring
+
+Update the ASCII table in the module docstring to reflect active vs pending exports:
+
+```text
+# ┌──────────────────────┬────────────────────────────────┐
+# │ Symbol               │ Source                         │
+# ├──────────────────────┼────────────────────────────────┤
+# │ Linear               │ shared.core.layers.linear      │
+# │ Conv2dLayer, Conv2D  │ shared.core.layers.conv2d      │
+# └──────────────────────┴────────────────────────────────┘
+# Not yet activated: Sequential, SGD/Adam/AdamW, TensorDataset
+```
+
+### Step 6 — Add a packaging test
+
+Add a test function that smoke-tests all newly activated symbols:
+
+```mojo
+fn test_layer_root_level_imports() raises:
+    """Test newly activated symbols are importable from shared."""
+    from shared import Linear, Conv2dLayer, Conv2D, ReLU
+
+    # Smoke-test: instantiate and use a layer
+    var layer = Linear(4, 2)
+    var x = zeros([1, 4], DType.float32)
+    var out = layer.forward(x)
+    assert_true(out.shape()[1] == 2, "Linear output features should be 2")
+
+    # Alias resolves to the same type
+    var conv = Conv2D(1, 4, 3)
+    assert_true(True, "Conv2D alias should resolve to Conv2dLayer")
+
+    print("✓ Layer root-level imports test passed")
+```
+
+Register it in `main()`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Import via intermediate `__init__.mojo` | `from shared.core import Linear` in `shared/__init__.mojo` | Mojo v0.26.1 re-export chain limitation: chained re-exports do not propagate | Always use absolute leaf-module paths in top-level `__init__.mojo` |
+| Activating `SGD`/`Adam` | Searched for `struct SGD` in `shared/training/optimizers/` | Only functional step-functions exist (`sgd_step`, `adam_step`), no struct classes | Verify struct names precisely — functions and structs have different activation requirements |
+| Activating `Sequential` | Expected single `Sequential` struct | Only parametric variants exist: `Sequential2`, `Sequential3`, `Sequential4`, `Sequential5` | Check for exact struct name match, not just module presence |
+| Activating `TensorDataset` | Searched `shared/data/` for `TensorDataset` | Only `ExTensorDataset` exists | Documented API names may not match implemented struct names — always grep |
+| Activating `train_epoch`/`validate_epoch` | Searched `shared/training/loops/` | Functions are named `train_one_epoch` and `validate`, not the documented names | API names documented in `__init__.mojo` may be aspirational, not actual |
+
+## Results & Parameters
+
+### What was activated (session result)
+
+```mojo
+# Core layers
+from shared.core.layers.linear import Linear
+from shared.core.layers.conv2d import Conv2dLayer
+from shared.core.layers.relu import ReLULayer
+from shared.core.layers.dropout import DropoutLayer
+from shared.core.layers.batchnorm import BatchNorm2dLayer
+comptime Conv2D = Conv2dLayer
+comptime ReLU = ReLULayer
+comptime Dropout = DropoutLayer
+comptime BatchNorm2d = BatchNorm2dLayer
+
+# Core activations
+from shared.core.activation import relu, sigmoid, tanh, softmax
+
+# Core module trait
+from shared.core.module import Module
+
+# Core tensors
+from shared.core.extensor import ExTensor, zeros, ones, randn
+comptime Tensor = ExTensor
+
+# Training schedulers
+from shared.training.schedulers.lr_schedulers import StepLR, CosineAnnealingLR
+
+# Training callbacks
+from shared.training.callbacks import EarlyStopping, ModelCheckpoint
+
+# Utils
+from shared.utils.logging import Logger
+from shared.utils.visualization import plot_training_curves
+```
+
+### grep patterns for verification
+
+```bash
+# Find all structs/traits in a directory
+grep -rn "^struct\|^fn\|^trait" <dir>/ | grep -v "__" | head -30
+
+# Check if a specific struct exists
+grep -rn "^struct Conv2D\b" shared/
+
+# Check what functions a module exports
+grep -rn "^fn " shared/training/loops/ | head -20
+```


### PR DESCRIPTION
## Summary

Documents the workflow for activating commented-out exports in Mojo `__init__.mojo` files,
with the key discovery about Mojo v0.26.1's re-export chain limitation and the `comptime`
alias pattern for bridging API name mismatches.

- Absolute leaf-module paths required (re-export chains don't work in v0.26.1)
- `comptime` aliases bridge documented names (`Conv2D`) to actual struct names (`Conv2dLayer`)
- Must verify exact struct/fn/trait names before activating — aspirational comment names often don't match

## Key Findings

**What Worked**:
- Importing directly from absolute leaf-module paths (`from shared.core.layers.linear import Linear`)
- Using `comptime X = Y` for API name aliases
- Grepping `^struct|^fn|^trait` to verify exact names before activating

**What Failed**:
- `from shared.core import Linear` in `shared/__init__.mojo` → re-export chain broken in v0.26.1
- Activating `SGD`/`Adam` → only step-functions exist, no struct classes
- Activating `Sequential` → only `Sequential2/3/4/5` variants, no single type
- Activating `train_epoch` → function is named `train_one_epoch` instead

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (mojo __init__ export, re-export chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
