### PR TITLE
feat: add mojo-trait-conformance-for-sequential-integration skill

### DIFF
--- a/skills/testing/mojo-trait-conformance-for-sequential-integration/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-trait-conformance-for-sequential-integration/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-trait-conformance-for-sequential-integration",
+  "version": "1.0.0",
+  "description": "Add Module trait conformance to Mojo layers to enable Sequential container integration. Use when: (1) existing Mojo layers need to be used inside Sequential2/Sequential3 containers, (2) layer structs need train()/inference() methods to satisfy Module trait, (3) forward() signature needs mut self to match Module trait requirements.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/mojo-trait-conformance-for-sequential-integration/references/notes.md
+++ b/skills/testing/mojo-trait-conformance-for-sequential-integration/references/notes.md
@@ -1,0 +1,85 @@
+# Session Notes: Issue #3742
+
+## Objective
+
+Integrate `Sequential3` into `SimpleMLP` fixture in `shared/testing` (GitHub Issue #3742).
+Add a `SimpleMLP2` variant that uses `Sequential3[Linear, ReLULayer, Linear]` as a real-world
+integration test of the Sequential containers.
+
+## Context Discovery
+
+### Module trait investigation
+
+Checked `shared/core/module.mojo` — the `Module` trait requires:
+
+- `fn forward(mut self, input: ExTensor) raises -> ExTensor`
+- `fn parameters(self) raises -> List[ExTensor]`
+- `fn train(mut self)`
+- `fn inference(mut self)`
+
+### Layer conformance gaps found
+
+- `Linear`: declared `(Copyable, Movable)` — missing `Module`; `forward()` used `self` not `mut self`
+- `ReLULayer`: same issues
+
+Both already had `forward()` and `parameters()` — only needed `Module` in trait list, `mut self`
+on `forward()`, and `train()`/`inference()` no-ops.
+
+## Implementation Steps
+
+1. Added `Module` trait conformance to `Linear` (linear.mojo)
+   - Added `from shared.core.module import Module`
+   - Changed struct to `struct Linear(Copyable, Module, Movable)`
+   - Changed `forward(self, ...)` to `forward(mut self, ...)`
+   - Added `train(mut self)` and `inference(mut self)` no-ops
+
+2. Same changes to `ReLULayer` (relu.mojo)
+
+3. Implemented `SimpleMLP2` in `shared/testing/models.mojo`
+   - Uses `Sequential3[Linear, ReLULayer, Linear]`
+   - Implements `Model` and `Movable` (NOT `Copyable`)
+   - Delegates `forward()`, `parameters()`, `train()`, `inference()` to `self.net`
+
+4. Exported `SimpleMLP2` from `shared/testing/__init__.mojo`
+
+5. Wrote tests in `tests/shared/testing/test_test_models_simple_mlp2.mojo`
+   - 5 test functions (under ADR-009 10-function limit)
+   - Tests: initialization, forward shape, parameter count, parameter shapes, train/inference mode
+
+## Key Decision: Path A vs Path B
+
+Two implementation paths were considered:
+
+**Path A**: Add `Module` to production `Linear`/`ReLULayer` directly
+**Path B**: Create thin wrapper structs `LinearModule`/`ReLUModule` in `shared/testing/`
+
+Chose **Path A** because:
+- Layers already had `forward()` and `parameters()` — adding `Module` is the correct thing
+- Avoids unnecessary indirection
+- Aligns with YAGNI and KISS principles
+
+## Pre-existing Failures
+
+`tests/shared/test_imports*.mojo` fail with:
+- `SGD` missing from `shared.training.optimizers`
+- `TrainingState` missing from `shared.training.loops`
+- Deprecated `alias` syntax in `shared/data/__init__.mojo`
+
+Verified these exist on `main` before any changes (via `git stash` + test run + `git stash pop`).
+
+## Files Changed
+
+- `shared/core/layers/linear.mojo` (+13 lines)
+- `shared/core/layers/relu.mojo` (+15 lines)
+- `shared/testing/__init__.mojo` (+1 line)
+- `shared/testing/models.mojo` (+136 lines)
+- `tests/shared/testing/test_test_models_simple_mlp2.mojo` (+165 lines, new file)
+
+## Commit
+
+```
+feat(testing): integrate Sequential3 into SimpleMLP2 fixture
+```
+
+Branch: `3742-auto-impl`
+PR: pending

--- a/skills/testing/mojo-trait-conformance-for-sequential-integration/skills/mojo-trait-conformance-for-sequential-integration/SKILL.md
+++ b/skills/testing/mojo-trait-conformance-for-sequential-integration/skills/mojo-trait-conformance-for-sequential-integration/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: mojo-trait-conformance-for-sequential-integration
+description: "Add Module trait conformance to Mojo layers for Sequential container use. Use when: existing layers lack train()/inference() methods, forward() uses self instead of mut self, or layers need to be composed inside Sequential2/Sequential3."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-trait-conformance-for-sequential-integration |
+| **Category** | testing |
+| **Issue** | #3742 — Integrate Sequential into SimpleMLP in shared/testing |
+| **Result** | SimpleMLP2 using Sequential3[Linear, ReLULayer, Linear] as integration test fixture |
+
+## When to Use
+
+Use this skill when:
+
+1. You need to use existing Mojo layer structs inside `Sequential2`/`Sequential3` containers
+2. A layer struct is declared `(Copyable, Movable)` but not `Module` — causing type mismatch
+3. `forward()` has signature `fn forward(self, ...)` but `Module` requires `fn forward(mut self, ...)`
+4. You want to add a test fixture that demonstrates real Sequential container usage
+5. Adding a `SimpleMLP2` (or similar) variant that uses Sequential internally
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Check Module trait requirements
+grep -n "trait Module" shared/core/module.mojo
+
+# 2. Add Module conformance to layer
+# In linear.mojo / relu.mojo:
+#   - Add "Module" to struct declaration
+#   - Change forward(self) to forward(mut self)
+#   - Add train(mut self) and inference(mut self) no-ops
+
+# 3. Add SimpleMLP2 to shared/testing/models.mojo
+# 4. Export from shared/testing/__init__.mojo
+# 5. Write tests in tests/shared/testing/
+just test-group "tests/shared/testing" "test_test_models_simple_mlp2.mojo"
+```
+
+### Step 1: Discover Module trait requirements
+
+Read `shared/core/module.mojo` to find the exact method signatures required by `Module`:
+
+```bash
+cat shared/core/module.mojo
+```
+
+Key requirements typically include:
+
+- `fn forward(mut self, input: ExTensor) raises -> ExTensor`
+- `fn parameters(self) raises -> List[ExTensor]`
+- `fn train(mut self)`
+- `fn inference(mut self)` (or the mode-switching equivalent)
+
+### Step 2: Check existing layer conformance
+
+```bash
+grep -n "fn forward\|fn train\|fn inference\|fn parameters" shared/core/layers/linear.mojo
+grep -n "struct Linear" shared/core/layers/linear.mojo
+```
+
+Look for gaps:
+
+- Is `Module` in the struct trait list?
+- Does `forward()` use `self` (immutable) vs `mut self` (mutable)?
+- Are `train()` and `inference()` present?
+
+### Step 3: Add Module conformance to layers
+
+For each layer (`linear.mojo`, `relu.mojo`, etc.):
+
+1. Add import: `from shared.core.module import Module`
+2. Add `Module` to struct declaration traits
+3. Change `fn forward(self, ...)` to `fn forward(mut self, ...)`
+4. Add no-op methods:
+
+```mojo
+fn train(mut self):
+    pass
+
+fn inference(mut self):
+    pass
+```
+
+**Key insight:** Even if `forward()` doesn't logically need mutation, `Module` requires `mut self`
+to allow stateful layers (e.g., BatchNorm) to switch between train/inference modes.
+
+### Step 4: Implement the fixture struct
+
+```mojo
+struct SimpleMLP2(Model, Movable):
+    var input_dim: Int
+    var hidden_dim: Int
+    var output_dim: Int
+    var net: Sequential3[Linear, ReLULayer, Linear]
+
+    fn __init__(out self, input_dim: Int, hidden_dim: Int, output_dim: Int) raises:
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim
+        self.net = Sequential3[Linear, ReLULayer, Linear](
+            Linear(input_dim, hidden_dim),
+            ReLULayer(),
+            Linear(hidden_dim, output_dim),
+        )
+
+    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+        return self.net.forward(input)
+
+    fn parameters(self) raises -> List[ExTensor]:
+        return self.net.parameters()
+
+    fn train(mut self):
+        self.net.train()
+
+    fn inference(mut self):
+        self.net.inference()
+```
+
+**Why `Sequential3` for 1-hidden-layer?** Layer count: `Linear(input->hidden)` + `ReLU` +
+`Linear(hidden->output)` = 3 layers -> `Sequential3`.
+
+**Why `Movable` only, not `Copyable`?** `Sequential3` is `Movable` only (contains
+non-copyable layers with heap-allocated weights).
+
+### Step 5: Export from `__init__.mojo`
+
+```mojo
+# In shared/testing/__init__.mojo
+from shared.testing.models import SimpleMLP2
+```
+
+### Step 6: Write tests
+
+Test file `tests/shared/testing/test_test_models_simple_mlp2.mojo`:
+
+```mojo
+fn test_simple_mlp2_initialization() raises:
+    var model = SimpleMLP2(10, 20, 5)
+    assert_equal(model.input_dim, 10)
+    assert_equal(model.hidden_dim, 20)
+    assert_equal(model.output_dim, 5)
+
+fn test_simple_mlp2_forward_shape() raises:
+    var model = SimpleMLP2(10, 20, 5)
+    var input = zeros([10])
+    var output = model.forward(input)
+    assert_equal(output.shape()[0], 5)
+
+fn test_simple_mlp2_parameters_count() raises:
+    var model = SimpleMLP2(10, 20, 5)
+    var params = model.parameters()
+    # W1: 10*20=200, b1: 20, W2: 20*5=100, b2: 5 -> 4 tensors, 325 elements
+    assert_equal(len(params), 4)
+```
+
+**Use FP-representable values** per project testing strategy: `0.0`, `0.5`, `1.0`, `1.5`, `-1.0`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Use Sequential3 without Module conformance | Passed `Linear`/`ReLULayer` directly into `Sequential3[Linear, ReLULayer, Linear]` | Compile error: `Linear` not in scope of `Module` trait; `T: Module & Movable` constraint unsatisfied | Must add `Module` to all layer structs before they can be used in Sequential containers |
+| Keep `forward(self, ...)` immutable | Left `forward()` as `fn forward(self, input: ExTensor)` | Mojo compiler error: signature mismatch with `Module` trait's `fn forward(mut self, ...)` | The `Module` trait requires `mut self` on `forward()` to allow stateful layers; all conforming layers must use `mut self` |
+| Add `Copyable` to `SimpleMLP2` | Tried `struct SimpleMLP2(Copyable, Model, Movable)` | `Sequential3` is `Movable` only; compiler rejects copying a type containing a non-Copyable field | Don't declare `Copyable` on model fixtures wrapping Sequential containers |
+| Path B (wrapper structs) | Create `LinearModule`/`ReLUModule` wrappers in `shared/testing/` | Works but adds unnecessary indirection and diverges from production code | Path A (add `Module` to production layers) is simpler and correct; layers that have `forward()`/`parameters()` should conform to `Module` |
+
+## Results & Parameters
+
+### Verified configuration
+
+```toml
+# Mojo version: 0.26.1 (pinned in pixi.toml)
+# Test runtime: just test-group "tests/shared/testing" "test_test_models_simple_mlp2.mojo"
+```
+
+### Parameter count formula
+
+For `SimpleMLP2(input_dim=I, hidden_dim=H, output_dim=O)`:
+
+- Tensors: 4 (`W1`, `b1`, `W2`, `b2`)
+- Total elements: `I*H + H + H*O + O`
+- Example `(10, 20, 5)`: `200 + 20 + 100 + 5 = 325`
+
+### Module trait conformance checklist
+
+```text
+[ ] Module import added to layer file
+[ ] "Module" added to struct trait list
+[ ] forward(self) changed to forward(mut self)
+[ ] train(mut self) method added (no-op for stateless layers)
+[ ] inference(mut self) method added (no-op for stateless layers)
+[ ] Struct compiles with: pixi run mojo build <layer-file>
+[ ] Existing layer tests still pass
+```
+
+### Pre-existing test failures to ignore
+
+The following test files fail on this branch due to unrelated missing symbols:
+
+- `tests/shared/test_imports.mojo` — `SGD` missing from `shared.training.optimizers`
+- `tests/shared/test_imports_part2.mojo` — same root cause
+- `tests/shared/test_imports_part3.mojo` — `TrainingState` missing from `shared.training.loops`
+
+These failures exist on `main` and are NOT introduced by this work.


### PR DESCRIPTION
## Summary

Documents how to add `Module` trait conformance to Mojo layer structs so they can be used
inside `Sequential2`/`Sequential3` containers — learned while implementing issue #3742
(Integrate Sequential into SimpleMLP in shared/testing).

- `Sequential3` requires `T: Module & Movable`; existing `Linear`/`ReLULayer` lacked `Module`
- `forward()` must use `mut self` to satisfy the `Module` trait (even for stateless layers)
- `SimpleMLP2` wrapping `Sequential3[Linear, ReLULayer, Linear]` validates the containers end-to-end

## Key Findings

**What Worked**:

- Path A: Adding `Module` directly to production `Linear`/`ReLULayer` (correct, minimal)
- No-op `train()`/`inference()` methods satisfy the trait without behavior change
- Omitting `Copyable` from `SimpleMLP2` avoids compile errors from non-copyable Sequential internals

**What Failed**:

- Using `Sequential3` before adding `Module` → compile error on type constraint
- Keeping `forward(self, ...)` immutable → signature mismatch with `Module` trait
- Adding `Copyable` to `SimpleMLP2` → `Sequential3` is `Movable` only

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in skills registry
- [ ] Check skill activation triggers are relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
