### PR TITLE
feat: add migrate-odyssey-deeply-nested-subdir-test skill

### DIFF
--- a/skills/testing/migrate-odyssey-deeply-nested-subdir-test/.claude-plugin/plugin.json
+++ b/skills/testing/migrate-odyssey-deeply-nested-subdir-test/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "migrate-odyssey-deeply-nested-subdir-test",
+  "version": "1.0.0",
+  "description": "Pattern for testing multi-level directory nesting in shutil.copytree migrations. Use when: (1) adding coverage for recursive copy of auxiliary subdirectories, (2) verifying scripts/utils/helper.sh style deep paths survive migration, (3) writing pytest tests for file-tree migration scripts.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/migrate-odyssey-deeply-nested-subdir-test/references/notes.md
+++ b/skills/testing/migrate-odyssey-deeply-nested-subdir-test/references/notes.md
@@ -1,0 +1,79 @@
+# Session Notes — migrate-odyssey-deeply-nested-subdir-test
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #3769
+- **Branch**: `3769-auto-impl`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4790
+
+## Objective
+
+Add a pytest test verifying that deeply nested subdirectory content (e.g. `scripts/utils/helper.sh`)
+is correctly preserved after migration via `shutil.copytree` in `migrate_odyssey_skills.py`.
+
+The issue noted that while `shutil.copytree` is recursive by default, there were no tests
+exercising multi-level nesting inside auxiliary subdirs.
+
+## What Was Done
+
+1. Read `.claude-prompt-3769.md` for task context.
+2. Located the test file: `tests/scripts/test_migrate_odyssey_skills.py`.
+3. Identified `TestMigrateSkillAuxiliaryDirs` class and the existing
+   `test_skill_with_nested_scripts_content` test as the closest template.
+4. Added `test_skill_with_deeply_nested_scripts_subdir` after the template test.
+5. Used `make_skill_dir` helper to build the base structure, then manually created
+   `scripts/utils/helper.sh` two levels deep.
+6. Asserted the full destination path exists after calling `migrate_skill`.
+7. Ran the full test class: 12/12 passed.
+8. Committed and pushed to `3769-auto-impl`, created PR #4790.
+
+## Key Files
+
+- `tests/scripts/test_migrate_odyssey_skills.py` — where the test was added (lines ~280-314)
+- `scripts/migrate_odyssey_skills.py` — migration script (no changes needed)
+
+## Code Pattern
+
+```python
+def test_skill_with_deeply_nested_scripts_subdir(self, tmp_path: Path, migrate_module) -> None:
+    """scripts/utils/helper.sh (subdir inside scripts/) is preserved after migration."""
+    odyssey_skills = tmp_path / "odyssey_skills"
+    mnemosyne_skills = tmp_path / "mnemosyne" / "skills"
+    mnemosyne_skills.mkdir(parents=True)
+
+    skill_dir = make_skill_dir(odyssey_skills, "agent-run-orchestrator")
+    nested_dir = skill_dir / "scripts" / "utils"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "helper.sh").write_text("#!/bin/bash\necho helper")
+
+    skill_md = odyssey_skills / "agent-run-orchestrator" / "SKILL.md"
+
+    with patch.object(migrate_module, "MNEMOSYNE_SKILLS_DIR", mnemosyne_skills):
+        result = migrate_module.migrate_skill(
+            skill_name="agent-run-orchestrator",
+            source_skill_md=skill_md,
+            category="tooling",
+            dry_run=False,
+        )
+
+    assert result is True
+    nested_helper = (
+        mnemosyne_skills
+        / "tooling"
+        / "agent-run-orchestrator"
+        / "skills"
+        / "agent-run-orchestrator"
+        / "scripts"
+        / "utils"
+        / "helper.sh"
+    )
+    assert nested_helper.exists(), f"Expected deeply nested helper at {nested_helper}"
+```
+
+## Observations
+
+- No production code change was required — `shutil.copytree` already handles recursion.
+- The test fills a documentation/coverage gap, not a behavioral gap.
+- The `make_skill_dir` return value is the skill root; use it to build nested paths.
+- Destination path follows pattern: `<category>/<skill>/<skills>/<skill>/<subdir>/<nested>`.

--- a/skills/testing/migrate-odyssey-deeply-nested-subdir-test/skills/migrate-odyssey-deeply-nested-subdir-test/SKILL.md
+++ b/skills/testing/migrate-odyssey-deeply-nested-subdir-test/skills/migrate-odyssey-deeply-nested-subdir-test/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: migrate-odyssey-deeply-nested-subdir-test
+description: "Pattern for testing multi-level directory nesting in shutil.copytree migrations. Use when: adding coverage for recursive copy of auxiliary subdirectories, verifying deep paths survive migration."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | migrate-odyssey-deeply-nested-subdir-test |
+| **Category** | testing |
+| **Task** | Add pytest test verifying deeply nested subdirs (e.g. `scripts/utils/helper.sh`) survive a `shutil.copytree`-based migration |
+| **Language** | Python / pytest |
+| **Trigger** | Issue requests test coverage for multi-level nesting inside auxiliary subdirs of a migration script |
+
+## When to Use
+
+- An issue mentions "no tests verifying multi-level nesting" for a copytree-based migration.
+- Existing tests only cover flat files within a subdirectory (e.g. `scripts/run.sh`) but not nested paths (`scripts/utils/helper.sh`).
+- The migration uses `shutil.copytree`, which is recursive by default, but coverage is missing.
+- A follow-up issue from a parent migration issue requests nesting tests.
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# Pattern: create a nested dir inside an existing auxiliary subdir, assert it arrives at dest
+nested_dir = skill_dir / "scripts" / "utils"
+nested_dir.mkdir(parents=True)
+(nested_dir / "helper.sh").write_text("#!/bin/bash\necho helper")
+
+# ... call migrate_skill(...)
+
+nested_helper = (
+    mnemosyne_skills
+    / "tooling" / "agent-run-orchestrator"
+    / "skills" / "agent-run-orchestrator"
+    / "scripts" / "utils" / "helper.sh"
+)
+assert nested_helper.exists(), f"Expected deeply nested helper at {nested_helper}"
+```
+
+### Step 1 — Read the existing test file
+
+Find which test class covers auxiliary subdirectory copying (e.g. `TestMigrateSkillAuxiliaryDirs`).
+Identify the nearest similar test (`test_skill_with_nested_scripts_content`) to use as a template.
+
+### Step 2 — Identify the insertion point
+
+The new test should be added directly after the flat-nesting test and before unrelated tests
+(e.g. `test_dry_run_does_not_copy_files`). This keeps related tests grouped.
+
+### Step 3 — Use the existing `make_skill_dir` helper
+
+The test helper already creates the base skill directory structure. Call it first, then
+**manually create** the nested subdirectory within `scripts/`:
+
+```python
+skill_dir = make_skill_dir(odyssey_skills, "agent-run-orchestrator")
+nested_dir = skill_dir / "scripts" / "utils"
+nested_dir.mkdir(parents=True)
+(nested_dir / "helper.sh").write_text("#!/bin/bash\necho helper")
+```
+
+Note: `make_skill_dir` returns the skill root directory — capture the return value.
+
+### Step 4 — Assert the full path at the destination
+
+Build the expected destination path component by component. The migration places content at:
+
+```
+mnemosyne_skills / <category> / <skill-name> / "skills" / <skill-name> / <subdir> / ...
+```
+
+So for `scripts/utils/helper.sh`:
+
+```python
+nested_helper = (
+    mnemosyne_skills
+    / "tooling"
+    / "agent-run-orchestrator"
+    / "skills"
+    / "agent-run-orchestrator"
+    / "scripts"
+    / "utils"
+    / "helper.sh"
+)
+assert nested_helper.exists(), f"Expected deeply nested helper at {nested_helper}"
+```
+
+### Step 5 — Run only the affected test class to confirm
+
+```bash
+pixi run python -m pytest tests/scripts/test_migrate_odyssey_skills.py::TestMigrateSkillAuxiliaryDirs -v
+```
+
+All tests in the class (not just the new one) must pass before committing.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A — direct approach worked | Read existing test class, identified pattern, inserted test immediately | — | The flat-nesting test (`test_skill_with_nested_scripts_content`) was a perfect template; no iteration needed |
+
+## Results & Parameters
+
+**Test added**: `test_skill_with_deeply_nested_scripts_subdir`
+
+**Class**: `TestMigrateSkillAuxiliaryDirs`
+
+**File**: `tests/scripts/test_migrate_odyssey_skills.py`
+
+**Run command**:
+
+```bash
+pixi run python -m pytest tests/scripts/test_migrate_odyssey_skills.py::TestMigrateSkillAuxiliaryDirs -v
+```
+
+**Result**: 12/12 passed (11 pre-existing + 1 new)
+
+**Key insight**: `shutil.copytree` is recursive by default, so no code change was needed — only
+a test to verify the behavior is exercised and protected against future regressions.


### PR DESCRIPTION
## Summary

Documents the pattern for testing multi-level directory nesting in `shutil.copytree`-based migration scripts (ProjectOdyssey #3769).

- `shutil.copytree` is recursive by default — no code change was needed, only a test to protect the behavior
- Pattern: use `make_skill_dir` return value to build nested source paths, assert full destination path
- Destination path formula: `<category>/<skill>/skills/<skill>/<subdir>/<nested-file>`

## Key Findings

**What Worked**:
- Reading the existing flat-nesting test (`test_skill_with_nested_scripts_content`) as a template — minimal delta needed
- Calling `make_skill_dir` then manually creating the nested subdir on top of its output
- Asserting `nested_helper.exists()` with an f-string message for debuggability

**What Failed**:
- N/A — direct approach succeeded on first attempt; no iteration required

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with relevant triggers (copytree migration coverage gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
