### PR TITLE
feat: add warn-on-existing-dest-subdir skill

### DIFF
--- a/skills/tooling/warn-on-existing-dest-subdir/.claude-plugin/plugin.json
+++ b/skills/tooling/warn-on-existing-dest-subdir/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "warn-on-existing-dest-subdir",
+  "version": "1.0.0",
+  "description": "Defensive copytree pattern: emit a stderr warning before shutil.copytree(dirs_exist_ok=True) when the destination subdir already exists. Use when: (1) implementing file migration scripts that can be re-run, (2) adding observability to merge-mode copies where silent overwrites are a risk, (3) reviewing migration code for accidental overwrite hazards.",
+  "category": "tooling",
+  "date": "2026-03-15"
+}

--- a/skills/tooling/warn-on-existing-dest-subdir/references/notes.md
+++ b/skills/tooling/warn-on-existing-dest-subdir/references/notes.md
@@ -1,0 +1,58 @@
+# Session Notes — warn-on-existing-dest-subdir
+
+## Context
+
+- **Issue**: #3770 — `migrate_odyssey_skills: log warning when auxiliary subdir already exists at dest`
+- **Follow-up from**: #3228
+- **Branch**: `3770-auto-impl`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4791
+- **Date**: 2026-03-15
+
+## Problem
+
+`shutil.copytree(dirs_exist_ok=True)` silently overwrites same-named files when the destination
+directory already exists. On re-migration, this can cause unexpected data loss if the destination
+was modified after the first migration. Operators had no way to detect this was happening.
+
+## Solution
+
+Add a `dest.exists()` check immediately before each `shutil.copytree` call. If the destination
+already exists, print a warning to `stderr` with the full path. The check applies to:
+
+1. Real-run `references/` branch
+2. Real-run generic (scripts/, templates/, hooks/, etc.) branch
+3. Dry-run `references/` branch
+4. Dry-run generic branch
+
+## Key Code Locations
+
+File: `scripts/migrate_odyssey_skills.py`
+
+- Lines ~585–603: real-run path (inside `if not dry_run:`)
+- Lines ~610–630: dry-run path (inside `else:`)
+
+Both paths share the same `dest` variable computed before the `if not dry_run:` split,
+so the `.exists()` check code is identical in both branches.
+
+## Test Coverage
+
+Two new tests added to `tests/scripts/test_migrate_odyssey_skills.py`:
+
+- `test_warns_when_dest_subdir_already_exists` — real-run mode
+- `test_warns_when_dest_subdir_already_exists_dry_run` — dry-run mode
+
+Both tests:
+1. Create a skill with a `scripts/` subdir
+2. Pre-create the destination `scripts/` directory
+3. Call `migrate_skill()` with `patch.object` for `MNEMOSYNE_SKILLS_DIR`
+4. Assert the warning appears in `capsys.readouterr().err`
+5. Assert the full path of the pre-existing directory is in the warning
+
+Total test count: 23 (21 existing + 2 new), all passing.
+
+## Commit
+
+```
+feat(migrate): warn when auxiliary subdir already exists at destination
+Closes #3770
+```

--- a/skills/tooling/warn-on-existing-dest-subdir/skills/warn-on-existing-dest-subdir/SKILL.md
+++ b/skills/tooling/warn-on-existing-dest-subdir/skills/warn-on-existing-dest-subdir/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: warn-on-existing-dest-subdir
+description: "Defensive copytree pattern: emit stderr warning before shutil.copytree(dirs_exist_ok=True) when destination already exists. Use when: adding observability to re-runnable migration scripts, preventing silent overwrites."
+category: tooling
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #3770 — migrate_odyssey_skills: log warning when auxiliary subdir already exists at dest |
+| **Follow-up from** | #3228 |
+| **File changed** | `scripts/migrate_odyssey_skills.py` |
+| **Pattern** | Check `dest.exists()` before `shutil.copytree(dirs_exist_ok=True)`, print to `stderr` |
+
+## When to Use
+
+- When a migration script can be run multiple times against the same destination
+- When `shutil.copytree(dirs_exist_ok=True)` is used and silent overwrites are a risk
+- When adding observability so operators can detect accidental overwrites on re-migration
+- When the same pattern applies to both real-run and dry-run code paths
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+if dest.exists():
+    print(
+        f"  WARNING: destination subdir already exists and will be merged: {dest}",
+        file=sys.stderr,
+    )
+shutil.copytree(src, dest, dirs_exist_ok=True)
+```
+
+1. **Locate every `shutil.copytree(…, dirs_exist_ok=True)` call** in the migration script — both
+   the real-run and dry-run code paths need the check.
+
+2. **Before each call, compute `dest`** (the same path `copytree` will write to) and add:
+
+   ```python
+   if dest.exists():
+       print(
+           f"  WARNING: destination subdir already exists and will be merged: {dest}",
+           file=sys.stderr,
+       )
+   ```
+
+3. **Write to `sys.stderr`** (not `stdout`) so the warning is always visible even when
+   stdout is piped or redirected. Ensure `import sys` is present at the top of the file.
+
+4. **Keep the dry-run path consistent** — the destination path variable (`dest`) is
+   computed outside the `if not dry_run:` / `else:` block in this codebase, so the same
+   `dest.exists()` check works unchanged in both branches.
+
+5. **Add two pytest tests** using `capsys`:
+   - One for `dry_run=False` — pre-create the destination dir, call `migrate_skill`, assert
+     `"WARNING: destination subdir already exists"` in `capsys.readouterr().err`
+   - One for `dry_run=True` — same setup, assert the warning fires without any files being
+     written
+
+6. **Run tests** to confirm all existing tests still pass and the two new tests pass:
+
+   ```bash
+   pixi run python -m pytest tests/scripts/test_migrate_odyssey_skills.py -v
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | No alternative approaches explored | N/A | Issue was well-scoped: one pattern, two code paths |
+
+## Results & Parameters
+
+```python
+# Pattern used in scripts/migrate_odyssey_skills.py
+if dest.exists():
+    print(
+        f"  WARNING: destination subdir already exists and will be merged: {dest}",
+        file=sys.stderr,
+    )
+shutil.copytree(subdir, dest, dirs_exist_ok=True)
+```
+
+- Warning message format: `"  WARNING: destination subdir already exists and will be merged: {dest}"`
+- Output stream: `sys.stderr` (not `print()` default stdout)
+- Applied in 4 locations: real-run references branch, real-run generic branch, dry-run references branch, dry-run generic branch
+- Tests: 23 total passing after adding 2 new warning tests


### PR DESCRIPTION
## Summary

Documents the defensive `copytree` pattern for re-runnable migration scripts: emit a `stderr`
warning before `shutil.copytree(dirs_exist_ok=True)` whenever the destination subdir already
exists, making silent overwrites visible to operators.

- Pattern applies to both real-run and dry-run code paths
- Warning goes to `sys.stderr` so it's visible even when stdout is piped
- Two `capsys`-based pytest tests verify the warning fires in each mode

## Key Findings

**What Worked**:
- `dest.exists()` check immediately before each `copytree` call — minimal, focused change
- Using `file=sys.stderr` ensures warnings are never silenced by stdout redirection
- Applying the same check in dry-run path gives operators early warning without any writes

**What Failed**:
- N/A — issue was well-scoped with a clear, unambiguous solution

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation for migration script implementation tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
