### PR TITLE
feat: add bulk-fix-orphan-quick-reference skill

### DIFF
--- a/skills/tooling/bulk-fix-orphan-quick-reference/.claude-plugin/plugin.json
+++ b/skills/tooling/bulk-fix-orphan-quick-reference/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "bulk-fix-orphan-quick-reference",
+  "version": "1.0.0",
+  "description": "Bulk-fix SKILL.md files where ## Quick Reference appears as a top-level section alongside ## Verified Workflow. Use when: (1) validate_plugins.py reports orphaned Quick Reference warnings, (2) migrating skills from Odyssey format to Mnemosyne format in batch, (3) running a post-migration cleanup pass.",
+  "category": "tooling",
+  "date": "2026-03-15"
+}

--- a/skills/tooling/bulk-fix-orphan-quick-reference/references/notes.md
+++ b/skills/tooling/bulk-fix-orphan-quick-reference/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes — bulk-fix-orphan-quick-reference
+
+**Date**: 2026-03-15
+**Issue**: ProjectOdyssey #3777
+**PR**: ProjectOdyssey #4795
+
+## Context
+
+During implementation of `validate_plugins.py`, a new warning was added for SKILL.md files
+where `## Quick Reference` appears as a top-level section alongside `## Verified Workflow`.
+Running this validator against the existing `skills/` directory in ProjectMnemosyne surfaced
+54 files with this structural issue.
+
+`fix_remaining_warnings.py` already had `merge_quick_reference_into_verified_workflow()` to
+fix this, but the `main()` function's hardcoded list of `plugins_with_workflow_warning` did
+not include these 54 files.
+
+## Key Discovery: Format Distinction
+
+The critical insight was understanding two distinct SKILL.md formats:
+
+- **Odyssey format** (`.claude/skills/`): Uses `## Workflow` — Quick Reference is a valid top-level section here per the SKILL_FORMAT_TEMPLATE.md
+- **Mnemosyne format** (`skills/`): Uses `## Verified Workflow` — Quick Reference must be a `### subsection` of Verified Workflow
+
+Running the fix against `.claude/skills/` correctly returned 0 hits because those files use
+`## Workflow`, not `## Verified Workflow`.
+
+## Implementation
+
+Created `scripts/fix_quick_reference_batch.py` with:
+- `has_orphan_quick_reference()` — regex check for top-level `## Quick Reference`
+- `has_verified_workflow()` — regex check for `## Verified Workflow`
+- `collect_affected_files()` — recursive scan filtering for both conditions
+- `merge_quick_reference_into_verified_workflow()` — extract+demote+reinsert transformation
+- `fix_skill_file()` — read/transform/write for single file
+- `run_batch_fix()` — orchestrates batch with dry-run support
+- `verify_no_warnings()` — second-pass check post-fix
+
+## Test Gotcha
+
+`assert "## Quick Reference" not in result` always fails because `### Quick Reference`
+contains `## Quick Reference` as a substring. Must use:
+
+```python
+assert not re.search(r"^## Quick Reference", result, re.MULTILINE)
+```
+
+## Files Created
+
+- `scripts/fix_quick_reference_batch.py` (ProjectOdyssey)
+- `tests/scripts/test_fix_quick_reference_batch.py` (33 tests, all passing)

--- a/skills/tooling/bulk-fix-orphan-quick-reference/skills/bulk-fix-orphan-quick-reference/SKILL.md
+++ b/skills/tooling/bulk-fix-orphan-quick-reference/skills/bulk-fix-orphan-quick-reference/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: bulk-fix-orphan-quick-reference
+description: "Bulk-fix SKILL.md files with orphaned top-level ## Quick Reference sections alongside ## Verified Workflow. Use when: validate_plugins.py reports Quick Reference warnings across many files."
+category: tooling
+date: 2026-03-15
+user-invocable: false
+---
+
+# Bulk-Fix Orphaned Quick Reference Sections
+
+Demote top-level `## Quick Reference` headings to `### Quick Reference` subsections
+inside `## Verified Workflow` across an entire skills directory in one pass.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Name | bulk-fix-orphan-quick-reference |
+| Category | tooling |
+| Trigger | validate_plugins.py warns about orphaned Quick Reference sections |
+| Script | `scripts/fix_quick_reference_batch.py` |
+| Scope | Any directory containing SKILL.md files (recursive) |
+
+## When to Use
+
+- `validate_plugins.py skills/ plugins/` emits warnings about `## Quick Reference` being a top-level section
+- A batch migration (e.g., `migrate_odyssey_skills.py`) produced files that kept `## Quick Reference` at h2 level
+- Post-migration cleanup pass needed before merging a skill import PR
+- `fix_remaining_warnings.py` `main()` hardcoded list does not cover all affected files
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Dry-run to preview which files would be changed
+python3 scripts/fix_quick_reference_batch.py skills/ --dry-run
+
+# Apply fixes
+python3 scripts/fix_quick_reference_batch.py skills/
+
+# Verify no warnings remain
+python3 scripts/validate_plugins.py skills/ plugins/
+```
+
+### 1. Identify affected files
+
+```bash
+# First-pass validation — collect files emitting the warning
+python3 scripts/validate_plugins.py skills/ plugins/ 2>&1 | grep "Quick Reference"
+```
+
+The warning fires when a SKILL.md contains **both**:
+- A top-level `## Quick Reference` heading, AND
+- A `## Verified Workflow` heading
+
+Skills that only have `## Quick Reference` alongside `## Workflow` (Odyssey format)
+are **not** affected — the warning only applies to Mnemosyne format.
+
+### 2. Run the batch fix script
+
+```bash
+# Preview (safe — no writes)
+python3 scripts/fix_quick_reference_batch.py skills/ --dry-run
+
+# Apply
+python3 scripts/fix_quick_reference_batch.py skills/
+```
+
+The script:
+
+1. Recursively finds all `SKILL.md` files in the target directory
+2. Filters to those with both `## Quick Reference` and `## Verified Workflow`
+3. Extracts the full `## Quick Reference` block (up to the next `##` or EOF)
+4. Demotes the heading: `## Quick Reference` → `### Quick Reference`
+5. Removes the block from its original position
+6. Inserts the demoted block immediately after the `## Verified Workflow` heading line
+7. Writes the result back (in-place)
+8. Runs a second pass to confirm zero files still trigger the warning
+
+### 3. Verify zero warnings remain
+
+```bash
+python3 scripts/validate_plugins.py skills/ plugins/
+# Should show no "Quick Reference" warnings
+```
+
+### 4. Commit and push
+
+```bash
+git add skills/
+git commit -m "fix(skills): merge orphaned Quick Reference sections into Verified Workflow"
+git push
+```
+
+## Implementation Details
+
+The core transformation in `merge_quick_reference_into_verified_workflow()`:
+
+```python
+import re
+
+def merge_quick_reference_into_verified_workflow(content: str) -> str:
+    # Extract ## Quick Reference block (up to next ## or EOF)
+    qr_match = re.search(
+        r"^(## Quick Reference\s*\n.*?)(?=^##|\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    qr_block = qr_match.group(1)
+
+    # Demote heading
+    qr_as_subsection = re.sub(
+        r"^## Quick Reference", "### Quick Reference", qr_block, count=1
+    )
+
+    # Remove from original position, insert after ## Verified Workflow
+    content_without_qr = content[:qr_match.start()] + content[qr_match.end():]
+    vw_match = re.search(r"^## Verified Workflow[^\n]*\n", content_without_qr, re.MULTILINE)
+    insert_pos = vw_match.end()
+    subsection_text = "\n" + qr_as_subsection.lstrip("\n")
+    return content_without_qr[:insert_pos] + subsection_text + content_without_qr[insert_pos:]
+```
+
+Key properties:
+- **Idempotent**: applying twice produces the same result as applying once
+- **No-op guards**: returns unchanged if either section is absent
+- **Preserves body content**: only the heading level changes, content is moved intact
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Simple string replace `## Quick Reference` → `### Quick Reference` | Used `str.replace()` without extracting and relocating the block | Demoted the heading in place without moving it under Verified Workflow — structural position unchanged | Must extract + remove + reinsert, not just replace heading in place |
+| Assert `"## Quick Reference" not in result` | Used plain substring check to verify heading was gone | `### Quick Reference` contains `## Quick Reference` as a substring, so the assertion always failed | Use `re.search(r"^## Quick Reference", result, re.MULTILINE)` to check for top-level heading only |
+| Running fix against `.claude/skills/` expecting 54+ hits | Assumed Odyssey `.claude/skills/` format would trigger the warning | Odyssey files have `## Workflow` (not `## Verified Workflow`), so 0 files matched the condition | The warning only fires in Mnemosyne format; the 54 affected files live in the migrated `skills/` directory |
+
+## Results & Parameters
+
+| Metric | Value |
+|--------|-------|
+| Script | `scripts/fix_quick_reference_batch.py` |
+| Tests | `tests/scripts/test_fix_quick_reference_batch.py` (33 tests) |
+| Target directory | Any `skills/` directory (pass as argument) |
+| Default directory | `.claude/skills/` |
+| Dry-run flag | `--dry-run` |
+| Second-pass validation | Built-in (`verify_no_warnings()`) |
+| Files affected in issue #3777 | 54+ in ProjectMnemosyne `skills/` |
+| Test pass rate | 33/33 (100%) |


### PR DESCRIPTION
## Summary

Documents the `bulk-fix-orphan-quick-reference` pattern: a batch script that demotes
top-level `## Quick Reference` sections to `### Quick Reference` subsections inside
`## Verified Workflow` across all affected SKILL.md files in one pass.

- Implements `scripts/fix_quick_reference_batch.py` with `--dry-run` support and two-pass validation
- Covers the format distinction between Odyssey (`## Workflow`) and Mnemosyne (`## Verified Workflow`)
- 33 unit tests with 100% pass rate

## Key Findings

**What Worked**:
- Extract the full `## Quick Reference` block → demote heading → remove from original position → reinsert after `## Verified Workflow` heading line
- `re.search(r"^## Quick Reference", content, re.MULTILINE)` correctly detects top-level heading only
- Two-pass validation (apply fixes, then re-scan) confirms zero files remain affected
- Recursive scan with `Path.rglob("SKILL.md")` handles nested skills directories cleanly

**What Failed**:
- Simple `str.replace("## Quick Reference", "### Quick Reference")` — demotes heading in place without relocating under Verified Workflow
- `assert "## Quick Reference" not in result` — always fails because `### Quick Reference` contains `## Quick Reference` as substring
- Running fix against `.claude/skills/` and expecting hits — Odyssey format uses `## Workflow` not `## Verified Workflow`, so 0 files match

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` → PASS
- [ ] Install plugin and verify skill appears in registry
- [ ] Apply `fix_quick_reference_batch.py` against ProjectMnemosyne `skills/` to fix the 54 affected files from issue #3777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
