### PR TITLE
feat: add noncontiguous-tensor-guard skill

### DIFF
--- a/skills/testing/noncontiguous-tensor-guard/.claude-plugin/plugin.json
+++ b/skills/testing/noncontiguous-tensor-guard/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "noncontiguous-tensor-guard",
+  "version": "1.0.0",
+  "description": "Add as_contiguous() guards to Mojo flat-buffer kernels so non-contiguous tensor views don't silently produce wrong results. Use when: (1) a kernel uses _data.bitcast[T]()[i] flat indexing, (2) adding support for transposed/sliced tensor inputs, (3) auditing kernels after a new non-contiguous tensor API is introduced.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/noncontiguous-tensor-guard/references/notes.md
+++ b/skills/testing/noncontiguous-tensor-guard/references/notes.md
@@ -1,0 +1,126 @@
+# Session Notes: noncontiguous-tensor-guard
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Project**: ProjectOdyssey
+- **Issue**: #3800 — "Add is_contiguous() guard to all flat-buffer kernels"
+- **PR**: #4804
+- **Branch**: `3800-auto-impl`
+- **Follow-up to**: #3236 (added `as_contiguous()` guard to `matmul()`)
+
+## Objective
+
+Audit all Mojo kernels that use `_data.bitcast[T]()[i]` flat-buffer arithmetic and
+add `as_contiguous()` guards. Non-contiguous view inputs (e.g. from `transpose()`)
+silently produce wrong results because flat index `i` assumes element `i` is at byte
+offset `i * sizeof(T)`.
+
+## Files Modified
+
+### `shared/core/arithmetic.mojo`
+
+Added guard in `_broadcast_binary` (handles add/sub/mul/div via broadcasting):
+
+```mojo
+from shared.core.shape import as_contiguous
+
+# In _broadcast_binary():
+var a_cont = a if a.is_contiguous() else as_contiguous(a)
+var b_cont = b if b.is_contiguous() else as_contiguous(b)
+# Use a_cont._data / b_cont._data / a_cont.shape() / b_cont.shape()
+```
+
+Also guarded `multiply_scalar`:
+
+```mojo
+var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+```
+
+### `shared/core/reduction.mojo`
+
+Added guard in dispatch functions (inner `_reduce_all_impl` / `_reduce_axis_impl` lack `raises`):
+
+```mojo
+fn _dispatch_reduce_all(tensor: ExTensor, ...) raises -> ExTensor:
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+    return _reduce_all_impl(t, ...)
+
+fn _dispatch_reduce_axis(tensor: ExTensor, ...) raises -> ExTensor:
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+    return _reduce_axis_impl(t, ...)
+```
+
+### `shared/core/conv.mojo`
+
+Guarded all 4 public functions: `conv2d`, `conv2d_backward`, `depthwise_conv2d`,
+`depthwise_conv2d_backward`. No guard needed for `depthwise_separable_conv2d*` because
+they delegate entirely to the already-guarded functions.
+
+## Test Files Created
+
+All pass locally with `just test-group tests/shared/core "test_*_noncontiguous_*.mojo"`.
+
+| File | Tests | Status |
+|------|-------|--------|
+| `test_arithmetic_noncontiguous_part1.mojo` | 10 (add/sub/mul/div + contiguous result check) | ✅ |
+| `test_arithmetic_noncontiguous_part2.mojo` | 2 (broadcasting, baseline comparison) | ✅ |
+| `test_reduction_noncontiguous_part1.mojo` | 6 (sum/mean all/axis0/axis1) | ✅ |
+| `test_reduction_noncontiguous_part2.mojo` | 6 (max_reduce/min_reduce all/axis0/axis1) | ✅ |
+| `test_conv_noncontiguous_part1.mojo` | 8 (conv2d forward) | ✅ |
+| `test_conv_noncontiguous_part2.mojo` | 8 (conv2d_backward) | ✅ |
+
+## Key Debugging Discoveries
+
+### Non-contiguous fixture failure
+
+**Error**: `Unhandled exception caught during execution: input must be non-contiguous`
+
+**Cause**: Tests used `tensor.transpose(0, 1)` on `(1,1,4,4)` tensors where both
+swapped dims have size 1. Swapping dims of equal size gives identical strides — the
+result is still C-contiguous.
+
+**Fix**: Use non-square spatial dimensions and transpose the spatial (H, W) dims:
+
+```mojo
+# Non-square: H=4, W=6
+var x = ones([1, 1, 4, 6], DType.float32)
+var nc = x.transpose(2, 3)  # shape (1,1,6,4)
+# Strides: [24, 24, 1, 6] ≠ C-order [24, 24, 4, 1] → genuinely non-contiguous
+```
+
+### Docstring capitalisation error
+
+Mojo requires docstring summaries to begin with a capital letter or non-alpha character.
+Fixed by running Python regex over all test files:
+
+```python
+import re
+content = re.sub(
+    r'("""|\'\'\')([a-z])',
+    lambda m: m.group(1) + m.group(2).upper(),
+    content
+)
+```
+
+### `raises` propagation constraint
+
+`as_contiguous()` is marked `raises`. Inner kernel functions without `raises` cannot
+call it. Solution: place guard in the public dispatcher (which already has `raises`),
+pass the contiguous copy to the inner function.
+
+## Commit
+
+```
+fix(core): add as_contiguous guard to all flat-buffer kernels
+
+Closes #3800
+```
+
+## Reference Pattern (from matrix.mojo matmul, PR #3236)
+
+```mojo
+var a_cont = a if a.is_contiguous() else as_contiguous(a)
+var b_cont = b if b.is_contiguous() else as_contiguous(b)
+# use a_cont._data.bitcast[...]()
+```

--- a/skills/testing/noncontiguous-tensor-guard/skills/noncontiguous-tensor-guard/SKILL.md
+++ b/skills/testing/noncontiguous-tensor-guard/skills/noncontiguous-tensor-guard/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: noncontiguous-tensor-guard
+description: "Add as_contiguous() guards to Mojo flat-buffer kernels so non-contiguous tensor views don't silently produce wrong results. Use when: a kernel uses _data.bitcast[T]()[i] flat indexing, adding support for transposed/sliced tensor inputs, or auditing kernels after a new non-contiguous tensor API is introduced."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | noncontiguous-tensor-guard |
+| **Category** | testing |
+| **Mojo Version** | v0.26.1 |
+| **Pattern Source** | matrix.mojo matmul() guard (PR #3236) |
+| **Files Affected** | arithmetic.mojo, reduction.mojo, conv.mojo |
+
+## When to Use
+
+- A Mojo kernel reads tensor data via `_data.bitcast[T]()[i]` (flat-buffer indexing)
+- The kernel receives inputs that may be non-contiguous (e.g. from `transpose()`, `slice()`)
+- A new non-contiguous view API has been introduced (e.g. `ExTensor.transpose(dim0, dim1)`)
+- CI tests pass but results are numerically wrong for transposed inputs
+- Auditing all kernels for correctness after a guard is added to one (follow-up PRs)
+
+## Verified Workflow
+
+### 1. Identify the root cause
+
+Flat-buffer kernels assume element `i` is at byte offset `i * sizeof(T)`. Non-contiguous
+tensors have gaps or reorderings in memory, so `_data.bitcast[T]()[i]` reads from the
+wrong position.
+
+```mojo
+# Bug: assumes contiguous layout
+var val = tensor._data.bitcast[Float32]()[i]
+
+# Fix: materialize contiguous copy first
+var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+var val = t._data.bitcast[Float32]()[i]
+```
+
+### 2. Add the import
+
+```mojo
+from shared.core.shape import as_contiguous
+```
+
+### 3. Add guard at the public API boundary
+
+Place the guard in the **public wrapper** or **dispatch function** (not deep in the
+inner kernel), so all call paths are covered:
+
+```mojo
+fn conv2d(x: ExTensor, kernel: ExTensor, bias: ExTensor, ...) raises -> ExTensor:
+    var x_cont = x if x.is_contiguous() else as_contiguous(x)
+    var kernel_cont = kernel if kernel.is_contiguous() else as_contiguous(kernel)
+    var bias_cont = bias if bias.is_contiguous() else as_contiguous(bias)
+    # Pass x_cont, kernel_cont, bias_cont to inner kernel
+```
+
+For functions without `raises` (e.g. `_reduce_all_impl`), guard in the **dispatching
+function** that does have `raises`:
+
+```mojo
+fn _dispatch_reduce_all(tensor: ExTensor, ...) raises -> ExTensor:
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+    return _reduce_all_impl(t, ...)  # inner fn has no raises
+```
+
+### 4. Write non-contiguous test fixtures
+
+**Critical**: `transpose(dim0, dim1)` only produces a non-contiguous tensor when the two
+swapped dimensions have **different sizes**. Swapping equal-size dims gives identical
+strides — the result is still contiguous and `is_contiguous()` returns true.
+
+```mojo
+# ✅ Correct: non-square spatial dims, swap H and W
+fn _make_nc_input() raises -> ExTensor:
+    var x = ones([1, 1, 4, 6], DType.float32)   # H=4, W=6 (different sizes)
+    var nc = x.transpose(2, 3)  # shape (1,1,6,4), strides [24,24,1,6] ≠ C-order [24,24,4,1]
+    assert_false(nc.is_contiguous(), "input must be non-contiguous")
+    return nc^
+
+# ❌ Wrong: square spatial dims — swapping gives identical strides
+var x = ones([1, 1, 4, 4], DType.float32)
+var nc = x.transpose(2, 3)  # strides [16,16,4,1] → still C-order!
+
+# ❌ Wrong: N=1, C=1 — swapping batch/channel dims
+var x = ones([1, 1, 4, 4], DType.float32)
+var nc = x.transpose(0, 1)  # dim0 stride==dim1 stride, no change
+```
+
+### 5. Structure tests to match contiguous baseline
+
+Use all-ones tensors so the non-contiguous view has the same logical values as a
+contiguous tensor of the same shape. Compare results element-by-element:
+
+```mojo
+fn test_add_noncontiguous_lhs() raises:
+    """Add with non-contiguous lhs matches contiguous baseline."""
+    var base = ones([1, 1, 6, 4], DType.float32)    # contiguous
+    var nc   = _make_nc_input()                       # non-contiguous, same logical values
+    var rhs  = ones([1, 1, 6, 4], DType.float32)
+
+    var expected = add(base, rhs)
+    var result   = add(nc,   rhs)
+
+    var ep = expected._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(expected.numel()):
+        assert_almost_equal(rp[i], ep[i], tolerance=1e-4)
+```
+
+### 6. Split test files per ADR-009
+
+Mojo v0.26.1 heap corruption triggers under high test load. Limit each file to ≤10
+`fn test_` functions. Use `_part1.mojo`, `_part2.mojo` naming:
+
+```text
+test_arithmetic_noncontiguous_part1.mojo   (8 tests: add/sub/mul/div element-wise)
+test_arithmetic_noncontiguous_part2.mojo   (2 tests: broadcasting variants)
+test_reduction_noncontiguous_part1.mojo    (6 tests: sum/mean all/axis0/axis1)
+test_reduction_noncontiguous_part2.mojo    (6 tests: max_reduce/min_reduce)
+test_conv_noncontiguous_part1.mojo         (8 tests: conv2d forward)
+test_conv_noncontiguous_part2.mojo         (8 tests: conv2d_backward)
+```
+
+### 7. Verify and commit
+
+```bash
+just test-group tests/shared/core "test_*_noncontiguous_*.mojo"
+git add shared/core/arithmetic.mojo shared/core/conv.mojo shared/core/reduction.mojo \
+        tests/shared/core/test_*_noncontiguous_*.mojo
+git commit -m "fix(core): add as_contiguous guard to all flat-buffer kernels"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `transpose(0, 1)` on `(1,1,4,4)` for NCHW fixture | Create non-contiguous (1,1,4,4) tensor by swapping N and C dims | N=1 and C=1 have the same size so strides are equal after swap — `is_contiguous()` returns true, assertion `assert_false(nc.is_contiguous())` triggers runtime error | Only `transpose(dim0, dim1)` with dims of **different sizes** produces non-contiguous strides |
+| `transpose(0, 1)` on `(1,1,2,2)` for grad_output | Create non-contiguous grad_output for backward pass tests | Same issue: all batch/channel dims have size 1, swapping gives identical strides | For NCHW tensors with N=C=1, always transpose the spatial dims H and W, using non-square spatial sizes (e.g., 4×6→transpose→6×4) |
+| Guard in inner `_reduce_all_impl` | Tried to add guard inside the implementation function which lacks `raises` | `as_contiguous()` is marked `raises`; functions without `raises` cannot call it | Place guard in the `_dispatch_*` wrapper that already has `raises`, pass the contiguous copy to the inner function |
+| Using `transpose_view()` for 4D tensors | Called `transpose_view(x_4d)` from `shared.core.matrix` | `transpose_view` is designed for 2D matrices — doesn't correctly handle 4D NCHW tensors | Use `ExTensor.transpose(dim0, dim1)` for N-dimensional stride-based transposition |
+
+## Results & Parameters
+
+### Verified Configuration (Issue #3800)
+
+**Pattern**: Public-API guard — materialize contiguous copy before any `_data.bitcast[T]()[i]` access.
+
+**Files modified**:
+
+- `shared/core/arithmetic.mojo`: guard in `_broadcast_binary`, `multiply_scalar`
+- `shared/core/reduction.mojo`: guard in `_dispatch_reduce_all`, `_dispatch_reduce_axis`
+- `shared/core/conv.mojo`: guard in `conv2d`, `conv2d_backward`, `depthwise_conv2d`, `depthwise_conv2d_backward`
+
+**Guard template**:
+
+```mojo
+from shared.core.shape import as_contiguous
+
+# At public API entry point:
+var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+# Use t._data.bitcast[...]() instead of tensor._data.bitcast[...]()
+```
+
+**Non-contiguous fixture template** (reliable):
+
+```mojo
+fn _make_nc_nchw() raises -> ExTensor:
+    """Non-contiguous (1,1,6,4) tensor via transpose of non-square spatial dims."""
+    var x = ones([1, 1, 4, 6], DType.float32)  # H != W required
+    var nc = x.transpose(2, 3)                  # (1,1,6,4), strides [24,24,1,6]
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+```
+
+**Test count per file**: ≤8 `fn test_` functions (ADR-009 headroom below 10-function limit).
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4804, Issue #3800 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern for adding `as_contiguous()` guards to Mojo flat-buffer kernels
that use `_data.bitcast[T]()[i]` arithmetic, so non-contiguous tensor views (e.g. from
`transpose()`) don't silently produce wrong results.

- Applied to `arithmetic.mojo`, `reduction.mojo`, and `conv.mojo` in ProjectOdyssey
- Covers 6 new test files (split per ADR-009 ≤10-fn limit)
- Documents 4 failed fixture approaches and their root causes

## Key Findings

**What Worked**:

- Guard at public API boundary: `var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)`
- Non-square spatial dims (`H≠W`) + `transpose(2, 3)` for reliable NCHW non-contiguous fixtures
- Placing guard in dispatcher (with `raises`) when inner kernel lacks `raises`
- All-ones input so non-contiguous logical values match contiguous baseline exactly

**What Failed**:

- `transpose(0, 1)` on `(1,1,4,4)` → same strides, still contiguous (N=C=1, equal sizes)
- `transpose(2, 3)` on `(1,1,4,4)` → H=W=4, identical strides after swap, still contiguous
- Guard in inner `_reduce_all_impl` → compile error because function lacks `raises`
- `transpose_view()` (2D matrix API) on 4D NCHW tensors → wrong behavior

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
