### PR TITLE
feat: add conv2d-backward-padding-gradient-tests skill

### DIFF
--- a/skills/testing/conv2d-backward-padding-gradient-tests/.claude-plugin/plugin.json
+++ b/skills/testing/conv2d-backward-padding-gradient-tests/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "conv2d-backward-padding-gradient-tests",
+  "version": "1.0.0",
+  "description": "Add numerical gradient checks for conv2d_backward with padding > 0 in Mojo. Use when: (1) existing conv backward tests only cover padding=0, (2) need to exercise boundary-handling in the transposed convolution path for grad_input, (3) extending padding coverage to padding=1 (same-size) and padding=2 (extended).",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/conv2d-backward-padding-gradient-tests/references/notes.md
+++ b/skills/testing/conv2d-backward-padding-gradient-tests/references/notes.md
@@ -1,0 +1,100 @@
+# Session Notes: conv2d-backward-padding-gradient-tests
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Project**: ProjectOdyssey
+- **Issue**: #3817 — Add numerical gradient check for conv2d_backward with padding > 0
+- **PR**: #4809
+- **Branch**: `3817-auto-impl`
+
+## Objective
+
+Issue #3817 was a follow-up to #3248. The #3248 tests added numerical gradient checks for
+`conv2d_backward` but only with `stride=1, padding=0`. The `grad_input` computation is most
+complex when `padding > 0` because it exercises the boundary-handling path in the transposed
+convolution. Issue #3817 requested parametrized tests covering `padding=1` and `padding=2`.
+
+## Discovery Phase
+
+### Files Examined
+
+- `tests/shared/core/test_backward_conv_pool.mojo` — primary target, had 11 test functions
+  (over ADR-009 ≤10 limit), so could not add more
+- `tests/shared/core/test_gradient_checking_dtype.mojo` — full at 10/10, main() docstring
+  explicitly says "Budget is FULL - no room for more tests"
+- `tests/shared/core/test_gradient_checking_dtype.mojo` — already had `test_conv2d_grad_3x3_same_padding`
+  with `padding=1`, but used `check_gradients` (exhaustive) with uniform `full(0.5)` input,
+  not `check_gradient` with non-uniform inputs
+- `tests/shared/core/test_conv.mojo` — mentioned in issue plan but was for different test style
+
+### Key Finding: ADR-009 File Split Pattern
+
+ADR-009 (heap corruption workaround for Mojo v0.26.1) limits each test file to ≤10 test functions.
+The canonical pattern is to create a new file with the ADR-009 header comment rather than
+exceeding the limit in an existing file.
+
+## Implementation
+
+### File Created
+
+`tests/shared/core/test_backward_conv_padding.mojo` — 4 test functions:
+
+1. `test_conv2d_backward_grad_input_padding1` — grad_input, padding=1
+2. `test_conv2d_backward_grad_weights_padding1` — grad_weights, padding=1
+3. `test_conv2d_backward_grad_input_padding2` — grad_input, padding=2
+4. `test_conv2d_backward_grad_weights_padding2` — grad_weights, padding=2
+
+### Why Non-Uniform `grad_output`
+
+The issue plan explicitly mentioned using non-uniform `grad_output` based on learnings from
+`batch-norm-gradient-test-fix`. With `padding > 0`, boundary positions in the transposed
+convolution are partially covered by padding zeros. If `grad_output` is uniform (`ones_like`),
+the contribution from padded positions can cancel with contributions from real positions,
+producing a gradient that doesn't distinguish the padded backward path from the unpadded path.
+
+The pattern `Float32(i % 4) * Float32(0.25) - Float32(0.3)` produces
+`[-0.3, -0.05, 0.2, 0.45]` cycling through output positions.
+
+### `grad_output` Size Note
+
+- `padding=1`, input `(1,1,4,4)`: output is `(1,1,4,4)` = 16 elements
+- `padding=2`, input `(1,1,5,5)`: output is `(1,1,7,7)` = 49 elements
+
+The `grad_output` initialization loop range must match the output size exactly.
+
+## Test Execution
+
+```
+Running conv2d_backward numerical gradient tests with padding > 0...
+✓ test_conv2d_backward_grad_input_padding1
+✓ test_conv2d_backward_grad_weights_padding1
+✓ test_conv2d_backward_grad_input_padding2
+✓ test_conv2d_backward_grad_weights_padding2
+All conv2d_backward padding gradient tests passed!
+✅ PASSED: tests/shared/core/test_backward_conv_padding.mojo
+
+Total: 1 tests
+Passed: 1 tests
+Failed: 0 tests
+```
+
+## Commit Message Used
+
+```
+test(conv): add numerical gradient checks for conv2d_backward with padding > 0
+
+Add test_backward_conv_padding.mojo with 4 parametrized tests covering
+padding=1 and padding=2 for both grad_input and grad_weights. The existing
+tests in test_backward_conv_pool.mojo only exercise padding=0; the padded
+backward path (boundary handling in the transposed convolution for grad_input)
+is only triggered when padding > 0.
+
+- padding=1, input (1,1,4,4): every position adjacent to a padded boundary
+- padding=2, input (1,1,5,5): double-padded boundaries where the kernel
+  can extend entirely into the padding region (not covered by padding=1)
+- Uses non-uniform grad_output to avoid pathological gradient cancellation
+- Uses check_gradient (not check_gradients) with rtol=1e-2, atol=1e-2
+
+Closes #3817
+```

--- a/skills/testing/conv2d-backward-padding-gradient-tests/skills/conv2d-backward-padding-gradient-tests/SKILL.md
+++ b/skills/testing/conv2d-backward-padding-gradient-tests/skills/conv2d-backward-padding-gradient-tests/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: conv2d-backward-padding-gradient-tests
+description: "Add numerical gradient checks for conv2d_backward with padding > 0 in Mojo. Use when: (1) existing conv backward tests only cover padding=0, (2) need to exercise boundary handling in transposed convolution for grad_input, (3) extending padding coverage to padding=1 and padding=2."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Skill Name** | conv2d-backward-padding-gradient-tests |
+| **Category** | testing |
+| **Language** | Mojo |
+| **Issue Type** | Gradient correctness with padding > 0 (boundary handling) |
+| **Resolution** | New test file `test_backward_conv_padding.mojo` with 4 `check_gradient` tests |
+
+## When to Use
+
+- Existing conv2d backward numerical gradient tests only cover `padding=0`
+- Need to validate the transposed convolution boundary-handling path for `grad_input` (only triggered when `padding > 0`)
+- Adding `padding=1` (same-size output) or `padding=2` (extended output) coverage to a backward test suite
+- The existing test files are full (ADR-009 ≤10 limit) and cannot accept more tests
+- Want to verify `grad_weights` with padded boundary accumulation paths
+
+## Verified Workflow
+
+### Quick Reference
+
+| padding | Input shape | Output shape | Boundary condition exercised |
+|---------|------------|--------------|------------------------------|
+| 1 | `(1,1,4,4)` | `(1,1,4,4)` | Every position adjacent to padding |
+| 2 | `(1,1,5,5)` | `(1,1,7,7)` | Kernel extends entirely into padding region |
+
+### Step 1: Check existing test files for capacity
+
+ADR-009 caps each test file at ≤10 `fn test_` functions. Before adding to an existing file, count its test functions:
+
+```bash
+grep -c "^fn test_" <test-root>/test_backward_conv_pool.mojo
+```
+
+If the file is at or over 10, create a new file (e.g., `test_backward_conv_padding.mojo`).
+
+### Step 2: Create the new test file
+
+Use this header (required for ADR-009 compliance):
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_backward_conv_pool.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Numerical gradient tests for conv2d_backward with padding > 0."""
+
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.conv import conv2d, conv2d_backward
+from shared.testing import check_gradient
+```
+
+### Step 3: Use non-uniform `grad_output` to avoid boundary cancellation
+
+**Critical insight**: With `padding > 0`, uniform `grad_output` (e.g., `ones_like`) can produce
+zero net gradient at boundary positions due to symmetric cancellation across padded zeros.
+Use a non-uniform `grad_output` to ensure all gradient paths carry distinct signal:
+
+```mojo
+var grad_output = zeros_like(output)
+for i in range(output.numel()):
+    grad_output._data.bitcast[Float32]()[i] = (
+        Float32(i % 4) * Float32(0.25) - Float32(0.3)
+    )
+```
+
+This pattern (`i % 4 * 0.25 - 0.3`) produces values `-0.3, -0.05, 0.2, 0.45` cycling through
+all output positions, ensuring no position receives zero gradient.
+
+### Step 4: Add `grad_input` test for padding=1
+
+```mojo
+fn test_conv2d_backward_grad_input_padding1() raises:
+    """Numerical gradient check for grad_input with padding=1."""
+    var input_shape = List[Int]()
+    input_shape.append(1); input_shape.append(1)
+    input_shape.append(4); input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(1); kernel_shape.append(1)
+    kernel_shape.append(3); kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+    for i in range(9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(1)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_input(inp: ExTensor) raises -> ExTensor:
+        return conv2d(inp, kernel, bias, stride=1, padding=1)
+
+    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+        var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
+        return grads.grad_input
+
+    var output = forward_input(x)
+    var grad_output = zeros_like(output)
+    for i in range(16):
+        grad_output._data.bitcast[Float32]()[i] = (
+            Float32(i % 4) * Float32(0.25) - Float32(0.3)
+        )
+    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+```
+
+### Step 5: Add `grad_weights` test for padding=1
+
+Same setup; pass `kernel` as the variable and capture `x` in the closure:
+
+```mojo
+fn test_conv2d_backward_grad_weights_padding1() raises:
+    """Numerical gradient check for grad_weights with padding=1."""
+    # (same x and kernel setup as above)
+
+    fn forward_weights(k: ExTensor) raises -> ExTensor:
+        return conv2d(x, k, bias, stride=1, padding=1)
+
+    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+        var grads = conv2d_backward(grad_out, x, k, stride=1, padding=1)
+        return grads.grad_weights
+
+    var output = forward_weights(kernel)
+    var grad_output = zeros_like(output)
+    for i in range(16):
+        grad_output._data.bitcast[Float32]()[i] = (
+            Float32(i % 4) * Float32(0.25) - Float32(0.3)
+        )
+    check_gradient(forward_weights, backward_weights, kernel, grad_output, rtol=1e-2, atol=1e-2)
+```
+
+### Step 6: Repeat for padding=2 with larger input
+
+Use `(1,1,5,5)` input → `(1,1,7,7)` output (49 elements). Iterate over 49 elements for `grad_output`:
+
+```mojo
+# padding=2 output size: (1,1,7,7) = 49 elements
+for i in range(49):
+    grad_output._data.bitcast[Float32]()[i] = (
+        Float32(i % 4) * Float32(0.25) - Float32(0.3)
+    )
+```
+
+### Step 7: Call all 4 tests from `main()`
+
+```mojo
+fn main() raises:
+    print("Running conv2d_backward numerical gradient tests with padding > 0...")
+    test_conv2d_backward_grad_input_padding1()
+    print("✓ test_conv2d_backward_grad_input_padding1")
+    test_conv2d_backward_grad_weights_padding1()
+    print("✓ test_conv2d_backward_grad_weights_padding1")
+    test_conv2d_backward_grad_input_padding2()
+    print("✓ test_conv2d_backward_grad_input_padding2")
+    test_conv2d_backward_grad_weights_padding2()
+    print("✓ test_conv2d_backward_grad_weights_padding2")
+    print("All conv2d_backward padding gradient tests passed!")
+```
+
+### Step 8: Run the new test file
+
+```bash
+just test-group "tests/shared/core" "test_backward_conv_padding.mojo"
+```
+
+Expected output:
+
+```text
+Running conv2d_backward numerical gradient tests with padding > 0...
+✓ test_conv2d_backward_grad_input_padding1
+✓ test_conv2d_backward_grad_weights_padding1
+✓ test_conv2d_backward_grad_input_padding2
+✓ test_conv2d_backward_grad_weights_padding2
+All conv2d_backward padding gradient tests passed!
+✅ PASSED: tests/shared/core/test_backward_conv_padding.mojo
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Adding to `test_backward_conv_pool.mojo` | Planned to insert 4 tests into existing file | File already has 11 tests (over ADR-009 ≤10 limit) | Always `grep -c "^fn test_"` existing files before adding; create new file if at/over limit |
+| Adding to `test_gradient_checking_dtype.mojo` | Considered adding padding=1 tests there | File already full at 10/10 with note "Budget is FULL" in main() | Read the `main()` docstring — it often documents the capacity status |
+| Using `ones_like(output)` as `grad_output` | Copied pattern from padding=0 tests | With padding > 0, symmetric boundary positions get uniform gradient → potential cancellation; non-uniform is safer | Always use non-uniform `grad_output` when testing padded convolutions |
+
+## Results & Parameters
+
+### Tensor Shapes
+
+| padding | Input | Kernel | Output | grad_output elements |
+|---------|-------|--------|--------|---------------------|
+| 1 | `(1,1,4,4)` | `(1,1,3,3)` | `(1,1,4,4)` | 16 |
+| 2 | `(1,1,5,5)` | `(1,1,3,3)` | `(1,1,7,7)` | 49 |
+
+### Tolerance Settings
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `rtol` | `1e-2` | Matches existing conv2d backward tests; padding adds boundary accumulation error |
+| `atol` | `1e-2` | Same as existing conv2d backward tests |
+| `epsilon` | auto (default) | `check_gradient` auto-selects `1e-4` for float32 |
+
+### Non-Uniform `grad_output` Pattern
+
+```mojo
+# Cycles -0.3, -0.05, 0.2, 0.45 across output positions
+for i in range(numel):
+    grad_output._data.bitcast[Float32]()[i] = (
+        Float32(i % 4) * Float32(0.25) - Float32(0.3)
+    )
+```
+
+### Initialization Pattern
+
+```mojo
+# Input: 0.0, 0.1, 0.2, ..., 1.5 (for 16 elements) or 2.4 (for 25 elements)
+for i in range(numel):
+    x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+# Kernel: 0.1, 0.15, 0.2, ..., 0.5 (for 9 elements)
+for i in range(9):
+    kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3817, PR #4809 | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern for adding numerical gradient checks for `conv2d_backward`
with `padding > 0` in Mojo (follow-up to issue #3817 in ProjectOdyssey).

- Creates `test_backward_conv_padding.mojo` as a new ADR-009-compliant split file
- Uses non-uniform `grad_output` to avoid boundary cancellation in padded convolutions
- Covers `padding=1` (same-size) and `padding=2` (extended) for both `grad_input` and `grad_weights`

## Key Findings

**What Worked**:
- Creating a new test file when existing files are at/over ADR-009 ≤10 test limit
- Non-uniform `grad_output` (`i % 4 * 0.25 - 0.3`) prevents cancellation at padded boundaries
- `check_gradient` (not `check_gradients`) with `rtol=1e-2, atol=1e-2` passes for all padding values

**What Failed**:
- Adding to `test_backward_conv_pool.mojo` → already at 11 tests (over ADR-009 limit)
- Adding to `test_gradient_checking_dtype.mojo` → full at 10/10, main() docstring says "Budget is FULL"
- Using `ones_like(output)` as `grad_output` → safer to use non-uniform to avoid boundary cancellation

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
