### PR TITLE
feat: add extend-structural-test-with-value-assertions skill

### DIFF
--- a/skills/testing/extend-structural-test-with-value-assertions/.claude-plugin/plugin.json
+++ b/skills/testing/extend-structural-test-with-value-assertions/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "extend-structural-test-with-value-assertions",
+  "version": "1.0.0",
+  "description": "Pattern for closing the value-correctness gap in Mojo tensor tests that only assert structure (strides, contiguity) but not element values. Use when: (1) an existing test verifies is_contiguous() or _strides but skips assert_almost_equal on values, (2) a follow-up issue requests value-correctness regression coverage for as_contiguous() after transpose.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/extend-structural-test-with-value-assertions/references/notes.md
+++ b/skills/testing/extend-structural-test-with-value-assertions/references/notes.md
@@ -1,0 +1,73 @@
+# Session Notes: extend-structural-test-with-value-assertions
+
+## Context
+
+- **Repository**: ProjectOdyssey
+- **Issue**: #3842 — "Add as_contiguous() value-correctness test after transpose_view"
+- **Parent issue**: #3274
+- **PR**: #4812
+- **Branch**: `3842-auto-impl`
+- **Date**: 2026-03-15
+
+## Problem Statement
+
+`test_contiguous_on_noncontiguous()` in `tests/shared/core/test_utility.mojo`
+only verified:
+
+1. `t.is_contiguous() == False` (transposed tensor is non-contiguous)
+2. `c.is_contiguous() == True` (result of `as_contiguous()` is contiguous)
+3. `c._strides[0] == 3` and `c._strides[1] == 1` (correct row-major strides)
+
+It did NOT verify that element values were correctly reordered. A broken
+implementation that flat-copied memory bytes would pass all three checks
+while producing wrong values.
+
+## Solution
+
+Appended 12 `assert_almost_equal` calls after the stride assertions. The
+tensor was built as:
+
+```mojo
+var a = arange(0.0, 12.0, 1.0, DType.float32)  # [0..11]
+var b = a.reshape(shape)   # (3, 4) row-major
+var t = b.transpose(0, 1)  # (4, 3) non-contiguous
+var c = as_contiguous(t)   # (4, 3) contiguous copy
+```
+
+Expected mapping (transpose stride formula: `c[j, i] = original[i, j]`):
+
+```
+Flat idx | Logical (j,i) | Original (i,j) | Expected value
+---------|----------------|----------------|---------------
+0        | c[0,0]         | orig[0,0]      | 0
+1        | c[0,1]         | orig[1,0]      | 4
+2        | c[0,2]         | orig[2,0]      | 8
+3        | c[1,0]         | orig[0,1]      | 1
+4        | c[1,1]         | orig[1,1]      | 5
+5        | c[1,2]         | orig[2,1]      | 9
+6        | c[2,0]         | orig[0,2]      | 2
+7        | c[2,1]         | orig[1,2]      | 6
+8        | c[2,2]         | orig[2,2]      | 10
+9        | c[3,0]         | orig[0,3]      | 3
+10       | c[3,1]         | orig[1,3]      | 7
+11       | c[3,2]         | orig[2,3]      | 11
+```
+
+## Implementation Notes
+
+- No new imports needed — `assert_almost_equal` already in scope
+- Added a comment block explaining the mapping before the assertions
+- Kept the change minimal: pure assertion additions, no refactoring
+- The existing standalone tests (`test_as_contiguous_values_correct`,
+  `test_as_contiguous_3d_values_correct`) were left unchanged
+
+## Distinction from mojo-as-contiguous-stride-verification
+
+The existing skill (`mojo-as-contiguous-stride-verification`) documents
+creating a new test with manually overwritten strides (column-major `[1,2]`
+for shape `[2,3]`). This session's pattern is different:
+
+- **No stride manipulation** — uses the natural strides from `.transpose()`
+- **Extends an existing test** — does not create a new test function
+- **Simpler value derivation** — `arange + reshape + transpose` gives a
+  fully predictable mapping without needing to reason about raw memory layout

--- a/skills/testing/extend-structural-test-with-value-assertions/skills/extend-structural-test-with-value-assertions/SKILL.md
+++ b/skills/testing/extend-structural-test-with-value-assertions/skills/extend-structural-test-with-value-assertions/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: extend-structural-test-with-value-assertions
+description: "Pattern for closing the value-correctness gap in Mojo tensor tests that only assert structure (strides, contiguity) but not element values. Use when: existing test verifies is_contiguous() or strides but skips element value checks after as_contiguous()."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | extend-structural-test-with-value-assertions |
+| **Category** | testing |
+| **Language** | Mojo |
+| **Issue** | #3842 (follow-up from #3274) |
+| **PR** | #4812 |
+
+Captures the pattern for extending an existing Mojo test that only checks
+structural properties (strides, `is_contiguous()`) to also verify that
+element values are correctly reordered after `as_contiguous()` on a
+transposed tensor.
+
+The key gap: a test can pass `is_contiguous() == True` and have correct
+`_strides` while silently producing wrong element values if the copy
+implementation uses flat indexing instead of stride-based indexing.
+Closing this gap requires appending `assert_almost_equal` calls that
+derive expected values from the transpose stride mapping.
+
+## When to Use
+
+- An existing test asserts `is_contiguous()` and `_strides[n]` after
+  `as_contiguous()` but has no element-value assertions
+- A follow-up issue requests value-correctness regression coverage for
+  `as_contiguous()` after `transpose()` or `transpose_view()`
+- You want to verify that a non-contiguous copy operation remaps elements
+  (not just metadata) correctly
+- The tensor was built with `arange` + `reshape` + `.transpose()`, giving
+  predictable values that can be derived by hand
+
+## Verified Workflow
+
+### Quick Reference
+
+- **Source tensor**: `arange(0.0, N, 1.0)` reshaped to `(rows, cols)`,
+  transposed to `(cols, rows)`
+- **Expected value formula**: `c._get_float64(j * rows + i)` == original
+  value at row `i`, col `j` == `i * cols + j`
+- **Assertion helper**: `assert_almost_equal(c._get_float64(flat_idx), expected, 1e-6, msg)`
+- **Tolerance**: `1e-6` for `DType.float32`
+
+1. **Locate the existing structural test** — find the function that calls
+   `as_contiguous()` and asserts only `is_contiguous()` and `_strides`.
+
+2. **Identify the tensor construction** — confirm it uses `arange` or a
+   similar sequential fill so values are predictable. Example:
+
+   ```mojo
+   var a = arange(0.0, 12.0, 1.0, DType.float32)
+   var b = a.reshape(shape)   # shape (3, 4)
+   var t = b.transpose(0, 1)  # shape (4, 3), non-contiguous
+   var c = as_contiguous(t)
+   ```
+
+3. **Derive expected values by hand** using the transpose mapping.
+   For a `(rows=3, cols=4)` source transposed to `(cols=4, rows=3)`:
+
+   ```
+   c[j, i] = original[i, j] = i * cols + j   (0-indexed)
+
+   Flat layout of c (row-major (4,3)):
+     index 0 → c[0,0] = original[0,0] = 0
+     index 1 → c[0,1] = original[1,0] = 4
+     index 2 → c[0,2] = original[2,0] = 8
+     index 3 → c[1,0] = original[0,1] = 1
+     index 4 → c[1,1] = original[1,1] = 5
+     ...
+   ```
+
+4. **Append assertions** directly after the existing stride assertions,
+   with a comment block explaining the mapping:
+
+   ```mojo
+   # Verify element values are correctly reordered per transpose stride mapping.
+   # Original (3,4) row-major: a[i,j] = i*4 + j (values 0..11)
+   # After transpose to (4,3), reading row-major: t[j,i] = a[i,j]
+   # Row 0 of transpose = col 0 of original: 0, 4, 8
+   assert_almost_equal(c._get_float64(0), 0.0, 1e-6, "c[0,0] should be 0")
+   assert_almost_equal(c._get_float64(1), 4.0, 1e-6, "c[0,1] should be 4")
+   assert_almost_equal(c._get_float64(2), 8.0, 1e-6, "c[0,2] should be 8")
+   # Row 1 of transpose = col 1 of original: 1, 5, 9
+   assert_almost_equal(c._get_float64(3), 1.0, 1e-6, "c[1,0] should be 1")
+   assert_almost_equal(c._get_float64(4), 5.0, 1e-6, "c[1,1] should be 5")
+   assert_almost_equal(c._get_float64(5), 9.0, 1e-6, "c[1,2] should be 9")
+   # ... all N elements
+   ```
+
+5. **Verify no new imports are needed** — `assert_almost_equal` is
+   typically already imported in Mojo utility test files.
+
+6. **Run the test** to confirm it passes (values are correct) or reveals
+   a bug (implementation uses flat copy):
+
+   ```bash
+   just test-group "tests/shared/core" "test_utility.mojo"
+   ```
+
+## Results & Parameters
+
+- **Source shape**: `(3, 4)` is the canonical minimal non-square case — clear
+  row/column ordering, 12 total elements (exhaustive but not tedious to enumerate)
+- **Value fill**: `arange(0.0, 12.0, 1.0, DType.float32)` — sequential, easy
+  to trace
+- **Transpose**: `.transpose(0, 1)` swaps dims 0 and 1 (same as `transpose_view`)
+- **Result shape**: `(4, 3)` — all 12 elements must be checked
+- **Tolerance**: `1e-6` for float32
+- **Test file**: `tests/shared/core/test_utility.mojo`
+- **Function extended**: `test_contiguous_on_noncontiguous()`
+- **Assertions added**: 12 `assert_almost_equal` calls (one per element)
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3842, PR #4812 | [notes.md](../references/notes.md) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Checking only strides and contiguity | Original test asserted `is_contiguous() == True` and `_strides[0] == 3`, `_strides[1] == 1` | Structural metadata can be correct while element values are wrong (flat copy instead of stride copy) | Always append element-value assertions after structural checks |
+| Using `_get_float64(i)` on the non-contiguous tensor before `as_contiguous()` | Asserting values on `t` (the transposed view) before copying | `_get_float64(i)` reads flat memory index `i`, ignoring strides — gives original row-major order, not transpose order | Assert values on `c` (the contiguous result), not on the non-contiguous view |
+| Manually overwriting `_strides` to create non-contiguous tensor | Alternative approach from `mojo-as-contiguous-stride-verification` skill | Harder to control predictable values when stride override decouples logical and physical layout | When the tensor is built with `arange + reshape + transpose`, the value mapping is derivable without stride manipulation — prefer the simpler path |


### PR DESCRIPTION
## Summary

Documents the pattern for closing the value-correctness gap in Mojo tensor tests
that only assert structural properties (strides, `is_contiguous()`) but skip
element-value verification after `as_contiguous()`.

- Captures the exact formula for deriving expected values from `arange + reshape + transpose`
- Distinguishes from the existing `mojo-as-contiguous-stride-verification` skill (which uses manual stride overwriting)
- Applicable whenever a follow-up issue requests value-correctness regression coverage

## Key Findings

**What Worked**:
- Appending `assert_almost_equal` calls directly after existing stride assertions — minimal diff, clear intent
- Using `arange(0.0, N, 1.0)` as the value source — sequential values make the transpose mapping trivially verifiable by hand
- Formula `c[j,i] = original[i,j] = i*cols + j` covers the full (4,3) output with no edge cases

**What Failed**:
- Asserting on the non-contiguous view `t` instead of `c` → `_get_float64(i)` reads flat memory (ignores strides), gives wrong expectations
- Checking only strides and contiguity → passes even when element values are wrong
- Manual stride overwriting → harder to derive predictable values (documented in existing skill)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates when searching for "value-correctness", "structural test", "assert_almost_equal transpose"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
