### PR TITLE
feat: add mojo-reexport-import-tests skill

### DIFF
--- a/skills/testing/mojo-reexport-import-tests/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-reexport-import-tests/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-reexport-import-tests",
+  "version": "1.0.0",
+  "description": "Add import tests for Mojo package re-exports, verifying symbols exported via __init__.mojo are importable at the package level. Use when: (1) adding new re-exports to a Mojo __init__.mojo, (2) implementing a GitHub issue that exports types from submodules, (3) verifying a package's public API is importable.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/mojo-reexport-import-tests/references/notes.md
+++ b/skills/testing/mojo-reexport-import-tests/references/notes.md
@@ -1,0 +1,52 @@
+# Session Notes: mojo-reexport-import-tests
+
+## Date
+2026-03-15
+
+## Issue
+GitHub Issue #3851: "Export DataLoader from shared.training package"
+
+## Objective
+Add `DataLoader` and `DataBatch` to `shared/training/__init__.mojo` exports so users
+can `from shared.training import DataLoader` instead of the longer submodule path.
+
+## What We Found
+
+The re-export was **already present** in `__init__.mojo`:
+
+```mojo
+# Export data loader interfaces (Issue #3851, #3856)
+from shared.training.trainer_interface import (
+    DataBatch,
+    DataLoader,
+)
+```
+
+The issue was that **no test coverage existed** for these exports.
+
+## Implementation Done
+
+1. Added `test_training_dataloader_imports()` to `tests/shared/test_imports_part1.mojo`
+   - Verifies `from shared.training import DataLoader, DataBatch`
+   - ADR-009: file had 8 functions, now 9 (within ≤10 limit)
+
+2. Added two functions to `tests/shared/test_imports.mojo`:
+   - `test_training_dataloader_imports()` — package-level import
+   - `test_training_dataloader_direct_imports()` — direct submodule import
+
+3. Both files' `main()` functions updated to call new tests.
+
+## Key Constraints Observed
+
+- **ADR-009**: Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers
+  under high test load. Split test files must stay ≤10 `fn test_` functions each.
+- **Mojo compile-time imports**: Cannot write negative import tests (tests that expect
+  an import to fail). Import failures are compile-time errors with no runtime exception
+  handling. Only test valid imports that compile successfully.
+- **Callback limitation**: Callbacks have a specific re-export limitation in Mojo v0.26.1
+  where they must be imported directly from submodules. This does NOT affect structs like
+  DataLoader/DataBatch.
+
+## PR Created
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4814
+Branch: `3851-auto-impl`

--- a/skills/testing/mojo-reexport-import-tests/skills/mojo-reexport-import-tests/SKILL.md
+++ b/skills/testing/mojo-reexport-import-tests/skills/mojo-reexport-import-tests/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: mojo-reexport-import-tests
+description: "Add import tests for Mojo package re-exports. Use when: adding exports to __init__.mojo, verifying package public API, or closing issues about missing package-level imports."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-reexport-import-tests |
+| **Category** | testing |
+| **Trigger** | Adding re-exports to `__init__.mojo`, package API verification issues |
+| **Output** | Test functions in `test_imports*.mojo` covering both package and direct import paths |
+| **Constraint** | ADR-009: ≤10 `fn test_` functions per file due to Mojo heap corruption risk |
+
+## When to Use
+
+1. A GitHub issue requests exporting a type from a submodule via `__init__.mojo`
+2. A package's public API has been extended and needs import test coverage
+3. Verifying that re-exported symbols are importable at the parent package level
+4. Validating both `from pkg import Symbol` and `from pkg.sub import Symbol` paths
+
+## Verified Workflow
+
+### Quick Reference
+
+```
+1. Check __init__.mojo for existing re-export (often already done)
+2. Verify source module has the struct/fn
+3. Check ADR-009 function count in split test files (≤10 per file)
+4. Add test_<type>_imports() to test_imports_part1.mojo (if count ≤9)
+5. Add test_<type>_imports() + test_<type>_direct_imports() to test_imports.mojo
+6. Add both calls to main() in each file
+7. Commit with "Closes #<issue>" in message
+```
+
+### Step 1: Check existing re-exports
+
+Read `shared/<pkg>/__init__.mojo`. The export is often **already present** but
+lacking test coverage — check for a comment like `# Issue #NNNN`:
+
+```bash
+grep -n "DataLoader\|DataBatch\|<TypeName>" shared/<pkg>/__init__.mojo
+```
+
+If missing, add:
+
+```mojo
+# Export <type> (Issue #NNNN)
+from shared.<pkg>.<submodule> import (
+    TypeName,
+)
+```
+
+### Step 2: Verify source struct exists
+
+```bash
+grep -n "struct TypeName" shared/<pkg>/<submodule>.mojo
+```
+
+### Step 3: Check ADR-009 function count
+
+```bash
+grep -c "^fn test_" tests/shared/test_imports_part1.mojo
+# Must be ≤ 9 before adding (limit is 10)
+```
+
+### Step 4: Add to test_imports_part1.mojo
+
+Add the new function **before** the `# Main Test Runner` comment block:
+
+```mojo
+fn test_training_<typename>_imports() raises:
+    """Test <TypeName> is importable from shared.<pkg> package.
+
+    Verifies Issue #NNNN: <TypeName> exported from
+    shared/<pkg>/__init__.mojo via the <submodule> submodule.
+    """
+    from shared.<pkg> import TypeName, OtherType
+
+    print("✓ Training <TypeName> package imports test passed")
+```
+
+Add the call in `main()`:
+
+```mojo
+    test_training_<typename>_imports()
+```
+
+### Step 5: Add two functions to test_imports.mojo
+
+Add both a package-level and a direct-submodule test:
+
+```mojo
+fn test_training_<typename>_imports() raises:
+    """Test <TypeName> is importable from shared.<pkg> package.
+
+    Verifies Issue #NNNN: <TypeName> exported from
+    shared/<pkg>/__init__.mojo via the <submodule> submodule.
+    """
+    from shared.<pkg> import TypeName, OtherType
+
+    print("✓ Training <TypeName> package imports test passed")
+
+
+fn test_training_<typename>_direct_imports() raises:
+    """Test <TypeName> is importable directly from <submodule>.
+
+    Validates the direct import path as documented fallback:
+        from shared.<pkg>.<submodule> import TypeName
+    """
+    from shared.<pkg>.<submodule> import TypeName, OtherType
+
+    print("✓ Training <TypeName> direct imports test passed")
+```
+
+Add both calls to `main()`:
+
+```mojo
+    test_training_<typename>_imports()
+    test_training_<typename>_direct_imports()
+```
+
+### Step 6: Commit and push
+
+```bash
+git add tests/shared/test_imports.mojo tests/shared/test_imports_part1.mojo
+git commit -m "test(<pkg>): add import tests for <TypeName> package export
+
+Add test coverage verifying <TypeName> are correctly exported
+from shared.<pkg> package (via __init__.mojo re-export from <submodule>).
+
+Tests added:
+- test_imports_part1.mojo: test_training_<typename>_imports() - package import
+- test_imports.mojo: test_training_<typename>_imports() - package import
+- test_imports.mojo: test_training_<typename>_direct_imports() - direct submodule import
+
+Closes #NNNN
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+git push -u origin <branch>
+gh pr create --title "test(<pkg>): add import tests for <TypeName> package export" \
+  --body "Closes #NNNN"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Modifying `__init__.mojo` | Tried to add re-exports from scratch | Export was already present (added in prior work with `# Issue #3851` comment) | Always check `__init__.mojo` first — the re-export is often done, only tests are missing |
+| Callback re-export pattern | Assumed same limitation applied to all types | Callbacks have a specific Mojo v0.26.1 re-export limitation; `DataLoader`/`DataBatch` work fine | Check the docstring in `__init__.mojo` for existing limitation notes before assuming failure |
+| Adding to test_imports.mojo only | Added tests to monolithic file only | ADR-009 split files exist for a reason — part1 also needs coverage for CI split runs | Always update both `test_imports.mojo` AND `test_imports_part1.mojo` |
+
+## Results & Parameters
+
+### Issue #3851 — DataLoader/DataBatch export
+
+- **Export location**: `shared/training/__init__.mojo` lines 93–97
+- **Source module**: `shared/training/trainer_interface.mojo`
+- **Types exported**: `DataLoader`, `DataBatch`
+- **Test files modified**: `tests/shared/test_imports.mojo`, `tests/shared/test_imports_part1.mojo`
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4814
+- **ADR-009 counts after**: part1 = 9 functions (within ≤10 limit)
+
+### File placement pattern
+
+```
+tests/shared/
+├── test_imports.mojo          # Full suite (all packages, 37 fns after)
+├── test_imports_part1.mojo    # Split: Core + Training (9 fns, ≤10 ADR-009 limit)
+├── test_imports_part2.mojo    # Split: additional sections
+└── test_imports_part3.mojo    # Split: additional sections
+```


### PR DESCRIPTION
## Summary

Documents the workflow for adding Mojo import tests when types are re-exported
via `__init__.mojo` but lack test coverage.

- Captures ADR-009 constraint (≤10 `fn test_` per file) for split test files
- Pattern for both package-level and direct submodule import tests
- Key insight: re-exports are often already in `__init__.mojo` — check first

## Key Findings

**What Worked**:
- Checking `__init__.mojo` for existing exports before modifying (saved unnecessary edits)
- Adding tests to both `test_imports_part1.mojo` AND `test_imports.mojo` for split CI coverage
- Two-function pattern: package import + direct submodule import

**What Failed**:
- Assuming `__init__.mojo` needed modification — the export was already there
- Assuming all types have the Callback re-export limitation — only Callbacks are affected in Mojo v0.26.1

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with Mojo import test triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
