### PR TITLE
feat: add unique-tmp-path-per-test-run skill

### DIFF
--- a/skills/testing/unique-tmp-path-per-test-run/.claude-plugin/plugin.json
+++ b/skills/testing/unique-tmp-path-per-test-run/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "unique-tmp-path-per-test-run",
+  "version": "1.0.0",
+  "description": "Replace hardcoded /tmp test file paths with unique per-run paths using a timestamp or random suffix to prevent stale state across test runs. Use when: (1) a test creates a temp file with a fixed path that may persist if the test aborts, (2) parallel or repeated test runs could collide on a shared temp file, (3) reviewing tests for stale-state cleanup issues.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/unique-tmp-path-per-test-run/references/notes.md
+++ b/skills/testing/unique-tmp-path-per-test-run/references/notes.md
@@ -1,0 +1,43 @@
+# Session Notes: unique-tmp-path-per-test-run
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #3878
+- **Branch**: 3878-auto-impl
+- **PR**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4818
+
+## Objective
+
+Fix `test_safe_remove()` in `tests/shared/utils/test_io_part2.mojo` to prevent
+stale `/tmp` files across test runs. The hardcoded path
+`/tmp/test_remove_safely_3283.txt` could be left behind if the test aborted
+between file creation and the `finally` block, causing subsequent runs to see
+unexpected filesystem state.
+
+## Steps Taken
+
+1. Read the issue body and existing implementation plan from `gh issue view 3878 --comments`
+2. Read `tests/shared/utils/test_io_part2.mojo` to understand the current structure
+3. Confirmed the `try/finally` was already correct — only the path was the problem
+4. Added `from time import perf_counter_ns` inline in the function
+5. Replaced the hardcoded path with `"/tmp/test_remove_safely_" + String(perf_counter_ns()) + ".txt"`
+6. Verified `grep -r "test_remove_safely_3283" tests/` returned no results
+7. Committed, pushed, and opened PR
+
+## What Worked
+
+- Inline `from time import perf_counter_ns` import compiles fine in Mojo v0.26.1
+- `String(perf_counter_ns())` produces a unique numeric suffix with nanosecond granularity
+- The change was 3 lines: +2 additions, -1 deletion — minimal and focused
+
+## What Failed / Was Rejected
+
+- `uuid` module not available in Mojo v0.26.1 stdlib
+- Considered extracting a helper function — rejected as YAGNI (single call site)
+
+## Key Insight
+
+The issue plan correctly identified that the `try/finally` structure was already
+sound. The only risk was the fixed path being shared across runs. Using
+`perf_counter_ns()` is the idiomatic Mojo solution when `uuid` is unavailable.

--- a/skills/testing/unique-tmp-path-per-test-run/skills/unique-tmp-path-per-test-run/SKILL.md
+++ b/skills/testing/unique-tmp-path-per-test-run/skills/unique-tmp-path-per-test-run/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: unique-tmp-path-per-test-run
+description: "Replace hardcoded /tmp test file paths with unique per-run paths to prevent stale state. Use when: a test writes a fixed temp path that can persist across aborted runs, or parallel runs may collide."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Tests using a hardcoded `/tmp/<name>.txt` path leave stale files if the test aborts before cleanup, causing false failures on subsequent runs |
+| **Solution** | Generate a unique path per run using a timestamp or nanosecond counter suffix |
+| **Language** | Mojo (Mojo v0.26.1) |
+| **Pattern** | `from time import perf_counter_ns` → `String(perf_counter_ns())` suffix |
+| **Effort** | Single targeted edit — 2-3 lines changed |
+
+## When to Use
+
+- A test file has a hardcoded `/tmp/<fixed-name>` path for a temporary file
+- Parallel CI matrix runs could execute the same test simultaneously and collide
+- A test aborted mid-run and left a stale `/tmp` file, causing the next run to fail
+- Reviewing tests for cleanup hygiene as part of a PR or code review
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+# Before
+var test_path = "/tmp/test_remove_safely_3283.txt"
+
+# After
+from time import perf_counter_ns
+var suffix = String(perf_counter_ns())
+var test_path = "/tmp/test_remove_safely_" + suffix + ".txt"
+```
+
+### Steps
+
+1. **Find the hardcoded path** — search for the fixed `/tmp/` path in the test file:
+
+   ```bash
+   grep -r "test_remove_safely_3283" tests/
+   ```
+
+2. **Add the import** inside the test function (or at module level if other
+   functions use it):
+
+   ```mojo
+   from time import perf_counter_ns
+   ```
+
+3. **Replace the fixed path** with a dynamic one:
+
+   ```mojo
+   var suffix = String(perf_counter_ns())
+   var test_path = "/tmp/test_remove_safely_" + suffix + ".txt"
+   ```
+
+4. **Verify the existing `try/finally` cleanup is in place** — the `finally`
+   block must call the removal function even on the unique path:
+
+   ```mojo
+   finally:
+       _ = remove_safely(test_path)
+   ```
+
+5. **Confirm the old path is gone**:
+
+   ```bash
+   grep -r "test_remove_safely_3283" tests/   # should return nothing
+   ```
+
+6. **Run the test twice consecutively** to confirm no stale-state interference:
+
+   ```bash
+   just test-mojo tests/shared/utils/test_io_part2.mojo
+   just test-mojo tests/shared/utils/test_io_part2.mojo
+   ls /tmp/test_remove_safely_*.txt 2>/dev/null || echo "No stale files"
+   ```
+
+## Key Decisions
+
+- **`perf_counter_ns()` over `uuid`**: Mojo v0.26.1 stdlib has no `uuid` module;
+  `perf_counter_ns()` provides a monotonically increasing nanosecond integer that
+  is unique per run on a single machine. Sufficient for serial test runs and most
+  parallel runs (nanosecond granularity makes collisions extremely unlikely).
+
+- **Import inside function is valid**: Mojo allows `from X import Y` at the start
+  of a function body. Place it next to the existing inline imports already in the
+  function to keep changes minimal.
+
+- **`try/finally` structure is correct as-is**: The fix is the *path* only.
+  The existing `try/finally` already guarantees cleanup — do not restructure it.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Use `uuid` module | Tried `from uuid import uuid4` | Mojo v0.26.1 stdlib has no `uuid` module — compile-time error | Check Mojo stdlib availability before choosing a uniqueness strategy |
+| Move import to module level | Considered adding `from time import perf_counter_ns` at the top of the file | Not needed — inline import works and minimises diff size | Prefer the smallest change that solves the problem |
+| Add a new helper function | Considered extracting `make_tmp_path()` utility | YAGNI — only one call site, a helper adds complexity for no gain | Don't abstract one-off patterns; inline is cleaner |
+
+## Results & Parameters
+
+### Exact Edit Applied (Mojo)
+
+```mojo
+# File: tests/shared/utils/test_io_part2.mojo
+# Function: test_safe_remove()
+
+# Add after existing imports in the function:
+from time import perf_counter_ns
+
+# Replace hardcoded path:
+var suffix = String(perf_counter_ns())
+var test_path = "/tmp/test_remove_safely_" + suffix + ".txt"
+```
+
+### Verification Commands
+
+```bash
+# Confirm old path removed
+grep -r "test_remove_safely_3283" tests/     # → no output
+
+# Run test to confirm it passes
+just test-mojo tests/shared/utils/test_io_part2.mojo
+
+# Confirm no stale files left after run
+ls /tmp/test_remove_safely_*.txt 2>/dev/null || echo "No stale files — good"
+```


### PR DESCRIPTION
## Summary

Documents the pattern of replacing hardcoded `/tmp` test file paths with
unique per-run paths using `perf_counter_ns()` in Mojo v0.26.1 tests.

- Prevents stale temp file state when a test aborts between file creation and cleanup
- Covers why `uuid` is not available in Mojo v0.26.1 and `perf_counter_ns()` is the right substitute
- Confirms that `try/finally` cleanup structure is correct as-is — only the fixed path needs changing

## Key Findings

**What Worked**:
- `from time import perf_counter_ns` as an inline function-level import compiles fine in Mojo v0.26.1
- `String(perf_counter_ns())` produces a unique nanosecond-granularity suffix — minimal diff (3 lines)

**What Failed**:
- `from uuid import uuid4` → Mojo v0.26.1 stdlib has no `uuid` module (compile-time error)
- Extracting a `make_tmp_path()` helper → rejected as YAGNI (single call site)

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with: hardcoded `/tmp` path in test, stale temp file issues, Mojo test cleanup review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
