### PR TITLE
feat: add mojo-docstring-format-precommit skill

### DIFF
--- a/skills/documentation/mojo-docstring-format-precommit/.claude-plugin/plugin.json
+++ b/skills/documentation/mojo-docstring-format-precommit/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-docstring-format-precommit",
+  "version": "1.0.0",
+  "description": "Enrich sparse Mojo test function docstrings to accurately describe what the test validates, pre-formatted to pass mojo format without producing a diff. Use when: (1) a one-liner docstring exists but needs detail after feature support is added, (2) a file was split and the receiving file got a minimal docstring, (3) updating stale placeholder language in a Mojo test fn docstring.",
+  "category": "documentation",
+  "date": "2026-03-15"
+}

--- a/skills/documentation/mojo-docstring-format-precommit/references/notes.md
+++ b/skills/documentation/mojo-docstring-format-precommit/references/notes.md
@@ -1,0 +1,73 @@
+# Session Notes: mojo-docstring-format-precommit
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Project**: ProjectOdyssey
+- **Issue**: #3904 — Update test_dtypes_bfloat16 docstring to reflect current support
+- **PR**: #4824
+- **Branch**: 3904-auto-impl
+
+## Objective
+
+Update the docstring in `test_dtypes_bfloat16()` which still described the test as
+skipped/placeholder even though bfloat16 is now fully supported in Mojo's DType enum
+and the test is active and passing.
+
+## Background
+
+The original `test_special_values.mojo` at lines 241-264 had a stale docstring saying
+"Mojo's DType enum does not include DType.bfloat16". This was fixed in an earlier PR,
+but when the file was split into `_part1/_part2/_part3` (commit `279b29d2`), the function
+received only a minimal one-liner: `"""Test special values work with bfloat16."""`
+
+Issue #3904 is a follow-up to #3300, requesting the docstring be enriched.
+
+## Steps Taken
+
+1. Read `.claude-prompt-3904.md` to understand the task
+2. Checked `gh issue view 3904 --comments` — found a detailed implementation plan
+3. Globbed for `test_special_values.mojo` — not found (file was split)
+4. Found actual files: `test_special_values_part1.mojo`, `_part2`, `_part3`
+5. Grepped for `test_dtypes_bfloat16` — found in `_part2.mojo` at line 124
+6. Read lines 120-134 to confirm current one-liner docstring
+7. Applied Edit to upgrade to multi-line trailing-newline docstring
+8. Committed with `docs(tests):` prefix and `Closes #3904`
+9. Pushed and created PR #4824 with `--label documentation`
+
+## What Worked
+
+- Globbing with wildcard `*test_special_values*` found the split files immediately
+- Reading specific line range (offset+limit) was efficient to confirm the exact text
+- Multi-line trailing-newline Mojo docstring pattern passes `mojo format` without diff
+- Line lengths kept ≤ 80 chars (well under 90-char limit)
+
+## Key Insight
+
+When an issue references specific line numbers in a file, those numbers are often stale
+because files get split or reorganized. Always use Grep/Glob to find the current location.
+
+## Files Changed
+
+- `tests/shared/testing/test_special_values_part2.mojo` — lines 124-125 (docstring only)
+
+## Exact Change
+
+```mojo
+# BEFORE
+fn test_dtypes_bfloat16() raises:
+    """Test special values work with bfloat16."""
+
+# AFTER
+fn test_dtypes_bfloat16() raises:
+    """Test special values work with bfloat16.
+
+    Verifies DType.bfloat16 is fully supported in Mojo's DType enum
+    and integrates correctly with the ExTensor special values API.
+
+    Tests:
+    - Tensor creation with DType.bfloat16 dtype
+    - dtype assertion confirms bfloat16 is preserved
+    - Special value invariants hold for value 1.0 (FP-representable)
+    """
+```

--- a/skills/documentation/mojo-docstring-format-precommit/skills/mojo-docstring-format-precommit/SKILL.md
+++ b/skills/documentation/mojo-docstring-format-precommit/skills/mojo-docstring-format-precommit/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: mojo-docstring-format-precommit
+description: "Enrich sparse Mojo test function docstrings to accurately describe what the test validates, pre-formatted to pass mojo format without producing a diff. Use when: (1) a one-liner docstring needs detail after feature support is added, (2) a split file got a minimal docstring, (3) stale placeholder language needs replacing in a test fn."
+category: documentation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Objective** | Replace sparse or stale docstrings in Mojo test functions with accurate multi-line descriptions |
+| **Trigger** | Issue flags a test fn docstring as inaccurate or placeholder; test is already active and passing |
+| **Outcome** | Docstring updated, pre-commit passes, PR merged |
+| **Time** | ~5 minutes |
+
+## When to Use
+
+- A Mojo test function docstring is a one-liner that doesn't describe what the test actually validates
+- A file was split (e.g. `test_special_values.mojo` → `_part1/_part2/_part3`) and the new file got a minimal docstring
+- The docstring says a feature is "not supported", "skipped", or "future" but the test is now active
+- Closing a follow-up issue that flags stale docstring language after a feature lands
+
+## Verified Workflow
+
+### Quick Reference
+
+| Step | Action |
+|------|--------|
+| 1 | Read issue + comments to get exact target file/function/line |
+| 2 | Glob for the file (the original path may have changed due to splitting) |
+| 3 | Grep for function name to confirm current docstring |
+| 4 | Edit: replace one-liner with multi-line trailing-newline docstring |
+| 5 | Verify line lengths ≤ 80-90 chars (4-space indent + `"""`) |
+| 6 | Commit, push, create PR |
+
+### Detailed Steps
+
+1. **Read the issue plan** (`gh issue view <N> --comments`) to learn:
+   - Original file path and line numbers (may be stale due to splits)
+   - What the updated docstring should say
+
+2. **Locate the actual file** — original path may have changed. Use Glob:
+
+   ```bash
+   find . -name "test_special_values*.mojo"
+   # e.g. discovers test_special_values_part2.mojo
+   ```
+
+3. **Grep for the function** to see the current docstring:
+
+   ```bash
+   grep -n "test_dtypes_bfloat16" tests/shared/testing/test_special_values_part2.mojo
+   ```
+
+4. **Read the target lines** to confirm the exact text before editing (required by Edit tool).
+
+5. **Apply the edit** — upgrade the one-liner to a multi-line docstring:
+
+   ```mojo
+   # BEFORE (sparse one-liner)
+   fn test_dtypes_bfloat16() raises:
+       """Test special values work with bfloat16."""
+
+   # AFTER (descriptive multi-line, trailing-newline pattern)
+   fn test_dtypes_bfloat16() raises:
+       """Test special values work with bfloat16.
+
+       Verifies DType.bfloat16 is fully supported in Mojo's DType enum
+       and integrates correctly with the ExTensor special values API.
+
+       Tests:
+       - Tensor creation with DType.bfloat16 dtype
+       - dtype assertion confirms bfloat16 is preserved
+       - Special value invariants hold for value 1.0 (FP-representable)
+       """
+   ```
+
+   **Line-length rule**: Each line in the docstring body (4-space indent + `"""` + text)
+   must stay ≤ ~90 chars to avoid `mojo format` reflow producing a diff.
+
+6. **Documentation-only change** — do not modify function body, signature, or imports.
+
+7. **Commit** with `docs(tests):` prefix and `Closes #<N>` in the body:
+
+   ```bash
+   git add tests/shared/testing/test_special_values_part2.mojo
+   git commit -m "docs(tests): update test_dtypes_bfloat16 docstring to reflect bfloat16 full support
+
+   Closes #3904"
+   ```
+
+8. **Create PR** with `--label documentation`.
+
+## Mojo Multi-Line Docstring Pattern
+
+The trailing-newline pattern is the correct Mojo style for multi-line docstrings:
+
+```mojo
+fn my_fn() raises:
+    """One-line summary.
+
+    Extended description paragraph.
+
+    Tests:
+    - item one
+    - item two
+    """
+    # function body...
+```
+
+Key rules:
+
+- Closing `"""` on its own line, indented to match opening
+- Blank line between summary and extended body
+- Lists use `- ` prefix (not `*`)
+- Keep all lines ≤ 90 chars including indent
+
+## Results & Parameters
+
+### Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #3904, PR #4824 | [notes.md](../references/notes.md) |
+
+### Commit Message Template
+
+```text
+docs(tests): update <function_name> docstring to reflect <feature> full support
+
+<Extended explanation if needed.>
+
+Closes #<issue-number>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Searching original file path | Globbed for `test_special_values.mojo` | File was split into `_part1/_part2/_part3` in a prior commit | Always glob with `*test_special_values*.mojo` when file might have been split |
+| Using Edit without Read | Called Edit tool immediately | Edit tool requires a prior Read of the file | Always Read first, even for a single-line change |
+| Assuming file was unchanged | Relied on line numbers from issue body | Issue said "lines 241-264" but split moved function to line 124 of `_part2` | Treat issue line numbers as hints only; Grep to confirm actual location |


### PR DESCRIPTION
## Summary

Documents how to enrich sparse Mojo test function docstrings to accurately reflect
current feature support, pre-formatted to pass `mojo format` without producing a diff.

- Covers the case where a file was split and the receiving file got a minimal one-liner docstring
- Documents the trailing-newline multi-line Mojo docstring pattern
- Captures the "stale line numbers in issue body" pitfall caused by file splits

## Key Findings

**What Worked**:
- Globbing with wildcards (`*test_special_values*`) finds split files when original path is gone
- Multi-line trailing-newline Mojo docstring pattern (`"""...\n    """`) passes `mojo format` without diff
- Reading specific line ranges (offset+limit) is efficient to confirm exact text before Edit

**What Failed**:
- Globbing for exact original filename → file was split, not found
- Calling Edit without Read → Edit tool requires prior Read
- Trusting issue body line numbers → split moved function from line 241 to line 124

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results for "docstring" queries
- [ ] Check skill triggers correctly for "mojo format", "docstring", "split file" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
