### PR TITLE
feat: add mojo-silent-noop-int8-dtype-fix skill

### DIFF
--- a/skills/debugging/mojo-silent-noop-int8-dtype-fix/.claude-plugin/plugin.json
+++ b/skills/debugging/mojo-silent-noop-int8-dtype-fix/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-silent-noop-int8-dtype-fix",
+  "version": "1.0.0",
+  "description": "Fix silent no-op writes in Mojo dtype dispatch functions missing integer branches. Use when: (1) a _set_float64/_set_float32-style function silently discards writes for an integer dtype, (2) a dtype dispatch chain has no branch for int8/int16/int32 and writes are ignored, (3) a test documents a known no-op instead of asserting the correct truncation behavior.",
+  "category": "debugging",
+  "date": "2026-03-15"
+}

--- a/skills/debugging/mojo-silent-noop-int8-dtype-fix/references/notes.md
+++ b/skills/debugging/mojo-silent-noop-int8-dtype-fix/references/notes.md
@@ -1,0 +1,60 @@
+# Session Notes: mojo-silent-noop-int8-dtype-fix
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: HomericIntelligence/ProjectOdyssey#3909
+- **PR**: HomericIntelligence/ProjectOdyssey#4825
+- **Branch**: `3909-auto-impl`
+- **Worktree**: `/home/mvillmow/ProjectOdyssey/.worktrees/issue-3909`
+
+## Objective
+
+`_set_float64` in `shared/core/extensor.mojo` was a silent no-op for `DType.int8`
+tensors — the `if/elif` dtype dispatch chain had no `int8` branch, so writes were
+silently discarded. The test `test_int8_set_float64_is_noop` documented this as a
+known limitation.
+
+The issue also noted that `_set_float32` likely had the same problem.
+
+## Root Cause Analysis
+
+Mojo `if/elif` chains without a final `else` are silent no-ops for unmatched
+conditions. In `_set_float64`:
+
+```mojo
+if self._dtype == DType.float16: ...
+elif self._dtype == DType.bfloat16: ...
+elif self._dtype == DType.float32: ...
+elif self._dtype == DType.float64: ...
+# int8: falls through with no write → silent no-op
+```
+
+Both `_set_float64` and `_set_float32` were missing the `int8` branch.
+
+## Fix Applied
+
+Added `elif self._dtype == DType.int8:` branch to both functions using the
+standard `bitcast[Int8]()` + `value.cast[DType.int8]()` pattern.
+
+## Test Changes
+
+- Deleted `test_int8_set_float64_is_noop` (documented the bug)
+- Added `test_int8_set_float64_truncates_to_int8` (asserts correct behavior)
+- Added `test_int8_set_float32_truncates_to_int8` (covers the _set_float32 fix)
+- Updated section header comment to remove the "TODO(#3301)" language
+- Updated `main()` to call both new tests
+
+## Key Observations
+
+1. **Pattern consistency**: Every branch in both functions uses `bitcast[T]()` +
+   `value.cast[DType.T]()`. The int8 fix follows the exact same pattern.
+
+2. **`_get_float64` was already correct**: The getter had a catch-all `else` branch
+   that fell through to `_get_int64()`, so reads worked fine. Only writes were broken.
+
+3. **Truncation semantics are correct**: `value.cast[DType.int8]()` in Mojo truncates
+   (not rounds) — 127.9 becomes 127. This matches C-style integer casts and numpy.
+
+4. **Both setter functions needed the fix**: `_set_float64` and `_set_float32` are
+   parallel in structure; fixing only one leaves the other broken.

--- a/skills/debugging/mojo-silent-noop-int8-dtype-fix/skills/mojo-silent-noop-int8-dtype-fix/SKILL.md
+++ b/skills/debugging/mojo-silent-noop-int8-dtype-fix/skills/mojo-silent-noop-int8-dtype-fix/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: mojo-silent-noop-int8-dtype-fix
+description: "Fix silent no-op writes in Mojo dtype dispatch functions missing integer branches. Use when: a _set_float* function silently discards writes for int8, a dtype chain has no integer branch, or a test documents a known no-op instead of asserting correct truncation."
+category: debugging
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo dtype dispatch functions (`_set_float64`, `_set_float32`) silently do nothing for integer dtypes when no matching `elif` branch exists |
+| **Root Cause** | `if/elif` chains without an `else` are silent no-ops in Mojo — unmatched dtypes fall through without error |
+| **Fix** | Add the missing integer `elif` branch with truncation cast (e.g. `value.cast[DType.int8]()`) |
+| **Test Update** | Replace no-op-documenting tests with truncation-assertion tests |
+| **Affected files** | `shared/core/extensor.mojo` — `_set_float64` and `_set_float32` |
+
+## When to Use
+
+- A test contains a comment like "silent no-op" or "TODO: add int8 branch" for a setter function
+- A dtype round-trip test uses `_set_int64` as a workaround because `_set_float64` doesn't work for that dtype
+- A dtype audit (`grep _set_float`) reveals an integer dtype has no branch in float setter functions
+- A write to an integer tensor silently has no effect
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Find all setter functions missing integer branches
+grep -n "_set_float64\|_set_float32" shared/core/extensor.mojo
+
+# 2. Read the function body (look for the last elif — that's where to add)
+# 3. Add the int8 branch immediately after the last float branch
+# 4. Mirror the fix to _set_float32
+# 5. Replace no-op test with truncation test
+# 6. Update main() in the test file
+```
+
+### Step 1: Identify the missing branch
+
+Grep for `_set_float` functions and read their `if/elif` chains. A missing
+integer dtype means any write for that dtype is silently discarded.
+
+```mojo
+# Before: _set_float64 stops at float64 — int8 falls through silently
+if self._dtype == DType.float16:
+    ...
+elif self._dtype == DType.float32:
+    ...
+elif self._dtype == DType.float64:
+    ...
+# int8: no branch → silent no-op
+```
+
+### Step 2: Add the int8 branch with truncation semantics
+
+Append the missing `elif` immediately after the last float branch. Use
+`bitcast[Int8]()` + `value.cast[DType.int8]()` to match the pattern used by
+all other branches.
+
+```mojo
+# After: add int8 branch with truncation cast
+elif self._dtype == DType.int8:
+    var ptr = (self._data + offset).bitcast[Int8]()
+    ptr[] = value.cast[DType.int8]()
+```
+
+Apply the same fix to `_set_float32`:
+
+```mojo
+elif self._dtype == DType.int8:
+    var ptr = (self._data + offset).bitcast[Int8]()
+    ptr[] = value.cast[DType.int8]()
+```
+
+### Step 3: Update the docstring
+
+Change "assumes float-compatible dtype" to "truncating to the tensor's dtype"
+and add a `Note:` section documenting the int8 truncation.
+
+### Step 4: Replace the no-op test
+
+Delete the test that documents the bug and replace it with a test that
+asserts correct truncation behavior:
+
+```mojo
+# Before: documents the bug
+fn test_int8_set_float64_is_noop() raises:
+    var t = zeros([1], DType.int8)
+    t._set_float64(0, 1.0)
+    assert_almost_equal(t._get_float64(0), 0.0, tolerance=1e-9)  # stays 0
+
+# After: asserts correct truncation
+fn test_int8_set_float64_truncates_to_int8() raises:
+    var t = zeros([4], DType.int8)
+    t._set_float64(0, 42.0)
+    t._set_float64(1, -1.0)
+    t._set_float64(2, 0.0)
+    t._set_float64(3, 127.9)   # truncates to 127 (max int8)
+    assert_almost_equal(t._get_float64(0), 42.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(1), -1.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(2), 0.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(3), 127.0, tolerance=1e-9)
+```
+
+Add a parallel test for `_set_float32`:
+
+```mojo
+fn test_int8_set_float32_truncates_to_int8() raises:
+    var t = zeros([4], DType.int8)
+    t._set_float32(0, 42.0)
+    t._set_float32(1, -1.0)
+    t._set_float32(2, 0.0)
+    t._set_float32(3, 127.9)
+    assert_almost_equal(t._get_float64(0), 42.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(1), -1.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(2), 0.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(3), 127.0, tolerance=1e-9)
+```
+
+### Step 5: Update main() in the test file
+
+Replace the call to the old test name with the new test names and add the
+`_set_float32` test call.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Option 2: raise on unsupported dtype | Issue proposed raising an error for int8 instead of truncating | Raises break all existing callers that pass int8 tensors — truncation is the correct semantic (mirrors Python/numpy behavior) | Silent no-ops are worse than errors, but truncation is better than errors when the operation is semantically valid |
+| Patching only `_set_float64` | Initially considered only fixing the one function mentioned in the issue title | `_set_float32` had the identical missing branch — fixing only one leaves the other broken | Always grep for sibling functions with the same pattern when fixing a dtype dispatch chain |
+| Adding `else: pass` | Considered adding an explicit `else` branch as a no-op documentation | Still silently discards writes — just makes the silence explicit rather than fixing it | Don't document bugs in code; fix them |
+
+## Results & Parameters
+
+**PR**: HomericIntelligence/ProjectOdyssey#4825
+
+**Files changed**:
+
+- `shared/core/extensor.mojo` — added `int8` branch to `_set_float64` (line ~1190) and `_set_float32` (line ~1253)
+- `tests/shared/core/test_extensor_dtype_roundtrip.mojo` — replaced noop test with two truncation tests
+
+**Cast pattern** (copy-paste):
+
+```mojo
+elif self._dtype == DType.int8:
+    var ptr = (self._data + offset).bitcast[Int8]()
+    ptr[] = value.cast[DType.int8]()
+```
+
+**Test values that cover the int8 range**:
+
+```text
+42.0   → 42    (positive integer)
+-1.0   → -1    (negative integer)
+0.0    → 0     (zero)
+127.9  → 127   (truncation at max int8, not rounding)
+```


### PR DESCRIPTION
## Summary

Documents how to fix silent no-op writes in Mojo dtype dispatch functions
(`_set_float64`, `_set_float32`) that are missing integer (`int8`) branches.

- Silent no-ops occur when a Mojo `if/elif` chain has no branch for the given dtype
- Fix: add `elif self._dtype == DType.int8:` with `value.cast[DType.int8]()` truncation
- Both setter functions (`_set_float64` and `_set_float32`) need the same fix
- Replace no-op-documenting tests with truncation-assertion tests

## Key Findings

**What Worked**:
- `bitcast[Int8]()` + `value.cast[DType.int8]()` pattern matches all other branches
- Adding the `int8` branch to both `_set_float64` and `_set_float32` in one pass
- Test values 42.0, -1.0, 0.0, 127.9→127.0 cover positive, negative, zero, and truncation at max int8

**What Failed**:
- Option to raise error for int8 → breaks callers; truncation is the correct semantic
- Fixing only `_set_float64` → `_set_float32` had the identical missing branch

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (silent no-op, dtype dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
