### PR TITLE
feat: add mojo-bfloat16-factory-dtype-guards skill

### DIFF
--- a/skills/testing/mojo-bfloat16-factory-dtype-guards/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-bfloat16-factory-dtype-guards/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mojo-bfloat16-factory-dtype-guards",
+  "version": "1.0.0",
+  "description": "Add bfloat16 dtype guard tests to Mojo tensor factory functions (arange, eye, linspace, randn). Use when: (1) a factory function has float16/float32/float64 dtype routing but is missing bfloat16, (2) bfloat16 tensors silently get int-truncated values instead of floats, (3) adding regression tests for a dtype routing bug fix.",
+  "category": "testing",
+  "date": "2026-03-15",
+  "tags": ["mojo", "bfloat16", "dtype-guard", "factory-functions", "regression-tests"]
+}

--- a/skills/testing/mojo-bfloat16-factory-dtype-guards/references/notes.md
+++ b/skills/testing/mojo-bfloat16-factory-dtype-guards/references/notes.md
@@ -1,0 +1,78 @@
+# Session Notes: mojo-bfloat16-factory-dtype-guards
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Project**: ProjectOdyssey
+- **Issue**: #3906 — "Add bfloat16 to arange, eye, linspace, randn dtype guards"
+- **PR**: #4826
+- **Branch**: `3906-auto-impl`
+
+## Objective
+
+Issue #3906 reported that factory functions in `shared/core/extensor.mojo` (arange ~line 3218,
+eye ~line 3267, linspace ~line 3311, randn ~line 3589) check only
+`dtype == DType.float16 or dtype == DType.float32 or dtype == DType.float64` to route to
+`_set_float64`. Missing `DType.bfloat16` would cause bfloat16 tensors to silently use
+`_set_int64`, truncating all float values.
+
+## Discovery
+
+After reading the issue and the source file, the implementation fix was already in place —
+all four functions already had `or dtype == DType.bfloat16` in their conditions. The missing
+piece was regression tests to verify this behavior and prevent regression.
+
+## Implementation
+
+Created `tests/shared/core/test_creation_bfloat16.mojo` with 8 tests (2 per function):
+
+### Test Strategy
+
+Each factory function gets:
+1. **dtype test**: Asserts `tensor.dtype() == DType.bfloat16` after creation
+2. **values test**: Asserts values are floats (not int-truncated zeros)
+
+The values test is the key regression test — if `bfloat16` were removed from the condition,
+`_set_int64` would be used instead, producing 0s for fractional values.
+
+### Tolerances Used
+
+- bfloat16 precision: ~2-3 decimal digits
+- Integer-valued sequences (0.0, 1.0, 2.0...): exact in bfloat16
+- Tolerance chosen: `1e-2` (safe for both integer and near-integer values)
+
+### randn Test Design
+
+Cannot use distribution statistics (mean, std) for bfloat16 because:
+- bfloat16 precision amplifies rounding errors
+- N(0,1) convergence requires more samples than small bfloat16 values can represent accurately
+
+Instead: count non-zero values (threshold: ≥40/50 with seed=42). If int path used,
+Box-Muller float outputs (e.g., 0.31, -1.22) would be truncated to Int64(0.31)=0.
+
+## Files Changed
+
+- `tests/shared/core/test_creation_bfloat16.mojo` (new, 178 lines)
+
+## Commands Used
+
+```bash
+# Run the new tests
+just test-group tests/shared/core "test_creation_bfloat16.mojo"
+
+# Commit
+git add tests/shared/core/test_creation_bfloat16.mojo
+git commit -m "test(extensor): add bfloat16 dtype guard tests for factory functions"
+
+# Push and create PR
+git push -u origin 3906-auto-impl
+gh pr create --title "..." --body "..." --label "testing"
+gh pr merge --auto --rebase 4826
+```
+
+## ADR-009 Compliance
+
+- File limit: ≤10 `fn test_` per file
+- This file: 8 tests (20% safety margin)
+- Existing part3.mojo: 8 tests (would exceed limit if we added here)
+- Decision: New dedicated file `test_creation_bfloat16.mojo`

--- a/skills/testing/mojo-bfloat16-factory-dtype-guards/skills/mojo-bfloat16-factory-dtype-guards/SKILL.md
+++ b/skills/testing/mojo-bfloat16-factory-dtype-guards/skills/mojo-bfloat16-factory-dtype-guards/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: mojo-bfloat16-factory-dtype-guards
+description: "Add bfloat16 dtype guard tests to Mojo tensor factory functions. Use when: a factory function routes float16/float32/float64 to a float path but is missing bfloat16, causing silent int-truncation of bfloat16 values."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo tensor factory functions (`arange`, `eye`, `linspace`, `randn`) check `dtype == DType.float16 or float32 or float64` to route values to `_set_float64`. Missing `DType.bfloat16` causes silent routing to `_set_int64`, truncating all float values to 0 |
+| **Symptom** | bfloat16 tensors created by factory functions have all-zero or integer-truncated values |
+| **Root Cause** | Dtype condition list `float16 or float32 or float64` does not include `bfloat16` |
+| **Fix** | Add `or dtype == DType.bfloat16` to each condition; write regression tests |
+| **Pattern** | Two-test-per-function: one for dtype preservation, one for correct float values |
+
+## When to Use
+
+- A Mojo tensor factory function routes to `_set_float64` for float types but bfloat16
+  values are silently wrong (truncated to int)
+- Adding tests for a bfloat16 dtype routing bug where the fix has already been applied
+- Verifying that `bfloat16` is included in a multi-dtype condition alongside `float16`,
+  `float32`, `float64`
+- Writing regression tests that would catch re-introduction of the missing dtype condition
+
+## Verified Workflow
+
+### Quick Reference
+
+| Function | Dtype test | Value test |
+|----------|-----------|------------|
+| `arange` | correct dtype preserved | [0.0, 1.0, 2.0, 3.0] not [0, 0, 0, 0] |
+| `eye` | correct dtype preserved | diagonal=1.0, off-diagonal=0.0 |
+| `linspace` | correct dtype preserved | [0.0, 1.0, 2.0, 3.0, 4.0] |
+| `randn` | correct dtype preserved | ≥40/50 values have \|val\| > 1e-3 |
+
+### Step 1: Locate all dtype-routing conditions in the factory functions
+
+```bash
+grep -n "DType.float16\|DType.float32\|DType.float64" shared/core/extensor.mojo \
+  | grep -v "bfloat16"
+```
+
+Any line that mentions `float16 or float32 or float64` without `bfloat16` is a bug.
+
+### Step 2: Verify the fix is in place
+
+Each condition should look like:
+
+```mojo
+if (
+    dtype == DType.float16
+    or dtype == DType.float32
+    or dtype == DType.float64
+    or dtype == DType.bfloat16
+):
+    tensor._set_float64(i, value)
+else:
+    tensor._set_int64(i, Int(value))
+```
+
+### Step 3: Create a dedicated test file per ADR-009
+
+Per ADR-009 (≤10 `fn test_` per file), create a separate file:
+
+```text
+tests/shared/core/test_creation_bfloat16.mojo
+```
+
+Add the ADR-009 header:
+
+```mojo
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+```
+
+### Step 4: Write two tests per factory function
+
+**Pattern A — dtype test**: verifies dtype is preserved after creation.
+
+```mojo
+fn test_arange_bfloat16_dtype() raises:
+    """Test arange() preserves bfloat16 dtype."""
+    var t = arange(0.0, 5.0, 1.0, DType.bfloat16)
+    assert_dtype(t, DType.bfloat16, "arange bfloat16 should preserve dtype")
+    assert_numel(t, 5, "arange(0, 5, 1) bfloat16 should have 5 elements")
+```
+
+**Pattern B — value test**: verifies float values are stored, not int-truncated zeros.
+
+```mojo
+fn test_arange_bfloat16_values() raises:
+    """Test arange() with bfloat16 stores float values (not silently truncated to int)."""
+    # bfloat16 has ~2 decimal digits of precision; use integer-valued sequence
+    var t = arange(0.0, 4.0, 1.0, DType.bfloat16)
+    # If routed to _set_int64, all values would be 0 (Int64 truncation)
+    # bfloat16 tolerance: ~1e-2 for small integers
+    assert_value_at(t, 0, 0.0, 1e-2, "arange bfloat16 [0] should be 0.0")
+    assert_value_at(t, 1, 1.0, 1e-2, "arange bfloat16 [1] should be 1.0")
+    assert_value_at(t, 2, 2.0, 1e-2, "arange bfloat16 [2] should be 2.0")
+    assert_value_at(t, 3, 3.0, 1e-2, "arange bfloat16 [3] should be 3.0")
+```
+
+### Step 5: Use a wider tolerance for bfloat16
+
+bfloat16 has only ~2-3 decimal digits of precision (vs 6 for float32). Use `1e-2`
+instead of `1e-6` for value assertions. For integer-valued sequences (0.0, 1.0, 2.0...),
+bfloat16 is exact, so either tolerance works — but `1e-2` is the safe default.
+
+### Step 6: For randn(), use a nonzero-count approach
+
+randn() values come from N(0,1). If routed to `_set_int64`, Box-Muller float values
+(0.3, -1.2, etc.) would be truncated to 0. Test this by counting non-zero values:
+
+```mojo
+fn test_randn_bfloat16_nonzero() raises:
+    var t = randn([50], DType.bfloat16, seed=42)
+    var nonzero_count = 0
+    for i in range(t.numel()):
+        var val = t._get_float64(i)
+        if val > 1e-3 or val < -1e-3:
+            nonzero_count += 1
+    # Most values from N(0,1) have |val| > 1e-3; require ≥40 of 50
+    assert_true(
+        nonzero_count >= 40,
+        "randn bfloat16 should store non-zero floats, not int-truncated zeros",
+    )
+```
+
+### Step 7: Run the new test file
+
+```bash
+just test-group tests/shared/core "test_creation_bfloat16.mojo"
+```
+
+Expected output:
+
+```text
+Running ExTensor bfloat16 dtype guard tests (issue #3906)...
+All bfloat16 dtype guard tests passed!
+✅ PASSED: tests/shared/core/test_creation_bfloat16.mojo
+```
+
+## Results & Parameters
+
+**Session results** (ProjectOdyssey, 2026-03-15, issue #3906):
+
+- 8 tests in `tests/shared/core/test_creation_bfloat16.mojo`
+- ADR-009 limit: ≤10; actual: 8 (20% safety margin)
+- All 8 tests passed on first run
+- Tolerance used: `1e-2` for bfloat16 value assertions (safe for small integers)
+- Seed used for randn: `42` (deterministic; threshold: ≥40/50 nonzero)
+
+**Test count breakdown**:
+
+| Function | Tests | Names |
+|----------|-------|-------|
+| `arange` | 2 | `test_arange_bfloat16_dtype`, `test_arange_bfloat16_values` |
+| `eye` | 2 | `test_eye_bfloat16_dtype`, `test_eye_bfloat16_values` |
+| `linspace` | 2 | `test_linspace_bfloat16_dtype`, `test_linspace_bfloat16_values` |
+| `randn` | 2 | `test_randn_bfloat16_dtype`, `test_randn_bfloat16_nonzero` |
+
+**Key config**:
+
+- File: `tests/shared/core/test_creation_bfloat16.mojo`
+- ADR-009 header: required
+- bfloat16 tolerance: `1e-2`
+- randn threshold: `≥40` of 50 non-zero values
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4826 / Issue #3906 | [notes.md](../references/notes.md) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Adding tests to existing part3/part4 files | Append bfloat16 tests directly to `test_creation_part3.mojo` (8 tests) and `test_creation_part4.mojo` (6 tests) | Part3 was at 8 tests — adding would hit ADR-009 limit | Create a new dedicated file per ADR-009 when existing files are near the limit |
+| Using `1e-6` tolerance for bfloat16 | Same tolerance as float32 tests | bfloat16 has only ~2 decimal digits of precision; could cause false failures with non-integer values | Use `1e-2` tolerance for bfloat16; `1e-6` is safe only for float32/float64 |
+| Asserting exact mean/std for randn bfloat16 | Testing distribution statistics (mean≈0, std≈1) like float32 randn tests | bfloat16 precision makes statistical convergence unreliable for small N | Test structural property (non-zero values) instead of distribution statistics |


### PR DESCRIPTION
## Summary

Documents the regression test pattern for bfloat16 dtype routing bugs in Mojo
tensor factory functions (`arange`, `eye`, `linspace`, `randn`).

- Two-test-per-function approach: dtype preservation + float value correctness
- The value test is the key regression test — catches silent int-truncation
- Use `1e-2` tolerance for bfloat16 (not `1e-6` like float32)
- `randn`: use nonzero-count check rather than distribution statistics

## Key Findings

**What Worked**:

- Separate dedicated test file per ADR-009 (existing part files were near the ≤10 limit)
- bfloat16 value assertions with `1e-2` tolerance for small integer sequences
- For `randn`: count non-zero values (≥40/50 with seed=42) instead of testing mean/std

**What Failed**:

- Adding to existing part files → would exceed ADR-009 ≤10 limit
- `1e-6` tolerance for bfloat16 → unsafe for non-integer values (precision mismatch)
- Distribution stats test for randn bfloat16 → unreliable at small N due to bfloat16 precision

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activates for "bfloat16 dtype guard" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
