### PR TITLE
feat: add bfloat16-regression-test-pattern skill

### DIFF
--- a/skills/testing/bfloat16-regression-test-pattern/.claude-plugin/plugin.json
+++ b/skills/testing/bfloat16-regression-test-pattern/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "bfloat16-regression-test-pattern",
+  "version": "1.0.0",
+  "description": "Pattern for writing bfloat16 regression tests in Mojo that catch silent-failure bugs (missing dtype branches). Use when: (1) adding bfloat16 support to dtype-dispatched functions, (2) auditing existing dtype handlers for missing bfloat16 branches, (3) writing regression tests after fixing a silent-write or silent-read bug.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/bfloat16-regression-test-pattern/references/notes.md
+++ b/skills/testing/bfloat16-regression-test-pattern/references/notes.md
@@ -1,0 +1,57 @@
+# Session Notes: bfloat16 regression test pattern
+
+## Date
+2026-03-15
+
+## Context
+
+Working in: `/home/mvillmow/ProjectOdyssey/.worktrees/issue-3910`
+Branch: `3910-auto-impl`
+Issue: #3910 — "Audit _set_float32/_get_float32 for missing bfloat16 branch"
+
+## What the issue asked for
+
+Issue #3910 was a follow-up from #3301. The #3301 fix added bfloat16 branches to
+`_set_float64` and `_get_float64`. Issue #3910 noted that `_set_float32` and `_get_float32`
+were not audited and likely had the same pre-fix state.
+
+## Investigation
+
+Grepped `extensor.mojo` for `_get_float32`, `_set_float32`, and `bfloat16` together.
+
+Found at lines 1213-1215 and 1244-1246:
+```mojo
+elif self._dtype == DType.bfloat16:
+    var ptr = (self._data + offset).bitcast[BFloat16]()
+    return ptr[].cast[DType.float32]()
+```
+
+The code fix was already in place — applied in commit `3c1b07fa` as part of prior work.
+
+## What was actually missing
+
+`tests/shared/core/test_extensor_getset_float32.mojo` had no bfloat16 tests.
+`test_get_float32_dtype_conversions` and `test_set_float32_dtype_conversions` tested
+float16 and float64 but skipped bfloat16.
+
+## Tests added
+
+Three new tests in `test_extensor_getset_float32.mojo`:
+
+1. `test_get_float32_bfloat16` — zero-guard + value check via `_set_float64` seed
+2. `test_get_float32_bfloat16_roundtrip` — full `_set_float32` → `_get_float32` roundtrip
+3. `test_set_float32_bfloat16` — zero-guard verifying write doesn't silently fail
+
+## Key design choices
+
+- Used `_set_float64` to seed the tensor in `test_get_float32_bfloat16` (the float64
+  path was fixed in #3301 and is trusted; this isolates the read path under test)
+- Used `_get_float64` to verify the write in `test_set_float32_bfloat16` (cross-checks
+  the write path by reading via a different trusted path)
+- Values: 1.0, 1.5, 2.0, 0.5, -1.0 — all exactly representable in bfloat16
+- Tolerance: 1e-2 (bfloat16 has 7-bit mantissa, ~2 decimal digits precision)
+- ADR-009 check: file had 6 tests before, adding 3 = 9 total, well under the ~15 limit
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4827

--- a/skills/testing/bfloat16-regression-test-pattern/skills/bfloat16-regression-test-pattern/SKILL.md
+++ b/skills/testing/bfloat16-regression-test-pattern/skills/bfloat16-regression-test-pattern/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: bfloat16-regression-test-pattern
+description: "Pattern for writing bfloat16 regression tests in Mojo that catch silent-failure bugs (missing dtype branches). Use when: (1) adding bfloat16 support to dtype-dispatched functions, (2) auditing existing dtype handlers, (3) writing regression tests after fixing a silent-write or silent-read bug."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Dtype-dispatched functions (e.g. `_get_float32`, `_set_float32`) often have `if/elif` chains for float16/float32/float64 but omit bfloat16, causing silent failures — writes are no-ops and reads return garbage via the integer fallback path. |
+| **Solution** | Three-part regression test: zero-guard, round-trip, and multi-element verification. The zero-guard is the most important — it exactly mirrors the failure mode. |
+| **Language** | Mojo 0.26.1 |
+| **Test File Pattern** | `tests/shared/core/test_extensor_getset_<fn>.mojo` |
+| **Tolerance** | `1e-2` for bfloat16 (7-bit mantissa, ~2 decimal digits precision) |
+
+## When to Use
+
+- After auditing a dtype-dispatched function (grep for `if self._dtype == DType.float16` chains)
+- When fixing a "bfloat16 silent no-op" or "bfloat16 reads garbage" bug
+- When a PR adds a bfloat16 branch but tests only cover float16/float32/float64
+- When reviewing follow-up issues from a prior bfloat16 fix (e.g. issue #3910 follow-up from #3301)
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+# 1. Zero-guard test (read path)
+fn test_get_<fn>_bfloat16() raises:
+    var t = zeros([1], DType.bfloat16)
+    t._set_float64(0, 1.5)  # use float64 path (already fixed) to seed
+    var got = t._get_<fn>(0)
+    assert_true(
+        Float64(got) != 0.0,
+        "bfloat16 _get_<fn> returned 0 — bfloat16 branch missing",
+    )
+    assert_almost_equal(Float64(got), 1.5, tolerance=1e-2)
+
+# 2. Zero-guard test (write path)
+fn test_set_<fn>_bfloat16() raises:
+    var t = zeros([1], DType.bfloat16)
+    t._set_<fn>(0, <FloatType>(1.5))
+    var got = t._get_float64(0)  # use float64 path (already fixed) to read back
+    assert_true(
+        got != 0.0,
+        "bfloat16 _set_<fn> silently wrote zero — bfloat16 branch missing",
+    )
+    assert_almost_equal(got, 1.5, tolerance=1e-2)
+
+# 3. Round-trip test (both read and write path together)
+fn test_get_<fn>_bfloat16_roundtrip() raises:
+    var t = zeros([4], DType.bfloat16)
+    t._set_<fn>(0, <FloatType>(1.0))
+    t._set_<fn>(1, <FloatType>(2.0))
+    t._set_<fn>(2, <FloatType>(0.5))
+    t._set_<fn>(3, <FloatType>(-1.0))
+    assert_almost_equal(Float64(t._get_<fn>(0)), 1.0, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_<fn>(1)), 2.0, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_<fn>(2)), 0.5, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_<fn>(3)), -1.0, tolerance=1e-2)
+```
+
+### Step 1: Audit the function under test
+
+```bash
+grep -n "elif self._dtype == DType" shared/core/extensor.mojo | grep -A1 "float64"
+```
+
+Look for chains that have float16/float32/float64 but not bfloat16. The pattern:
+
+```mojo
+# BROKEN — missing bfloat16
+if self._dtype == DType.float16:
+    ...
+elif self._dtype == DType.float32:
+    ...
+elif self._dtype == DType.float64:
+    ...
+else:
+    return Float32(self._get_int64(index))  # bfloat16 hits this → garbage
+```
+
+### Step 2: Apply the fix
+
+```mojo
+# FIXED — with bfloat16 branch
+elif self._dtype == DType.bfloat16:
+    var ptr = (self._data + offset).bitcast[BFloat16]()
+    return ptr[].cast[DType.float32]()  # for _get_float32
+    # OR for _set_float32:
+    # ptr[] = value.cast[DType.bfloat16]()
+```
+
+### Step 3: Write the three regression tests
+
+Use exactly-representable values to avoid precision ambiguity: `1.0`, `1.5`, `2.0`, `0.5`, `-1.0`.
+These are all exactly representable in bfloat16 (power-of-2 fractions).
+
+Avoid values like `1.3`, `2.7` — they are not exactly representable and will fail even with a
+correct implementation at `1e-2` tolerance.
+
+### Step 4: Register in `main()`
+
+```mojo
+print("Running _get_<fn> bfloat16 tests (regression for #<issue>)...")
+test_get_<fn>_bfloat16()
+test_get_<fn>_bfloat16_roundtrip()
+
+print("Running _set_<fn> bfloat16 tests (regression for #<issue>)...")
+test_set_<fn>_bfloat16()
+```
+
+### Step 5: ADR-009 heap corruption constraint
+
+Mojo 0.26.1 has a heap corruption bug after ~15 cumulative tests in a single file.
+If the target test file already has ≥12 tests, split to a new file:
+
+```
+tests/shared/core/test_extensor_getset_<fn>.mojo  # ≥12 tests → split
+tests/shared/core/test_extensor_getset_<fn>_bf16.mojo  # new file for bfloat16 tests
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `1.5` in round-trip via `_set_float32` | Called `t._set_float32(0, Float32(1.5))` then `_get_float32` on bfloat16 | 1.5 IS exactly representable in bfloat16 (= 1 + 1/2), this actually works | Verify representability before assuming a value is "safe" |
+| Using `2.7` for bfloat16 test | Test value `2.7` used in float32 tests copy-pasted to bfloat16 | 2.7 is not exactly representable in bfloat16; test would fail even with correct code | Use only power-of-2 fractions for bfloat16: 0.5, 1.0, 1.5, 2.0, -1.0 |
+| Reading back via `_get_int64` to verify | Used the int64 fallback to confirm writes | The int64 path reinterprets bfloat16 bits as integers — misread. Confirmed fix actually works | Always use the float64 cross-check path (`_get_float64`) to verify bfloat16 writes |
+| Checking if fix was needed | Grepped for "bfloat16" in extensor.mojo lines 1188–1246 | Found the fix was already applied in a prior commit; only the tests were missing | Always check both the implementation AND the tests. A fixed function can still lack regression coverage. |
+
+## Results & Parameters
+
+### Session outcome
+
+- **Issue**: #3910 — audit `_set_float32`/`_get_float32` for missing bfloat16 branch
+- **Finding**: Code fix was already present (`3c1b07fa`). Tests were missing.
+- **PR**: #4827 — added 3 regression tests to `test_extensor_getset_float32.mojo`
+
+### Bfloat16 tolerance rationale
+
+```text
+bfloat16: 1 sign bit, 8 exponent bits, 7 mantissa bits
+→ ~2 decimal digits of precision
+→ tolerance = 1e-2
+
+float16:  1 sign bit, 5 exponent bits, 10 mantissa bits
+→ ~3 decimal digits of precision
+→ tolerance = 1e-3
+
+float32:  1 sign bit, 8 exponent bits, 23 mantissa bits
+→ ~7 decimal digits of precision
+→ tolerance = 1e-6
+```
+
+### Exactly-representable bfloat16 test values
+
+```text
+Safe (power-of-2 fractions):   0.0, 0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -1.5, -2.0
+Unsafe (not exact in bfloat16): 0.1, 0.3, 1.3, 2.7, 3.9
+```


### PR DESCRIPTION
## Summary

Documents the pattern for writing bfloat16 regression tests in Mojo that catch silent-failure
bugs in dtype-dispatched functions (missing bfloat16 branches in `if/elif` dtype chains).

- Zero-guard assertion pattern that directly mirrors the failure mode
- Cross-path verification strategy (use trusted path to seed/read when isolating one path)
- Exactly-representable bfloat16 test value reference (power-of-2 fractions only)
- ADR-009 heap corruption constraint awareness for test file splitting

## Key Findings

**What Worked**:
- Zero-guard (`assert_true(value != 0.0)`) is the most reliable detector for the silent-write/read
  failure mode — exactly matches what breaks when a bfloat16 branch is missing
- Cross-path verification: use `_set_float64` (fixed path) to seed a tensor, then test `_get_float32`
  in isolation; and vice versa for the write path
- Test values 1.0, 1.5, 2.0, 0.5, -1.0 are all exactly representable in bfloat16

**What Failed**:
- Using non-power-of-2 values like `2.7` → fails at 1e-2 even with correct implementation
- Assuming the fix was missing → turned out code was already fixed, only tests were missing
- Using `_get_int64` to cross-verify bfloat16 writes → reinterprets bits incorrectly

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with bfloat16 dtype audit triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
