### PR TITLE
feat: add getting-started-doc-audit skill

### DIFF
--- a/skills/documentation/getting-started-doc-audit/.claude-plugin/plugin.json
+++ b/skills/documentation/getting-started-doc-audit/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "getting-started-doc-audit",
+  "version": "1.0.0",
+  "description": "Audit and rewrite getting-started documentation stubs by sourcing real commands from justfile and versions from pixi.toml, removing fabricated APIs. Use when: (1) getting-started docs contain placeholder text or non-existent APIs, (2) follow-up audit requested after initial doc stub is written, (3) markdown linting fails on documentation files with broken fenced code blocks.",
+  "category": "documentation",
+  "date": "2026-03-15"
+}

--- a/skills/documentation/getting-started-doc-audit/references/notes.md
+++ b/skills/documentation/getting-started-doc-audit/references/notes.md
@@ -1,0 +1,85 @@
+# Session Notes: getting-started-doc-audit
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #3914 — "Add quick-start guide for getting-started/ section"
+- **Follow-up from**: #3304 (installation.md)
+- **Branch**: `3914-auto-impl`
+- **PR**: HomericIntelligence/ProjectOdyssey#4828
+
+## Objective
+
+Audit `docs/getting-started/` for stub/placeholder files after `installation.md` was written.
+Rewrite any files with placeholder text, sourcing commands from `justfile` and versions from
+`pixi.toml`.
+
+## Files Audited
+
+| File | Status | Action |
+|------|--------|--------|
+| `quickstart.md` | Accurate | No changes |
+| `installation.md` | Accurate (written in #3304) | No changes |
+| `first_model.md` | Fabricated APIs throughout | Full rewrite |
+| `repository-structure.md` | Broken code blocks + non-existent scripts | Fix code blocks + commands |
+
+## Fabricated APIs Found in first_model.md
+
+All of these were shown as imports/usage but do NOT exist in `shared/`:
+
+- `shared.data.TensorDataset`
+- `shared.data.BatchLoader`
+- `shared.utils.download_mnist`
+- `shared.utils.normalize_images`
+- `shared.utils.load_model`
+- `shared.utils.load_image`
+- `shared.utils.plot_image`
+- `shared.utils.plot_confusion_matrix`
+- `shared.training.evaluate_model`
+- `shared.training.Adam` (class)
+- `shared.training.Trainer` (class)
+- `shared.training.schedulers.StepLR`
+- `shared.data.transforms.RandomRotation`
+- `shared.data.transforms.RandomShift`
+- `Sequential`, `Layer`, `ReLU`, `Softmax`, `EarlyStopping`, `ModelCheckpoint`
+
+Also: malformed fenced code blocks with duplicate/nested delimiters:
+```
+```bash
+```bash
+...
+```text
+```
+
+## Broken Commands Found in repository-structure.md
+
+| Fabricated Command | Real Equivalent |
+|--------------------|-----------------|
+| `python scripts/validate_links.py docs/` | `just pre-commit-all` |
+| `python scripts/validate_structure.py` | (does not exist) |
+| `python tools/paper-scaffold/scaffold.py --paper {name}` | `cp -r papers/_template papers/{name}` |
+| `mojo benchmarks/scripts/run_benchmarks.mojo` | `pixi run mojo shared/benchmarking/run_benchmarks.mojo` |
+| `mojo test tests/` | `just test-mojo` |
+| `python scripts/setup.py` | (does not exist) |
+| `python scripts/check_readmes.py` | (does not exist) |
+| `mojo papers/lenet5/train.mojo --config ...` | `just train lenet-emnist fp32 10` |
+
+## Markdown Lint Errors Encountered
+
+### MD001 heading-increment (repository-structure.md lines 169, 185, 199)
+
+**Cause**: `#####` items 2, 3, 4 in "Supporting Directories" section. Item 1 (`##### 1. docs/`)
+contained `### Key Sections` and `### Common Tasks` inner headings. Markdownlint tracks the
+running heading level; after seeing `###`, the next `#####` jumps 2 levels.
+
+**Fix**: Demoted items 2, 3, 4 from `#####` to `####`.
+
+## Key Learnings
+
+1. **Grep APIs before keeping them** — fabricated APIs look plausible but break user trust when
+   they try to run the code
+2. **Justfile is authoritative for commands** — `just --list` reveals all real recipes
+3. **MD001 can trigger from headings inside a block** — a `###` inside a `#####` block resets
+   the lint's "current level" counter; the next `#####` is then flagged as skipping levels
+4. **"Conceptual orientation" is valid when APIs don't exist** — better to explain what exists
+   and what's planned than to fabricate

--- a/skills/documentation/getting-started-doc-audit/skills/getting-started-doc-audit/SKILL.md
+++ b/skills/documentation/getting-started-doc-audit/skills/getting-started-doc-audit/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: getting-started-doc-audit
+description: "Audit and rewrite getting-started documentation stubs by sourcing real commands from justfile and versions from pixi.toml, removing fabricated APIs. Use when: stub files contain placeholder text, follow-up audit after installation.md is written, or markdown linting fails on broken fenced code blocks."
+category: documentation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | getting-started-doc-audit |
+| **Category** | documentation |
+| **Trigger** | Follow-up audit of `docs/getting-started/` after one doc is written |
+| **Output** | Rewritten stubs with accurate commands, no fabricated APIs, clean markdown |
+
+## When to Use
+
+- A follow-up issue requests auditing remaining stubs in `docs/getting-started/` after
+  `installation.md` was written
+- Any file in `docs/getting-started/` contains fabricated function calls or API names that
+  don't exist in the codebase (e.g., `TensorDataset`, `Trainer`, `EarlyStopping`)
+- Fenced code blocks are malformed (duplicate delimiters, missing language tags, unclosed blocks)
+- Commands in docs reference scripts or tools that don't exist (e.g., non-existent Python scripts,
+  benchmark tools not yet implemented)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. List files to audit
+ls docs/getting-started/
+
+# 2. Read each file to identify placeholder content
+# 3. Check real commands
+grep -E "^(train|build|test|infer)" justfile
+grep -E "mojo|version" pixi.toml
+
+# 4. Check what actually exists in the codebase
+ls shared/ papers/ scripts/
+
+# 5. Rewrite placeholder files, then lint
+pixi run npx markdownlint-cli2 docs/getting-started/*.md
+```
+
+### Step 1: Audit all files in the directory
+
+Read every file in `docs/getting-started/` and classify each as:
+
+- **Accurate** — commands and APIs are real; no rewrite needed
+- **Placeholder text** — contains fabricated API calls or stub prose
+- **Broken markdown** — malformed fenced code blocks (common: duplicate delimiters like
+  ` ```bash\n```bash ` or unclosed blocks ending in ` ```text `)
+
+The most reliable signal for fabricated APIs: check whether the imported modules or function
+calls actually exist by grepping the codebase.
+
+```bash
+# Verify API exists before keeping it in docs
+grep -r "TensorDataset" shared/ papers/
+grep -r "class Trainer" shared/
+```
+
+### Step 2: Establish ground truth from build system files
+
+**Never invent commands.** Source everything from:
+
+```bash
+# Real justfile recipes
+cat justfile | grep -E "^[a-z]"
+
+# Pinned dependency versions
+grep -E "mojo|version" pixi.toml
+
+# What directories actually exist
+ls papers/ shared/ scripts/ tools/ 2>&1
+```
+
+### Step 3: Rewrite placeholder files
+
+For each file with placeholder content:
+
+1. Keep the document's purpose and headings
+2. Replace all fabricated API calls with real ones (or remove the section entirely if
+   the feature doesn't exist yet)
+3. Replace all non-existent commands with confirmed `just` or `pixi run` commands
+4. Fix malformed fenced code blocks (one opening delimiter, one language tag, one closing delimiter)
+
+**Pattern for conceptual content over fabricated API docs**:
+
+When the APIs shown don't exist yet, rewrite the doc as a conceptual orientation:
+- What exists today (real shared library, real recipes)
+- What is still planned (clearly labeled)
+- How to use what currently exists
+
+### Step 4: Lint and fix
+
+```bash
+pixi run npx markdownlint-cli2 docs/getting-started/*.md
+```
+
+Common lint errors and fixes:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| MD001 heading-increment | h5 after h3 (h3 inside h5 block resets level) | Change inner `#####` to `####` |
+| MD040 fenced-code-language | Code block missing language tag | Add language after opening ` ``` ` |
+| MD031 blanks-around-fences | No blank line before/after code block | Add blank lines |
+
+### Step 5: Commit and PR
+
+```bash
+git add docs/getting-started/<file1>.md docs/getting-started/<file2>.md
+git commit -m "docs(getting-started): rewrite <files> with accurate commands"
+git push -u origin <branch>
+gh pr create --title "..." --body "Closes #<issue>"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Keeping fabricated APIs | Preserved `TensorDataset`, `Trainer`, `EarlyStopping` imports in first_model.md | These types don't exist in `shared/`; docs would mislead users and fail when tried | Always grep the codebase to verify APIs before keeping them in docs |
+| Using `#####` subsections inside `####` blocks that also contain `###` headings | Kept original heading structure with h3 inner sections | Markdownlint MD001: after a `###` resets the "current level", a subsequent `#####` is seen as jumping 2 levels | Flatten inner subsections to bold text, or demote the `#####` items to `####` |
+| Referencing non-existent scripts | Kept `python scripts/validate_links.py`, `python tools/paper-scaffold/scaffold.py` in repository-structure.md | Scripts don't exist in the repo; running them fails | Check `ls scripts/` and `ls tools/` before including any script path in docs |
+| Using `mojo test tests/` command | Showed `mojo test tests/` as the test command | Project uses `just test-mojo` and `just test-group`; bare `mojo test` not configured | Always check justfile for the project's actual test recipes |
+
+## Results & Parameters
+
+**Session outcome**: 2 files rewritten, 0 markdownlint errors, PR #4828 created.
+
+**Files changed**:
+
+- `docs/getting-started/first_model.md` — full rewrite (760→252 lines net after removing
+  fabricated content)
+- `docs/getting-started/repository-structure.md` — fixed all malformed fenced code blocks,
+  replaced non-existent scripts with real `just` commands
+
+**Files with no changes needed**:
+
+- `docs/getting-started/quickstart.md` — already accurate with real commands and verified output
+- `docs/getting-started/installation.md` — written in the previous issue (#3304), already accurate
+
+**Lint validation**:
+
+```bash
+pixi run npx markdownlint-cli2 docs/getting-started/first_model.md docs/getting-started/repository-structure.md
+# Summary: 0 error(s)
+```
+
+**Mojo version in pixi.toml**: `0.26.1`
+
+**Justfile recipes used in docs** (confirmed real):
+
+```text
+train, infer, build, build-release, test-mojo, test-group, pre-commit, pre-commit-all
+```


### PR DESCRIPTION
## Summary

Documents the workflow for auditing and rewriting getting-started documentation stubs by
sourcing real commands from justfile and versions from pixi.toml, removing fabricated APIs.

- Covers the full audit pattern: read files, verify APIs via grep, check justfile for real
  commands, rewrite with accurate content, fix markdown lint errors
- Documents 8+ fabricated commands found in repository-structure.md and 14+ fabricated API
  calls found in first_model.md during the ProjectOdyssey #3914 session
- Includes specific guidance on MD001 heading-increment triggered by nested headings

## Key Findings

**What Worked**:
- Grepping codebase to verify APIs before keeping them in docs
- Using `just --list` as the authoritative source for all command references
- Rewriting as "conceptual orientation" when APIs don't exist yet

**What Failed**:
- Keeping fabricated APIs → they don't exist in `shared/`; mislead users
- Using `#####` subsections after `###` inner headings → triggers MD001
- Referencing scripts that don't exist (`scripts/validate_links.py`, etc.)

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py skills/ plugins/` — PASS
- [x] Session sourced from real issue work (ProjectOdyssey #3914, PR #4828)

🤖 Generated with [Claude Code](https://claude.com/claude-code)