### PR TITLE
feat: add installation-anchor-validator skill

### DIFF
--- a/skills/documentation/installation-anchor-validator/.claude-plugin/plugin.json
+++ b/skills/documentation/installation-anchor-validator/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "installation-anchor-validator",
+  "version": "1.0.0",
+  "description": "Validate anchor fragments in markdown links pointing to an installation guide to catch regressions when headings are renamed. Use when: (1) a doc file has anchor deep-links to installation.md and headings may change, (2) adding a CI step to verify README-to-installation-guide links, (3) implementing GitHub-style slug anchors with pytest hermetic tests.",
+  "category": "documentation",
+  "date": "2026-03-15"
+}

--- a/skills/documentation/installation-anchor-validator/references/notes.md
+++ b/skills/documentation/installation-anchor-validator/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes — installation-anchor-validator
+
+## Issue
+
+GitHub issue #3915: Verify links from README to installation.md are correct.
+Follow-up from #3304 and #3141.
+
+## Context
+
+- `README.md` had a plain link `[Installation Guide](docs/getting-started/installation.md)` — no anchor
+- `docs/getting-started/installation.md` had 17 headings with potential anchor targets
+- Existing `scripts/validate_links.py` explicitly strips anchors (line 77: `link.split("#")[0]`)
+- Existing link-check CI workflow uses lychee but does not validate internal anchor fragments
+- Pattern for scripts and tests established by `scripts/audit_shared_links.py` and `tests/test_audit_shared_links.py`
+
+## What Was Built
+
+- `scripts/validate_installation_anchors.py` — 160 lines, pure stdlib, typed
+- `tests/test_validate_installation_anchors.py` — 33 hermetic tests, all passing
+- `.github/workflows/link-check.yml` — new step after lychee
+- `scripts/README.md` — documentation added
+
+## Key Design Decisions
+
+1. **Separate script, not a modification to validate_links.py** — existing script intentionally
+   ignores anchors; modifying it would risk breaking callers and expand scope (YAGNI)
+
+2. **GitHub slug algorithm in pure Python** — no external dependencies; regex-based approach
+   handles all edge cases (backticks, parens, numbers)
+
+3. **TemporaryDirectory in class-based tests** — `tmp_path` pytest fixture works with function-
+   based tests; for class-based tests, `TemporaryDirectory` context manager is more portable
+
+4. **Two-arg CLI convention** — `<sources...> <installation.md>` follows convention of other
+   validation scripts; last positional arg = target file
+
+## Real-world State
+
+Current README only has a plain link (no anchor). The script passes cleanly today.
+When a future PR adds a deep-link (e.g., `installation.md#prerequisites`), CI will catch
+any regression if the heading is renamed.
+
+## PR
+
+- Branch: `3915-auto-impl`
+- PR: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4829
+- Date: 2026-03-15

--- a/skills/documentation/installation-anchor-validator/skills/installation-anchor-validator/SKILL.md
+++ b/skills/documentation/installation-anchor-validator/skills/installation-anchor-validator/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: installation-anchor-validator
+description: "Validate anchor fragments in markdown deep-links to an installation guide. Use when: README or other docs link to specific sections of installation.md and you need CI to catch broken anchors when headings are renamed or removed."
+category: documentation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Skill** | installation-anchor-validator |
+| **Category** | documentation |
+| **Complexity** | Low |
+| **Typical Duration** | 30–60 min |
+| **Key Tools** | Write, Edit, Bash (pytest, gh) |
+
+## When to Use
+
+- A repository has one or more markdown files linking to specific sections of an installation
+  guide (e.g., `installation.md#prerequisites`) and you want CI to catch regressions
+- Headings in an installation guide are being reorganised or renamed and you want to be
+  sure all deep-links remain valid
+- You are adding a lightweight anchor validation script alongside an existing `validate_links.py`
+  that intentionally strips anchors for file-existence checks
+- You need hermetic pytest tests that do NOT touch real repo files (TemporaryDirectory pattern)
+
+## Verified Workflow
+
+### Quick Reference
+
+| Step | Command |
+|------|---------|
+| Run script | `python3 scripts/validate_installation_anchors.py README.md docs/getting-started/installation.md` |
+| Run tests | `python3 -m pytest tests/test_validate_installation_anchors.py -v` |
+| Check CI step | see `.github/workflows/link-check.yml` |
+
+### 1. Audit the current state
+
+Check what links to `installation.md` already exist and whether they have anchors:
+
+```bash
+grep -rn "installation\.md" README.md docs/ --include="*.md"
+```
+
+Most projects start with a plain link (no anchor). The validator will pass cleanly until
+a deep-link is added, at which point it catches regressions.
+
+### 2. Understand the existing validate_links.py
+
+Before creating a new script, read the existing link-validation script. It likely strips
+anchors intentionally (to check file existence only):
+
+```python
+# scripts/validate_links.py line ~77 — intentionally ignores anchors
+link_path = link.split("#")[0]
+```
+
+Do **not** modify this script — it serves a different purpose. Create a focused, additive
+script instead.
+
+### 3. Implement heading_to_anchor (GitHub slug algorithm)
+
+GitHub's anchor slug rules (implement in pure Python, no extra deps):
+
+```python
+import re
+
+def heading_to_anchor(heading: str) -> str:
+    slug = heading.lower()
+    slug = slug.replace(" ", "-")
+    slug = re.sub(r"[^a-z0-9\-]", "", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    slug = slug.strip("-")
+    return slug
+```
+
+Key edge cases to test:
+- Backtick-wrapped text: `` `pixi install` fails `` → `pixi-install-fails`
+- Parenthesised suffixes: `Run Tests (without shell)` → `run-tests-without-shell`
+- Numbers preserved: `Step 1 Setup` → `step-1-setup`
+
+### 4. Implement extract_headings and extract_installation_links
+
+```python
+def extract_headings(content: str) -> List[str]:
+    headings = []
+    for line in content.splitlines():
+        match = re.match(r"^#{1,6}\s+(.*)", line)
+        if match:
+            headings.append(match.group(1).strip())
+    return headings
+
+def extract_installation_links(
+    content: str, source_path: str
+) -> List[Tuple[str, str, Optional[str]]]:
+    results = []
+    link_pattern = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+    for line in content.splitlines():
+        for match in link_pattern.finditer(line):
+            target = match.group(2).strip()
+            base, _, fragment = target.partition("#")
+            if not base.endswith("installation.md"):
+                continue
+            anchor = fragment if fragment else None
+            results.append((source_path, target, anchor))
+    return results
+```
+
+### 5. Write the validate() function and CLI main()
+
+```python
+def validate(source_paths: List[Path], installation_path: Path) -> List[str]:
+    errors: List[str] = []
+    if not installation_path.exists():
+        return [f"installation.md not found: {installation_path}"]
+    installation_content = installation_path.read_text(encoding="utf-8")
+    headings = extract_headings(installation_content)
+    valid_anchors = {heading_to_anchor(h) for h in headings}
+    for source_path in source_paths:
+        if not source_path.exists():
+            errors.append(f"Source file not found: {source_path}")
+            continue
+        content = source_path.read_text(encoding="utf-8")
+        for src, target, anchor in extract_installation_links(content, str(source_path)):
+            if anchor is None:
+                continue  # plain link without anchor — always valid
+            if anchor not in valid_anchors:
+                errors.append(
+                    f"{src}: broken anchor '#{anchor}' in '{target}' "
+                    f"(valid: {sorted(valid_anchors)})"
+                )
+    return errors
+
+def main(argv: List[str]) -> int:
+    # If 2+ positional args: last = installation.md, rest = sources
+    # If 1 positional arg: treat as installation.md, scan whole repo
+    # If 0 args: use default paths
+    ...
+    errors = validate(source_paths, installation_path)
+    if errors:
+        for e in errors: logger.error(e)
+        return 1
+    logger.info("All installation.md anchor links are valid.")
+    return 0
+```
+
+### 6. Write hermetic tests (TemporaryDirectory pattern)
+
+Mirror the pattern from `tests/test_audit_shared_links.py`:
+
+```python
+_INSTALLATION_CONTENT = """\
+# Installation
+
+## Prerequisites
+
+Install required tools.
+
+## Installing Pixi
+
+Use the install script.
+"""
+
+class TestValidate:
+    def test_no_anchor_links_passes(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            installation = tmp / "installation.md"
+            installation.write_text(_INSTALLATION_CONTENT)
+            readme = tmp / "README.md"
+            readme.write_text("[Guide](installation.md)\n")
+            assert validate([readme], installation) == []
+
+    def test_invalid_anchor_fails(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            ...
+            readme.write_text("[Guide](installation.md#nonexistent)\n")
+            errors = validate([readme], installation)
+            assert len(errors) == 1
+            assert "nonexistent" in errors[0]
+```
+
+### 7. Add step to CI workflow
+
+Append after the lychee step in `.github/workflows/link-check.yml`:
+
+```yaml
+- name: Validate installation.md anchor links
+  run: |
+    python3 scripts/validate_installation_anchors.py \
+      README.md \
+      docs/getting-started/installation.md
+```
+
+No secrets or user-controlled input — the step is injection-safe.
+
+### 8. Document in scripts/README.md
+
+Add the script to the directory listing AND add a full documentation section
+(with Features, Usage, Exit Codes) immediately before `validate_links.py`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Modifying validate_links.py to check anchors | Considered extending the existing script | It intentionally strips anchors for file-existence checking; changing it would break existing callers | Create a focused additive script instead of modifying an existing one |
+| Using `--include-fragments` in lychee | Considered relying solely on lychee for anchor validation | lychee validates external URLs well but internal markdown anchor resolution is better handled with a Python script that implements GitHub's exact slug algorithm | Python gives full control over the slug algorithm and produces precise error messages |
+| Importing `common.py` in the new script | Considered reusing `get_repo_root()` from common.py | The script needed to be self-contained with `Path(__file__).resolve().parent.parent` for repo root detection; common.py import added complexity for a function not needed in tests | Only import shared modules when the benefit clearly outweighs the coupling |
+
+## Results & Parameters
+
+**Script**: `scripts/validate_installation_anchors.py`
+**Tests**: `tests/test_validate_installation_anchors.py` — 33 tests, all passing
+**Workflow**: `.github/workflows/link-check.yml` — new step appended after lychee
+
+### GitHub slug algorithm — key regex
+
+```python
+slug = heading.lower()
+slug = slug.replace(" ", "-")
+slug = re.sub(r"[^a-z0-9\-]", "", slug)  # strip non-alphanumeric except hyphen
+slug = re.sub(r"-{2,}", "-", slug)         # collapse consecutive hyphens
+slug = slug.strip("-")                     # remove leading/trailing hyphens
+```
+
+### Edge cases verified
+
+| Heading | Expected anchor |
+|---------|----------------|
+| `Installation` | `installation` |
+| `Installing Pixi` | `installing-pixi` |
+| `` `pixi install` fails with channel errors `` | `pixi-install-fails-with-channel-errors` |
+| `Run Tests Directly (without interactive shell)` | `run-tests-directly-without-interactive-shell` |
+| `Step 1 Setup` | `step-1-setup` |
+
+### Test pattern — TemporaryDirectory
+
+Use `TemporaryDirectory` (not `tmp_path` alone) for compatibility with class-based
+test classes that don't use pytest fixtures:
+
+```python
+class TestValidate:
+    def test_foo(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            ...
+```


### PR DESCRIPTION
## Summary

Documents the pattern for validating anchor fragments in markdown deep-links
to an installation guide (`installation.md`), catching regressions when
headings are renamed or removed.

- `heading_to_anchor()` implements GitHub's slug algorithm in pure Python (no deps)
- `extract_installation_links()` finds links to `installation.md` with anchor fragments
- `validate()` cross-references anchors against valid heading slugs
- 33 hermetic tests using `TemporaryDirectory` (class-based, no pytest fixtures needed)
- CI step appended after lychee in `link-check.yml`

## Key Findings

**What Worked**:
- Pure Python regex slug algorithm handles all edge cases (backticks, parens, numbers, consecutive spaces)
- Additive script approach avoids modifying the existing `validate_links.py` which intentionally strips anchors
- `TemporaryDirectory` context manager works in class-based test classes where `tmp_path` fixture is unavailable

**What Failed**:
- Considered modifying `validate_links.py` — rejected because it strips anchors intentionally for file-existence checks
- Considered relying on lychee `--include-fragments` — rejected because Python gives more precise slug-algorithm control
- Considered importing `common.py` — unnecessary coupling for a self-contained script

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
