### PR TITLE
feat: add fix-yaml-frontmatter-colon-bug skill

### DIFF
--- a/skills/ci-cd/fix-yaml-frontmatter-colon-bug/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-yaml-frontmatter-colon-bug/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-yaml-frontmatter-colon-bug",
+  "version": "1.0.0",
+  "description": "Fix YAML frontmatter parsing bugs where line.partition(':') silently truncates values containing colons. Use when: (1) a script parses YAML frontmatter with manual string splitting, (2) description or value fields are silently truncated at the first colon, (3) applying the same yaml.safe_load() fix pattern across sibling scripts.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/fix-yaml-frontmatter-colon-bug/references/notes.md
+++ b/skills/ci-cd/fix-yaml-frontmatter-colon-bug/references/notes.md
@@ -1,0 +1,63 @@
+# Session Notes: fix-yaml-frontmatter-colon-bug
+
+## Context
+
+- **Issue**: #3929 — Fix same `partition(':')` bug in `ProjectMnemosyne/scripts/migrate_to_skills.py`
+- **Parent fix**: PR #3928 — `fix(migrate): use yaml.safe_load() to handle colons in frontmatter values`
+- **Parent issue**: #3310
+- **Branch**: `3929-auto-impl`
+- **Date**: 2026-03-15
+
+## What Happened
+
+### Problem
+
+`extract_frontmatter()` in `ProjectMnemosyne/scripts/migrate_to_skills.py` (lines 65-68) used
+`line.partition(":")` to parse YAML frontmatter. This silently truncated any value containing a
+colon — e.g. `description: "Create PR linked to issue: #123"` would be parsed as
+`description = "Create PR linked to issue"`.
+
+The identical bug had already been fixed in `scripts/migrate_odyssey_skills.py` via PR #3928.
+
+### Fix Applied
+
+1. Added `import yaml` to `ProjectMnemosyne/scripts/migrate_to_skills.py`
+2. Replaced the `for line in frontmatter_text.splitlines()` loop with `yaml.safe_load()`
+3. Created 7 regression tests in `tests/scripts/test_migrate_to_skills_frontmatter.py`
+
+### Key Discovery
+
+The script is NOT tracked in the ProjectOdyssey git repo. It lives in a separate
+`ProjectMnemosyne` repository, cloned locally at `~/ProjectMnemosyne/` and dynamically at
+`build/<PID>/ProjectMnemosyne/` during skill commands. The fix must be committed to the
+ProjectMnemosyne repo directly.
+
+Tests in ProjectOdyssey use `importlib.util.spec_from_file_location()` with multiple candidate
+paths (local checkout + PID-scoped build) and `pytest.mark.skipif` when neither is found.
+
+### Tests
+
+All 7 new tests passed:
+
+```text
+7 passed in 0.07s
+```
+
+Test cases:
+- `test_plain_value` — baseline
+- `test_colon_in_quoted_value` — regression case
+- `test_colon_in_unquoted_value` — bare string with colon
+- `test_no_frontmatter` — returns `{}`
+- `test_unclosed_frontmatter` — returns `{}`
+- `test_invalid_yaml_returns_empty_dict` — no exception raised
+- `test_multiple_colons_in_value` — full value preserved
+
+## Files Changed
+
+- `ProjectMnemosyne/scripts/migrate_to_skills.py` — fix applied
+- `tests/scripts/test_migrate_to_skills_frontmatter.py` — regression tests (ProjectOdyssey)
+
+## PRs
+
+- ProjectOdyssey PR #4832: test file
+- ProjectMnemosyne PR: fix (on branch `3929-fix-extract-frontmatter-colon-bug`)

--- a/skills/ci-cd/fix-yaml-frontmatter-colon-bug/skills/fix-yaml-frontmatter-colon-bug/SKILL.md
+++ b/skills/ci-cd/fix-yaml-frontmatter-colon-bug/skills/fix-yaml-frontmatter-colon-bug/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: fix-yaml-frontmatter-colon-bug
+description: "Fix YAML frontmatter parsing bugs where line.partition(':') silently truncates values containing colons. Use when: migrating a manual-split frontmatter parser to yaml.safe_load() following the partition-colon bug pattern."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Bug Pattern** | `key, _, value = line.partition(":")` silently drops everything after the first colon |
+| **Trigger** | Script reads YAML frontmatter by splitting on `:` instead of using a YAML parser |
+| **Fix** | Replace with `yaml.safe_load()` — handles colons in values, quoted strings, invalid YAML |
+| **Scope** | Any Python script using the `partition(":")` or `split(":", 1)` pattern for YAML frontmatter |
+| **Risk** | Low — `yaml.safe_load()` returns `{}` for invalid YAML instead of raising |
+
+## When to Use
+
+- A sibling or related script has the same `line.partition(":")` bug that was fixed in a parent issue
+- A description field like `"Create PR linked to issue: #123"` is being silently truncated to `"Create PR linked to issue"`
+- You need to propagate a `yaml.safe_load()` fix from one script to another using the same pattern
+- Multiple scripts share the same manual-parsing logic and one was already fixed
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# ❌ Buggy — silently truncates values with colons
+for line in frontmatter_text.splitlines():
+    if ":" in line:
+        key, _, value = line.partition(":")
+        result[key.strip()] = value.strip().strip('"').strip("'")
+
+# ✅ Fixed — yaml.safe_load() handles colons correctly
+import yaml
+
+try:
+    parsed = yaml.safe_load(frontmatter_text)
+    result = parsed if isinstance(parsed, dict) else {}
+except yaml.YAMLError:
+    result = {}
+```
+
+### Steps
+
+1. **Find the parent fix** — read the PR or issue that first fixed this pattern (e.g., `gh pr view <N>`)
+   to understand the exact replacement used
+
+2. **Locate the sibling script** — use `find` or `grep` to find all scripts with the same
+   `line.partition(":")` pattern:
+
+   ```bash
+   grep -r 'partition.*":"' scripts/
+   grep -r "partition.*':'" scripts/
+   ```
+
+3. **Read the full file** — understand context (function name, imports, return type) before editing
+
+4. **Apply the fix** — two changes required:
+   - Add `import yaml` to the imports block (alphabetically sorted)
+   - Replace the `for line in ...` loop with the `yaml.safe_load()` pattern
+
+5. **Write regression tests** — follow the same test class structure used for the parent fix.
+   Tests should cover:
+   - Plain value (baseline)
+   - Colon in quoted value (regression case — the exact bug)
+   - Colon in unquoted value
+   - No frontmatter (returns `{}`)
+   - Unclosed frontmatter (returns `{}`)
+   - Invalid YAML (returns `{}` without raising)
+   - Multiple colons in a single value
+
+6. **Handle test file discovery** — when the script lives in an external repo
+   (e.g., `ProjectMnemosyne`), use `importlib.util.spec_from_file_location()` with
+   multiple candidate paths and `pytest.mark.skipif` if none exist:
+
+   ```python
+   _CANDIDATES = [
+       Path.home() / "ProjectMnemosyne" / "scripts" / "migrate_to_skills.py",
+       Path(__file__).parent.parent.parent / "build" / str(os.getpid())
+           / "ProjectMnemosyne" / "scripts" / "migrate_to_skills.py",
+   ]
+   _SCRIPT_PATH = next((p for p in _CANDIDATES if p.exists()), None)
+
+   pytestmark = pytest.mark.skipif(
+       _SCRIPT_PATH is None,
+       reason="Script not found; skipping",
+   )
+   ```
+
+7. **Run tests** — confirm all pass:
+
+   ```bash
+   pixi run python -m pytest tests/scripts/test_<script_name>_frontmatter.py -v
+   ```
+
+8. **Commit the fix** to the external repo on a feature branch; commit the tests to the
+   main repo on its own branch
+
+9. **Create PRs** for both repos and enable auto-merge
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Search for file in worktree | `find` in `.worktrees/issue-3929/` for `migrate_to_skills.py` | File lives in `ProjectMnemosyne` repo, not in the ProjectOdyssey worktree | Check `build/*/ProjectMnemosyne/` and `~/ProjectMnemosyne/` for sibling repo scripts |
+| Look for tracked file in git | `git ls-files \| grep migrate_to_skills` | Script is in a separate cloned repo, never committed to ProjectOdyssey | For cross-repo fixes, always look for the local checkout of the target repo first |
+| Assume `build/` in worktree | Looked for `build/` under `.worktrees/issue-3929/` | `build/` is under the main repo root, not under worktree paths | PID-scoped builds live at `<repo_root>/build/<PID>/`, not under worktree subdirectories |
+
+## Results & Parameters
+
+### Regression Test Template
+
+```python
+class TestExtractFrontmatter:
+    """Regression tests for extract_frontmatter() colon handling."""
+
+    def test_colon_in_quoted_value(self, migrate_module) -> None:
+        """Regression: description with a colon inside a quoted value must not be truncated."""
+        content = '---\nname: my-skill\ndescription: "Create PR linked to issue: #123"\n---\n# Body'
+        fm = migrate_module.extract_frontmatter(content)
+        assert fm["description"] == "Create PR linked to issue: #123"
+
+    def test_invalid_yaml_returns_empty_dict(self, migrate_module) -> None:
+        """Malformed YAML in frontmatter returns {} without raising."""
+        content = "---\n: invalid: yaml: [\n---\n# Body"
+        fm = migrate_module.extract_frontmatter(content)
+        assert fm == {}
+```
+
+### Fix Diff Pattern
+
+```diff
++import yaml
++
+ def extract_frontmatter(content: str) -> dict:
+     ...
+     frontmatter_text = content[3:end].strip()
+-    result = {}
+-    for line in frontmatter_text.splitlines():
+-        if ":" in line:
+-            key, _, value = line.partition(":")
+-            result[key.strip()] = value.strip().strip('"').strip("'")
+-    return result
++    try:
++        parsed = yaml.safe_load(frontmatter_text)
++        return parsed if isinstance(parsed, dict) else {}
++    except yaml.YAMLError:
++        return {}
+```


### PR DESCRIPTION
## Summary

Documents the `yaml.safe_load()` fix pattern for Python scripts that silently truncate YAML
frontmatter values containing colons due to `line.partition(':')`.

- Captures the exact bug, fix, and regression test pattern from issue #3929
- Covers cross-repo script discovery (ProjectMnemosyne vs ProjectOdyssey worktree)
- Includes `importlib`-based test loading pattern with `skipif` guard for external scripts

## Key Findings

**What Worked**:
- `yaml.safe_load()` correctly handles colons in quoted and unquoted values
- `except yaml.YAMLError: return {}` prevents crashes on malformed frontmatter
- `importlib.util.spec_from_file_location()` + multiple candidate paths enables testing external-repo scripts from ProjectOdyssey's test suite

**What Failed**:
- Searching for the file in the ProjectOdyssey worktree — it lives in a separate cloned repo
- Looking for `build/` under the worktree path — PID-scoped builds are under the main repo root

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears under `ci-cd` category
- [ ] Check skill activation with "frontmatter colon" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
