### PR TITLE
feat: add delegates-to-file-existence-check skill

### DIFF
--- a/skills/ci-cd/delegates-to-file-existence-check/.claude-plugin/plugin.json
+++ b/skills/ci-cd/delegates-to-file-existence-check/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "delegates-to-file-existence-check",
+  "version": "1.0.0",
+  "description": "Add CI validation that every agent name listed in delegates_to frontmatter has a corresponding .md file in .claude/agents/. Use when: (1) adding delegates_to validation to an existing AgentConfigValidator, (2) catching stale cross-agent references automatically on every PR, (3) enforcing referential integrity in agent configuration files.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/delegates-to-file-existence-check/references/notes.md
+++ b/skills/ci-cd/delegates-to-file-existence-check/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: delegates_to File Existence Check
+
+## Date
+2026-03-15
+
+## Issue
+GitHub issue #3965 — Add CI check to enforce delegates_to references exist as files
+Follow-up from #3333 (junior-documentation-engineer stale reference discovered manually)
+
+## Problem Statement
+
+Agent `.md` files in `.claude/agents/` use a `delegates_to` YAML frontmatter field to declare
+which sub-agents they delegate to. When an agent is renamed or deleted, these references can
+go stale without any automated detection. The issue requested a CI validation step that would
+automatically catch broken references on every PR.
+
+## Approach Taken
+
+1. Explored existing `validate_configs.py` to understand the `AgentConfigValidator` class
+2. Searched all `delegates_to` fields with `grep -r "delegates_to" .claude/agents/`
+3. Found stale reference: `security-specialist.md` had `senior-implementation-engineer`
+4. Added `existing_agents` set to `__init__` (one glob call, stores stems)
+5. Added inline list parser in `_validate_frontmatter` — hard error for missing refs
+6. Fixed the stale reference in security-specialist.md
+7. Wrote 16 pytest tests in `test_validate_delegates_to.py`
+8. All 54 agent tests passed
+
+## Key Decision: error vs warning
+
+Stale `delegates_to` references are treated as hard **errors** (not warnings) because:
+- They represent definite bugs in the delegation chain
+- Warnings don't fail CI
+- The whole point is to gate PRs on this check
+
+## Key Decision: inline list format
+
+The project's agent files use YAML inline list syntax `[a, b, c]` for `delegates_to`.
+The validator parses this by stripping `[` `]` and splitting on `,`. This matches
+the actual format in all 29 agent files.
+
+## Stale Reference Found
+
+`security-specialist.md`:
+- Before: `delegates_to: [implementation-engineer, senior-implementation-engineer, test-engineer]`
+- After: `delegates_to: [implementation-engineer, test-engineer]`
+
+`senior-implementation-engineer.md` does not exist in `.claude/agents/`.
+
+## PR
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4843

--- a/skills/ci-cd/delegates-to-file-existence-check/skills/delegates-to-file-existence-check/SKILL.md
+++ b/skills/ci-cd/delegates-to-file-existence-check/skills/delegates-to-file-existence-check/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: delegates-to-file-existence-check
+description: "Add CI validation that every agent name in delegates_to frontmatter maps to a real .md file. Use when: adding referential integrity checks to agent config validators, catching stale cross-agent references automatically on PRs."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `delegates_to` fields in agent frontmatter can reference agents that no longer exist, silently creating broken delegation chains |
+| **Solution** | Build a set of known agent stems at validator init time; check each `delegates_to` name against this set during frontmatter validation |
+| **Scope** | `AgentConfigValidator` class in `tests/agents/validate_configs.py` |
+| **Language** | Python 3.7+ |
+| **Test file** | `tests/agents/test_validate_delegates_to.py` (16 pytest tests) |
+
+## When to Use
+
+- You have a directory of agent `.md` files with YAML frontmatter that includes `delegates_to` fields
+- You want CI to automatically block PRs that introduce stale agent references
+- You are extending `AgentConfigValidator` to enforce agent referential integrity
+- A PR was merged that deleted an agent file but left `delegates_to` references pointing to it
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# In AgentConfigValidator.__init__
+self.existing_agents: set = (
+    {f.stem for f in agents_dir.glob("*.md")}
+    if agents_dir.exists()
+    else set()
+)
+
+# In _validate_frontmatter, after model validation
+if "delegates_to" in frontmatter:
+    raw = frontmatter["delegates_to"].strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if inner:
+            names = [n.strip() for n in inner.split(",") if n.strip()]
+            for name in names:
+                if name not in self.existing_agents:
+                    errors.append(
+                        f"delegates_to references non-existent agent: '{name}'"
+                        f" (no .claude/agents/{name}.md)"
+                    )
+    else:
+        errors.append(f"delegates_to must be a YAML inline list, got: '{raw}'")
+```
+
+### Step 1 — Build known-agents set in `__init__`
+
+Add one line to `AgentConfigValidator.__init__` after `self.results`:
+
+```python
+self.existing_agents: set = (
+    {f.stem for f in agents_dir.glob("*.md")}
+    if agents_dir.exists()
+    else set()
+)
+```
+
+This captures all `.md` file stems (e.g. `implementation-engineer` from `implementation-engineer.md`)
+at construction time, before any validation runs.
+
+### Step 2 — Add `delegates_to` check in `_validate_frontmatter`
+
+At the end of `_validate_frontmatter`, just before `return errors, warnings, frontmatter`:
+
+```python
+if "delegates_to" in frontmatter:
+    raw = frontmatter["delegates_to"].strip()
+    # Parse YAML inline list: [name-a, name-b] or empty []
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if inner:
+            names = [n.strip() for n in inner.split(",") if n.strip()]
+            for name in names:
+                if name not in self.existing_agents:
+                    errors.append(
+                        f"delegates_to references non-existent agent: '{name}'"
+                        f" (no .claude/agents/{name}.md)"
+                    )
+    else:
+        errors.append(f"delegates_to must be a YAML inline list, got: '{raw}'")
+```
+
+Key details:
+- Inline list format `[a, b, c]` must match the actual YAML frontmatter convention in the project
+- Empty list `[]` is valid (no error)
+- The error message includes the expected filename to make fixing obvious
+
+### Step 3 — Fix any stale references caught by the new check
+
+Run the validator to find existing broken references:
+
+```bash
+python3 tests/agents/validate_configs.py .claude/agents/
+```
+
+For each error like `delegates_to references non-existent agent: 'senior-implementation-engineer'`,
+remove the name from the relevant agent's `delegates_to` field.
+
+### Step 4 — Write pytest tests
+
+Create `tests/agents/test_validate_delegates_to.py` with tests covering:
+
+```python
+class TestExistingAgentsSetInit:       # init populates set, empty dir, nonexistent dir
+class TestDelegatesToValidationValid:  # [], single ref, multiple refs, spaces around commas
+class TestDelegatesToValidationInvalid:  # missing ref → error, error message content, is_valid=False
+class TestDelegatesToFormatValidation: # non-list value → error
+class TestDelegatesToRealAgents:       # integration: all .claude/agents/ refs are valid
+```
+
+The integration test is the key regression guard:
+
+```python
+def test_all_agent_delegates_to_references_exist(self) -> None:
+    agents_dir = self._find_agents_dir()
+    validator = AgentConfigValidator(agents_dir)
+    results = validator.validate_all()
+
+    stale_errors = [
+        f"{result.file_path.name}: {error}"
+        for result in results
+        for error in result.errors
+        if "delegates_to references non-existent agent" in error
+    ]
+    assert stale_errors == [], (
+        "Stale delegates_to references found:\n"
+        + "\n".join(f"  {e}" for e in stale_errors)
+    )
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Lazy lookup per validation | Re-glob the agents directory on each `_validate_frontmatter` call | Would be slow for large directories and misses the point of a single-pass validator | Build the set once at `__init__` time |
+| Storing full paths instead of stems | `existing_agents = {f for f in agents_dir.glob("*.md")}` | Comparison against string names from frontmatter always fails | Store stems (`f.stem`) not full `Path` objects |
+| Warning instead of error | Treating missing refs as warnings | Warnings don't fail CI; stale references are definite bugs not style issues | Use `errors.append(...)`, not `warnings.append(...)` |
+| Validating format outside `_validate_frontmatter` | Adding a separate `_validate_delegates_to` method | Worked but required passing `frontmatter` dict as an extra argument, adding complexity | Inline the check inside `_validate_frontmatter` where `frontmatter` is already available |
+
+## Results & Parameters
+
+### Final configuration that passed all 54 tests
+
+```python
+# In AgentConfigValidator.__init__
+self.existing_agents: set = (
+    {f.stem for f in agents_dir.glob("*.md")}
+    if agents_dir.exists()
+    else set()
+)
+```
+
+```python
+# In _validate_frontmatter (inline list parser)
+if "delegates_to" in frontmatter:
+    raw = frontmatter["delegates_to"].strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if inner:
+            names = [n.strip() for n in inner.split(",") if n.strip()]
+            for name in names:
+                if name not in self.existing_agents:
+                    errors.append(
+                        f"delegates_to references non-existent agent: '{name}'"
+                        f" (no .claude/agents/{name}.md)"
+                    )
+    else:
+        errors.append(f"delegates_to must be a YAML inline list, got: '{raw}'")
+```
+
+### Test results
+
+```
+54 passed in 0.14s
+```
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `tests/agents/validate_configs.py` | Added `existing_agents` set to `__init__`; added `delegates_to` check in `_validate_frontmatter` |
+| `.claude/agents/security-specialist.md` | Removed stale `senior-implementation-engineer` from `delegates_to` |
+| `tests/agents/test_validate_delegates_to.py` | 16 new pytest tests (new file) |


### PR DESCRIPTION
## Summary

Documents how to add CI validation that every agent name in `delegates_to` frontmatter
maps to a real `.md` file in `.claude/agents/`, catching stale cross-agent references
automatically on every PR.

- Build `existing_agents` set once at `__init__` time via `glob("*.md")` stems
- Hard errors (not warnings) so stale references actually fail CI
- Inline list parser handles `[a, b, c]` YAML frontmatter convention
- Integration test against the real agents directory acts as a regression guard

## Key Findings

**What Worked**:
- Building the known-agents set at `__init__` time (one glob call, cheap)
- Using `f.stem` not full `Path` objects for set membership tests
- Treating stale refs as hard errors so CI gates on them
- Integration test (`test_all_agent_delegates_to_references_exist`) catches future regressions

**What Failed**:
- Lazy per-call glob lookups → slower and architecturally wrong
- Storing full Path objects instead of stems → set membership always fails
- Using warnings instead of errors → doesn't block CI
- Separate `_validate_delegates_to` method → extra complexity for no benefit

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
