### PR TITLE
feat: add workflow-readme-migration-sync skill

### DIFF
--- a/skills/documentation/workflow-readme-migration-sync/.claude-plugin/plugin.json
+++ b/skills/documentation/workflow-readme-migration-sync/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "workflow-readme-migration-sync",
+  "version": "1.0.0",
+  "description": "Update workflow README documentation to reflect completed CI/CD migrations (e.g. composite action adoption, workflow consolidation). Use when: (1) a GitHub issue closes a deferred documentation gap after workflows are already migrated, (2) a README still describes inline steps that were replaced by composite actions, (3) cross-references in a workflow README point to sections that are now stale.",
+  "category": "documentation",
+  "date": "2026-03-15"
+}

--- a/skills/documentation/workflow-readme-migration-sync/references/notes.md
+++ b/skills/documentation/workflow-readme-migration-sync/references/notes.md
@@ -1,0 +1,58 @@
+# Session Notes: workflow-readme-migration-sync
+
+## Session Context
+
+**Date**: 2026-03-15
+**Issue**: HomericIntelligence/ProjectOdyssey#3979
+**PR**: HomericIntelligence/ProjectOdyssey#4847
+**Branch**: `3979-auto-impl`
+
+## Objective
+
+Close issue #3979: "Create composite action for setup-pixi to eliminate 13 duplications".
+
+The issue described creating `.github/actions/setup-pixi/action.yml` and replacing 13
+inline `prefix-dev/setup-pixi` steps. However, upon inspection the composite action and
+workflow migrations were already complete from a prior session. The only remaining work was
+updating `.github/workflows/README.md` which still described the state before migration.
+
+## Discovery
+
+```bash
+# Composite action already existed
+cat .github/actions/setup-pixi/action.yml  # -> found, complete
+
+# All 13 workflows already migrated
+grep -rn "setup-pixi" .github/workflows/*.yml | grep -v README
+# -> 21 results, all "uses: ./.github/actions/setup-pixi"
+
+# README was stale
+grep -n "inline\|Not Yet Migrated" .github/workflows/README.md
+# -> Multiple hits describing the old state
+```
+
+## Changes Made
+
+1. **3 workflow description bullets** — replaced "Uses inline `prefix-dev/setup-pixi`" with
+   composite action reference (benchmark, paper-validation, release)
+2. **"Remaining Duplication" section** — removed entirely; replaced with "Composite Actions"
+   section listing all 13 migrated workflows with verification command
+3. **"Pixi-Based Environment Setup"** — replaced old inline YAML snippet with composite
+   action `uses:` line plus explanation
+4. **"Adding New Workflows" step 8** — replaced "add to Remaining Duplication table" with
+   instruction to use composite action
+5. **"Audit Inline Duplication"** — updated grep commands to verify zero inline remains
+
+## Key Gotcha
+
+The `replace_all: false` Edit tool call for "Uses inline ... for Mojo environment" failed
+because the context string wasn't unique. Used `replace_all: true` on second attempt.
+
+SHA-pinning documentation examples contain `prefix-dev/setup-pixi@v0.9.3` intentionally —
+these illustrate correct vs incorrect SHA pinning and should NOT be modified.
+
+## Validation
+
+```
+markdownlint-cli2 -> Passed
+```

--- a/skills/documentation/workflow-readme-migration-sync/skills/workflow-readme-migration-sync/SKILL.md
+++ b/skills/documentation/workflow-readme-migration-sync/skills/workflow-readme-migration-sync/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: workflow-readme-migration-sync
+description: "Update workflow README documentation to reflect completed CI/CD migrations. Use when: a README still describes inline steps replaced by composite actions, deferred documentation work is being closed out, or cross-references in a workflow README are stale after consolidation."
+category: documentation
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | workflow-readme-migration-sync |
+| **Category** | documentation |
+| **Trigger** | Issue closing deferred README documentation after workflows are already migrated |
+| **Effort** | ~15 min |
+| **Risk** | Low — documentation only, no code changes |
+
+## When to Use
+
+- A GitHub issue references "deferred documentation" from a prior consolidation pass
+- Workflow files already use the new pattern (e.g. composite action) but README still shows the old inline pattern
+- "Remaining Duplication" or similar stale sections exist in a workflow README
+- "Adding New Workflows" guidance still directs contributors to the old approach
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Grep workflows to confirm migration is complete
+grep -rn "prefix-dev/setup-pixi" .github/workflows/*.yml | grep -v README
+
+# 2. Grep README to find stale prose
+grep -n "inline\|Not Yet Migrated\|Remaining Duplication\|no composite action" .github/workflows/README.md
+
+# 3. Run markdownlint after edits
+pixi run pre-commit run markdownlint-cli2 --files .github/workflows/README.md
+```
+
+### Step 1 — Verify the migration is actually done
+
+Before touching the README, confirm the workflows already use the new pattern:
+
+```bash
+# Should return 0 results if migration is complete
+grep -rn "prefix-dev/setup-pixi" .github/workflows/*.yml | grep -v README | wc -l
+
+# Should return results for each migrated workflow
+grep -rn "uses: ./.github/actions/setup-pixi" .github/workflows/*.yml | wc -l
+```
+
+If the inline pattern is still present in `.yml` files, the README update is premature — do
+the workflow migration first.
+
+### Step 2 — Identify all stale README locations
+
+```bash
+grep -n "inline\|Not Yet Migrated\|no composite action\|prefix-dev/setup-pixi\|Remaining Duplication" \
+  .github/workflows/README.md
+```
+
+Typical stale locations in a post-migration README:
+
+1. **Individual workflow description bullets** — e.g. "Uses inline `prefix-dev/setup-pixi`"
+2. **"Remaining Duplication" section** — lists workflows as not-yet-migrated
+3. **"Common Patterns > Composite Actions"** — says no composite actions exist
+4. **"Pixi-Based Environment Setup"** — shows old inline YAML snippet
+5. **"Adding New Workflows"** checklist — tells contributors to add to duplication table
+6. **Audit quick-reference commands** — grep command checks for inline usage count
+
+### Step 3 — Apply targeted edits
+
+**Workflow description bullets** (use `replace_all: true` when the same phrase appears multiple times):
+
+```
+Before: - Uses inline `prefix-dev/setup-pixi` for Mojo environment
+After:  - Uses `.github/actions/setup-pixi` composite action for Mojo environment
+```
+
+**"Remaining Duplication" section** — replace with a "Composite Actions" section that:
+- Names the composite action file
+- Lists migrated workflows in a table
+- Includes a verification command showing expected count = 0
+
+**"Pixi-Based Environment Setup"** — replace old YAML example with the composite action `uses:` line and note why the explicit cache step is preferred over `cache: true`.
+
+**"Adding New Workflows"** — replace "add to Remaining Duplication table" with "use the composite action".
+
+**Audit commands** — update to verify zero inline usage remains.
+
+### Step 4 — Validate markdown
+
+```bash
+SKIP=mojo-format pixi run pre-commit run markdownlint-cli2 --files .github/workflows/README.md
+```
+
+Fix any lint errors before committing.
+
+### Step 5 — Commit and PR
+
+```bash
+git add .github/workflows/README.md
+git commit -m "docs(workflows): update README to reflect completed <migration-name>
+
+<Brief description of what changed and why the old README was stale.>
+
+Closes #<issue-number>"
+
+git push -u origin <branch>
+gh pr create --title "docs(workflows): ..." --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Editing "Uses inline" bullets one at a time | Used `replace_all: false` for the first bullet, then tried to match the second with trailing context | Context string wasn't unique — edit tool reported string not found | When the same phrase appears multiple times, use `replace_all: true` on the first pass; only use contextual matching when the surrounding text differs |
+| Updating SHA-pinning documentation examples | Considered replacing `prefix-dev/setup-pixi@v0.9.3` in the SHA-pinning examples section | Those lines are intentional documentation of the pinning pattern, not actual workflow steps | Always check whether a `prefix-dev/setup-pixi` reference is in a code example block explaining a concept vs. a step to be migrated |
+
+## Results & Parameters
+
+**PR created**: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4847
+
+**Files changed**: `.github/workflows/README.md` only (26 insertions, 45 deletions)
+
+**Validation command**:
+
+```bash
+# After migration, inline count should be 0
+grep -rl "prefix-dev/setup-pixi" .github/workflows/*.yml | wc -l
+```
+
+**Key replacement patterns** (copy-paste):
+
+```bash
+# Count remaining inline uses
+grep -rn "prefix-dev/setup-pixi" .github/workflows/*.yml | grep -v README | wc -l
+
+# Confirm composite action is in use
+grep -rn "uses: ./.github/actions/setup-pixi" .github/workflows/*.yml | wc -l
+```


### PR DESCRIPTION
## Summary

Documents the `workflow-readme-migration-sync` pattern: updating a workflow README after a CI/CD migration is already complete but documentation still reflects the pre-migration state.

- Skill captures the specific README locations that go stale after composite action adoption
- Includes the "stale SHA-pinning examples" gotcha (don't replace those)
- Documents the `replace_all: true` fix when the same phrase appears multiple times

## Key Findings

**What Worked**:
- Reading the existing `.yml` files first to confirm migration state before touching README
- Using `replace_all: true` for repeated phrases like "Uses inline `prefix-dev/setup-pixi`"
- Running `markdownlint-cli2` via pre-commit after edits to catch formatting issues

**What Failed**:
- `replace_all: false` with contextual string matching when the same phrase appeared multiple times → string not unique error
- Attempting to "fix" SHA-pinning documentation examples that contained old action references → those are intentional

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
