### PR TITLE
feat: add multi-pattern-stale-detection skill

### DIFF
--- a/skills/testing/multi-pattern-stale-detection/.claude-plugin/plugin.json
+++ b/skills/testing/multi-pattern-stale-detection/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "multi-pattern-stale-detection",
+  "version": "1.0.0",
+  "description": "Detect stale CI matrix patterns at the sub-pattern level when space-separated multi-pattern strings are used. Use when: (1) extending coverage validators that use pattern.split() expansion, (2) a CI group has multiple space-separated patterns and individual patterns may go stale while sibling patterns keep the group alive, (3) implementing check_stale_patterns() style functions.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/multi-pattern-stale-detection/references/notes.md
+++ b/skills/testing/multi-pattern-stale-detection/references/notes.md
@@ -1,0 +1,39 @@
+# Session Notes — multi-pattern-stale-detection
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #4012
+- **PR**: ProjectOdyssey #4854
+- **Branch**: 4012-auto-impl
+
+## Objective
+
+`validate_test_coverage.py` had a `check_stale_patterns()` function referenced by tests
+but not yet implemented. The issue asked for per-sub-pattern stale detection: a CI matrix
+group with `pattern: "test_foo.mojo test_gone.mojo"` should flag `test_gone.mojo` as stale
+even when `test_foo.mojo` still exists.
+
+## Files Changed
+
+- `scripts/validate_test_coverage.py` — added `check_stale_patterns()` (45 lines)
+- `tests/scripts/test_validate_test_coverage.py` — added `TestCheckStalePatternsMultiPattern` (5 tests)
+
+## Key Discovery
+
+`expand_pattern()` already splits on spaces internally and returns a union of all matches.
+So calling it with the full multi-pattern string would always return non-empty results
+as long as any one sub-pattern matched files. The fix was to call `expand_pattern` once
+per individual sub-pattern, then apply two-branch logic:
+
+- All dead → group name (backward compatible with existing single-pattern tests)
+- Some dead → `"GroupName (sub-pattern: pat)"` for each dead one
+
+## Test Results
+
+18 passed in 0.11s — 9 pre-existing tests + 5 new multi-pattern tests + 4 expand_pattern regression tests.
+
+## Implementation Time
+
+Single iteration, no rework needed. The existing `expand_pattern` abstraction made the
+fix straightforward once the calling convention was understood.

--- a/skills/testing/multi-pattern-stale-detection/skills/multi-pattern-stale-detection/SKILL.md
+++ b/skills/testing/multi-pattern-stale-detection/skills/multi-pattern-stale-detection/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: multi-pattern-stale-detection
+description: "Detect stale CI matrix patterns at the sub-pattern level when space-separated multi-pattern strings are used. Use when: extending CI coverage validators, a group has multiple patterns where a subset may silently go stale, or implementing check_stale_patterns() style functions."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | CI matrix pattern groups use space-separated multi-pattern strings. A group with `pattern: "test_foo.mojo test_gone.mojo"` would not be flagged as stale if `test_gone.mojo` was deleted but `test_foo.mojo` still existed — the surviving sibling silently masked the stale pattern. |
+| **Solution** | Per-sub-pattern breakdown in `check_stale_patterns()`: split on whitespace, expand each sub-pattern independently, distinguish fully-stale groups (all sub-patterns dead) from partially-stale groups (some dead). |
+| **Language** | Python 3.7+ |
+| **Test framework** | pytest |
+| **Scope** | `scripts/validate_test_coverage.py` + `tests/scripts/test_validate_test_coverage.py` |
+
+## When to Use
+
+- You have a CI matrix validator that calls `pattern.split()` to expand multiple patterns
+- A CI group references multiple test files via a space-separated pattern string
+- You want granular staleness reporting (which specific sub-pattern is dead, not just which group)
+- Existing `check_stale_patterns()` only checks combined expansion (all-or-nothing)
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# Before: all-or-nothing group-level check
+def check_stale_patterns(ci_groups, root_dir):
+    stale = []
+    for name, info in ci_groups.items():
+        matched = expand_pattern(info["path"], info["pattern"], root_dir)
+        if not matched:
+            stale.append(name)
+    return sorted(stale)
+
+# After: per-sub-pattern breakdown
+def check_stale_patterns(ci_groups, root_dir):
+    stale = []
+    for group_name, info in ci_groups.items():
+        sub_patterns = info["pattern"].split()
+        stale_subs = []
+        live_subs = []
+        for sub_pat in sub_patterns:
+            matched = expand_pattern(info["path"], sub_pat, root_dir)
+            if not matched:
+                stale_subs.append(sub_pat)
+            else:
+                live_subs.append(sub_pat)
+        if len(stale_subs) == len(sub_patterns):
+            # All dead — original group-level report (backward compatible)
+            stale.append(group_name)
+        else:
+            # Partial: report each dead sub-pattern individually
+            for sub_pat in stale_subs:
+                stale.append(f"{group_name} (sub-pattern: {sub_pat})")
+    return sorted(stale)
+```
+
+### Step 1 — Understand the existing `expand_pattern` contract
+
+`expand_pattern(base_path, pattern, root_dir)` already handles space-separated patterns by splitting internally and returning a combined `Set[Path]`. This means a single call to `expand_pattern` with a multi-pattern string can return non-empty results even if some sub-patterns are dead.
+
+**Key insight**: call `expand_pattern` once per sub-pattern (not once per group) to see individual match counts.
+
+### Step 2 — Implement the per-sub-pattern loop
+
+```python
+sub_patterns = group_info["pattern"].split()
+stale_subs: List[str] = []
+live_subs: List[str] = []
+
+for sub_pat in sub_patterns:
+    matched = expand_pattern(group_info["path"], sub_pat, root_dir)
+    if not matched:
+        stale_subs.append(sub_pat)
+    else:
+        live_subs.append(sub_pat)
+```
+
+### Step 3 — Apply the two-branch reporting logic
+
+```python
+if len(stale_subs) == len(sub_patterns):
+    # Entire group matches nothing — backward-compatible group-level name
+    stale.append(group_name)
+else:
+    # Partial staleness — report each dead sub-pattern with context
+    for sub_pat in stale_subs:
+        stale.append(f"{group_name} (sub-pattern: {sub_pat})")
+```
+
+This preserves backward compatibility: callers already checking for `"Group Name"` in the list still work correctly for fully-stale groups.
+
+### Step 4 — Write tests covering all four cases
+
+```python
+class TestCheckStalePatternsMultiPattern:
+    def test_one_stale_sub_pattern_reports_sub_pattern_not_group(self, tmp_repo):
+        ci_groups = {
+            "Mixed Group": {
+                "path": "tests/unit",
+                "pattern": "test_foo.mojo test_gone.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Mixed Group (sub-pattern: test_gone.mojo)"]
+
+    def test_all_sub_patterns_stale_reports_group_name(self, tmp_repo):
+        ci_groups = {
+            "Dead Group": {
+                "path": "tests/unit",
+                "pattern": "test_missing1.mojo test_missing2.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Dead Group"]
+
+    def test_both_sub_patterns_live_not_reported(self, tmp_repo):
+        ci_groups = {
+            "Healthy Group": {
+                "path": "tests/unit",
+                "pattern": "test_foo.mojo test_bar.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == []
+
+    def test_multiple_stale_sub_patterns_all_reported(self, tmp_repo):
+        ci_groups = {
+            "Partial Group": {
+                "path": "tests/unit",
+                "pattern": "test_bar.mojo test_gone1.mojo test_gone2.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == [
+            "Partial Group (sub-pattern: test_gone1.mojo)",
+            "Partial Group (sub-pattern: test_gone2.mojo)",
+        ]
+
+    def test_mixed_and_fully_stale_groups_sorted_together(self, tmp_repo):
+        ci_groups = {
+            "Zebra Group": {
+                "path": "tests/unit",
+                "pattern": "test_foo.mojo test_gone.mojo",
+            },
+            "Alpha Group": {"path": "tests/nowhere", "pattern": "test_*.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == [
+            "Alpha Group",
+            "Zebra Group (sub-pattern: test_gone.mojo)",
+        ]
+```
+
+### Step 5 — Verify all tests pass
+
+```bash
+pixi run python -m pytest tests/scripts/test_validate_test_coverage.py -v
+# 18 passed in 0.11s
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Single `expand_pattern` call per group | Called `expand_pattern(path, full_pattern, root)` where `full_pattern` is the entire space-separated string | `expand_pattern` splits internally and unions results — a live sibling masks the dead sub-pattern, returning non-empty set | Must call `expand_pattern` once per individual sub-pattern to detect partial staleness |
+| Reporting all stale sub-patterns as group-level | Returning `group_name` for both fully-stale and partially-stale groups | Caller cannot distinguish "group is entirely gone" from "one pattern in a healthy group was deleted" | Use `"GroupName (sub-pattern: pat)"` format for partial staleness, preserve plain group name for full staleness |
+
+## Results & Parameters
+
+### Output format contract
+
+```text
+# Fully stale group (all sub-patterns dead):
+"Alpha Group"
+
+# Partially stale group (one dead sub-pattern):
+"Zebra Group (sub-pattern: test_gone.mojo)"
+
+# Multiple dead sub-patterns in one partially-live group:
+"Partial Group (sub-pattern: test_gone1.mojo)"
+"Partial Group (sub-pattern: test_gone2.mojo)"
+```
+
+### Return type
+
+`List[str]` — always sorted, always `str` elements. Empty list when nothing is stale.
+
+### Backward compatibility
+
+Pre-existing callers that check `"Group Name" in stale` for fully-stale groups continue to work unchanged. The `(sub-pattern: …)` suffix only appears for the partial-staleness case.


### PR DESCRIPTION
## Summary

Documents per-sub-pattern stale detection for CI matrix pattern groups that use
space-separated multi-pattern strings (e.g., `pattern: "test_foo.mojo test_gone.mojo"`).

- Implements `check_stale_patterns()` with two-branch reporting
- Backward compatible: fully-stale groups still return plain group name
- Partially-stale groups return `"GroupName (sub-pattern: test_gone.mojo)"` for each dead sub-pattern

## Key Findings

**What Worked**:
- Calling `expand_pattern()` once per individual sub-pattern (not once per group) exposes dead patterns hidden by live siblings
- Two-branch logic (all-dead vs some-dead) preserves backward compatibility with existing callers

**What Failed**:
- Single `expand_pattern` call with the full multi-pattern string → `expand_pattern` splits internally and unions results, masking dead sub-patterns behind live ones
- Returning plain group name for partial staleness → caller cannot distinguish fully-gone groups from partially-stale groups

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in registry
- [ ] Check skill activation with multi-pattern CI matrix patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
