### PR TITLE
feat: add mypy-hyphenated-dir-per-file skill

### DIFF
--- a/skills/ci-cd/mypy-hyphenated-dir-per-file/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mypy-hyphenated-dir-per-file/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mypy-hyphenated-dir-per-file",
+  "version": "1.0.0",
+  "description": "Add mypy pre-commit coverage for directories with hyphenated names by running mypy per-file to avoid 'Duplicate module named' errors. Use when: (1) extending mypy to cover examples/ or similar dirs with hyphenated subdirectory names, (2) pre-commit mypy hook fails with 'Duplicate module named' on files sharing a basename across hyphenated dirs.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/mypy-hyphenated-dir-per-file/references/notes.md
+++ b/skills/ci-cd/mypy-hyphenated-dir-per-file/references/notes.md
@@ -1,0 +1,63 @@
+# Session Notes: mypy-hyphenated-dir-per-file
+
+## Context
+
+- **Issue**: HomericIntelligence/ProjectOdyssey#4013
+- **PR**: HomericIntelligence/ProjectOdyssey#4856
+- **Branch**: `4013-auto-impl`
+- **Date**: 2026-03-15
+
+## Objective
+
+Extend mypy type-checking in `.pre-commit-config.yaml` to cover `examples/` in addition to
+`scripts/`. The gap was identified because bandit already covers `tools/` and `examples/`, but
+mypy only covered `^scripts/.*\.py$`.
+
+## Root Cause Discovery
+
+The naive approach of adding a second mypy hook with `files: ^examples/.*\.py$` and
+`pass_filenames: true` fails immediately with:
+
+```
+error: Duplicate module named 'download_cifar10'
+  (also at 'examples/resnet-cifar10/download_cifar10.py')
+note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules
+note: Common resolutions include: a) using `--exclude` to avoid checking one of them,
+b) adding `__init__.py` somewhere, c) using `--explicit-package-bases`, or
+d) using `--package` or `--module` or `--file`
+```
+
+The subdirectories are named `alexnet-cifar10`, `resnet-cifar10` etc. — hyphenated names that
+Python cannot use as package identifiers. `--explicit-package-bases` does not help because the
+root cause is that two files literally have the same module-qualified name from mypy's perspective.
+
+## Solution
+
+A per-file wrapper script (`scripts/mypy-each-file.py`) that:
+
+1. Receives all the files from pre-commit (via `pass_filenames: true`).
+2. Splits the argument list into mypy flags vs file paths.
+3. Invokes `python -m mypy <flags> <one-file>` for each file individually.
+4. Aggregates exit codes (non-zero if any invocation fails).
+
+The pre-commit hook uses `language: system` and `entry: pixi run python scripts/mypy-each-file.py`
+so it runs in the project's pixi environment without needing a separate virtualenv.
+
+## Files Changed
+
+- `.pre-commit-config.yaml`: added `mypy-examples` local hook
+- `scripts/mypy-each-file.py`: new wrapper script (55 lines)
+
+## Key Decisions
+
+- Used `language: system` (not `language: python`) to reuse the pixi-managed mypy installation.
+- Matched existing mypy flags from the `scripts/` hook for consistency.
+- The script returns 0 with a message when called with no files (pre-commit may call with empty
+  list in some scenarios, e.g. `--files` filter with no matches).
+- No `capture_output` on subprocess — mypy output streams directly to the terminal for visibility.
+
+## What Was Skipped
+
+- Did not add `additional_dependencies` — the `language: system` hook uses pixi's environment
+  where mypy and type stubs are already installed.
+- Did not use `--package` or `--module` flags — per-file invocation is simpler and more robust.

--- a/skills/ci-cd/mypy-hyphenated-dir-per-file/skills/mypy-hyphenated-dir-per-file/SKILL.md
+++ b/skills/ci-cd/mypy-hyphenated-dir-per-file/skills/mypy-hyphenated-dir-per-file/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: mypy-hyphenated-dir-per-file
+description: "Add mypy pre-commit coverage for directories with hyphenated names by running mypy per-file. Use when: extending mypy to examples/ with hyphenated subdirs, or fixing 'Duplicate module named' errors."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `mypy` receives multiple files sharing the same basename (e.g. `download_cifar10.py`) from different hyphenated subdirectories (e.g. `examples/alexnet-cifar10/`, `examples/resnet-cifar10/`). Because hyphens are not valid Python identifiers, mypy cannot resolve the parent directory as a package, and emits an unrecoverable **"Duplicate module named X"** blocker error. |
+| **Root cause** | `pre-commit` passes all matched files in one `mypy` invocation. Hyphenated directory names cannot be used as Python package components, so mypy has no way to disambiguate duplicate basenames. |
+| **Solution** | A thin wrapper script (`scripts/mypy-each-file.py`) that invokes `mypy` once per file, aggregating exit codes. The pre-commit hook is configured as a `local` hook pointing at this wrapper. |
+| **Scope** | Any directory tree where subdirectory names contain hyphens and files may share basenames. Typical example: `examples/` in ML repos. |
+
+## When to Use
+
+Trigger this skill when:
+
+1. You need to add mypy type-checking to `examples/` (or similar dirs) in `.pre-commit-config.yaml`.
+2. A pre-commit mypy run fails with **"error: Duplicate module named 'X' (also at '...')"**.
+3. The duplicated modules live in directories with hyphenated names that cannot be Python packages.
+4. Extending bandit or other linters to `examples/` surfaces the need to add matching mypy coverage.
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# .pre-commit-config.yaml — add this block
+- repo: local
+  hooks:
+    - id: mypy-examples
+      name: mypy (examples)
+      description: Type-check Python files in examples/ one file at a time
+      entry: pixi run python scripts/mypy-each-file.py --ignore-missing-imports --no-strict-optional --explicit-package-bases --check-untyped-defs --python-version 3.10
+      language: system
+      files: ^examples/.*\.py$
+      types: [python]
+      pass_filenames: true
+```
+
+```python
+# scripts/mypy-each-file.py
+#!/usr/bin/env python3
+"""Run mypy on each file individually to avoid duplicate module name errors.
+
+This wrapper is needed for directories with hyphenated names (e.g. examples/alexnet-cifar10/)
+where multiple files share the same basename (download_cifar10.py). Passing them all to a
+single mypy invocation causes a "Duplicate module named" blocker error because mypy cannot
+resolve the hyphenated directory as a Python package component.
+
+Usage:
+    python scripts/mypy-each-file.py [mypy-args...] file1.py file2.py ...
+
+The script separates mypy flags (starting with '-') from file paths, then runs mypy once
+per file, aggregating exit codes.
+"""
+
+import sys
+import subprocess
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    # Separate mypy flags from file paths (flags start with '-')
+    flags: list[str] = []
+    files: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("-"):
+            flags.append(arg)
+            # Some flags take a value argument (e.g. --python-version 3.10)
+            if arg in ("--python-version", "--config-file", "--shadow-file", "--exclude"):
+                i += 1
+                if i < len(args):
+                    flags.append(args[i])
+        else:
+            files.append(arg)
+        i += 1
+
+    if not files:
+        print("mypy-each-file: no files to check", file=sys.stderr)
+        return 0
+
+    overall_rc = 0
+    for filepath in files:
+        cmd = [sys.executable, "-m", "mypy"] + flags + [filepath]
+        result = subprocess.run(cmd, capture_output=False)
+        if result.returncode != 0:
+            overall_rc = result.returncode
+
+    return overall_rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Step-by-step
+
+1. **Identify the gap**: Check `.pre-commit-config.yaml` — confirm mypy only covers `^scripts/.*\.py$`
+   while linters like bandit already cover `^(tools|examples)/.*\.py$`.
+
+2. **Understand why bulk invocation fails**: Run `pixi run python -m mypy --explicit-package-bases
+   examples/alexnet-cifar10/download_cifar10.py examples/resnet-cifar10/download_cifar10.py` and
+   observe the "Duplicate module named" error.
+
+3. **Create the wrapper script** at `scripts/mypy-each-file.py` (see Quick Reference above).
+   Key design decisions:
+   - Parse flags (leading `-`) vs file paths separately.
+   - Handle two-argument flags like `--python-version 3.10`.
+   - Aggregate exit codes — return non-zero if any file fails.
+   - Return 0 with a message when no files are provided (pre-commit may call with empty list).
+
+4. **Add a `local` hook** to `.pre-commit-config.yaml` using `pass_filenames: true` so
+   pre-commit passes the matched files to the wrapper.
+
+5. **Match the existing mypy flags** from the `scripts/` hook (`--ignore-missing-imports`,
+   `--no-strict-optional`, `--explicit-package-bases`, `--check-untyped-defs`,
+   `--python-version 3.10`) for consistency.
+
+6. **Verify locally**:
+
+   ```bash
+   just pre-commit-all
+   # or
+   pixi run pre-commit run mypy-examples --all-files
+   ```
+
+7. **Commit and PR**:
+
+   ```bash
+   git add .pre-commit-config.yaml scripts/mypy-each-file.py
+   git commit -m "feat(pre-commit): add mypy type-checking coverage for examples/"
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Bulk `mypy` invocation on all examples files | Pass all `^examples/.*\.py$` files directly to a single `mypy` run with `--explicit-package-bases` | `mypy` emits "Duplicate module named 'download_cifar10'" because `alexnet-cifar10` and `resnet-cifar10` are not valid Python identifiers — mypy cannot disambiguate the two `download_cifar10.py` files | Hyphenated directory names can never serve as Python package components; per-file invocation is the only robust solution |
+| Using `namespace_packages = true` in mypy config | Attempted to configure mypy namespace package support to handle non-standard paths | Does not resolve the duplicate-module conflict when two files truly share the same basename at the same namespace level | The issue is a name collision, not a package discovery problem |
+| Adding `--exclude` patterns | Tried excluding one of the duplicate subdirs per invocation | Would suppress legitimate type-check coverage on excluded dirs | Defeats the purpose of extending coverage; per-file wrapper is cleaner |
+
+## Results & Parameters
+
+### Wrapper Script Parameters
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `--ignore-missing-imports` | (flag) | Suppress errors for unresolved third-party imports |
+| `--no-strict-optional` | (flag) | Allow implicit `Optional` — matches project's existing mypy config |
+| `--explicit-package-bases` | (flag) | Required to avoid package-root confusion in non-package dirs |
+| `--check-untyped-defs` | (flag) | Type-check function bodies even without annotations |
+| `--python-version` | `3.10` | Matches the project's minimum supported Python version |
+
+### Pre-commit Hook Config
+
+```yaml
+- repo: local
+  hooks:
+    - id: mypy-examples
+      name: mypy (examples)
+      description: Type-check Python files in examples/ one file at a time
+      entry: pixi run python scripts/mypy-each-file.py --ignore-missing-imports --no-strict-optional --explicit-package-bases --check-untyped-defs --python-version 3.10
+      language: system
+      files: ^examples/.*\.py$
+      types: [python]
+      pass_filenames: true
+```
+
+### Wrapper Script Exit Code Behaviour
+
+- Returns `0` if all files pass or no files are provided.
+- Returns the last non-zero exit code if any file fails.
+- Streams mypy output directly (no `capture_output`) so errors appear inline in the terminal.


### PR DESCRIPTION
## Summary

Documents the per-file mypy wrapper pattern for extending pre-commit type-checking
to directories whose subdirectory names contain hyphens (e.g. `examples/alexnet-cifar10/`).

- Root cause: bulk `mypy` invocation on files from hyphenated dirs fails with "Duplicate module named"
- Solution: thin `scripts/mypy-each-file.py` wrapper that invokes mypy once per file
- Pattern: `local` pre-commit hook with `pass_filenames: true` pointing at the wrapper

## Key Findings

**What Worked**:
- Per-file wrapper script invoking `python -m mypy <flags> <file>` for each file individually
- `language: system` hook with `pixi run python` entry to reuse the managed mypy environment
- Aggregating exit codes — return non-zero if any single-file invocation fails

**What Failed**:
- Bulk mypy invocation → "Duplicate module named 'download_cifar10'" blocker error
- `--explicit-package-bases` flag → does not resolve name collisions for files sharing basenames
- `--exclude` patterns → suppresses legitimate coverage, defeats the purpose

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers (mypy, pre-commit, examples/ coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
