### PR TITLE
feat: update mojo-hash-collision-test skill with same-dtype different-shapes pattern

### DIFF
--- a/skills/testing/mojo-hash-collision-test/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-hash-collision-test/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "mojo-hash-collision-test",
-  "version": "1.0.0",
-  "description": "Add hash collision resistance tests for Mojo tensors with same values but different dtypes. Use when: (1) verifying __hash__ distinguishes float32 vs float64 tensors, (2) expanding hash test coverage in test_utility.mojo.",
+  "version": "1.1.0",
+  "description": "Pattern for adding hash collision tests to Mojo ExTensor test files. Use when: (1) issue requests verifying hash distinguishes same-dtype tensors with different shapes, (2) verifying __hash__ distinguishes float32 vs float64 tensors, (3) adding collision tests for shape/dtype/value sensitivity.",
   "category": "testing",
-  "date": "2026-03-07",
-  "tags": ["mojo", "hash", "tensor", "dtype", "collision", "unit-test"]
+  "date": "2026-03-15",
+  "tags": ["mojo", "hash", "tensor", "dtype", "shape", "collision", "unit-test", "extensor"]
 }

--- a/skills/testing/mojo-hash-collision-test/references/notes.md
+++ b/skills/testing/mojo-hash-collision-test/references/notes.md
@@ -63,3 +63,64 @@ Committed on branch `3379-auto-impl` in ProjectOdyssey worktree at
 `/home/mvillmow/Odyssey2/.worktrees/issue-3379/`.
 
 Commit hash: `45163b87` (test(utility): add hash collision resistance test for same-shape different-dtype tensors)
+
+---
+
+## Session Context (Issue #4056)
+
+Implemented as part of ProjectOdyssey GitHub issue #4056 (worktree `4056-auto-impl`, branch `4056-auto-impl`).
+
+## Objective
+
+Add `test_hash_same_dtype_different_shapes()` to `tests/shared/core/test_hash.mojo` asserting that
+tensors with identical data and dtype but different shapes (e.g. [2,3] vs [6]) produce different hashes.
+
+## Steps Taken
+
+1. Read `.claude-prompt-4056.md` to understand requirements
+2. Found the existing test file at `tests/shared/core/test_hash.mojo`
+3. Read the file to understand existing patterns (NaN tests, shape sensitivity tests, dtype sensitivity tests)
+4. Discovered the existing `test_hash_shape_sensitivity` test only tested different-size shapes ([2] vs [3]) — not same-total-elements different-shape
+5. Added `test_hash_same_dtype_different_shapes()` function testing [2,3] vs [6] tensors both filled with 1.0 as float32
+6. Added the test call to `main()`
+7. Ran tests — all 17 tests passed
+8. Committed with `git add` + `git commit`
+9. Pushed to origin
+10. Created PR #4860 with `gh pr create`
+
+## Key Code Patterns Observed
+
+```mojo
+fn test_hash_same_dtype_different_shapes() raises:
+    var shape_2x3 = List[Int]()
+    shape_2x3.append(2)
+    shape_2x3.append(3)
+    var shape_6 = List[Int]()
+    shape_6.append(6)
+    var a = full(shape_2x3, 1.0, DType.float32)
+    var b = full(shape_6, 1.0, DType.float32)
+    if hash(a) == hash(b):
+        raise Error(
+            "Tensors with same dtype/data but different shapes ([2,3] vs [6]) should not collide on hash"
+        )
+```
+
+Registration in `main()`:
+
+```mojo
+print("Running test_hash_same_dtype_different_shapes...")
+test_hash_same_dtype_different_shapes()
+```
+
+## Environment Details
+
+- Host OS: WSL2 Ubuntu (GLIBC 2.35) — compatible with Mojo runtime
+- Tests ran successfully locally: all 17 tests passed
+- Used `just test-group "tests/shared/core" "test_hash.mojo"` to run tests
+
+## Commit
+
+Committed on branch `4056-auto-impl` in ProjectOdyssey worktree at
+`/home/mvillmow/ProjectOdyssey/.worktrees/issue-4056/`.
+
+Commit hash: `c0ecf9c8` (test(hash): add hash collision test for same dtype different shapes)

--- a/skills/testing/mojo-hash-collision-test/skills/mojo-hash-collision-test/SKILL.md
+++ b/skills/testing/mojo-hash-collision-test/skills/mojo-hash-collision-test/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: mojo-hash-collision-test
-description: "Add hash collision resistance tests for Mojo tensors with same values but different dtypes. Use when verifying __hash__ distinguishes float32 vs float64 tensors."
+description: "Pattern for adding hash collision tests to Mojo ExTensor test files. Use when: (1) issue requests verifying hash distinguishes same-dtype tensors with different shapes, (2) verifying __hash__ distinguishes float32 vs float64 tensors, (3) adding collision tests for shape/dtype/value sensitivity."
 category: testing
-date: 2026-03-07
-user-invocable: true
+date: 2026-03-15
+user-invocable: false
 ---
 
 # Mojo Hash Collision Test Skill
@@ -12,20 +12,38 @@ user-invocable: true
 
 | Item | Details |
 |------|---------|
-| Date | 2026-03-07 |
-| Objective | Add `test_hash_same_values_different_dtype()` asserting that tensors with identical numeric values but different dtypes (float32 vs float64) produce different hashes. |
-| Outcome | Successful — test added, pre-commit hooks passed, PR created |
+| Date | 2026-03-15 |
+| Objective | Add hash collision resistance tests verifying ExTensor `__hash__` distinguishes tensors by shape, dtype, and values |
+| Outcome | Successful — tests added, pre-commit hooks passed, PRs created |
 
 ## When to Use
 
-- Adding hash collision resistance tests to `tests/shared/core/test_utility.mojo`
-- Verifying that `__hash__` encodes dtype information (not just values and shape)
+- Issue requests adding a hash collision test for same dtype, different shapes (e.g. [2,3] vs [6])
+- Adding hash collision resistance tests to `tests/shared/core/test_hash.mojo` or similar files
+- Verifying that `__hash__` encodes shape, dtype, and value information in ExTensors
 - Following TDD to guard against regressions in tensor hash uniqueness
-- Expanding hash test coverage alongside `test_hash_different_values` and `test_hash_small_values_distinguish`
+- Expanding hash test coverage alongside existing shape/dtype/value sensitivity tests
 
 ## Verified Workflow
 
-### Quick Reference
+### Quick Reference — Same Dtype, Different Shapes ([2,3] vs [6])
+
+```mojo
+fn test_hash_same_dtype_different_shapes() raises:
+    var shape_2x3 = List[Int]()
+    shape_2x3.append(2)
+    shape_2x3.append(3)
+    var shape_6 = List[Int]()
+    shape_6.append(6)
+    var a = full(shape_2x3, 1.0, DType.float32)
+    var b = full(shape_6, 1.0, DType.float32)
+    if hash(a) == hash(b):
+        raise Error(
+            "Tensors with same dtype/data but different shapes ([2,3] vs [6]) should not collide on hash"
+        )
+```
+
+### Quick Reference — Same Values, Different Dtype
 
 ```mojo
 fn test_hash_same_values_different_dtype() raises:
@@ -41,43 +59,64 @@ fn test_hash_same_values_different_dtype() raises:
         )
 ```
 
-1. **Locate insertion point** — find `test_hash_small_values_distinguish` in `tests/shared/core/test_utility.mojo`
-2. **Add function** — insert `test_hash_same_values_different_dtype()` immediately after that function
-3. **Register in main()** — add a call to the new function in the `main()` runner at the bottom of the file
-4. **Commit** — run pre-commit hooks; the "Validate Test Count Badge" hook requires no extra action if counts are updated automatically
-5. **Push and create PR** — branch naming: `<issue-number>-<description>`
+### Step-by-Step Workflow
+
+1. **Read the existing test file** to understand existing patterns before adding anything
+2. **Find the right insertion point** — place new test function near related tests (shape/dtype section)
+3. **Follow the `if hash(a) == hash(b): raise Error(...)` pattern** used by all collision tests
+4. **Use `full(shape, value, DType)` to create tensors** with identical data
+5. **Construct shapes with `List[Int]` + `.append()`** for each dimension (required — shape literals not supported)
+6. **Register the test in `main()`** with a print statement followed by the function call
+7. **Run tests** with `just test-group "tests/shared/core" "test_hash.mojo"` to verify all pass
+8. **Commit, push, create PR** with `Closes #NNNN` in body
 
 ### Pattern Notes
 
-- Shape setup: `var shape = List[Int](); shape.append(1)` (not a literal, append required)
-- Tensor creation: `full(shape, value, DType.float32)` (imported from `shared.core.utility`)
+- Shape setup: `var shape = List[Int](); shape.append(2); shape.append(3)` (not a literal, append each dim)
+- Tensor creation: `full(shape, value, DType.float32)` (imported from `shared.core`)
 - Hash assertion: use `if hash_a == hash_b: raise Error(...)` — NOT `assert_equal` or similar macros
-- Function signature: `fn test_hash_same_values_different_dtype() raises:`
+- Function signature: `fn test_hash_...() raises:`
+- Registration in `main()`: typically a print statement + direct function call
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Issue #3379, worktree `3379-auto-impl` | [notes.md](../references/notes.md) |
+| ProjectOdyssey | Issue #3379, branch `3379-auto-impl` — same values, different dtype | [notes.md](../../references/notes.md) |
+| ProjectOdyssey | Issue #4056, branch `4056-auto-impl` — same dtype, different shapes | [notes.md](../../references/notes.md) |
 
 ## Failed Attempts
 
-| Attempt | Why Failed | Lesson |
-|---------|------------|--------|
-| `pixi run mojo test tests/shared/core/test_utility.mojo` locally | GLIBC_2.32/2.33/2.34 not found — host OS (Debian Buster) too old | Mojo tests require Docker or CI environment; do not expect local `mojo test` to work outside container |
-| `just test-mojo` locally | `just` command not found outside Docker | The `justfile` recipes are designed for use inside the container; use CI to verify test execution |
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `pixi run mojo test` locally | Running tests on host Debian Buster | GLIBC_2.32/2.33/2.34 not found — host OS too old | Mojo tests require Docker or CI environment |
+| `just test-mojo` locally | Running `just` outside Docker | `just` command not found outside container | Use CI to verify test execution |
+| N/A (issue #4056) | Implementation was direct — no failed attempts | — | Reading existing patterns first made implementation straightforward |
 
 ## Results & Parameters
 
-- Test function name: `test_hash_same_values_different_dtype`
-- File: `tests/shared/core/test_utility.mojo`
-- Insert after: `test_hash_small_values_distinguish()`
-- Register in: `main()` at the bottom of the same file
-- Pre-commit hooks that run: `mojo format`, `Validate Test Count Badge`, `trailing-whitespace`, `end-of-file-fixer`
-- All hooks passed on first attempt when following exact existing code style
+### Issue #4056 (same dtype, different shapes)
+
+- **Test added**: `test_hash_same_dtype_different_shapes()`
+- **File**: `tests/shared/core/test_hash.mojo`
+- **Shapes tested**: `[2, 3]` vs `[6]` (same 6 total elements, different rank/shape)
+- **DType**: `float32` (same for both)
+- **Value**: `1.0` for all elements (same data)
+- **All 17 tests passed** after the addition
+- **PR**: #4860
+
+### Issue #3379 (same values, different dtype)
+
+- **Test added**: `test_hash_same_values_different_dtype()`
+- **File**: `tests/shared/core/test_utility.mojo`
+- **Dtypes tested**: `float32` vs `float64` (same scalar value `1.0`)
+- **Shape**: `[1]`
+- **Pre-commit hooks**: `mojo format`, `Validate Test Count Badge`, `trailing-whitespace`, `end-of-file-fixer` — all passed
 
 ## References
 
-- `tests/shared/core/test_utility.mojo` — test file containing hash tests
+- `tests/shared/core/test_hash.mojo` — hash test file (issue #4056)
+- `tests/shared/core/test_utility.mojo` — utility test file (issue #3379)
 - `.claude/shared/mojo-anti-patterns.md` — common Mojo test failure patterns
-- ProjectOdyssey issue #3379 — original work item
+- ProjectOdyssey issue #4056 — same dtype, different shapes hash collision test
+- ProjectOdyssey issue #3379 — same values, different dtype hash collision test


### PR DESCRIPTION
## Summary

Updates the `mojo-hash-collision-test` skill to document the pattern for verifying that
same-dtype ExTensors with different shapes (e.g. [2,3] vs [6]) produce different hashes.

- Adds same-dtype different-shapes pattern alongside existing same-values different-dtype pattern
- Expands `plugin.json` description and version to v1.1.0 with new trigger conditions
- Updates `SKILL.md` with new Quick Reference, second Verified On entry, and merged Failed Attempts table
- Appends issue #4056 session notes to `references/notes.md`

## Key Findings

**What Worked**:
- Reading existing patterns first made implementation straightforward
- Using `full(shape_2x3, 1.0, DType.float32)` for a 2D tensor with identical data to a 1D tensor
- Constructing 2D shapes with `List[Int]` + two `.append()` calls
- Placing new test between related shape/dtype tests for logical grouping

**What Failed**:
- No failures encountered in issue #4056 — pattern was clear from existing code

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — ALL VALIDATIONS PASSED
- [ ] Install plugin and verify skill appears in `/advise` results
- [ ] Check skill activation with relevant triggers (hash, collision, shape, dtype)

🤖 Generated with [Claude Code](https://claude.com/claude-code)