### PR TITLE
feat: add mojo-hash-stability-test skill

### DIFF
--- a/skills/testing/mojo-hash-stability-test/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-hash-stability-test/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-hash-stability-test",
+  "version": "1.0.0",
+  "description": "Pattern for testing Mojo __hash__ determinism by hashing the same instance multiple times. Use when: (1) verifying hash stability for edge-case tensors (0-element, single-element), (2) confirming no side effects from repeated hash calls, (3) following up on hash correctness issues discovered via two-tensor comparison tests.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/mojo-hash-stability-test/references/notes.md
+++ b/skills/testing/mojo-hash-stability-test/references/notes.md
@@ -1,0 +1,43 @@
+# Session Notes — mojo-hash-stability-test
+
+## Context
+
+- **Repository**: HomericIntelligence/ProjectOdyssey
+- **Issue**: #4069 — "Test hash stability across repeated calls on same empty tensor"
+- **Follow-up from**: #3384 (original hash correctness work)
+- **Branch**: `4069-auto-impl`
+- **Date**: 2026-03-15
+
+## Objective
+
+The existing hash tests for `ExTensor` used two independent tensor instances (`hash(a) == hash(b)`)
+to verify equal tensors produce equal hashes. Issue #4069 requested a stronger test: hash the
+**same** instance multiple times and assert all results are equal, confirming `__hash__` is
+truly deterministic with no side effects for 0-element tensors.
+
+## Steps Taken
+
+1. Read `.claude-prompt-4069.md` for task context.
+2. Searched `tests/shared/core/test_utility.mojo` for existing hash test block (line ~667).
+3. Identified available helpers: `assert_equal_int`, `full`, `arange`, `ones`, `zeros`.
+4. Read lines 790–810 to find exact insertion point after `test_hash_integer_dtype_consistent`.
+5. Added `test_hash_stability_repeated_calls()` using a single empty tensor instance.
+6. Registered the call in `main()` after `test_hash_same_values_different_dtype()`.
+7. Committed with message `test(utility): add hash stability test for repeated calls on same empty tensor`.
+8. Pushed branch and created PR #4864.
+
+## What Worked
+
+- Using `var a = full(List[Int](), 0.0, DType.float32)` for an empty 0-element tensor
+- Paired `assert_equal_int(Int(hash(a)), Int(hash(a)), "...")` calls to check 3 invocations total
+- Following the exact pattern of surrounding tests (helper names, DType choice, shape construction)
+
+## Key Decision
+
+Asserting equality between `hash(a)` calls rather than against a hardcoded expected value,
+because hash seeds and dtype ordinals can differ across builds. The goal is stability, not
+a specific value.
+
+## PR
+
+- PR #4864: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4864

--- a/skills/testing/mojo-hash-stability-test/skills/mojo-hash-stability-test/SKILL.md
+++ b/skills/testing/mojo-hash-stability-test/skills/mojo-hash-stability-test/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: mojo-hash-stability-test
+description: "Pattern for testing Mojo __hash__ determinism by hashing the same instance multiple times. Use when: verifying hash stability for edge-case tensors, confirming no side effects from repeated hash calls."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-hash-stability-test |
+| **Category** | testing |
+| **Trigger** | Writing hash tests for Mojo types, especially edge cases like 0-element tensors |
+| **Outcome** | A determinism test that hashes one instance N times and asserts all results are equal |
+
+## When to Use
+
+- A prior test used two independent instances (`hash(a) == hash(b)`) and you want a stronger guarantee
+- You need to confirm `__hash__` has no side effects (e.g., mutating internal state) for a given instance
+- The type under test has edge-case shapes (empty, single-element) where hash behavior may be non-obvious
+- Following up on issue comments requesting "hash the same tensor instance multiple times"
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+fn test_hash_stability_repeated_calls() raises:
+    """Test that hashing the same instance repeatedly returns equal values."""
+    var shape = List[Int]()
+    var a = full(shape, 0.0, DType.float32)
+
+    assert_equal_int(
+        Int(hash(a)),
+        Int(hash(a)),
+        "hash of empty tensor must be stable across repeated calls",
+    )
+    assert_equal_int(
+        Int(hash(a)),
+        Int(hash(a)),
+        "hash of empty tensor must be stable on third call",
+    )
+```
+
+### Step 1 — Identify the existing hash test block
+
+Find the `# Test __hash__` section in the relevant test file (e.g., `tests/shared/core/test_utility.mojo`).
+Read the existing tests to understand which helper functions (`assert_equal_int`, `full`, `arange`) are available.
+
+### Step 2 — Write the stability test
+
+Create a new `fn test_hash_stability_repeated_calls() raises:` after the last existing hash test.
+
+Key points:
+
+- Use a **single variable** (`var a = ...`), not two separate instances
+- Call `hash(a)` at least three times in paired assertions
+- Use the same assertion helper used elsewhere in the file (`assert_equal_int`)
+- Cast the `UInt` hash result to `Int` to match the helper signature
+- Choose an edge-case shape (empty `List[Int]()` for a 0-element tensor)
+
+### Step 3 — Register in main()
+
+Add the function call immediately after the last existing hash test call in `main()`:
+
+```mojo
+    test_hash_same_values_different_dtype()
+    test_hash_stability_repeated_calls()   # ← add here
+```
+
+### Step 4 — Verify
+
+Run the specific test group locally or via CI:
+
+```bash
+just test-group "tests/shared/core" "test_utility.mojo"
+# or
+pixi run mojo test tests/shared/core/test_utility.mojo
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Two-instance comparison only | `hash(a) == hash(b)` with two separate instances | Passes even if hash has side effects that reset on each new instance | Single-instance repeated calls are a stronger stability guarantee |
+| Asserting exact hash value | Hardcoding expected hash value in assertion | Hash seed or dtype ordinal may vary across builds/platforms | Assert equality between calls, not against a magic constant |
+
+## Results & Parameters
+
+- **Test file**: `tests/shared/core/test_utility.mojo`
+- **Dtype used**: `DType.float32` (matches existing empty-tensor hash tests)
+- **Shape**: empty `List[Int]()` → 0-element scalar tensor
+- **Number of calls checked**: 3 (two `assert_equal_int` calls, each comparing consecutive `hash(a)` invocations)
+- **Assert helper**: `assert_equal_int(Int(hash(a)), Int(hash(a)), "<message>")`
+- **Registration location**: after `test_hash_same_values_different_dtype()` in `main()`


### PR DESCRIPTION
## Summary

Documents the pattern for testing Mojo `__hash__` determinism by hashing the same
instance multiple times rather than comparing two independent instances.

- Single-instance repeated-call approach catches side effects that two-instance tests miss
- Assert equality between calls, not against a hardcoded magic constant
- Pattern applied to 0-element `ExTensor` in ProjectOdyssey issue #4069

## Key Findings

**What Worked**:
- `assert_equal_int(Int(hash(a)), Int(hash(a)), "...")` called twice for 3 total invocations
- Empty shape `List[Int]()` to create a 0-element tensor edge case
- Following the exact helper/dtype conventions of the surrounding test block

**What Failed**:
- Two-instance comparison only (`hash(a) == hash(b)`) — passes even if hash has per-instance side effects
- Hardcoding expected hash values — unstable across builds due to seed and dtype ordinal differences

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with hash stability test triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
