### PR TITLE
feat(testing): add split-file-group-tracking skill

### DIFF
--- a/skills/testing/split-file-group-tracking/.claude-plugin/plugin.json
+++ b/skills/testing/split-file-group-tracking/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "split-file-group-tracking",
+  "version": "1.0.0",
+  "description": "TRIGGER CONDITIONS: Use when adding coverage tracking for _partN.mojo test files split from a single logical test, or when validate_test_coverage.py needs to group part files by base name.",
+  "author": { "name": "ML Odyssey Team" },
+  "category": "testing",
+  "date": "2026-03-15",
+  "tags": ["coverage", "mojo", "split-files", "partN", "test-grouping", "validate_test_coverage"],
+  "skills": "./skills"
+}

--- a/skills/testing/split-file-group-tracking/references/notes.md
+++ b/skills/testing/split-file-group-tracking/references/notes.md
@@ -1,0 +1,96 @@
+# split-file-group-tracking — Raw Session Notes
+
+## Context
+
+- **Project**: ProjectOdyssey
+- **Issue**: #4109 — Update validate_test_coverage.py to track split file groups
+- **Branch**: `4109-auto-impl`
+- **PR**: #4871
+
+## What the Issue Asked For
+
+Add tracking for `_partN.mojo` test files in `validate_test_coverage.py` so that files like
+`test_lenet5_layers_part1.mojo` and `test_lenet5_layers_part2.mojo` are reported as a single
+logical group rather than two separate files.
+
+Specifically:
+- Add `group_split_files(test_files: List[Path]) -> Dict[str, List[Path]]`
+- Add `check_stale_patterns(ci_groups, root_dir) -> List[str]`
+- Update `generate_report()` to show split groups in the output
+- Wire everything into `main()`
+- Add unit tests for `group_split_files()`
+
+## TDD Discovery Pattern
+
+The existing test file (`tests/scripts/test_validate_test_coverage.py`) already had imports at
+the top:
+
+```python
+from validate_test_coverage import (
+    check_stale_patterns,
+    group_split_files,
+    ...
+)
+```
+
+These imports caused an `ImportError` at pytest collection time — all 13 existing tests were
+failing before any ran. Reading the test imports first revealed the complete API contract
+(function names, signatures) that needed to be implemented.
+
+**Key insight**: When a test file pre-imports functions that don't exist yet, it's a form of
+TDD where the test author defined the API contract but left the implementation for later.
+Always read the test file imports before writing any implementation code.
+
+## Implementation Details
+
+### `group_split_files()` — Key Decisions
+
+1. **Regex**: `re.compile(r"^(.+)_part(\d+)\.mojo$")` matches `test_foo_part1.mojo`
+   - `(.+)` captures the base (everything before `_partN`)
+   - `(\d+)` captures the part number (not used in key, just for detection)
+
+2. **Group key**: `str(f.parent / m.group(1))`
+   - Uses full parent path to avoid collisions between files in different directories
+   - E.g., `tests/models/test_lenet5_layers` vs `tests/shared/test_lenet5_layers`
+
+3. **Minimum group size**: Groups with fewer than 2 files are excluded
+   - A lone `_part1.mojo` with no `_part2.mojo` is not a true split file
+
+4. **Sort**: `sorted(v)` for deterministic part ordering in reports
+
+### `check_stale_patterns()` — Key Decisions
+
+- Takes `ci_groups: Dict[str, str]` (name -> glob pattern) and `root_dir: Path`
+- Uses `root_dir.glob(pattern)` to check each pattern
+- Returns `sorted(stale)` for deterministic output
+
+### `generate_report()` — Backwards Compatibility
+
+Added `split_groups: Optional[Dict[str, List[Path]]] = None` as a keyword-only argument.
+The section is only appended when `split_groups` is truthy, so existing callers that don't
+pass it continue to work unchanged.
+
+## Test Coverage Added
+
+10 new tests in `TestGroupSplitFiles`:
+
+1. `test_groups_two_parts` — basic happy path
+2. `test_groups_three_parts` — more than two parts
+3. `test_ignores_non_part_files` — plain `.mojo` files not matched
+4. `test_excludes_lone_part` — single part file not included
+5. `test_empty_input` — empty list returns empty dict
+6. `test_different_base_names` — two separate groups returned
+7. `test_parts_are_sorted` — part1 before part2 in output
+8. `test_files_in_different_dirs_not_grouped` — path-stable key prevents cross-dir collision
+9. `test_key_uses_parent_path` — key includes full parent directory path
+10. `test_mixed_part_and_non_part` — only part files grouped, others ignored
+
+## Pre-commit Notes
+
+No pre-commit issues encountered. `Optional` was added to the existing `typing` import.
+The script uses Python 3.7+ type hints throughout.
+
+## Commit Reference
+
+Commit on branch `4109-auto-impl` in ProjectOdyssey:
+`feat(coverage): add split file group tracking to validate_test_coverage.py`

--- a/skills/testing/split-file-group-tracking/skills/split-file-group-tracking/SKILL.md
+++ b/skills/testing/split-file-group-tracking/skills/split-file-group-tracking/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: split-file-group-tracking
+description: "TRIGGER CONDITIONS: Use when adding coverage tracking for _partN.mojo test files split from a single logical test, or when validate_test_coverage.py needs to group part files by base name using regex."
+user-invocable: false
+category: testing
+date: 2026-03-15
+---
+
+# split-file-group-tracking
+
+How to extend a test coverage validator to track split test files (e.g., `test_foo_part1.mojo`,
+`test_foo_part2.mojo`) as a single logical group, using a regex-based grouping function and
+optional report sections.
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | 2026-03-15 |
+| Objective | Add `group_split_files()` and `check_stale_patterns()` to `validate_test_coverage.py` (issue #4109) |
+| Outcome | Success — 10 new unit tests added, all 23 tests passing, script exits 0 on live repo |
+
+## When to Use
+
+- You need to group `_partN.mojo` files in a coverage report so that split files count as one
+  logical test rather than N separate entries
+- An existing test file imports functions that do not yet exist in the script under test
+  (pre-existing TDD contract)
+- You are extending a coverage script with new optional report sections while preserving
+  backwards compatibility for callers that do not pass the new parameter
+
+## Verified Workflow
+
+### Step 1 — Read both the script and its test file first
+
+Before writing any code, read both files:
+
+1. `<project-root>/scripts/validate_test_coverage.py` — understand existing functions,
+   imports, and `main()` structure
+2. `<project-root>/tests/scripts/test_validate_test_coverage.py` — look at **every import**
+   at the top of the file
+
+The test file imports define the full API contract you must implement. In this session the
+test file already imported `check_stale_patterns` and `group_split_files` — functions that
+did not yet exist in the script. This caused an `ImportError` at collection time, failing
+all tests before any ran.
+
+### Step 2 — Implement `group_split_files()`
+
+```python
+import re
+from pathlib import Path
+from typing import Dict, List
+
+_PART_RE = re.compile(r"^(.+)_part(\d+)\.mojo$")
+
+def group_split_files(test_files: List[Path]) -> Dict[str, List[Path]]:
+    """Group test_*_partN.mojo files by their logical base name.
+
+    Returns a dict mapping base key -> sorted list of part paths.
+    Only entries with 2+ parts are included.
+    """
+    groups: Dict[str, List[Path]] = {}
+    for f in test_files:
+        m = _PART_RE.match(f.name)
+        if m:
+            key = str(f.parent / m.group(1))
+            groups.setdefault(key, []).append(f)
+    return {k: sorted(v) for k, v in groups.items() if len(v) >= 2}
+```
+
+Key design choices:
+
+- **Path-stable key**: `str(f.parent / m.group(1))` uses the full parent path so files in
+  different directories never collide even if they share a base name.
+- **Sort after grouping**: `sorted(v)` gives deterministic part order for report output.
+- **Filter singles**: Only groups with 2+ parts are returned — a lone `_part1.mojo` with no
+  `_part2.mojo` is not a true split file.
+
+### Step 3 — Implement `check_stale_patterns()`
+
+```python
+def check_stale_patterns(
+    ci_groups: Dict[str, str],
+    root_dir: Path,
+) -> List[str]:
+    """Return CI group names whose glob pattern matches zero files.
+
+    ci_groups maps group name -> glob pattern relative to root_dir.
+    """
+    stale = []
+    for name, pattern in ci_groups.items():
+        matched = list(root_dir.glob(pattern))
+        if not matched:
+            stale.append(name)
+    return sorted(stale)
+```
+
+### Step 4 — Add an optional `split_groups` param to `generate_report()`
+
+Preserve backwards compatibility by making the new param optional:
+
+```python
+def generate_report(
+    ...,
+    split_groups: Optional[Dict[str, List[Path]]] = None,
+) -> str:
+    ...
+    if split_groups:
+        lines.append("\n## Split File Groups\n")
+        for key, parts in sorted(split_groups.items()):
+            lines.append(f"- {key}: {len(parts)} parts")
+            for p in parts:
+                lines.append(f"  - {p.name}")
+    return "\n".join(lines)
+```
+
+### Step 5 — Wire into `main()`
+
+```python
+def main() -> int:
+    ...
+    split_groups = group_split_files(test_files)
+    report = generate_report(..., split_groups=split_groups)
+    ...
+```
+
+### Step 6 — Write unit tests for `group_split_files()`
+
+Use `tmp_path` to create real file paths (no disk I/O needed — the function only inspects
+`Path.name`):
+
+```python
+class TestGroupSplitFiles:
+    def test_groups_two_parts(self, tmp_path: Path) -> None:
+        files = [tmp_path / "test_foo_part1.mojo", tmp_path / "test_foo_part2.mojo"]
+        result = group_split_files(files)
+        key = str(tmp_path / "test_foo")
+        assert key in result
+        assert result[key] == sorted(files)
+
+    def test_ignores_non_part_files(self, tmp_path: Path) -> None:
+        files = [tmp_path / "test_foo.mojo"]
+        assert group_split_files(files) == {}
+
+    def test_excludes_lone_part(self, tmp_path: Path) -> None:
+        files = [tmp_path / "test_bar_part1.mojo"]
+        assert group_split_files(files) == {}
+```
+
+Test cases to cover:
+
+1. Two parts grouped correctly
+2. Three or more parts grouped correctly
+3. Non-part file ignored
+4. Lone part excluded (only one part, no group)
+5. Files in different directories never merged
+6. Empty input returns empty dict
+7. Files from multiple distinct groups returned separately
+8. Parts are sorted (part1 before part2)
+
+### Step 7 — Run tests and verify
+
+```bash
+cd <project-root>
+python -m pytest tests/scripts/test_validate_test_coverage.py -v
+python scripts/validate_test_coverage.py  # should exit 0
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|-----------|--------|
+| N/A — no failed attempts in this session | The test file's imports revealed the full API contract before writing any code | Read the test file imports first; they define the API you must implement |
+
+## Results & Parameters
+
+**Regex pattern**: `r"^(.+)_part(\d+)\.mojo$"`
+
+- Group 1 (`m.group(1)`): base name, e.g., `test_lenet5_layers`
+- Group 2 (`m.group(2)`): part number (not used in grouping key)
+
+**Group key format**: `str(f.parent / m.group(1))` — full path without extension and without
+`_partN` suffix, ensuring files from different directories never collide.
+
+**New tests added**: 10 (in `TestGroupSplitFiles` class)
+
+**Total tests after**: 23 (all passing)
+
+**Files modified**:
+
+- `scripts/validate_test_coverage.py` — added `group_split_files()`, `check_stale_patterns()`,
+  updated `generate_report()` and `main()`
+- `tests/scripts/test_validate_test_coverage.py` — added `TestGroupSplitFiles` class
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #4109, PR #4871, branch `4109-auto-impl` | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

- Documents the pattern for grouping `_partN.mojo` test files by logical base name in `validate_test_coverage.py`
- Captures the TDD discovery pattern where pre-existing test imports reveal the full API contract before implementation begins
- Provides copy-paste ready `group_split_files()` and `check_stale_patterns()` implementations with regex `^(.+)_part(\d+)\.mojo$`

## What the skill documents

When a large Mojo test file is split into `test_foo_part1.mojo`, `test_foo_part2.mojo`, etc., a
coverage script must group them as a single logical test. The key implementation detail is using
`str(f.parent / m.group(1))` as a path-stable group key so files in different directories with
the same base name never collide.

## TDD discovery pattern

The existing test file already imported `check_stale_patterns` and `group_split_files` — functions
that did not yet exist. This caused an `ImportError` at pytest collection time, failing all tests.
Reading the test file imports **first** reveals the complete API contract that must be implemented.

## Key implementation pattern

```python
_PART_RE = re.compile(r"^(.+)_part(\d+)\.mojo$")

def group_split_files(test_files: List[Path]) -> Dict[str, List[Path]]:
    groups: Dict[str, List[Path]] = {}
    for f in test_files:
        m = _PART_RE.match(f.name)
        if m:
            key = str(f.parent / m.group(1))
            groups.setdefault(key, []).append(f)
    return {k: sorted(v) for k, v in groups.items() if len(v) >= 2}
```

## Validation

All 701 plugins pass `python3 scripts/validate_plugins.py skills/ plugins/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)