### PR TITLE
feat: add placeholder-test-staleness-annotations skill

### DIFF
--- a/skills/testing/placeholder-test-staleness-annotations/.claude-plugin/plugin.json
+++ b/skills/testing/placeholder-test-staleness-annotations/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "placeholder-test-staleness-annotations",
+  "version": "1.0.0",
+  "description": "Upgrade pass-only placeholder tests with TODO annotations, cross-issue references, and concrete test specs to prevent indefinite staleness. Use when: (1) placeholder tests contain only `pass` and a vague NOTE comment, (2) tests are blocked on an unimplemented dependency and tracked by a separate issue, (3) you need to make stale placeholders grep-discoverable via TODO(#N).",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/placeholder-test-staleness-annotations/references/notes.md
+++ b/skills/testing/placeholder-test-staleness-annotations/references/notes.md
@@ -1,0 +1,58 @@
+# Session Notes — placeholder-test-staleness-annotations
+
+## Date
+
+2026-03-15
+
+## Session Summary
+
+**Repo**: HomericIntelligence/ProjectOdyssey
+**Branch**: 4127-auto-impl
+**Issue**: #4127 — "from_array() tests are pass-only placeholders (#3013)"
+
+## Objective
+
+GitHub issue #4127 tracked that three `from_array()` tests in
+`test_creation_part2.mojo` and `test_creation_part3.mojo` were pure
+pass-only placeholders. Issue #3013 (unimplemented `from_array()`) was the
+blocking dependency. The goal was to prevent indefinite staleness by
+annotating the placeholders properly.
+
+## Files Modified
+
+- `tests/shared/core/test_creation_part2.mojo:130` — `test_from_array_1d`
+- `tests/shared/core/test_creation_part3.mojo:39` — `test_from_array_2d`
+- `tests/shared/core/test_creation_part3.mojo:48` — `test_from_array_3d`
+
+## Steps Taken
+
+1. Read `.claude-prompt-4127.md` for task context
+2. Located test files with `Glob **/test_creation_part*.mojo`
+3. Searched for `test_from_array` with `Grep` to find all three placeholders
+4. Read the placeholder implementations — all were `pass` with `NOTE(#3013)` in docstring
+5. For each test:
+   - Added `# TODO(#3013): implement when from_array() ships` above `pass`
+   - Rewrote docstring to reference both #3013 (blocker) and #4127 (staleness-tracker)
+   - Added concrete test spec (specific array values and expected shapes)
+6. Committed with `docs(tests):` prefix (SKIP=mojo-format for GLIBC compat)
+7. Pushed and created PR #4873 with auto-merge enabled
+
+## PR Created
+
+https://github.com/HomericIntelligence/ProjectOdyssey/pull/4873
+
+## Key Decisions
+
+- **`docs(tests):` prefix, not `fix:`**: No behavior changes — purely documentation
+- **SKIP=mojo-format**: GLIBC incompatibility on local host; documented pattern in project
+- **Keep `pass`**: Actual implementation impossible without `from_array()` in codebase
+- **Reference both issues in docstring**: Blocker (#3013) + tracker (#4127) for full context
+- **FP-representable values for specs**: 0.5, 1.0, 1.5, -0.5, -1.0, 0.0 — project standard
+
+## What Made This Non-Trivial
+
+The issue was labeled as requiring "implementation" but the correct deliverable
+was annotation-only. Attempting to actually implement would fail compilation
+since `from_array()` doesn't exist. The insight: upgrading comments/docstrings
+to be machine-readable (`# TODO(#N)`) and include implementation specs IS the
+correct implementation of a staleness-tracking issue.

--- a/skills/testing/placeholder-test-staleness-annotations/skills/placeholder-test-staleness-annotations/SKILL.md
+++ b/skills/testing/placeholder-test-staleness-annotations/skills/placeholder-test-staleness-annotations/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: placeholder-test-staleness-annotations
+description: "Upgrade pass-only placeholder tests with TODO annotations, cross-issue references, and concrete test specs. Use when: placeholder tests contain only `pass`, are blocked on an unimplemented dependency, or need to be made grep-discoverable."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Goal** | Prevent placeholder tests from going silently stale |
+| **Language** | Mojo (applies to any language) |
+| **Trigger** | Issue tracking stale/pass-only placeholder tests |
+| **Output** | Annotated tests with `# TODO(#N)`, cross-issue docstrings, and concrete test specs |
+
+## When to Use
+
+- Placeholder tests contain only `pass` and a vague `NOTE(#N)` comment in the docstring
+- A separate tracking issue (e.g. #4127) was filed to prevent the placeholder from becoming stale
+- The blocking dependency (e.g. `from_array()` in #3013) is not yet implemented
+- You want `grep -r 'TODO(#3013)'` to surface all tests waiting on a dependency
+
+## Verified Workflow
+
+### Quick Reference
+
+```
+1. grep for placeholder tests (fn test_foo.*raises)
+2. For each: add # TODO(#<dep-issue>) above pass
+3. Update docstring: reference both dep issue and tracking issue
+4. Add concrete test spec (array values, expected shapes/dtypes)
+5. Commit with docs(tests): prefix
+```
+
+### Step 1 — Locate placeholders
+
+```bash
+grep -rn "pass$" tests/ --include="*.mojo"
+# Also search for vague NOTE comments
+grep -rn "NOTE(#" tests/ --include="*.mojo"
+```
+
+### Step 2 — Identify both issues
+
+Every placeholder upgrade involves two issues:
+
+- **Dependency issue** (`#3013`): the feature being waited on (`from_array()`)
+- **Tracking issue** (`#4127`): filed to avoid indefinite staleness
+
+Read both with:
+
+```bash
+gh issue view 3013
+gh issue view 4127
+```
+
+### Step 3 — Upgrade the docstring
+
+Replace vague `NOTE(#N)` comments with structured docstrings:
+
+**Before:**
+
+```mojo
+fn test_from_array_1d() raises:
+    """Test creating tensor from 1D array.
+
+    NOTE(#3013): from_array() is not yet implemented. This test is a
+    placeholder for array-to-tensor conversion. Current workaround
+    is to use arange(), zeros(), or manual element initialization.
+    """
+    pass
+```
+
+**After:**
+
+```mojo
+fn test_from_array_1d() raises:
+    """Test creating tensor from 1D array.
+
+    Blocked on #3013 (from_array() not yet implemented).
+    Tracked by #4127 to prevent this placeholder from going stale.
+    Once #3013 merges, implement using a 3-element Float32 array:
+      [0.5, 1.0, 1.5] -> shape [3], dtype float32.
+    """
+    # TODO(#3013): implement when from_array() ships
+    pass
+```
+
+### Step 4 — Choose test spec values
+
+Use the project's standard FP-representable special values for specs:
+
+| Values | Rationale |
+|--------|-----------|
+| `0.0, 0.5, 1.0, 1.5, -0.5, -1.0` | Tier 1 layerwise test values (exactly representable in FP32) |
+
+For multi-dimensional tests, scale up:
+
+- 1D: `[0.5, 1.0, 1.5]` → shape `[3]`
+- 2D: `[[0.5, 1.0, 1.5], [-0.5, -1.0, 0.0]]` → shape `[2, 3]`
+- 3D: 2×2×3 array → shape `[2, 2, 3]`
+
+### Step 5 — Commit
+
+Use the `docs(tests):` conventional commit prefix (not `fix:` or `feat:` — no behavior changes):
+
+```bash
+git commit -m "docs(tests): upgrade from_array() placeholder tests with TODO annotations"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Implement the actual test | Write real assertions without `from_array()` existing | `from_array()` is not in the codebase yet; compilation would fail | Don't implement until the dependency ships; annotation is the right deliverable |
+| Remove the placeholder entirely | Delete the `pass`-only test functions | Loses intent and spec — future implementor has no guidance | Keep placeholders; they document what must be tested |
+| Use `NOTE(#N)` prose only | Leave as vague comment in docstring | Not grep-discoverable; Claude would generate the same vague comment again | `# TODO(#N)` above `pass` is machine-readable and survives issue searches |
+| Combine dep and tracking issue refs | Only reference `#3013` | The tracking issue (#4127) context lost — why was this annotated now? | Always reference both: the blocker and the staleness-tracker |
+
+## Results & Parameters
+
+### Commit message template
+
+```text
+docs(tests): upgrade <feature> placeholder tests with TODO annotations
+
+Add # TODO(#<dep>) comments and detailed implementation specs to all
+<N> <feature> placeholder tests, preventing silent staleness. Updated
+docstrings reference both the blocking dependency (#<dep>) and tracking
+issue (#<tracker>) with concrete test specs (array values, expected shapes).
+
+Closes #<tracker>
+```
+
+### PR description template
+
+```markdown
+## Summary
+
+- Add `# TODO(#<dep>)` comments above each `pass` statement
+- Update docstrings to reference both the blocking dependency (#<dep>) and tracking issue (#<tracker>)
+- Include concrete test specs (array values, expected shapes) so implementors know exactly what to write when #<dep> ships
+
+## Files Modified
+
+- `tests/.../test_foo_part2.mojo` — `test_feature_1d`
+- `tests/.../test_foo_part3.mojo` — `test_feature_2d`, `test_feature_3d`
+
+## Verification
+
+- Pre-commit hooks pass
+- No regressions (placeholder tests unchanged functionally — still `pass`)
+
+Closes #<tracker>
+```


### PR DESCRIPTION
## Summary

Documents how to upgrade pass-only placeholder tests with `# TODO(#N)` annotations,
cross-issue docstring references, and concrete test specs to prevent indefinite staleness.

- Captures the distinction: a *staleness-tracking* issue's deliverable is annotation, not implementation
- `# TODO(#N)` above `pass` is machine-readable; a `NOTE(...)` buried in a docstring is not
- Concrete test specs (array values + expected shapes/dtypes) guide future implementors

## Key Findings

**What Worked**:
- `# TODO(#<dep>): implement when <feature> ships` above `pass` — grep-discoverable
- Docstring referencing both blocking dep (`#3013`) and tracking issue (`#4127`)
- `docs(tests):` conventional commit prefix (no behavior change, so not `fix:` or `feat:`)

**What Failed**:
- Trying to implement the actual test → compilation fails; `from_array()` doesn't exist yet
- Removing the placeholder → loses intent and spec for future implementor
- Only referencing the dep issue → loses the "why now" context from the tracking issue

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
