### PR TITLE
feat: add stale-plan-already-resolved skill

### DIFF
--- a/skills/ci-cd/stale-plan-already-resolved/.claude-plugin/plugin.json
+++ b/skills/ci-cd/stale-plan-already-resolved/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "stale-plan-already-resolved",
+  "version": "1.0.0",
+  "description": "Detect when an issue's implementation plan is stale because the fix was already applied. Use when: (1) an issue has a detailed plan referencing specific line numbers but the code no longer matches, (2) implementing a CI pattern change but the current pattern is already broader than requested, (3) a follow-up issue references an earlier fix that may have been superseded.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/stale-plan-already-resolved/references/notes.md
+++ b/skills/ci-cd/stale-plan-already-resolved/references/notes.md
@@ -1,0 +1,93 @@
+# Session Notes: stale-plan-already-resolved
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #4280 "Update CI Models pattern to use glob for part files"
+- **Follow-up from**: #3458 (split test_googlenet_layers.mojo per ADR-009)
+- **Branch**: 4280-auto-impl
+- **PR created**: #4880
+
+## What Happened
+
+### Plan (from issue comment)
+
+The implementation plan (written before the session started) said:
+
+> **Current State** (verified): The "Models" CI group at line 234 uses `test_*_layers.mojo`
+
+And requested:
+
+> **Line 234**: Change pattern from `test_*_layers.mojo` → `test_*_layers*.mojo`
+
+### Actual State Found
+
+Reading the actual file:
+
+```bash
+grep -A3 '"Models"' .github/workflows/comprehensive-tests.yml
+```
+
+Output:
+```yaml
+- name: "Models"
+  path: "tests/models"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+```
+
+The pattern was already `test_*.mojo` — broader than even the requested `test_*_layers*.mojo`.
+The plan's "before" state (`test_*_layers.mojo`) no longer existed.
+
+### Root Cause of Staleness
+
+The plan was created at a point in time when the Models group used `test_*_layers.mojo`.
+Between plan creation and this session, another PR consolidated the pattern to `test_*.mojo`
+(verified via `git log --oneline -- .github/workflows/comprehensive-tests.yml`).
+
+### The Part Files
+
+The issue plan also said "no _partN files yet — this is proactive prevention" but by the time
+of this session, the part files already existed:
+
+```
+tests/models/test_googlenet_layers_part1.mojo
+tests/models/test_googlenet_layers_part2.mojo
+tests/models/test_googlenet_layers_part3.mojo
+```
+
+These were created by #3458 (the parent issue).
+
+### Resolution
+
+Since `test_*.mojo` already covers all part files:
+
+1. Updated the YAML comment to explicitly state that `test_*.mojo` auto-discovers `_partN` files
+2. Created PR #4880 with `Closes #4280`
+3. Ran `python3 scripts/validate_test_coverage.py` — exits 0
+
+### Change Made
+
+```diff
+- # ADR-009: test_googlenet_layers.mojo split into 3 parts (≤8 tests each)
+- # to avoid Mojo v0.26.1 heap corruption under high test load.
++ # test_*.mojo glob auto-discovers all model tests including ADR-009 _partN split files
++ # (e.g., test_googlenet_layers_part1.mojo) without requiring manual CI updates.
+```
+
+## Key Diagnostic Commands Used
+
+```bash
+# Check if plan's "before" state exists
+grep -n "test_\*_layers\.mojo" .github/workflows/comprehensive-tests.yml
+# Result: empty → plan is stale
+
+# Read actual current state
+grep -A3 '"Models"' .github/workflows/comprehensive-tests.yml
+
+# Check git history to understand when pattern changed
+git log --oneline -20 -- .github/workflows/comprehensive-tests.yml
+
+# Verify coverage still passes
+python3 scripts/validate_test_coverage.py; echo "Exit: $?"
+```

--- a/skills/ci-cd/stale-plan-already-resolved/skills/stale-plan-already-resolved/SKILL.md
+++ b/skills/ci-cd/stale-plan-already-resolved/skills/stale-plan-already-resolved/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: stale-plan-already-resolved
+description: "Detect when an issue's implementation plan is stale because the fix was already applied. Use when: the plan references specific line numbers that don't match current code, or the requested change is already satisfied by a broader fix already in place."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Issue plan was written when code was in state A, but code is now in state B (already fixed or changed further) |
+| **Key insight** | Always verify actual current state before applying a plan — plans can become stale after other PRs merge |
+| **Impact** | Prevents unnecessary changes and incorrect "fixes" that would revert progress |
+| **Context** | Issue #4280: plan said change `test_*_layers.mojo` → `test_*_layers*.mojo`, but code already used `test_*.mojo` |
+
+## When to Use
+
+1. An issue's implementation plan references specific line numbers but the diff shows different content
+2. A plan says "change X to Y" but X is not present — a broader/different change is already there
+3. A follow-up issue references a prior fix (e.g., "follow-up from #3458") and the code may have evolved
+4. The plan was written weeks ago and many PRs have merged since
+5. CI pattern change issues where the pattern may have been updated as part of a broader consolidation
+
+## Verified Workflow
+
+### 1. Read the plan carefully for specific anchors
+
+Look for references to:
+
+- Specific line numbers (`line 234`)
+- Specific patterns that should exist (`pattern: "test_*_layers.mojo"`)
+- "Current state" described in the plan
+
+```bash
+# Issue plan said: "line 234: change test_*_layers.mojo → test_*_layers*.mojo"
+```
+
+### 2. Verify current file state against the plan's "before"
+
+```bash
+# Check if the "before" state from the plan still exists
+grep -n "test_\*_layers\.mojo" .github/workflows/comprehensive-tests.yml
+# If no output → the plan's "before" state is gone; something already changed it
+```
+
+### 3. Check what's actually there now
+
+```bash
+# Read the relevant section to understand current state
+grep -A3 '"Models"' .github/workflows/comprehensive-tests.yml
+```
+
+### 4. Determine if the issue's goal is already satisfied
+
+The key question: does the current state **achieve the same objective** as the planned change?
+
+| Plan objective | Current state | Action |
+|----------------|---------------|--------|
+| `test_*_layers*.mojo` (match part files) | `test_*.mojo` (even broader, also matches part files) | Goal already met — add clarifying comment only |
+| Add explicit filenames | Wildcard already present | Goal already met — no change needed |
+| Remove explicit filenames | Already using wildcard | Goal already met — document only |
+
+### 5. Apply the minimal appropriate change
+
+If the goal is already met, the appropriate fix is:
+
+- Update the **comment** to reflect current intent clearly
+- Create a PR that closes the issue by documenting the already-correct state
+
+```diff
+- # ADR-009: test_googlenet_layers.mojo split into 3 parts (≤8 tests each)
+- # to avoid Mojo v0.26.1 heap corruption under high test load.
++ # test_*.mojo glob auto-discovers all model tests including ADR-009 _partN split files
++ # (e.g., test_googlenet_layers_part1.mojo) without requiring manual CI updates.
+```
+
+### 6. Verify with validate_test_coverage.py
+
+```bash
+python3 scripts/validate_test_coverage.py
+# Must exit 0 before committing
+```
+
+### 7. Close the issue via PR
+
+Create the PR with `Closes #<issue>` even if the change is purely a comment update — this
+formally closes the issue and documents that the goal was already achieved.
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Key diagnostic | `grep -n "<pattern from plan>" <file>` — if empty, plan is stale |
+| Validation command | `python3 scripts/validate_test_coverage.py` |
+| Correct change scope | Comment-only update when the functional fix already exists |
+| PR label | `cleanup` |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Applying plan verbatim | Would have changed `test_*.mojo` back to `test_*_layers*.mojo` | This would have been a regression — narrowing a working broad pattern | Always read actual file before applying a "before → after" from a plan |
+| Skipping verification | Assuming plan's "before" state was current | Plan said line 234 had `test_*_layers.mojo`; actual line 283 had `test_*.mojo` | Verify anchors (line numbers, patterns) before touching anything |
+| Treating as no-op | Issue already resolved, do nothing | Issue remains open; no PR closes it | Even when goal is met, create a PR with a comment clarification to formally close |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #4280 (follow-up from #3458) | [notes.md](../references/notes.md) |


### PR DESCRIPTION
## Summary

Documents the pattern of detecting when an issue's implementation plan is stale
because the fix was already applied by a prior PR.

- Identifies diagnostic commands to verify plan's "before" state exists
- Documents when a broader glob already in place satisfies a narrower request
- Establishes that even fully-resolved issues need a comment-update PR to close

## Key Findings

**What Worked**:
- `grep -n "<pattern from plan>" <file>` — empty output means plan is stale
- Reading actual current state before applying any changes
- Creating a comment-only PR to formally close an already-resolved issue

**What Failed**:
- Applying the plan verbatim would have narrowed `test_*.mojo` back to `test_*_layers*.mojo` (a regression)
- Treating it as a no-op without a PR leaves the issue open

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [x] ALL VALIDATIONS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
