### PR TITLE
feat: add training-tests-weekly-workflow skill

### DIFF
--- a/skills/ci-cd/training-tests-weekly-workflow/.claude-plugin/plugin.json
+++ b/skills/ci-cd/training-tests-weekly-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "training-tests-weekly-workflow",
+  "version": "1.0.0",
+  "description": "Create a weekly GitHub Actions workflow for Mojo training tests excluded from per-PR CI. Use when: (1) test files are excluded from PR CI but have no periodic workflow covering them, (2) silently-untested training/slow test files need a coverage guarantee, (3) validate_test_coverage.py exclusion lists grow without a corresponding weekly workflow.",
+  "category": "ci-cd",
+  "date": "2026-03-15"
+}

--- a/skills/ci-cd/training-tests-weekly-workflow/references/notes.md
+++ b/skills/ci-cd/training-tests-weekly-workflow/references/notes.md
@@ -1,0 +1,50 @@
+# Session Notes: training-tests-weekly-workflow
+
+## Session Context
+
+- **Date**: 2026-03-15
+- **Issue**: ProjectOdyssey #4457 — Add new training tests to weekly E2E workflow coverage
+- **Follow-up from**: Issue #3640 (which added 9 new training test files to PR CI exclusion list)
+
+## Problem Description
+
+Nine training test files were added to the `exclude_training_patterns` list in
+`scripts/validate_test_coverage.py` (via issue #3640) without being added to any periodic
+workflow. This created a silent coverage gap: the files were excluded from per-PR CI *and*
+not run anywhere else.
+
+The files:
+- `tests/shared/training/test_checkpoint.mojo`
+- `tests/shared/training/test_config.mojo`
+- `tests/shared/training/test_csv_metrics_logger.mojo`
+- `tests/shared/training/test_exponential_scheduler.mojo`
+- `tests/shared/training/test_gradient_clipping.mojo`
+- `tests/shared/training/test_gradient_ops.mojo`
+- `tests/shared/training/test_mixed_precision_simd.mojo`
+- `tests/shared/training/test_multistep_scheduler.mojo`
+- `tests/shared/training/test_warmup_composite_scheduler.mojo`
+
+## Investigation
+
+1. Read `comprehensive-tests.yml` — found comment: `NOTE: Training tests moved to weekly workflow (requires dataset downloads)`
+2. Searched for existing weekly workflow — found `simd-benchmarks-weekly.yml` but NO training-focused weekly workflow
+3. Confirmed all 9 files were already in `validate_test_coverage.py` exclusion list (lines 100-143)
+4. Conclusion: Only need to create the weekly workflow; no changes to validator needed
+
+## Implementation
+
+- Created `.github/workflows/training-tests-weekly.yml`
+- Runs `just test-group tests/shared/training "test_*.mojo"` on Sundays at 3 AM UTC
+- Used same pinned action versions as `comprehensive-tests.yml`:
+  - `actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8`
+  - `extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b`
+  - `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f`
+- `simd-benchmarks-weekly.yml` used as structural template (cron offset by 1 hour)
+- `validate_test_coverage.py` exits 0 with no changes
+- `check-yaml` pre-commit hook passes
+
+## PR
+
+- PR #4882 created, linked to issue #4457 with `Closes #4457`
+- Auto-merge enabled with `gh pr merge --auto --rebase`
+- Single-file change (just the new workflow)

--- a/skills/ci-cd/training-tests-weekly-workflow/skills/training-tests-weekly-workflow/SKILL.md
+++ b/skills/ci-cd/training-tests-weekly-workflow/skills/training-tests-weekly-workflow/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: training-tests-weekly-workflow
+description: "Create a weekly GitHub Actions workflow for Mojo training tests excluded from per-PR CI. Use when: test files are in validate_test_coverage.py exclusion list but have no periodic workflow running them."
+category: ci-cd
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Training/slow test files excluded from per-PR CI become silently untested unless a separate periodic workflow covers them |
+| **Solution** | Create a weekly GitHub Actions workflow that runs all files in `tests/shared/training/` (or similar excluded directories) |
+| **Key Insight** | The `validate_test_coverage.py` exclusion list is the source of truth — if a file is excluded from PR CI, it MUST appear in a periodic workflow |
+| **Scope** | One new workflow file; `validate_test_coverage.py` typically needs no changes if files are already in the exclusion list |
+| **Verification** | `python scripts/validate_test_coverage.py` exits 0 + YAML syntax check |
+
+## When to Use
+
+- New test files were added to the `exclude_training_patterns` (or similar) list in `validate_test_coverage.py` without a corresponding weekly workflow
+- Follow-up issue specifically asks to verify weekly E2E workflow covers excluded training tests
+- `NOTE: Training tests moved to weekly workflow` comment exists in `comprehensive-tests.yml` but the weekly workflow was never created
+- Any periodic workflow needs to be created to cover a batch of excluded test files
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Check existing weekly workflows
+ls .github/workflows/*weekly*.yml
+
+# 2. Verify test files ARE already in exclusion list
+grep -n "test_checkpoint\|test_config" scripts/validate_test_coverage.py
+
+# 3. Create the weekly workflow (see template below)
+# Use action versions consistent with comprehensive-tests.yml
+
+# 4. Validate
+python scripts/validate_test_coverage.py  # must exit 0
+pixi run pre-commit run check-yaml --files .github/workflows/training-tests-weekly.yml
+```
+
+### Step-by-Step
+
+1. **Identify the gap**: Read the issue. Check `comprehensive-tests.yml` for `NOTE: ... moved to weekly workflow` comments. Confirm there is no `training-tests-weekly.yml` (or equivalent).
+
+2. **Confirm exclusion list state**: The new test files should already be in the `exclude_training_patterns` list in `validate_test_coverage.py`. If they are, no changes to that file are needed.
+
+3. **Identify action pin versions**: Read `comprehensive-tests.yml` to find the pinned SHA hashes for:
+   - `actions/checkout@<sha>`
+   - `extractions/setup-just@<sha>`
+   - `actions/upload-artifact@<sha>`
+   Use these same versions in the new workflow for consistency.
+
+4. **Create the workflow file** at `.github/workflows/training-tests-weekly.yml`:
+
+   ```yaml
+   name: Weekly Training Tests
+
+   # Weekly training tests that are excluded from per-PR CI
+   # Runs every Sunday at 3 AM UTC (offset from simd-benchmarks-weekly at 2 AM)
+
+   on:
+     schedule:
+       - cron: '0 3 * * 0'
+     workflow_dispatch:
+
+   permissions:
+     contents: read
+
+   jobs:
+     training-tests:
+       name: Training Unit Tests
+       runs-on: ubuntu-latest
+       timeout-minutes: 60
+       if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+
+       steps:
+         - name: Checkout code
+           uses: actions/checkout@<sha>  # v6.0.1
+
+         - name: Set up Pixi
+           uses: ./.github/actions/setup-pixi
+
+         - name: Install Just
+           uses: extractions/setup-just@<sha>  # v3
+
+         - name: Run training tests
+           run: just test-group tests/shared/training "test_*.mojo"
+
+         - name: Upload test results
+           if: always()
+           uses: actions/upload-artifact@<sha>  # v7
+           with:
+             name: test-results-Training-Weekly
+             path: test-results/
+             retention-days: 30
+   ```
+
+5. **Verify**:
+   ```bash
+   python scripts/validate_test_coverage.py  # exit 0
+   pixi run pre-commit run check-yaml --files .github/workflows/training-tests-weekly.yml
+   ```
+
+6. **Commit and PR**: Single-file change. Link `Closes #<issue>` in commit and PR body.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Adding test files to `comprehensive-tests.yml` | Initially considered adding 9 new files directly to PR CI matrix | Training tests are excluded from PR CI intentionally (slow/dataset-dependent); adding them back breaks the design | Always check WHY files were excluded before deciding where to add coverage |
+| Modifying `validate_test_coverage.py` | Considered adding 9 files to exclusion list as part of this change | Files were already in the exclusion list — the gap was the missing workflow, not the validator | Always check if exclusion list already contains the files before editing it |
+
+## Results & Parameters
+
+### Cron Schedule Offset Pattern
+
+Offset weekly workflows from each other to avoid resource contention:
+
+| Workflow | Schedule | Time |
+|----------|----------|------|
+| `simd-benchmarks-weekly.yml` | `0 2 * * 0` | Sunday 2 AM UTC |
+| `training-tests-weekly.yml` | `0 3 * * 0` | Sunday 3 AM UTC |
+
+### Key Decisions
+
+- **`timeout-minutes: 60`**: Training tests can be slow; generous timeout prevents false failures
+- **`retention-days: 30`**: Weekly artifacts don't need 1-year retention (unlike benchmark trend data)
+- **`if: ... || github.ref == 'refs/heads/main'`**: Scheduled runs only on main; `workflow_dispatch` allows any branch for debugging
+- **`permissions: contents: read`**: Minimal permissions — no PR write needed


### PR DESCRIPTION
## Summary

Documents the pattern for creating a weekly GitHub Actions workflow to cover
Mojo test files that are excluded from per-PR CI — preventing silent coverage gaps.

- Derived from ProjectOdyssey issue #4457 (training tests excluded but no weekly workflow existed)
- Captures the investigation pattern: check exclusion list state before editing, find the structural template, offset cron schedules
- Single-file fix: create the workflow; `validate_test_coverage.py` needs no changes if files are already excluded

## Key Findings

**What Worked**:
- Using `simd-benchmarks-weekly.yml` as a structural template (same action versions, same `if:` guard)
- Offsetting cron by 1 hour from existing weekly workflow to avoid resource contention
- Verifying `validate_test_coverage.py` exits 0 without editing it (files already in exclusion list)

**What Failed**:
- Adding test files back to `comprehensive-tests.yml` → wrong approach; they're excluded intentionally
- Editing `validate_test_coverage.py` unnecessarily → files were already in exclusion list

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with weekly workflow / silent coverage triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
