### PR TITLE
feat: add mojo-api-signature-test-fix skill

### DIFF
--- a/skills/testing/mojo-api-signature-test-fix/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-api-signature-test-fix/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-api-signature-test-fix",
+  "version": "1.0.0",
+  "description": "Fix Mojo test files when API signatures change (missing required positional args, positional/keyword conflicts). Use when: (1) tests fail with 'missing required positional arguments', (2) tests fail with 'argument passed both as positional and keyword operand', (3) updating tests after function signatures are updated.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/mojo-api-signature-test-fix/references/notes.md
+++ b/skills/testing/mojo-api-signature-test-fix/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes: mojo-api-signature-test-fix
+
+**Date**: 2026-03-15
+**Issue**: #4525
+**PR**: #4892
+**Branch**: 4525-auto-impl
+
+## Objective
+
+Fix two Mojo test compile errors discovered during a `--Werror` audit (PR #4512):
+
+1. `test_normalization_part3.mojo` — `batch_norm2d` and `batch_norm2d_backward`
+   API updated to require `running_mean` and `running_var` as positional args.
+   Tests were calling the old signature without these args.
+
+2. `test_shape_part4.mojo` — `concatenate(a, b, axis=1)` was passing two tensors
+   as positional args but the function signature takes `List[ExTensor]` as first
+   arg. Mojo interpreted `b` as the positional `axis` (Int) and `axis=1` as a
+   conflicting keyword.
+
+## Steps Taken
+
+1. Read the prompt file to understand the two errors
+2. Read the failing test files at the reported line numbers
+3. Read the actual function signatures in `shared/core/normalization.mojo` and
+   `shared/core/shape.mojo`
+4. Identified the fix patterns (Type A: missing positional args; Type B: positional/keyword conflict)
+5. Applied Type A fix to `test_normalization_part3.mojo` (lines ~285-295 and ~331-340)
+6. Applied Type B fix to `test_shape_part4.mojo` (line 77)
+7. Committed and pushed; created PR #4892
+
+## Key Files
+
+- `tests/shared/core/test_normalization_part3.mojo` — two test functions fixed
+- `tests/shared/core/test_shape_part4.mojo` — one call site fixed
+- `shared/core/normalization.mojo:29` — `batch_norm2d` signature
+- `shared/core/normalization.mojo:463` — `batch_norm2d_backward` signature
+- `shared/core/shape.mojo:427` — `concatenate` signature
+
+## Discoveries
+
+- The `batch_norm2d` signature changed from `(x, gamma, beta, epsilon, training)`
+  to `(x, gamma, beta, running_mean, running_var, training, momentum, epsilon)`
+- Running variance initial value should be `ones`, not `zeros` (variance=1, not 0)
+- `concatenate` takes `List[ExTensor]` as first arg — cannot pass tensors positionally
+- There were TWO test functions in the same file calling `batch_norm2d_backward`
+  with the old signature — always grep for all occurrences

--- a/skills/testing/mojo-api-signature-test-fix/skills/mojo-api-signature-test-fix/SKILL.md
+++ b/skills/testing/mojo-api-signature-test-fix/skills/mojo-api-signature-test-fix/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: mojo-api-signature-test-fix
+description: "Fix Mojo test files when API signatures change (missing required positional args, positional/keyword conflicts). Use when: tests fail with 'missing required positional arguments' or 'argument passed both as positional and keyword operand'."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Skill** | mojo-api-signature-test-fix |
+| **Category** | testing |
+| **Trigger** | Mojo test compile errors about missing args or positional/keyword conflicts |
+| **Scope** | Test files in `tests/` — never modifies the implementation |
+| **Result** | Compile errors resolved, PR created |
+
+## When to Use
+
+- Test fails with: `error: invalid call to 'fn_name': missing N required positional arguments: 'arg1', 'arg2'`
+- Test fails with: `error: invalid call to 'fn_name': argument passed both as positional and keyword operand: 'arg_name'`
+- API function signatures were updated but test call sites were not updated to match
+- Fixing test files discovered during `--Werror` audit passes (e.g. in batch CI fix PRs)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Read the actual function signature
+grep -n "fn function_name" shared/core/module.mojo
+
+# 2. Read the failing test call site
+# (use offset/limit to go to the reported line number)
+
+# 3. Fix: add missing positional args before keyword args
+# Fix: wrap separate tensor args in List[ExTensor](a, b) for list-taking functions
+
+# 4. Search for ALL calls in the file (not just the first one)
+grep -n "function_name" tests/path/to/test_file.mojo
+
+# 5. Commit and push
+git add <files> && git commit -m "fix(tests): ..."
+gh pr create ...
+```
+
+### Step-by-Step
+
+1. **Read the error message carefully** — it tells you the function name and which
+   arguments are missing or conflicting.
+
+2. **Read the actual function signature** from the implementation file:
+
+   ```bash
+   grep -n "fn batch_norm2d" shared/core/normalization.mojo
+   # Then read the full signature with Read tool at that offset
+   ```
+
+3. **Identify the fix type**:
+
+   **Type A — Missing required positional args**: The API added new required
+   parameters. Create the necessary tensors (typically `zeros`/`ones` with the
+   appropriate shape) and insert them at the correct positional position before
+   any keyword arguments.
+
+   ```mojo
+   # Before (broken):
+   var result = batch_norm2d(x, gamma, beta, epsilon=1e-5, training=True)
+
+   # After (fixed): running_mean and running_var are now required
+   var running_mean = zeros(param_shape, DType.float32)
+   var running_var = ones(param_shape, DType.float32)
+   var result = batch_norm2d(
+       x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+   )
+   ```
+
+   **Type B — Positional/keyword conflict**: A function takes a `List[T]` as its
+   first arg but the call site passes individual values positionally. Mojo
+   interprets the second positional as the next parameter (e.g., `axis`), then
+   the keyword `axis=N` conflicts.
+
+   ```mojo
+   # Before (broken): b is treated as positional axis, axis=1 is also keyword
+   var result = concatenate(a, b, axis=1)
+
+   # After (fixed): wrap in List
+   var result = concatenate(List[ExTensor](a, b), 1)
+   ```
+
+4. **Search for ALL call sites** in the file — there are often multiple test
+   functions calling the same API. Always grep for all occurrences before
+   declaring done.
+
+5. **Verify the fix compiles** by checking the argument order matches the
+   signature exactly (positional args first, keyword args after, in signature order).
+
+6. **Commit with a descriptive message** referencing the issue number.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Only fixing the first reported call site | Patched line 288 of test_normalization_part3.mojo | A second call at line 338 had the same missing-args issue | Always grep for all calls to the changed function, not just the first reported error |
+| Passing `axis` as keyword with two positional tensors | `concatenate(a, b, axis=1)` | Mojo sees `b` as the positional `axis` arg (Int) and `axis=1` as a conflicting keyword | When a function takes `List[T]` as first arg, wrap separate values in `List[T](a, b)` |
+
+## Results & Parameters
+
+### Working call pattern for batch_norm2d (with running stats)
+
+```mojo
+var param_shape = List[Int]()
+param_shape.append(C)  # number of channels
+var running_mean = zeros(param_shape, DType.float32)
+var running_var = ones(param_shape, DType.float32)  # ones, not zeros (variance)
+
+var result = batch_norm2d(
+    x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+)
+```
+
+### Working call pattern for concatenate with axis
+
+```mojo
+# Function signature: fn concatenate(tensors: List[ExTensor], axis: Int = 0)
+var result = concatenate(List[ExTensor](a, b), 1)  # axis=1
+```
+
+### PR format used
+
+```
+fix(tests): pass running_mean/running_var to batch_norm2d; fix concatenate axis arg
+
+- test_normalization_part3.mojo: Add running_mean/running_var tensors and pass
+  them to batch_norm2d() and batch_norm2d_backward() calls (required positional args)
+- test_shape_part4.mojo: Fix concatenate() call to pass tensors as List[ExTensor]
+  instead of positional args with conflicting keyword axis argument
+
+Closes #<issue-number>
+```


### PR DESCRIPTION
## Summary

Documents the pattern for fixing Mojo test files when API function signatures change,
covering two distinct error types discovered during a `--Werror` audit.

- **Type A**: Missing required positional args after API update (e.g. `batch_norm2d` gained `running_mean`/`running_var`)
- **Type B**: Positional/keyword conflict when a function takes `List[T]` but test passes individual values positionally

## Key Findings

**What Worked**:
- Reading the actual implementation signature before writing any fix
- Grepping for ALL occurrences of the changed function in the test file (not just the first reported error)
- Using `ones` (not `zeros`) as initial `running_var` for batch normalization
- Wrapping `List[ExTensor](a, b)` to fix positional/keyword conflicts on list-taking functions

**What Failed**:
- Only patching the first reported error line → a second call site with the same issue was missed
- `concatenate(a, b, axis=1)` → Mojo interprets `b` as positional `axis` and `axis=1` as conflicting keyword

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
