### PR TITLE
feat: add mojo-test-split-compile-hang skill

### DIFF
--- a/skills/testing/mojo-test-split-compile-hang/.claude-plugin/plugin.json
+++ b/skills/testing/mojo-test-split-compile-hang/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mojo-test-split-compile-hang",
+  "version": "1.0.0",
+  "description": "Fix Mojo test compilation hangs by splitting large test files into smaller parts. Use when: (1) a Mojo test file takes >120s to compile, (2) a test file has >8 fn test_ functions with large parametric types, (3) you need to move specific tests between part files while respecting ADR-009 ≤10 test limit.",
+  "category": "testing",
+  "date": "2026-03-15"
+}

--- a/skills/testing/mojo-test-split-compile-hang/references/notes.md
+++ b/skills/testing/mojo-test-split-compile-hang/references/notes.md
@@ -1,0 +1,40 @@
+# Session Notes — mojo-test-split-compile-hang
+
+## Context
+
+- **Issue**: #4526 — fix: test_extensor_slicing_part3 runtime failure and test_alexnet_layers_part4 compilation hang
+- **Branch**: 4526-auto-impl
+- **Date**: 2026-03-15
+
+## Problem 1: test_extensor_slicing_part3 — Runtime Failure
+
+**Error**: `Unhandled exception caught during execution: Single slice only supported for 1D tensors`
+
+**Root cause**: `test_slice_2d_value_correctness` called `t2d[1:4]` on a 2D tensor. The
+`__getitem__(Slice)` overload only handles 1D tensors. The variadic overload
+`__getitem__(*slices: Slice)` handles multi-dimensional slicing.
+
+**Fix**: Change `t2d[1:4]` → `t2d[1:4, :]` (multi-dimensional syntax triggers the right overload).
+
+## Problem 2: test_alexnet_layers_part4 — Compilation Hang
+
+**Symptom**: File takes >120s to compile. CI times out.
+
+**Root cause**: Part4 had 8 test functions including `test_fc1_backward_float32` and
+`test_fc2_backward_float32`. These instantiate `LayerTester.test_linear_layer_backward` with
+large FC layers (9216→4096 and 4096→4096), creating massive template instantiation.
+Combined with other tests in the same compilation unit, this triggers what appears to be
+a Mojo v0.26.1 compiler issue (possibly related to ADR-009 heap corruption).
+
+**Fix**: Moved both backward tests to part5 (which had only 6 tests, well under the ≤10 limit).
+Part4 went from 8→6 tests; part5 went from 6→8 tests.
+
+## Files Changed
+
+- `tests/shared/core/test_extensor_slicing_part3.mojo` — line 82: `t2d[1:4]` → `t2d[1:4, :]`
+- `tests/models/test_alexnet_layers_part4.mojo` — removed 2 backward test functions + main() calls
+- `tests/models/test_alexnet_layers_part5.mojo` — added 2 backward test functions + main() calls
+
+## PR
+
+PR #4893: https://github.com/HomericIntelligence/ProjectOdyssey/pull/4893

--- a/skills/testing/mojo-test-split-compile-hang/skills/mojo-test-split-compile-hang/SKILL.md
+++ b/skills/testing/mojo-test-split-compile-hang/skills/mojo-test-split-compile-hang/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: mojo-test-split-compile-hang
+description: "Fix Mojo test compilation hangs by splitting large test files. Use when: a test file takes >120s to compile, has backward-pass tests alongside forward-pass tests, or exceeds the ADR-009 ≤10 test function limit."
+category: testing
+date: 2026-03-15
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Mojo v0.26.1 compilation hangs (>120s) when a test file instantiates too many large parametric types (e.g. FC layer backward passes with 9216→4096 weights) |
+| **Solution** | Move heavyweight test functions to a sibling part file that is already under the ≤10 limit |
+| **ADR** | ADR-009: test files limited to ≤10 `fn test_` functions to avoid heap corruption and compile hangs |
+| **Verified on** | ProjectOdyssey — `test_alexnet_layers_part4.mojo` and `test_extensor_slicing_part3.mojo` |
+
+## When to Use
+
+- A Mojo test file takes >120s to compile (possible infinite template instantiation loop)
+- A test file has backward-pass tests alongside forward-pass tests for large layers (FC layers with thousands of features)
+- A test file is approaching or exceeding 10 `fn test_` functions
+- CI times out on a specific test compilation step
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Count test functions in a file
+grep -c "^fn test_" tests/models/test_foo_part4.mojo
+
+# Find the sibling part file with room (≤10 limit)
+for f in tests/models/test_foo_part*.mojo; do
+  echo "$f: $(grep -c '^fn test_' $f)"
+done
+```
+
+### Step 1 — Identify the overloaded file
+
+```bash
+# Count test functions per part file
+grep -n "fn test_" tests/models/test_alexnet_layers_part4.mojo
+```
+
+If a file has backward-pass tests that reference large weight matrices (FC 9216→4096, FC 4096→4096),
+these are the compile-time bottleneck — each backward test instantiates heavyweight gradient checking code.
+
+### Step 2 — Find a sibling part file with capacity
+
+```bash
+# Check all sibling part files
+for f in tests/models/test_alexnet_layers_part*.mojo; do
+  count=$(grep -c "^fn test_" "$f" 2>/dev/null || echo 0)
+  echo "$f: $count tests"
+done
+```
+
+Pick a sibling with fewer than 8 tests (leaving headroom for the 2 you'll move).
+
+### Step 3 — Move the heavyweight tests
+
+For each test function to move:
+
+1. **Copy the function body** from part4 to part5 (include the full `fn test_..() raises:` block)
+2. **Add section comment** above the function in part5 (e.g. `# FC1 Backward - moved from part4`)
+3. **Add to part5 `main()`** — insert the print + call before existing tests
+4. **Delete the function body** from part4
+5. **Remove the call** from part4's `main()`
+
+### Step 4 — Update docstrings
+
+- Update part5's module docstring to list the newly added layers
+- Update part5's `main()` print statement to reflect new content
+- Update part5's final success print message
+
+### Step 5 — Verify counts
+
+```bash
+grep -c "^fn test_" tests/models/test_alexnet_layers_part4.mojo  # Should decrease
+grep -c "^fn test_" tests/models/test_alexnet_layers_part5.mojo  # Should increase, ≤10
+```
+
+### Step 6 — Commit (use SKIP=mojo-format if GLIBC mismatch)
+
+```bash
+SKIP=mojo-format git commit -m "fix(tests): move backward tests from part4 to part5 to resolve compile hang"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Delete backward tests entirely | Removing `test_fc1_backward_float32` and `test_fc2_backward_float32` | Loses test coverage for backward passes | Move to sibling part, never delete |
+| Split into a new part6 | Create a brand new `test_alexnet_layers_part6.mojo` | Overkill — part5 had capacity (only 6 tests out of 10) | Check existing sibling capacity first |
+| Add `# TODO: split this file` comment | Document the problem without fixing it | CI still hangs | Always fix the root cause in the same PR |
+
+## Results & Parameters
+
+### Part4 before/after
+
+```
+Before: 8 fn test_ functions (2 backward tests causing hang)
+After:  6 fn test_ functions (forward-pass only — compiles fast)
+```
+
+### Part5 before/after
+
+```
+Before: 6 fn test_ functions
+After:  8 fn test_ functions (still ≤10, ADR-009 compliant)
+```
+
+### Commit message template
+
+```
+fix(tests): move <LayerName> backward tests from part<N> to part<M> to resolve compile hang
+
+- <filename>_part<N>: remove test_<layer>_backward_float32 (N→M tests)
+- <filename>_part<M>: add test_<layer>_backward_float32 (M→P tests, ≤10)
+
+Closes #<issue>
+```


### PR DESCRIPTION
## Summary

Documents how to diagnose and fix Mojo test file compilation hangs (>120s timeout)
by moving heavyweight backward-pass tests into sibling part files with available capacity.

- Root cause: FC backward tests with large weight matrices (9216→4096) create massive
  template instantiation pressure in Mojo v0.26.1's compiler
- Fix: move backward tests to a sibling part file that is below the ADR-009 ≤10 limit
- Avoids creating unnecessary new part files when siblings have capacity

## Key Findings

**What Worked**:
- Counting `fn test_` functions per part file to find available capacity
- Moving heavyweight backward tests (not forward tests) as they are the bottleneck
- Using `SKIP=mojo-format` for commits when local GLIBC mismatches CI

**What Failed**:
- Deleting backward tests entirely → loses test coverage
- Creating a new part6 → overkill when part5 had 4 slots free

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with "compilation hang", "test split", "ADR-009" triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
