### PR TITLE
refactor(scripts): replace hardcoded lists with dynamic SKILL.md scan

### DIFF
--- a/scripts/fix_remaining_warnings.py
+++ b/scripts/fix_remaining_warnings.py
@@ -7,7 +7,7 @@ Handles:
 2. Files with Failed Attempts that need better table formatting
 """
 
-import os
+import argparse
 import re
 from pathlib import Path
 from typing import List, Tuple
@@ -158,8 +158,18 @@ def improve_failed_attempts_table(content: str) -> str:
     return content[:insert_pos] + table + content[insert_pos:]
 
 
-def fix_skill_file(skill_path: Path) -> Tuple[bool, List[str]]:
-    """Fix a single SKILL.md file. Returns (modified, fixes_applied)."""
+def fix_skill_file(skill_path: Path, dry_run: bool = False) -> Tuple[bool, List[str]]:
+    """Fix a single SKILL.md file. Returns (modified, fixes_applied).
+
+    Args:
+        skill_path: Path to the SKILL.md file to process.
+        dry_run: If True, determine what would change but do not write the file.
+
+    Returns:
+        Tuple of (modified, fixes_applied) where modified is True if the file
+        was changed (or would be changed in dry-run mode) and fixes_applied is
+        a list of description strings for each fix that was applied.
+    """
     content = read_file(skill_path)
     original_content = content
     fixes = []
@@ -186,93 +196,77 @@ def fix_skill_file(skill_path: Path) -> Tuple[bool, List[str]]:
         elif content != original_content:
             fixes.append("Improved Failed Attempts table")
 
-    # Write back if modified
+    # Write back if modified (skip write in dry-run mode)
     if content != original_content:
-        write_file(skill_path, content)
+        if not dry_run:
+            write_file(skill_path, content)
         return True, fixes
 
     return False, []
 
 
-def main():
-    """Main execution."""
-    skills_dir = Path('/home/mvillmow/ProjectMnemosyne/skills')
+def main(argv: List[str] | None = None) -> None:
+    """Main execution.
 
-    # List of skills with remaining warnings (from validation output)
-    plugins_with_workflow_warning = [
-        'optimization/analyze-simd-usage',
-        'tooling/agent-run-orchestrator',
-        'architecture/track-implementation-progress',
-        'architecture/doc-update-blog',
-        'architecture/agent-hierarchy-diagram',
-        'architecture/agent-coverage-check',
-        'architecture/agent-validate-config',
-        'architecture/plan-validate-structure',
-        'testing/quality-coverage-report',
-        'testing/check-memory-safety',
-        'testing/validate-mojo-patterns',
-        'testing/agent-test-delegation',
-        'testing/review-pr-changes',
-        'testing/mojo-lint-syntax',
-        'ci-cd/install-workflow',
-    ]
+    Dynamically discovers all SKILL.md files under ``skills_dir`` via
+    ``Path.rglob("SKILL.md")`` and applies fixes to each one.  This replaces
+    the previously hardcoded plugin lists so that new skills are handled
+    automatically without requiring manual list maintenance.
 
-    plugins_with_table_warning = [
-        'evaluation/add-analysis-metric',
-        'evaluation/dryrun-validation',
-        'evaluation/e2e-checkpoint-resume',
-        'evaluation/publication-pipeline-enhancement',
-        'evaluation/processpool-rate-limit-recovery',
-        'evaluation/granular-scoring-systems',
-        'evaluation/parallel-metrics-integration',
-        'evaluation/containerize-e2e-experiments',
-        'debugging/retry-transient-errors',
-        'tooling/experiment-recovery-tools',
-        'tooling/review-task-orchestration',
-        'architecture/refactor-for-extensibility',
-        'documentation/arxiv-paper-polish',
-        'documentation/paper-final-review',
-        'documentation/academic-paper-qa',
-        'documentation/latex-architecture-section',
-        'documentation/paper-revision-workflow',
-        'documentation/paper-validation-workflow',
-        'documentation/paper-consolidation',
-        'documentation/publication-readiness-check',
-        'ci-cd/fix-ruff-linting-errors',
-        'ci-cd/ci-test-failure-diagnosis',
-        'ci-cd/rescue-broken-prs',
-    ]
+    Args:
+        argv: Argument list for parsing (defaults to sys.argv when None).
+    """
+    parser = argparse.ArgumentParser(
+        description="Fix SKILL.md validation warnings across all skills",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        default="/home/mvillmow/ProjectMnemosyne/skills",
+        help="Root directory containing SKILL.md files (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing any files",
+    )
+    args = parser.parse_args(argv)
 
-    all_plugins = set(plugins_with_workflow_warning + plugins_with_table_warning)
+    skills_dir = Path(args.skills_dir)
+    dry_run: bool = args.dry_run
+
+    if dry_run:
+        print("DRY RUN — no files will be written\n")
+
+    skill_files = sorted(skills_dir.rglob("SKILL.md"))
 
     total_files = 0
     modified_files = 0
-    all_fixes = []
+    all_fixes: List[str] = []
 
-    for plugin_path in all_plugins:
-        skill_file = skills_dir / plugin_path / 'skills' / Path(plugin_path).name / 'SKILL.md'
-
-        if not skill_file.exists():
-            print(f"⚠ Skipping {plugin_path} - SKILL.md not found")
-            continue
-
+    for skill_file in skill_files:
         total_files += 1
-        modified, fixes = fix_skill_file(skill_file)
+        modified, fixes = fix_skill_file(skill_file, dry_run=dry_run)
 
         if modified:
             modified_files += 1
-            print(f"✓ {plugin_path}")
+            rel_path = skill_file.relative_to(skills_dir)
+            action = "Would fix" if dry_run else "Fixed"
+            print(f"{'~' if dry_run else '✓'} {action}: {rel_path}")
             for fix in fixes:
                 print(f"  - {fix}")
                 all_fixes.append(fix)
 
     print(f"\n{'='*60}")
     print(f"Processed {total_files} SKILL.md files")
-    print(f"Modified {modified_files} files")
-    print(f"\nFixes applied:")
-    for fix_type in set(all_fixes):
-        count = all_fixes.count(fix_type)
-        print(f"  - {fix_type}: {count} files")
+    if dry_run:
+        print(f"Would modify {modified_files} files")
+    else:
+        print(f"Modified {modified_files} files")
+    if all_fixes:
+        print(f"\nFixes {'that would be ' if dry_run else ''}applied:")
+        for fix_type in set(all_fixes):
+            count = all_fixes.count(fix_type)
+            print(f"  - {fix_type}: {count} files")
 
 
 if __name__ == '__main__':

--- a/tests/test_fix_remaining_warnings.py
+++ b/tests/test_fix_remaining_warnings.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Tests for the dynamic scan and --dry-run features in fix_remaining_warnings.py.
+
+Verifies that:
+- main() discovers all SKILL.md files dynamically via rglob (no hardcoded lists)
+- --dry-run reports what would change without writing any files
+- Empty skills directory is handled gracefully
+- Files without warnings are left untouched
+- fix_skill_file() respects the dry_run parameter
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from fix_remaining_warnings import fix_skill_file, main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CLEAN_SKILL_MD = """\
+---
+name: test-skill
+description: "A test skill."
+category: tooling
+date: 2026-01-01
+user-invocable: false
+---
+
+# Test Skill
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Test |
+| Outcome | Pass |
+
+## When to Use
+
+- When testing
+
+## Verified Workflow
+
+### Step 1
+
+Do the thing.
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| N/A | No failures | Document as they occur |
+
+## Results & Parameters
+
+N/A
+"""
+
+NEEDS_WORKFLOW_FIX = """\
+---
+name: needs-fix-skill
+description: "A skill missing ## Verified Workflow."
+category: tooling
+date: 2026-01-01
+user-invocable: false
+---
+
+# Needs Fix Skill
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Test |
+| Outcome | Fix |
+
+## When to Use
+
+- When testing dynamic scan
+
+## Quick Reference
+
+```bash
+git status
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson |
+|---------|------------|--------|
+| N/A | No failures | N/A |
+
+## Results & Parameters
+
+N/A
+"""
+
+NEEDS_TABLE_FIX = """\
+---
+name: needs-table-skill
+description: "A skill with Failed Attempts missing a pipe table."
+category: tooling
+date: 2026-01-01
+user-invocable: false
+---
+
+# Needs Table Skill
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Test |
+| Outcome | Fix |
+
+## When to Use
+
+- When testing
+
+## Verified Workflow
+
+### Step 1
+
+Do the thing.
+
+## Failed Attempts
+
+No failures recorded.
+
+## Results & Parameters
+
+N/A
+"""
+
+
+def make_skill_file(directory: Path, content: str) -> Path:
+    """Write a SKILL.md into *directory* and return its path."""
+    skill_file = directory / "SKILL.md"
+    skill_file.write_text(content)
+    return skill_file
+
+
+# ---------------------------------------------------------------------------
+# Tests: fix_skill_file() dry_run parameter
+# ---------------------------------------------------------------------------
+
+
+class TestFixSkillFileDryRun:
+    def test_dry_run_does_not_write_file(self, tmp_path: Path) -> None:
+        """File must remain unchanged when dry_run=True even if fixes would apply."""
+        skill_file = make_skill_file(tmp_path, NEEDS_WORKFLOW_FIX)
+        original_content = skill_file.read_text()
+
+        modified, fixes = fix_skill_file(skill_file, dry_run=True)
+
+        assert modified is True, "Expected fix to be detected"
+        assert fixes, "Expected at least one fix description"
+        assert skill_file.read_text() == original_content, "File must not be written in dry-run mode"
+
+    def test_dry_run_returns_same_fixes_as_live_run(self, tmp_path: Path) -> None:
+        """dry_run mode should report the same fixes as a live run."""
+        content = NEEDS_WORKFLOW_FIX
+
+        dry_file = tmp_path / "dry" / "SKILL.md"
+        dry_file.parent.mkdir()
+        dry_file.write_text(content)
+
+        live_file = tmp_path / "live" / "SKILL.md"
+        live_file.parent.mkdir()
+        live_file.write_text(content)
+
+        _, dry_fixes = fix_skill_file(dry_file, dry_run=True)
+        _, live_fixes = fix_skill_file(live_file, dry_run=False)
+
+        assert dry_fixes == live_fixes
+
+    def test_live_run_writes_file(self, tmp_path: Path) -> None:
+        """File must be written when dry_run=False (default)."""
+        skill_file = make_skill_file(tmp_path, NEEDS_WORKFLOW_FIX)
+        original_content = skill_file.read_text()
+
+        modified, fixes = fix_skill_file(skill_file, dry_run=False)
+
+        assert modified is True
+        assert skill_file.read_text() != original_content
+
+    def test_dry_run_no_change_when_file_is_clean(self, tmp_path: Path) -> None:
+        """A clean file reports no modifications in dry-run mode."""
+        skill_file = make_skill_file(tmp_path, CLEAN_SKILL_MD)
+
+        modified, fixes = fix_skill_file(skill_file, dry_run=True)
+
+        assert modified is False
+        assert fixes == []
+        assert skill_file.read_text() == CLEAN_SKILL_MD
+
+    def test_dry_run_table_fix_detected_but_not_written(self, tmp_path: Path) -> None:
+        """Table fix is reported but the file is not modified in dry-run mode."""
+        skill_file = make_skill_file(tmp_path, NEEDS_TABLE_FIX)
+        original_content = skill_file.read_text()
+
+        modified, fixes = fix_skill_file(skill_file, dry_run=True)
+
+        assert modified is True
+        assert any("Failed Attempts" in fix or "table" in fix.lower() for fix in fixes)
+        assert skill_file.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() dynamic discovery
+# ---------------------------------------------------------------------------
+
+
+class TestMainDynamicDiscovery:
+    def _build_skills_tree(self, root: Path) -> list[Path]:
+        """Create a nested skills directory tree with several SKILL.md files."""
+        files = []
+        for category, skill_name, content in [
+            ("tooling", "skill-clean", CLEAN_SKILL_MD),
+            ("tooling", "skill-needs-fix", NEEDS_WORKFLOW_FIX),
+            ("testing", "skill-needs-table", NEEDS_TABLE_FIX),
+            ("documentation", "skill-also-clean", CLEAN_SKILL_MD),
+        ]:
+            skill_dir = root / category / skill_name
+            skill_dir.mkdir(parents=True)
+            skill_file = skill_dir / "SKILL.md"
+            skill_file.write_text(content)
+            files.append(skill_file)
+        return files
+
+    def test_discovers_all_skill_files_dynamically(self, tmp_path: Path) -> None:
+        """main() must process every SKILL.md in the tree without a hardcoded list."""
+        skill_files = self._build_skills_tree(tmp_path)
+
+        # Run without dry-run so files are actually written
+        main(["--skills-dir", str(tmp_path)])
+
+        # At minimum, files that needed fixing should now be different
+        needs_fix_path = tmp_path / "tooling" / "skill-needs-fix" / "SKILL.md"
+        assert "## Verified Workflow" in needs_fix_path.read_text()
+
+    def test_dry_run_does_not_modify_any_files(self, tmp_path: Path) -> None:
+        """--dry-run must leave every discovered file untouched."""
+        self._build_skills_tree(tmp_path)
+
+        # Snapshot all contents before dry run
+        before: dict[Path, str] = {
+            p: p.read_text() for p in tmp_path.rglob("SKILL.md")
+        }
+
+        main(["--skills-dir", str(tmp_path), "--dry-run"])
+
+        after: dict[Path, str] = {
+            p: p.read_text() for p in tmp_path.rglob("SKILL.md")
+        }
+
+        assert before == after, "No files should be modified during dry-run"
+
+    def test_empty_skills_dir_handled_gracefully(self, tmp_path: Path) -> None:
+        """main() must not raise when there are no SKILL.md files."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        # Should complete without exception
+        main(["--skills-dir", str(empty_dir)])
+
+    def test_processes_files_in_subdirectories(self, tmp_path: Path) -> None:
+        """main() discovers SKILL.md files nested arbitrarily deep."""
+        deep_dir = tmp_path / "a" / "b" / "c"
+        deep_dir.mkdir(parents=True)
+        skill_file = deep_dir / "SKILL.md"
+        skill_file.write_text(NEEDS_WORKFLOW_FIX)
+
+        main(["--skills-dir", str(tmp_path)])
+
+        assert "## Verified Workflow" in skill_file.read_text()
+
+    def test_clean_files_are_not_modified(self, tmp_path: Path) -> None:
+        """main() must not touch files that already pass all checks."""
+        clean_dir = tmp_path / "category" / "clean-skill"
+        clean_dir.mkdir(parents=True)
+        skill_file = clean_dir / "SKILL.md"
+        skill_file.write_text(CLEAN_SKILL_MD)
+
+        main(["--skills-dir", str(tmp_path)])
+
+        assert skill_file.read_text() == CLEAN_SKILL_MD
+
+    def test_multiple_categories_all_processed(self, tmp_path: Path) -> None:
+        """Files in distinct category subdirectories are all discovered."""
+        self._build_skills_tree(tmp_path)
+
+        discovered = sorted(tmp_path.rglob("SKILL.md"))
+        assert len(discovered) == 4, f"Expected 4 SKILL.md files, found {len(discovered)}"
+
+        # Confirm main processes all of them (dry run to avoid mutating state)
+        main(["--skills-dir", str(tmp_path), "--dry-run"])
+        # If main raised an exception for any file, the test would have failed above
+
+    def test_dry_run_flag_output_contains_would_fix(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """--dry-run output should indicate what would be fixed."""
+        fix_dir = tmp_path / "cat" / "skill-a"
+        fix_dir.mkdir(parents=True)
+        (fix_dir / "SKILL.md").write_text(NEEDS_WORKFLOW_FIX)
+
+        main(["--skills-dir", str(tmp_path), "--dry-run"])
+
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+        assert "Would fix" in captured.out or "would" in captured.out.lower()
+
+    def test_no_dry_run_output_shows_fixed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Normal run output should report files that were fixed."""
+        fix_dir = tmp_path / "cat" / "skill-b"
+        fix_dir.mkdir(parents=True)
+        (fix_dir / "SKILL.md").write_text(NEEDS_WORKFLOW_FIX)
+
+        main(["--skills-dir", str(tmp_path)])
+
+        captured = capsys.readouterr()
+        assert "Fixed" in captured.out or "✓" in captured.out


### PR DESCRIPTION
## Summary

- Replaces hardcoded `plugins_with_workflow_warning` and `plugins_with_table_warning` lists in `fix_remaining_warnings.py` with dynamic discovery via `Path.rglob("SKILL.md")`
- Adds `--dry-run` flag to report changes without writing files
- Adds `--skills-dir` flag to override the default skills directory
- Adds `dry_run: bool = False` parameter to `fix_skill_file()`

## Test plan

- [ ] Run `python scripts/fix_remaining_warnings.py --dry-run` and verify it reports files without modifying them
- [ ] Run `python scripts/fix_remaining_warnings.py` and verify fixes are applied to all discovered SKILL.md files
- [ ] Verify no regression: previously fixed files are not re-modified

Closes #3779