### PR TITLE
feat: add dryrun3-analysis-fix skill

### DIFF
--- a/skills/evaluation/dryrun3-analysis-fix/.claude-plugin/plugin.json
+++ b/skills/evaluation/dryrun3-analysis-fix/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "dryrun3-analysis-fix",
+  "version": "1.0.0",
+  "description": "Fix 1-based subtest ID misclassification in dryrun3 analysis scripts. Use when: (1) analysis script reports 0 complete tests despite runs being finished, (2) orphan counts are unexpectedly high, (3) subtest IDs use mixed 0-based and 1-based numbering schemes.",
+  "category": "evaluation",
+  "date": "2026-03-16"
+}

--- a/skills/evaluation/dryrun3-analysis-fix/references/notes.md
+++ b/skills/evaluation/dryrun3-analysis-fix/references/notes.md
@@ -1,0 +1,56 @@
+# Dryrun3 Analysis Fix — Session Notes
+
+## Date: 2026-03-16
+
+## Context
+
+PR #1502 (always-retry infra failures in `resume_manager.py`) was already merged.
+This session focused on the analysis script bug discovered during live dryrun3 analysis.
+
+## Bug Details
+
+### Root Cause
+
+`scripts/analyze_dryrun3.py` has two functions that classify subtests as active vs orphan:
+
+1. `classify_runs()` (line 94-95): `is_orphan = int(sub_id) >= effective_max`
+2. `check_subtest_coverage()` (line 131): `active = sum(1 for sub_id in subtests if int(sub_id) < effective_max)`
+
+Both assume 0-based subtest IDs. T0 is 0-based (00, 01, ..., 23) but T1-T6 are 1-based (01, 02, ..., N).
+
+### Example: T1 with max_subtests=10
+
+- Subtests: `{01, 02, 03, 04, 05, 06, 07, 08, 09, 10}`
+- `effective_max = min(10, 10) = 10`
+- Old code: `int("10") = 10`, `10 >= 10` → orphan (WRONG — subtest 10 is valid)
+- Old code also expected `int("00") = 0`, `0 < 10` → counted, but `00` doesn't exist → reported as missing
+
+### Fix Pattern
+
+Sort subtest keys by numeric value, take first `effective_max` as the active set:
+
+```python
+sorted_sub_ids = sorted(subtests.keys(), key=lambda s: int(s))
+active_sub_ids = set(sorted_sub_ids[:effective_max])
+```
+
+This works regardless of whether IDs start at 0 or 1.
+
+## Ruff Lint Fixes (Pre-existing)
+
+7 ruff issues fixed across 3 files:
+- `RUF059`: Unused unpacked variables `state` and `reasons` → prefixed with `_`
+- `SIM108`: If-else block → ternary for `expected_runs`
+- `B007`: Unused loop variable `tier_id` → `_tier_id`
+- `D103`: Missing docstring for `main()`
+- `D205`: Docstring summary/description blank line in `manage_experiment.py`
+- `E501`: Line too long in test file → wrapped comment
+
+## Commit
+
+```
+fix(dryrun3): fix 1-based subtest ID bug in analyze_dryrun3.py and resolve ruff lint issues
+```
+
+Branch: `1490-always-retry-infra-failures`
+All 4873 tests passed, 77.19% coverage.

--- a/skills/evaluation/dryrun3-analysis-fix/skills/dryrun3-analysis-fix/SKILL.md
+++ b/skills/evaluation/dryrun3-analysis-fix/skills/dryrun3-analysis-fix/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: dryrun3-analysis-fix
+description: "Fix 1-based subtest ID misclassification in dryrun3 analysis scripts. Use when: analysis script misreports complete/orphan/missing counts due to mixed ID numbering schemes."
+category: evaluation
+date: 2026-03-16
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | `analyze_dryrun3.py` misclassified active vs orphan subtests due to 1-based IDs |
+| **Root Cause** | `int(sub_id) < effective_max` assumes 0-based IDs; T1-T6 use 1-based (01, 02, ...) |
+| **Impact** | Script reported 0 complete tests (actual: 44), 286 missing subtests (actual: 7), 299 orphans (actual: 20) |
+| **Fix** | Sort subtests by numeric ID, take first N as active (ID-scheme-agnostic) |
+| **Files** | `scripts/analyze_dryrun3.py` — `classify_runs()` and `check_subtest_coverage()` |
+
+## When to Use
+
+- Analysis script reports 0 complete tests when runs are clearly finished
+- Orphan run counts are unexpectedly high (close to total run count)
+- Missing subtest counts include IDs that shouldn't exist (e.g., `00` for 1-based tiers)
+- Any code that classifies subtests by numeric ID threshold with mixed numbering schemes
+
+## Verified Workflow
+
+### Quick Reference
+
+The bug is in two functions in `scripts/analyze_dryrun3.py`:
+
+**`classify_runs()`** — determines if a subtest is active or orphan:
+```python
+# BROKEN (assumes 0-based IDs):
+sub_index = int(sub_id)
+is_orphan = sub_index >= effective_max
+
+# FIXED (ID-scheme-agnostic):
+sorted_sub_ids = sorted(subtests.keys(), key=lambda s: int(s))
+active_sub_ids = set(sorted_sub_ids[:effective_max])
+is_orphan = sub_id not in active_sub_ids
+```
+
+**`check_subtest_coverage()`** — counts active subtests per tier:
+```python
+# BROKEN:
+active = sum(1 for sub_id in subtests if int(sub_id) < effective_max)
+
+# FIXED:
+sorted_sub_ids = sorted(subtests.keys(), key=lambda s: int(s))
+active = min(len(sorted_sub_ids), effective_max)
+```
+
+### Step-by-Step
+
+1. **Identify the symptom**: Analysis script shows all tests incomplete, high orphan counts
+2. **Trace the ID scheme**: T0 uses 0-based (00, 01, ..., 23), T1-T6 use 1-based (01, 02, ..., N)
+3. **Fix `classify_runs()`**: Sort subtest keys numerically, slice first `effective_max` as active set
+4. **Fix `check_subtest_coverage()`**: Same sort-and-slice pattern for counting active subtests
+5. **Verify**: Run `pixi run python scripts/analyze_dryrun3.py --results-dir ~/dryrun3`
+
+### Why Sort-and-Slice Works
+
+For T1 with `effective_max=3` and subtests `{01, 02, 03}`:
+- Old: `int("03") = 3`, `3 >= 3` = orphan (WRONG)
+- New: sorted = `[01, 02, 03]`, active = `{01, 02, 03}`, all active (CORRECT)
+
+For T0 with `effective_max=3` and subtests `{00, 01, 02}`:
+- Old: `int("02") = 2`, `2 >= 3` = active (correct by accident)
+- New: sorted = `[00, 01, 02]`, active = `{00, 01, 02}`, all active (CORRECT)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Original index-based approach | `int(sub_id) >= effective_max` to classify orphans | T1-T6 subtests are 1-based, so highest valid ID (e.g., 10 for T1) equals `effective_max` and gets classified as orphan | Never assume ID numbering scheme; use positional (sort-and-slice) instead of value-based comparison |
+| Original coverage counting | `int(sub_id) < effective_max` to count active subtests | Same 1-based issue: counts `00` (doesn't exist) as expected, misses highest valid subtest | Same fix: count actual subtests present, capped at expected max |
+
+## Results & Parameters
+
+### Corrected Analysis Numbers (Post-Fix)
+
+| Category | Old (Buggy) | Corrected |
+|----------|-------------|-----------|
+| Tests fully complete | 0 | 44 |
+| Tests needing work | 47 | 3 |
+| Complete runs (active) | 892 | 1,171 |
+| Missing subtests | 286 | 7 |
+| Orphan runs | 299 | 20 |
+
+### Corrected Pass Rates (Active Runs Only)
+
+| Tier | Pass Rate |
+|------|-----------|
+| T0 | 60% (119/200) |
+| T1 | 54% (85/157) |
+| T2 | 59% (102/172) |
+| T3 | 65% (163/249) |
+| T4 | 62% (105/169) |
+| T5 | 67% (119/177) |
+| T6 | 36% (17/47) |
+| **Overall** | **60.6% (710/1171)** |
+
+### Related Fixes in Same PR
+
+- 7 pre-existing ruff lint issues fixed (unused vars, missing docstring, ternary simplification, line length, docstring formatting)
+- Files: `scripts/analyze_dryrun3.py`, `scripts/manage_experiment.py`, `tests/unit/e2e/test_manage_experiment_run.py`


### PR DESCRIPTION
## Summary

Documents fix for 1-based subtest ID misclassification in `analyze_dryrun3.py` that caused the dryrun3 analysis script to report 0 complete tests (actual: 44) and 286 missing subtests (actual: 7).

- Sort-and-slice pattern is ID-scheme-agnostic (works for both 0-based and 1-based subtest IDs)
- Two functions affected: `classify_runs()` and `check_subtest_coverage()`
- Corrected overall pass rate: 60.6% (710/1171 active runs)

## Key Findings

**What Worked**:
- Sorting subtest keys by numeric value and slicing first N as active set
- `min(len(sorted_sub_ids), effective_max)` for counting active subtests

**What Failed**:
- `int(sub_id) >= effective_max` for orphan detection → breaks when IDs are 1-based (highest valid ID equals effective_max)
- `int(sub_id) < effective_max` for active counting → expects ID 00 which doesn't exist in 1-based tiers

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
