### PR TITLE
feat: add ecosystem-audit-remediation skill

### DIFF
--- a/skills/architecture/ecosystem-audit-remediation/.claude-plugin/plugin.json
+++ b/skills/architecture/ecosystem-audit-remediation/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "ecosystem-audit-remediation",
+  "version": "1.0.0",
+  "description": "Systematic cross-repo ecosystem audit and remediation workflow. Use when: (1) validating that multiple repos integrate correctly with documented boundaries, (2) performing ecosystem-wide bug hunts across shared contracts (NATS subjects, API fields, status enums), (3) remediating documentation drift where docs no longer match implementation.",
+  "category": "architecture",
+  "date": "2026-03-16"
+}

--- a/skills/architecture/ecosystem-audit-remediation/references/notes.md
+++ b/skills/architecture/ecosystem-audit-remediation/references/notes.md
@@ -1,0 +1,86 @@
+# Ecosystem Audit & Remediation — Session Notes
+
+## Date: 2026-03-16
+
+## Context
+
+The HomericIntelligence ecosystem has 12 repositories organized around ai-maestro (core platform). This session performed a full audit validating repo integration boundaries, documentation accuracy, and code correctness.
+
+## Repositories Audited
+
+1. ai-maestro (core, not modified)
+2. AchaeanFleet
+3. ProjectHermes — webhook → NATS bridge
+4. ProjectArgus — observability
+5. Myrmidons — GitOps agent provisioning
+6. ProjectTelemachy — workflow engine
+7. ProjectKeystone — DAG executor (most bugs found here)
+8. ProjectProteus — CI/CD
+9. ProjectMnemosyne — skills marketplace
+10. ProjectHephaestus — shared utilities
+11. ProjectOdyssey — research/training
+12. ProjectScylla — testing/chaos
+
+## Critical Findings Detail
+
+### C1: NATSListener Subject Parsing Bug
+
+**File**: `ProjectKeystone/src/keystone/nats_listener.py:42-43`
+
+The code had:
+```python
+# Expected: hi . tasks . {team_id} . {task_id} . updated  (6 parts)
+if len(parts) < 6:
+```
+
+But `"hi.tasks.team.task.updated".split(".")` produces `["hi", "tasks", "team", "task", "updated"]` = 5 parts, not 6. Every single NATS message was silently dropped with a warning log. The daemon's only working path was the startup scan.
+
+### C2: Daemon AttributeError
+
+**File**: `ProjectKeystone/src/keystone/daemon.py:79-82`
+
+Used `task.title`, `task.assigned_to`, `task.depends_on` but the Task model has `task.subject`, `task.assignee_agent_id`, `task.blocked_by`. This was clearly a case of writing code against CLAUDE.md documentation rather than the actual model.
+
+### C3: Missing close() Method
+
+**File**: `ProjectKeystone/src/keystone/daemon.py:95,114`
+
+Called `await maestro_client.close()` but MaestroClient created new httpx.AsyncClient per request and had no close() method. Fixed by refactoring to persistent client with proper lifecycle.
+
+### C4: Odysseus Architecture Completely Wrong About Keystone
+
+**File**: `Odysseus/docs/architecture.md`
+
+Described Keystone as "Secrets and credential management; injects secrets into ai-maestro agent configs" with "Vault or SOPS backend". Keystone has zero secrets-related code — it's a DAG executor that watches NATS events. This was likely a placeholder from initial scaffolding that was never updated.
+
+## Integration Contract Mismatches Found
+
+| Contract | Publisher (Hermes) | Subscriber (Keystone) | Docs (Odysseus) |
+|----------|-------------------|----------------------|-----------------|
+| NATS subjects | `hi.tasks.{team}.{task}.{verb}` | Was: `hi.tasks.*.*.updated` only | Was: `maestro.task.*` |
+| Task verbs | `updated`, `completed`, `failed` | Was: only `updated` | Not documented |
+| Subscribed events | `_TASK_EVENTS` has 3 | `_SUBSCRIBED_EVENTS` had only 1 task event | N/A |
+| Status values | Passes through from ai-maestro | Code: `completed`, CLAUDE.md: `done` | Not documented |
+
+## Config Pattern Audit
+
+| Repo | Before | After |
+|------|--------|-------|
+| Keystone | pydantic-settings (good) | unchanged |
+| Hermes | os.environ.get + python-dotenv | pydantic-settings |
+| Telemachy | os.environ.get + python-dotenv | pydantic-settings |
+
+## PRs Created
+
+| Repo | PR | URL |
+|------|-----|-----|
+| ProjectKeystone | #82 | https://github.com/HomericIntelligence/ProjectKeystone/pull/82 |
+| ProjectHermes | #1 | https://github.com/HomericIntelligence/ProjectHermes/pull/1 |
+| ProjectTelemachy | #1 | https://github.com/HomericIntelligence/ProjectTelemachy/pull/1 |
+| Odysseus | #1 | https://github.com/HomericIntelligence/Odysseus/pull/1 |
+| Myrmidons | #1 | https://github.com/HomericIntelligence/Myrmidons/pull/1 |
+| ProjectHephaestus | #17 (updated) | https://github.com/HomericIntelligence/ProjectHephaestus/pull/17 |
+
+## Key Lesson
+
+The most dangerous bugs were "silent" — NATSListener dropping all messages logged a warning but never crashed. If you only look at error logs, you'd think it was working. The startup scan masked the problem by advancing DAGs on boot. Only by tracing the actual subject string through `.split(".")` and counting parts could you find the off-by-one.

--- a/skills/architecture/ecosystem-audit-remediation/skills/ecosystem-audit-remediation/SKILL.md
+++ b/skills/architecture/ecosystem-audit-remediation/skills/ecosystem-audit-remediation/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ecosystem-audit-remediation
+description: "Systematic cross-repo ecosystem audit and remediation. Use when: validating multi-repo integration boundaries, hunting cross-repo contract bugs, or remediating documentation drift."
+category: architecture
+date: 2026-03-16
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Objective** | Audit and remediate a distributed multi-repo ecosystem for integration bugs, documentation drift, and pattern inconsistencies |
+| **Scope** | 12 repositories, 6 PRs, 6 issues filed |
+| **Findings** | 4 critical bugs, 9 important issues, 5 minor issues |
+| **Duration** | Single session — plan mode audit → 5-wave remediation → verification → PRs |
+
+## When to Use
+
+- Multiple repos share contracts (NATS subjects, REST API fields, status enums) and you need to verify they agree
+- Documentation (architecture.md, ADRs) may have drifted from implementation
+- A new repo was scaffolded and needs validation against the ecosystem's actual integration points
+- You need to find "silent failures" where code runs without errors but drops messages or uses wrong field names
+
+## Verified Workflow
+
+### Quick Reference
+
+1. **Audit phase** (plan mode): Read every repo's code + docs, build alignment matrix
+2. **Categorize**: Critical (runtime breaks) > Important (confusion/drift) > Minor (style)
+3. **Wave execution**: Fix criticals first, docs second, integration third, standardization fourth, cleanup fifth
+4. **Verification**: Run tests after each wave, use sub-agents for parallel file-level verification
+5. **PR creation**: One PR per repo, file follow-up issues for remaining work
+
+### Phase 1: Cross-Repo Audit
+
+Build an alignment matrix comparing documented behavior vs actual behavior:
+
+| Repo | Documented Role | Actual Role | Aligned? |
+|------|----------------|-------------|----------|
+| Each repo | What docs say | What code does | Yes/No |
+
+Key areas to cross-check:
+- **NATS subjects**: Compare publisher subjects (Hermes) vs subscriber filters (Keystone, Telemachy) vs documentation (Odysseus ADRs)
+- **API field names**: Compare REST client field mappings vs Pydantic model attributes vs CLAUDE.md references
+- **Status enums**: Compare status values across all repos that handle task lifecycle
+- **Dependency claims**: Verify "imported by X" claims in architecture docs against actual `pixi.toml`/`pyproject.toml` dependencies
+
+### Phase 2: Wave-Based Remediation
+
+Execute fixes in dependency order:
+
+1. **Wave 1 — Critical runtime bugs**: Fix code that crashes or silently drops data
+2. **Wave 2 — Documentation**: Fix architecture docs, create missing ADRs, add central references
+3. **Wave 3 — Integration gaps**: Fix subscription mismatches, missing event types
+4. **Wave 4 — Pattern standardization**: Unify config patterns, client patterns, status values
+5. **Wave 5 — Cleanup**: Gitignore, naming conventions, minor consistency
+
+### Phase 3: Verification
+
+- Run `just test` in every modified repo
+- Use parallel sub-agents for file-level verification (PASS/FAIL per check)
+- Fix any issues found during verification before committing
+
+### Phase 4: PR and Issue Creation
+
+- One branch + PR per repo (consistent naming: `ecosystem-audit-remediation`)
+- File GitHub issues for follow-up work discovered but out of scope
+- Set PRs to auto-merge
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trusting CLAUDE.md status values over code | Used `todo`/`done` from CLAUDE.md as authoritative | Code actually uses `pending`/`completed` — CLAUDE.md was stale | Always treat code (especially Pydantic models and enums) as the source of truth for field names and status values |
+| Assuming NATS subject part count from comments | Code comment said "6 parts" so check was `< 6` | `hi.tasks.team.task.updated` is actually 5 parts — the comment was wrong | Count the actual dots in the subject string; never trust comments over split() behavior |
+| Creating PRs targeting default branch without checking | Used `gh pr create` without `--base` flag | Some repos use `main`, others `master` — PR creation failed with "no common history" | Always check `gh repo view --json defaultBranchRef` and verify local branch was created from the correct base |
+| Skipping HMAC in webhook tests | Tests sent raw JSON without computing HMAC signature | `.env` file had `WEBHOOK_SECRET` set, so server validated HMAC and returned 401 | When migrating config to pydantic-settings (which auto-loads `.env`), check if `.env` contains values that change behavior — especially secrets that gate auth checks |
+| Removing `close()` calls without adding the method | Removed `await maestro_client.close()` from daemon.py as the fix for C3 | When later refactoring MaestroClient to persistent connections, `close()` became valid and needed | Consider the full fix arc — if you're going to refactor a client later in the same session, plan the close() story end-to-end |
+
+## Results & Parameters
+
+### Bugs Fixed
+
+```yaml
+critical:
+  C1: NATSListener parts count < 6 → < 5 (was dropping ALL messages)
+  C2: daemon.py task.title/assigned_to/depends_on → subject/assignee_agent_id/blocked_by
+  C3: MaestroClient refactored to persistent connections with close()
+  C4: Odysseus architecture.md Keystone "secrets management" → "DAG execution"
+
+important:
+  I1: NATS subject hi.tasks.*.*.updated → hi.tasks.> (catch all verbs)
+  I2: Hermes registrar missing task.completed/task.failed subscriptions
+  I3: Core NATS → JetStream durable consumer (at-least-once delivery)
+  I4: CLAUDE.md status values aligned with code (todo→pending, done→completed)
+  I5: ADR 005 created documenting actual NATS subject schema
+  I6: Keystone MaestroClient persistent httpx.AsyncClient
+  I7: Hephaestus "imported by all" → "not yet imported"
+  I8: Hermes + Telemachy config migrated to pydantic-settings
+  I9: .gitignore cleanup for ProjectMnemosyne/ and build/ artifacts
+
+minor:
+  M1: 8 new NATSListener tests
+  M2: pixi.toml names standardized (project-telemachy, project-hephaestus)
+  M4: docs/nats-subjects.md central reference created
+  M5: Odysseus justfile recipes for keystone-start/status, scylla-test
+```
+
+### Test Results
+
+```yaml
+ProjectKeystone: 27/27 passed
+ProjectHermes: 19/19 passed (was 14/18 — fixed HMAC in tests)
+ProjectTelemachy: 24/24 passed
+```
+
+### Cross-Check Pattern (reusable)
+
+```bash
+# Find all NATS subject definitions across ecosystem
+grep -r "hi\.tasks\|hi\.agents\|TASK_SUBJECT\|AGENT_EVENTS" ~/Project*/src/ ~/Odysseus/docs/
+
+# Find all status enum definitions
+grep -r "completed\|pending\|backlog\|in_progress" ~/Project*/src/*/models.py
+
+# Find all maestro_client patterns
+grep -r "httpx.AsyncClient\|async with.*client" ~/Project*/src/*/maestro_client.py
+
+# Verify config patterns
+grep -r "BaseSettings\|os.environ.get\|load_dotenv" ~/Project*/src/*/config.py
+```


### PR DESCRIPTION
## Summary

Documents the systematic cross-repo ecosystem audit and remediation workflow used to find and fix 4 critical bugs, 9 important issues, and 5 minor issues across the HomericIntelligence ecosystem.

- Wave-based remediation pattern (critical → docs → integration → standardization → cleanup)
- Cross-repo contract verification (NATS subjects, API fields, status enums)
- Parallel verification with sub-agents for file-level PASS/FAIL checks

## Key Findings

**What Worked**:
- Building an alignment matrix (documented role vs actual role per repo) immediately surfaced the 2 biggest misalignments (Keystone, Hephaestus)
- Counting NATS subject parts by hand (`"hi.tasks.team.task.updated".split(".")` = 5, not 6) found a critical silent-failure bug
- Running `just test` after each wave caught a pydantic-settings migration issue (HMAC tests broke because `.env` had a secret)

**What Failed**:
- Trusting CLAUDE.md status values over code (docs said `todo`/`done`, code used `pending`/`completed`)
- Creating PRs without checking `gh repo view --json defaultBranchRef` (some repos use `main`, others `master`)
- Removing `close()` calls before refactoring the client to support `close()` (had to restore later)

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` — 838/838 passed
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
