### PR TITLE
feat: add mass-pr-rebase-parallel-agents skill

### DIFF
--- a/skills/ci-cd/mass-pr-rebase-parallel-agents/.claude-plugin/plugin.json
+++ b/skills/ci-cd/mass-pr-rebase-parallel-agents/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "mass-pr-rebase-parallel-agents",
+  "version": "1.0.0",
+  "description": "Batch rebase and fix 100+ open PRs using parallel sub-agents with worktree isolation. Use when: (1) many PRs are CONFLICTING after main branch changes, (2) systemic CI failures need fixing before mass rebase, (3) orchestrating parallel worktree-based rebases at scale.",
+  "category": "ci-cd",
+  "date": "2026-03-17"
+}

--- a/skills/ci-cd/mass-pr-rebase-parallel-agents/references/notes.md
+++ b/skills/ci-cd/mass-pr-rebase-parallel-agents/references/notes.md
@@ -1,0 +1,78 @@
+# Mass PR Rebase - Session Notes
+
+## Context
+
+ProjectOdyssey had 138 open PRs after a major refactor (reverting targeted imports
+to package imports, c0289eb1). 80+ PRs became CONFLICTING. Additionally, 4 systemic
+CI failures were blocking all PRs from passing CI.
+
+## Timeline
+
+1. **Triage** (~5 min): Used `gh pr list` to classify PRs as CONFLICTING/MERGEABLE
+2. **Phase 0** (~15 min): Created PR #4902 fixing 5 systemic CI issues
+3. **Phase 2 Wave 1** (~10 min): Launched 5 parallel agents for 48 PRs
+4. **Phase 2 Wave 2** (~5 min): Found 34 more older PRs, launched 3 more agents
+5. **Phase 2 Wave 3** (~5 min): Launched 1 more agent for 11 remaining PRs
+6. **Result**: 0 CONFLICTING, 136 MERGEABLE, all auto-merge enabled
+
+## Systemic CI Fixes (PR #4902)
+
+### Fix 1: pre-commit no-matmul-call-sites
+- **Problem**: Hook entry was `just check-matmul-calls` but `just` isn't installed
+  in pre-commit CI environment
+- **Fix**: Inlined the grep command directly in `.pre-commit-config.yaml`
+
+### Fix 2: pre-commit mypy-examples
+- **Problem**: `download_cifar10.py` wrapper in examples/ uses `sys.path.insert()`
+  to import from `scripts/download_cifar10.py`, but mypy resolves to the local file
+- **Fix**: Added `# type: ignore[attr-defined]` to all 3 copies (alexnet, resnet18, vgg16)
+- **Lesson**: Always search for ALL copies: `find examples -name "download_cifar10.py"`
+
+### Fix 3: markdownlint
+- **Problem**: `*_backward` and `hard_*` in table cells interpreted as emphasis markers
+- **Fix**: Escaped as `\*\_backward` and `hard\_\*`
+- **Also**: Added missing `\`\`\`mojo` fence opening in first_model.md
+
+### Fix 4: Docker build permission
+- **Problem**: `just build` runs `mkdir -p build/debug` inside Docker container,
+  but the bind-mounted workspace has host UID permissions
+- **Fix**: Added `@just _ensure_build_dir {{mode}}` BEFORE `@just _run` to create
+  the directory on the host side first
+
+### Fix 5: Build template exclusion
+- **Problem**: `papers/_template/examples/train.mojo` has placeholder code that
+  fails `mojo build` ("use of unknown declaration 'print'")
+- **Fix**: Added `-not -path "./papers/_template/*"` to the find command in justfile
+
+## Rebase Agent Strategy
+
+### Prompt template (what each agent received):
+1. git fetch origin <branch>
+2. git worktree add worktrees/<pr> origin/<branch>
+3. git -C worktrees/<pr> rebase origin/main
+4. Resolve conflicts with --theirs
+5. git push --force-with-lease
+6. gh pr merge --auto --rebase
+7. git worktree remove
+
+### Conflict resolution:
+- All conflicts used `--theirs` (keep PR branch version)
+- Some rename/rename conflicts needed `git show REBASE_HEAD:` extraction
+- Modify/delete conflicts used `git rm`
+- Multi-round rebases needed repeated --theirs + add + continue cycles
+
+### Batch allocation:
+- Batch 1-5: 10 PRs each (original 48 from top-100 listing)
+- Batch 6: 11 PRs (missed by --limit 100)
+- Batch A-C: 11-12 PRs each (34 older PRs)
+- Total: 9 agents, all run_in_background: true
+
+## Key Numbers
+
+- 138 total open PRs
+- 96 PRs rebased and pushed
+- 17 PRs already closed (cherry-picked to main)
+- 0 rebase failures
+- 9 parallel agents used
+- ~20 min total rebase time
+- CI queue backed up ~30 min from mass force-pushes

--- a/skills/ci-cd/mass-pr-rebase-parallel-agents/skills/mass-pr-rebase-parallel-agents/SKILL.md
+++ b/skills/ci-cd/mass-pr-rebase-parallel-agents/skills/mass-pr-rebase-parallel-agents/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: mass-pr-rebase-parallel-agents
+description: "Batch rebase 100+ conflicting PRs using parallel sub-agents with worktree isolation. Use when: many PRs are CONFLICTING after main changes, systemic CI needs fixing first."
+category: ci-cd
+date: 2026-03-17
+user-invocable: false
+---
+
+# Mass PR Rebase with Parallel Agents
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Scope** | Repository-wide PR maintenance |
+| **Scale** | 138 open PRs, 80+ conflicting |
+| **Duration** | ~20 minutes for all rebases |
+| **Parallelism** | 5-9 sub-agents simultaneously |
+| **Success Rate** | 100% (0 failures across 96 rebases) |
+
+## When to Use
+
+- A major refactor lands on main (e.g., import style change) causing mass conflicts
+- 10+ PRs show CONFLICTING status simultaneously
+- CI has systemic failures blocking all PRs (fix main first, then rebase)
+- Need to rebase PRs that touch overlapping files (e.g., shared/__init__.mojo)
+
+## Verified Workflow
+
+### Phase 0: Fix Systemic CI on Main First
+
+Before rebasing any PRs, identify and fix failures that affect ALL PRs:
+
+1. Check CI on a recent MERGEABLE PR: `gh pr checks <number>`
+2. Check CI on main: `gh run list --branch main --limit 5`
+3. Categorize failures as systemic vs PR-specific
+4. Create a single fix PR for all systemic issues
+
+**Common systemic failures found:**
+
+| Failure | Root Cause | Fix |
+|---------|-----------|-----|
+| pre-commit hook uses `just` | `just` not installed in pre-commit CI env | Inline the bash command directly |
+| mypy on wrapper scripts | `sys.path` manipulation invisible to static analysis | Add `# type: ignore[attr-defined]` |
+| markdownlint on `*_backward` in tables | Unescaped `*` interpreted as emphasis | Escape with `\*\_backward` |
+| Docker `mkdir: Permission denied` | `build/` dir created inside container on bind mount | Create dir on host before entering Docker |
+| Template .mojo files fail build | Placeholder code doesn't compile | Exclude `papers/_template/` from build find |
+
+### Phase 1: Classify PRs
+
+```bash
+# Get all PRs grouped by mergeability
+gh pr list --state open --limit 200 --json number,headRefName,mergeable \
+  --jq '[group_by(.mergeable)[] | {status: .[0].mergeable, count: length}]'
+
+# List all CONFLICTING PRs with branch names
+gh pr list --state open --limit 200 --json number,headRefName,mergeable \
+  --jq '.[] | select(.mergeable == "CONFLICTING") | "\(.number) \(.headRefName)"'
+```
+
+**IMPORTANT**: `gh pr list --limit 100` is the default and may miss older PRs. Always use `--limit 200` or higher.
+
+### Phase 2: Batch Rebase with Parallel Agents
+
+Split PRs into batches of 10-12 and launch sub-agents in parallel:
+
+```
+Agent prompt template for each batch:
+- Fetch branch, create worktree under worktrees/<pr-number>
+- Rebase onto origin/main
+- Resolve conflicts with --theirs strategy
+- Force push with --force-with-lease
+- Enable auto-merge: gh pr merge <number> --auto --rebase
+- Clean up worktree
+```
+
+**Key conflict resolution strategies:**
+
+| File Pattern | Strategy |
+|-------------|----------|
+| `.github/workflows/*.yml` | `--theirs` (keep PR's version) |
+| `scripts/*.py` | `--theirs` (keep PR's version) |
+| `shared/**/*.mojo` | `--theirs` (keep PR's version) |
+| `tests/**/*.mojo` | `--theirs` (keep PR's version) |
+| `.pre-commit-config.yaml` | `--theirs` (keep PR's version) |
+| Rename/rename conflicts | Use `git show REBASE_HEAD:<path>` to extract content |
+| Modify/delete conflicts | `git rm` if PR intended deletion |
+
+**Conflict resolution command pattern:**
+
+```bash
+# Standard --theirs resolution
+git -C worktrees/<pr> checkout --theirs <file>
+git -C worktrees/<pr> add <file>
+GIT_EDITOR=true git -C worktrees/<pr> rebase --continue
+
+# For rename conflicts where --theirs doesn't work
+git -C worktrees/<pr> show REBASE_HEAD:<original-path> > worktrees/<pr>/<new-path>
+git -C worktrees/<pr> add <new-path>
+GIT_EDITOR=true git -C worktrees/<pr> rebase --continue
+```
+
+### Phase 3: Monitor and Clean Up
+
+```bash
+# Verify all PRs are MERGEABLE
+gh pr list --state open --limit 200 --json number,mergeable \
+  --jq '[group_by(.mergeable)[] | {status: .[0].mergeable, count: length}]'
+
+# Clean up worktrees
+git worktree prune
+
+# Check CI queue status
+gh run list --branch <branch> --limit 5 --json status,conclusion
+```
+
+### Quick Reference
+
+| Step | Command | Notes |
+|------|---------|-------|
+| List conflicting | `gh pr list --limit 200 --json number,mergeable --jq '...'` | Use limit 200+ |
+| Create worktree | `git worktree add worktrees/<pr> origin/<branch>` | Use worktrees/ dir |
+| Rebase | `git -C worktrees/<pr> rebase origin/main` | In worktree |
+| Resolve conflicts | `git checkout --theirs <file> && git add <file>` | --theirs for most |
+| Continue rebase | `GIT_EDITOR=true git rebase --continue` | Avoid editor |
+| Force push | `git push --force-with-lease origin <branch>` | Never --force |
+| Auto-merge | `gh pr merge <pr> --auto --rebase` | Enable immediately |
+| Cleanup | `git worktree remove worktrees/<pr>` | Per worktree |
+| Prune | `git worktree prune` | After all done |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Native builds in CI | Changed `just build` to `just native build` in workflows | User wants Docker builds, not native | Fix Docker permissions instead of bypassing Docker |
+| Fix only alexnet download_cifar10.py | Added type:ignore to one wrapper | Same file exists in resnet18/ and vgg16/ | Always search for all copies of a file pattern |
+| Using `--limit 100` for PR listing | Default gh pr list limit | Missed 34 older conflicting PRs | Always use `--limit 200` or higher |
+| Single agent for all rebases | Considered processing sequentially | Would take hours for 80+ PRs | Parallel agents (5-9) complete in ~20 minutes |
+
+## Results & Parameters
+
+### Session Results
+
+- **138 total open PRs** processed
+- **96 PRs rebased** and force-pushed (0 failures)
+- **17 PRs** were already closed (commits on main)
+- **All conflicts** resolved with `--theirs` strategy
+- **Auto-merge** enabled on all open PRs
+
+### Optimal Batch Size
+
+```
+PRs per agent: 10-12 (sweet spot)
+Parallel agents: 5-9 (limited by git lock contention)
+Total time: ~20 min for 80+ PRs
+```
+
+### Agent Configuration
+
+```yaml
+subagent_type: general-purpose
+run_in_background: true
+# No isolation: "worktree" needed - agents create their own worktrees
+```
+
+### CI Impact
+
+Mass force-pushing overwhelms CI runners. All PR runs queue simultaneously.
+Plan for 30-60 min CI queue drain after batch rebases.


### PR DESCRIPTION
## Summary

Documents batch rebasing 138 open PRs using 9 parallel sub-agents after a major refactor caused mass conflicts.

- Fixed 5 systemic CI failures on main before rebasing
- Rebased 96 PRs with 0 failures using parallel worktree-based agents
- All 136 remaining open PRs now MERGEABLE with auto-merge enabled

## Key Findings

**What Worked**:
- Parallel sub-agents (batches of 10-12) with `run_in_background: true`
- `--theirs` conflict resolution for all auto-impl branch conflicts
- Fixing systemic CI issues on main first (PR #4902) before mass rebase
- `git worktree add` for isolated per-PR rebase workspaces
- `GIT_EDITOR=true` to avoid interactive editor during `rebase --continue`

**What Failed**:
- Using `just native build` in CI workflows -> user wants Docker builds, fix Docker instead
- Fixing only one copy of `download_cifar10.py` -> 3 copies existed across examples/
- Default `--limit 100` on `gh pr list` -> missed 34 older conflicting PRs

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
