### PR TITLE
feat: add multi-experiment-figure-pipeline skill

### DIFF
--- a/skills/evaluation/multi-experiment-figure-pipeline/.claude-plugin/plugin.json
+++ b/skills/evaluation/multi-experiment-figure-pipeline/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "multi-experiment-figure-pipeline",
+  "version": "1.0.0",
+  "description": "Patterns for adding conditional figure generation to multi-experiment analysis pipelines. Use when: (1) adding new Altair figures to an existing figure registry, (2) implementing data-dependent guard sets for single-model or single-judge datasets, (3) creating task-level analysis figures across many experiments.",
+  "category": "evaluation",
+  "date": "2026-03-17"
+}

--- a/skills/evaluation/multi-experiment-figure-pipeline/references/notes.md
+++ b/skills/evaluation/multi-experiment-figure-pipeline/references/notes.md
@@ -1,0 +1,74 @@
+# Session Notes: Multi-Experiment Figure Pipeline Enhancement
+
+## Date: 2026-03-17
+
+## Context
+
+ProjectScylla dryrun3 experiment completed with 47 tests, ~1196 runs, 60.1% pass rate using
+Haiku 4.5 as both agent and judge. The existing analysis infrastructure had figures designed
+for a smaller 5-test dataset. Needed to add task-level analysis figures and handle degenerate
+cases from single-model/single-judge datasets.
+
+## Session Objective
+
+Implement Phases 1-3 of the haiku paper infrastructure plan:
+1. Single-judge figure guards
+2. New figures (fig35-39) for 47-test analysis
+3. Stats enhancement (Kendall's tau)
+
+## Approach
+
+### Phase 1: Single-Judge Guards
+
+Added a `single_judge_figures` set in `generate_figures.py` mirroring the existing
+`multi_model_figures` pattern. Detection via `judges_df["judge_model"].nunique() < 2`.
+Three figures guarded: fig02, fig14, fig17 — all would produce degenerate output with
+a single judge model.
+
+### Phase 2: New Figures
+
+Created `scylla/analysis/figures/task_analysis.py` as a new module with 4 figures:
+- fig35: Histogram of per-experiment pass rates — shows difficulty spectrum
+- fig36: Heatmap of tier ranks per experiment — visualizes rank stability (RQ2)
+- fig37: Scatter of difficulty vs tier std — shows differentiation patterns
+- fig38: Grouped bar comparing full-ablation vs standard — auto-detects by subtest count
+
+Added fig39 to existing `cost_analysis.py`:
+- Scatter of cost vs pass rate, colored by tier — shows cost scaling
+
+Key design decisions:
+- All figures use early-return guards for missing columns or insufficient data
+- fig38 auto-detects full-ablation experiments (>3 subtests per tier) but also accepts explicit list
+- fig36 uses rank(ascending=False, method="average") for ties
+- All figures export CSV alongside Vega-Lite spec
+
+### Phase 3: Kendall's Tau
+
+Added `kendall_tau()` to `scylla/analysis/stats.py` wrapping `scipy.stats.kendalltau`.
+Guards for n < 2. Added to `__all__` in alphabetical order.
+
+## Key Learnings
+
+1. **Guard-set pattern scales well**: Adding new guard sets (single_judge_figures) follows
+   the same pattern as multi_model_figures. Detection at runtime is more robust than
+   hardcoded exclusion.
+
+2. **Kendall's tau p-values are exact for small N**: With n=5, even perfect correlation
+   gives p=0.017 (not <0.01). This is because scipy uses the exact permutation distribution,
+   not an asymptotic approximation. Tests should use p < 0.05.
+
+3. **Auto-detection over configuration**: fig38's auto-detection of full-ablation experiments
+   by subtest count eliminates the need for user configuration.
+
+4. **Category routing in FIGURES dict**: The category string ("tier", "cost", "judge") determines
+   which DataFrame gets passed to the generator function. New task-analysis figures use "tier"
+   category since they consume `runs_df`.
+
+## Raw Stats
+
+- 5 new figures created
+- 1 new stats function (kendall_tau)
+- 14 new tests (12 figure + 2 stats)
+- 1380 total analysis tests pass
+- 43 total figures in registry
+- All pre-commit hooks pass

--- a/skills/evaluation/multi-experiment-figure-pipeline/skills/multi-experiment-figure-pipeline/SKILL.md
+++ b/skills/evaluation/multi-experiment-figure-pipeline/skills/multi-experiment-figure-pipeline/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: multi-experiment-figure-pipeline
+description: "Patterns for adding conditional figure generation to multi-experiment analysis pipelines. Use when: adding new Altair figures with data-dependent guards, creating task-level analysis, or scaling figure pipelines to large experiment counts."
+category: evaluation
+date: 2026-03-17
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Adding new figures to an existing Altair pipeline for a multi-experiment dataset (47 tests, ~1196 runs) while gracefully handling degenerate cases (single model, single judge, N=1 runs/subtest) |
+| **Solution** | Guard-set pattern for conditional generation + task-analysis module with 5 new figures + Kendall's tau for rank stability |
+| **Key Insight** | Data-dependent guards (detecting model/judge count at generation time) are more robust than hardcoded exclusion lists |
+| **Scope** | ProjectScylla analysis infrastructure: `scylla/analysis/figures/`, `scripts/generate_figures.py`, `scylla/analysis/stats.py` |
+
+## When to Use
+
+- Adding new Altair/Vega-Lite figures to an existing figure registry with `save_figure()` pattern
+- Implementing conditional figure generation based on dataset characteristics (single-model, single-judge, N=1)
+- Creating task-level (per-experiment) analysis figures for datasets with many experiments
+- Adding new statistical functions to the stats module
+- Scaling a figure pipeline from 5-test to 47-test datasets
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# 1. Guard-set pattern in generate_figures.py
+single_judge_figures = {"fig02_judge_variance", "fig14_judge_agreement", "fig17_judge_variance_overall"}
+n_judges = int(judges_df["judge_model"].nunique())
+
+for fig_name in figures_to_generate:
+    if fig_name in single_judge_figures and n_judges < 2:
+        print(f"\n{fig_name}: SKIPPED (requires >=2 judges, found {n_judges})")
+        success_count += 1  # Not a failure, just inapplicable
+        continue
+
+# 2. Figure function pattern (early-return guards)
+def fig35_task_difficulty_distribution(runs_df, output_dir, render=True):
+    if "experiment" not in runs_df.columns or "passed" not in runs_df.columns:
+        return
+    exp_pass_rates = runs_df.groupby("experiment")["passed"].mean().reset_index()
+    if len(exp_pass_rates) < 2:
+        return  # Need multiple experiments
+    chart = alt.Chart(exp_pass_rates).mark_bar().encode(...)
+    save_figure(chart, "fig35_task_difficulty_distribution", output_dir, render)
+    exp_pass_rates.to_csv(output_dir / "fig35_task_difficulty_distribution.csv", index=False)
+
+# 3. Register in FIGURES dict
+FIGURES = {
+    ...
+    "fig35_task_difficulty_distribution": ("tier", fig35_task_difficulty_distribution),
+}
+```
+
+### Step-by-Step: Adding a New Figure
+
+1. **Create the figure function** in the appropriate module under `scylla/analysis/figures/`:
+   - Use `derive_tier_order(runs_df)` for consistent tier sorting
+   - Use `get_color_scale("tiers", tier_order)` for color consistency
+   - Call `save_figure(chart, name, output_dir, render)` to write `.vl.json` + optional render
+   - Export CSV alongside the figure for reproducibility
+   - Add early-return guards for missing columns or insufficient data
+
+2. **Register the figure** in `scripts/generate_figures.py`:
+   - Add import at top
+   - Add entry to `FIGURES` dict: `"fig_name": ("category", func)`
+   - Category determines which DataFrame is passed: `"tier"/"cost"/"variance"` → `runs_df`, `"judge"` → `judges_df`, `"criteria"` → `criteria_df`
+
+3. **Add guard sets** if the figure has preconditions:
+   - `multi_model_figures`: requires `runs_df["agent_model"].nunique() >= 2`
+   - `single_judge_figures`: requires `judges_df["judge_model"].nunique() >= 2`
+   - Guard check happens in the generation loop, counts as success (not failure)
+
+4. **Write smoke tests** in `tests/unit/analysis/test_figures.py`:
+   - Minimum 3 tests per figure: happy path, edge case (insufficient data → no output), registry check
+   - Use `render=False` to skip PNG generation in tests
+   - Assert both `.vl.json` and `.csv` files exist
+
+5. **Add stats functions** to `scylla/analysis/stats.py`:
+   - Add to `__all__` list (alphabetical order)
+   - Guard for n < 2 samples
+   - Return tuple of (statistic, p-value)
+
+### Auto-Detection Pattern (Full-Ablation)
+
+```python
+# Detect full-ablation experiments by subtest count
+subtests_per_exp_tier = runs_df.groupby(["experiment", "tier"])["subtest"].nunique().reset_index()
+max_subtests = subtests_per_exp_tier.groupby("experiment")["subtest"].max()
+full_ablation_experiments = list(max_subtests[max_subtests > 3].index)
+```
+
+### Figures Created in This Session
+
+| Figure | Type | Purpose |
+|--------|------|---------|
+| fig35 | Histogram | Task difficulty distribution (per-experiment pass rates) |
+| fig36 | Heatmap | Tier rank stability (rank 1=best per experiment, sorted by difficulty) |
+| fig37 | Scatter | Task complexity vs tier differentiation (mean pass rate vs std) |
+| fig38 | Grouped bar | Full-ablation vs standard sampling comparison |
+| fig39 | Scatter | Cost scaling with difficulty (cost vs pass rate, colored by tier) |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Kendall's tau test with p < 0.01 | Used strict threshold in unit test for perfect correlation | With n=5 samples, `scipy.stats.kendalltau` returns p=0.017 even for perfect correlation (exact test, not asymptotic) | Use p < 0.05 for small-sample rank correlation tests; Kendall's tau p-values are larger than Spearman's for small N |
+
+## Results & Parameters
+
+### Configuration
+
+```yaml
+# Figure generation
+render: false  # For tests (skip PNG)
+render: true   # For production (300 DPI via scale_factor=3.0)
+
+# Guard thresholds
+min_models_for_multi_model: 2
+min_judges_for_multi_judge: 2
+min_experiments_for_histogram: 2
+min_subtests_for_full_ablation: 4  # >3 triggers full-ablation detection
+
+# Stats
+kendall_tau_min_samples: 2
+```
+
+### Test Results
+
+```
+Tests added: 14 (12 figure tests + 2 stats tests)
+Total analysis tests: 1380 passed, 1 skipped
+Pre-commit: all hooks pass
+Figures registered: 43 total (38 existing + 5 new)
+```
+
+### Key Files Modified
+
+| File | Change |
+|------|--------|
+| `scylla/analysis/figures/task_analysis.py` | NEW — fig35, fig36, fig37, fig38 |
+| `scylla/analysis/figures/cost_analysis.py` | Added fig39_cost_scaling_with_difficulty |
+| `scylla/analysis/stats.py` | Added kendall_tau() |
+| `scripts/generate_figures.py` | Single-judge guards, registered fig35-39 |
+| `tests/unit/analysis/test_figures.py` | 12 new smoke tests |
+| `tests/unit/analysis/test_stats.py` | 2 new kendall_tau tests |


### PR DESCRIPTION
## Summary

Documents patterns for adding conditional figure generation to multi-experiment analysis pipelines with data-dependent guards.

- Guard-set pattern for single-judge and single-model datasets
- 5 new task-level analysis figures (fig35-39) with auto-detection and early-return guards
- Kendall's tau stat function with small-sample p-value caveats

## Key Findings

**What Worked**:
- Guard-set pattern (`single_judge_figures`, `multi_model_figures`) scales cleanly — detect at runtime, count as success not failure
- Auto-detection of full-ablation experiments by subtest count > 3 eliminates user configuration
- Early-return guards in figure functions handle all edge cases gracefully

**What Failed**:
- Kendall's tau test with p < 0.01 threshold → scipy exact test returns p=0.017 for n=5 perfect correlation; fixed to p < 0.05

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
