### PR TITLE
feat: add orphan-aware-test-fixtures skill

### DIFF
--- a/skills/testing/orphan-aware-test-fixtures/.claude-plugin/plugin.json
+++ b/skills/testing/orphan-aware-test-fixtures/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "orphan-aware-test-fixtures",
+  "version": "1.0.0",
+  "description": "Patterns for fixing test fixtures that break when checkpoint integrity detectors are added. Use when: (1) adding orphan/integrity detection to resume pipelines, (2) fixing test failures where aggregated states get unexpectedly reset to pending, (3) rebasing branches that add checkpoint invariants.",
+  "category": "testing",
+  "date": "2026-03-17"
+}

--- a/skills/testing/orphan-aware-test-fixtures/references/notes.md
+++ b/skills/testing/orphan-aware-test-fixtures/references/notes.md
@@ -1,0 +1,61 @@
+# Session Notes: Orphan-Aware Test Fixtures
+
+## Date: 2026-03-17
+
+## Context
+
+After implementing the dryrun3 analysis infrastructure (fig35-39, single-judge guards,
+Kendall's tau, table11, resume retry logic), the branch needed to be committed, rebased
+onto origin/main (20 commits behind), and pushed.
+
+## The Problem
+
+The push pre-hook runs the full test suite. Two tests failed sequentially:
+
+### Failure 1: `test_resume_failed_experiment_resets_failed_subtest_states_to_pending`
+- **Expected**: `subtest_states["T0"]["01"] == "aggregated"` (should survive reset)
+- **Got**: `"pending"` (orphan detector reset it)
+- **Root cause**: The fixture set `subtest_states={"T0": {"00": "failed", "01": "aggregated"}}`
+  but no `run_states`. The `_find_orphaned_subtest_states()` method found `"01"` was
+  `"aggregated"` with no backing runs → orphaned → reset to `"pending"`.
+
+### Failure 2: `test_resume_detects_missing_subtests_and_resets_tier_to_pending`
+- **Expected**: `tier_states["T0"] == "pending"` (should be reset due to missing subtests)
+- **Got**: `"config_loaded"` (orphan detector reset tier before the missing-subtests check)
+- **Root cause**: Same pattern — `subtest_states={"T0": {"00": "aggregated", "01": "aggregated"}}`
+  with no `run_states`. Orphan detector fired first, resetting tier to `"config_loaded"`.
+
+## The Fix
+
+Add `run_states` with `worktree_cleaned` entries for every subtest that tests expect to
+remain in `"aggregated"` state:
+
+```python
+# Before
+checkpoint = E2ECheckpoint(
+    subtest_states={"T0": {"00": "aggregated", "01": "aggregated"}},
+)
+
+# After
+checkpoint = E2ECheckpoint(
+    subtest_states={"T0": {"00": "aggregated", "01": "aggregated"}},
+    run_states={"T0": {"00": {"1": "worktree_cleaned"}, "01": {"1": "worktree_cleaned"}}},
+)
+```
+
+## Key Insight
+
+Adding an integrity detector creates an IMPLICIT INVARIANT on all existing test fixtures.
+The `_reset_orphaned_subtest_states()` method was added to `resume_manager.py` as part of
+the dryrun3 analysis work. It validated cross-field consistency (subtest_states vs run_states)
+that previous tests never needed to maintain because the check didn't exist.
+
+This is a general pattern: any new validation/invariant check in a pipeline will retroactively
+break tests that violate the invariant, even if those tests were correct before.
+
+## Rebase Summary
+
+- 20 commits on main ahead of branch
+- 3 merge conflicts resolved (all docstring/comment wording + run multiplier fixes)
+- 2 test fixtures fixed for orphan detection invariant
+- Final: 4914 passed, 77.34% coverage, push succeeded

--- a/skills/testing/orphan-aware-test-fixtures/skills/orphan-aware-test-fixtures/SKILL.md
+++ b/skills/testing/orphan-aware-test-fixtures/skills/orphan-aware-test-fixtures/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: orphan-aware-test-fixtures
+description: "Patterns for fixing test fixtures that break when checkpoint integrity detectors are added. Use when: adding orphan detection to resume pipelines, or when aggregated states get unexpectedly reset."
+category: testing
+date: 2026-03-17
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Adding `_reset_orphaned_subtest_states()` to the resume pipeline created a new invariant: subtest states in `aggregated`/`runs_complete` must have backing `run_states`, or they get reset to `pending`. Existing tests that set `subtest_states` without `run_states` broke silently — the orphan detector correctly reset them. |
+| **Solution** | Add `run_states` entries with `worktree_cleaned` for any test fixture subtest in `aggregated` or `runs_complete` state |
+| **Key Insight** | Integrity detectors create implicit invariants on test fixtures. When you add a detector that validates cross-field consistency (e.g., subtest_states must have backing run_states), ALL existing fixtures that set those fields must be updated. |
+| **Scope** | `tests/unit/e2e/test_runner.py` — `TestInitializeOrResumeExperimentFailedReset` and `TestInitializeOrResumeExperimentMaxSubtests` |
+
+## When to Use
+
+- Adding an orphan/integrity detector to a resume or state machine pipeline
+- Debugging tests where checkpoint states get unexpectedly reset to `pending`
+- Rebasing branches that add new checkpoint invariants onto branches with existing test fixtures
+- Seeing `assert 'pending' == 'aggregated'` or `assert 'config_loaded' == 'pending'` failures in resume tests
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# BEFORE (broken — orphan detector resets "01" to "pending"):
+checkpoint = E2ECheckpoint(
+    experiment_state="failed",
+    subtest_states={"T0": {"00": "failed", "01": "aggregated"}},
+    # No run_states → "01" is orphaned → reset to pending
+)
+
+# AFTER (fixed — "01" has backing run_states):
+checkpoint = E2ECheckpoint(
+    experiment_state="failed",
+    subtest_states={"T0": {"00": "failed", "01": "aggregated"}},
+    run_states={"T0": {"01": {"1": "worktree_cleaned"}}},
+)
+```
+
+### Step-by-Step: Diagnosing Orphan-Related Test Failures
+
+1. **Identify the symptom**: Test asserts a subtest state is `"aggregated"` or `"runs_complete"` but gets `"pending"` instead.
+
+2. **Check if an orphan detector exists**: Search for `_find_orphaned_subtest_states` or similar cross-field validation in the resume pipeline.
+
+3. **Trace the execution order**: In `reset_failed_states()`, the orphan reset runs BEFORE the failed/interrupted reset:
+   ```python
+   def reset_failed_states(self):
+       self._reset_infra_error_runs()           # Step 1
+       self._reset_intermediate_runs_in_complete_experiment()  # Step 2
+       self._reset_orphaned_subtest_states()     # Step 3 ← resets "aggregated" without run_states
+       self._reset_failed_and_interrupted()      # Step 4
+   ```
+
+4. **Fix**: Add `run_states` entries for every subtest that the test expects to remain in `aggregated` or `runs_complete` state. Use `"worktree_cleaned"` as the terminal run state.
+
+5. **Audit**: `grep` for `"aggregated"` and `"runs_complete"` across all test fixtures:
+   ```bash
+   grep -n '"aggregated"\|"runs_complete"' tests/unit/e2e/test_runner.py
+   ```
+   For each match, verify there's a corresponding `run_states` entry.
+
+### Cascade Effects
+
+The orphan detector also calls `_reset_tier_to_config_loaded()` and `_reset_experiment_to_tiers_running()`, which can change tier and experiment states as side effects:
+
+| Orphan detected | Tier state changes to | Experiment state changes to |
+|---|---|---|
+| Any subtest orphaned | `config_loaded` (if was complete-family) | `tiers_running` (if was complete-family) |
+
+This means a test expecting `tier_states["T0"] == "pending"` might get `"config_loaded"` instead if the orphan detector fires first.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| First push after rebase | Rebased onto main, resolved 3 merge conflicts, pushed | `test_resume_failed_experiment_resets_failed_subtest_states_to_pending` failed — `"aggregated"` subtest without `run_states` was orphan-detected | Adding integrity detectors creates implicit invariants on ALL fixtures that touch the validated fields |
+| Second push after fixing one test | Fixed the first failing test, pushed | `test_resume_detects_missing_subtests_and_resets_tier_to_pending` failed — same root cause in different test class | Must audit ALL test fixtures for the pattern, not just the first failure; use `grep '"aggregated"'` across the entire file |
+
+## Results & Parameters
+
+### Fix Pattern
+
+```python
+# For every subtest in "aggregated" state in a test fixture,
+# add a terminal run_states entry:
+run_states={"T0": {"00": {"1": "worktree_cleaned"}, "01": {"1": "worktree_cleaned"}}}
+```
+
+### Audit Command
+
+```bash
+# Find all test fixtures with aggregated/runs_complete without run_states
+grep -n '"aggregated"\|"runs_complete"' tests/unit/e2e/test_runner.py
+```
+
+### Test Results
+
+```
+Before fix: 2 failures (2637 passed, 1 failed; then 2648 passed, 1 failed)
+After fix: 4914 passed, 2 skipped, 77.34% coverage
+Push: succeeded with --force-with-lease (rebased branch)
+```


### PR DESCRIPTION
## Summary

Documents patterns for fixing test fixtures that break when checkpoint integrity detectors are added to resume pipelines.

- Integrity detectors create implicit invariants on ALL existing test fixtures
- Aggregated/runs_complete subtest states need backing run_states entries
- Audit pattern: `grep '"aggregated"' tests/` to find all affected fixtures

## Key Findings

**What Worked**:
- Adding `run_states={"T0": {"01": {"1": "worktree_cleaned"}}}` for every aggregated subtest
- Using `grep` audit to find all instances after discovering the pattern

**What Failed**:
- First push: 1 test failed (orphan detector reset aggregated subtest) → fixed
- Second push: Different test same pattern → fixed, then audited all occurrences

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
