### PR TITLE
feat: add docker-pixi-isolation skill

### DIFF
--- a/skills/ci-cd/docker-pixi-isolation/.claude-plugin/plugin.json
+++ b/skills/ci-cd/docker-pixi-isolation/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "docker-pixi-isolation",
+  "version": "1.0.0",
+  "description": "Fix Docker container Mojo stdlib failures caused by host .pixi/ bind-mount contamination. Use when: (1) CI tests fail with 'unable to locate module std' inside Docker, (2) host pixi environment leaks into container via bind mounts.",
+  "category": "ci-cd",
+  "date": "2026-03-18"
+}

--- a/skills/ci-cd/docker-pixi-isolation/references/notes.md
+++ b/skills/ci-cd/docker-pixi-isolation/references/notes.md
@@ -1,0 +1,50 @@
+# Session Notes: Docker Pixi Isolation Fix
+
+## Date: 2026-03-18
+
+## Context
+
+Main branch had 2 failing CI workflows after PR #4927 (workflow fixes) and #4928 (alias to comptime):
+
+1. **Comprehensive Tests** — ALL 20 test jobs failed with `error: unable to locate module 'std'` inside Docker
+2. **Build Validation** — `ExTensor.split()` type conversion error: `cannot be converted from 'ExTensor' to 'ExTensor'`
+
+## Root Cause Analysis
+
+### Docker Stdlib Failure
+
+The CI pipeline uses `setup-pixi` action which installs pixi on the **runner host**, creating `.pixi/envs/default/` with native Mojo binaries. The `docker-compose.yml` bind-mounts `.:/workspace:delegated`, which brings the runner's `.pixi/` into the container. The runner's native Mojo binaries can't find their stdlib inside the container's filesystem, resulting in `unable to locate module 'std'`.
+
+### ExTensor Type Identity Split
+
+`extensor.mojo` lines 3441/3475 used absolute imports (`from shared.core.shape import split`), while `shape.mojo` imports `ExTensor` via `from .extensor import ExTensor`. The absolute path resolves through `shared/core/__init__.mojo`, creating a different `ExTensor` type identity than the one resolved via relative imports. This caused the Mojo compiler to treat them as different types.
+
+## Changes Made
+
+### PR #4929: fix-docker-mojo-stdlib
+
+**Commit 1: Docker fix + import fix**
+- Created `docker/entrypoint.sh` — ensures pixi env exists inside container
+- Modified `Dockerfile` — copies entrypoint into image
+- Modified `docker-compose.yml` — added `workspace-pixi` named volume to dev and ci services, added entrypoint
+- Fixed `shared/core/extensor.mojo` — changed absolute imports to relative imports on lines 3441 and 3475
+
+**Commit 2: Remove native execution from CI**
+- Removed `setup-pixi` from comprehensive-tests.yml (7 occurrences), build-validation.yml (1), training-tests-weekly.yml (1)
+- Removed `NATIVE=1` from comprehensive-tests.yml mojo-compilation job
+- Removed direct `pixi run mojo --version` call from data-utilities test job
+- Replaced direct `pixi run mojo package` compilation step with `just package` (routes through Docker)
+
+## Key Insight
+
+The user's feedback was clear: "I don't want ANY CI/CD workflows to use native, they all must use container." Initially I only removed the explicit `NATIVE=1` but kept `setup-pixi` in some workflows. The user's directive required removing `setup-pixi` from ALL workflows that route through Docker, not just the ones with `NATIVE=1`.
+
+## Files Modified
+
+- `docker/entrypoint.sh` (NEW)
+- `Dockerfile`
+- `docker-compose.yml`
+- `shared/core/extensor.mojo`
+- `.github/workflows/comprehensive-tests.yml`
+- `.github/workflows/build-validation.yml`
+- `.github/workflows/training-tests-weekly.yml`

--- a/skills/ci-cd/docker-pixi-isolation/skills/docker-pixi-isolation/SKILL.md
+++ b/skills/ci-cd/docker-pixi-isolation/skills/docker-pixi-isolation/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: docker-pixi-isolation
+description: "Fix Docker container Mojo stdlib failures caused by host .pixi/ bind-mount contamination. Use when: CI tests fail with 'unable to locate module std' inside Docker containers."
+category: ci-cd
+date: 2026-03-18
+user-invocable: false
+---
+
+# Docker Pixi Isolation
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Problem** | CI test jobs inside Docker fail with `error: unable to locate module 'std'` |
+| **Root Cause** | Host `.pixi/` directory (with native Mojo binaries) bind-mounted into container shadows container's own Mojo installation |
+| **Solution** | Named Docker volume at `/workspace/.pixi` + entrypoint script + remove `setup-pixi` from Docker-routed CI jobs |
+| **Scope** | Docker-compose services, CI workflow files, justfile `_run` recipe |
+
+## When to Use
+
+- CI test jobs fail with `unable to locate module 'std'` inside Docker containers
+- Host environment tools (pixi, Mojo) leak into Docker containers via bind mounts
+- `docker-compose.yml` bind-mounts the entire workspace (`.:/workspace`) and host has `.pixi/` installed
+- CI workflows use `setup-pixi` action but route commands through Docker via justfile
+
+## Verified Workflow
+
+### Quick Reference
+
+1. **Add named volume** to `docker-compose.yml` that shadows the bind-mounted `.pixi/`:
+
+```yaml
+services:
+  myservice:
+    volumes:
+      - .:/workspace:delegated
+      - workspace-pixi:/workspace/.pixi  # Shadows host .pixi/
+
+volumes:
+  workspace-pixi:
+    driver: local
+```
+
+2. **Create entrypoint script** (`docker/entrypoint.sh`) that initializes pixi if needed:
+
+```bash
+#!/usr/bin/env bash
+set -e
+if [ ! -x ".pixi/envs/default/bin/mojo" ]; then
+    echo "Initializing pixi environment inside container..."
+    pixi install
+fi
+exec "$@"
+```
+
+3. **Add entrypoint to Dockerfile** (before `CMD`):
+
+```dockerfile
+COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+```
+
+4. **Add entrypoint to docker-compose services**:
+
+```yaml
+entrypoint: ["/usr/local/bin/entrypoint.sh"]
+```
+
+5. **Remove `setup-pixi` from CI workflows** that route through Docker:
+   - If a workflow calls `just build`, `just test-group`, etc. (which route through Docker via `_run` recipe), it does NOT need `setup-pixi`
+   - Remove `NATIVE=1` prefixes that bypass Docker
+   - Remove direct `pixi run mojo` calls that won't work without host pixi
+
+### Why Named Volumes Work
+
+Docker named volumes take precedence over bind mount subdirectories. When you have:
+- Bind mount: `.:/workspace` (brings host `.pixi/` into container)
+- Named volume: `workspace-pixi:/workspace/.pixi` (empty initially)
+
+The named volume wins at `/workspace/.pixi`, effectively hiding the host's incompatible `.pixi/` directory. The entrypoint script then populates it with `pixi install` on first run.
+
+### Identifying Affected CI Jobs
+
+A CI job needs this fix if it:
+1. Uses `setup-pixi` (installs pixi on the host, creating `.pixi/`)
+2. Routes commands through Docker (via justfile `_run` recipe or `docker compose exec`)
+3. The justfile `_run` recipe checks `NATIVE` env var — without `NATIVE=1`, commands run in Docker
+
+Check with: `grep -l "setup-pixi" .github/workflows/*.yml` cross-referenced with `grep -l "just " .github/workflows/*.yml`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Add `NATIVE=1` to CI jobs | Force all Mojo commands to run natively on the runner | Defeats the purpose of Docker isolation; inconsistent with other jobs that use Docker | All CI jobs should use the same execution environment (Docker) |
+| Keep `setup-pixi` alongside Docker volume fix | Let pixi install on host but shadow with volume | Wastes CI time installing pixi on host when it's not used; `.pixi/` still created on host | Remove unnecessary setup steps entirely, don't just work around them |
+| Use absolute imports in Mojo (`from shared.core.shape import ...`) | Import functions using full package path | Creates different type identity when module is also imported via `__init__.mojo`, causing `cannot be converted from 'ExTensor' to 'ExTensor'` errors | Always use relative imports (`from .shape import ...`) within a package to avoid type identity splits |
+
+## Results & Parameters
+
+### docker-compose.yml Configuration
+
+```yaml
+services:
+  projectodyssey-dev:
+    volumes:
+      - .:/workspace:delegated
+      - workspace-pixi:/workspace/.pixi
+      - pixi-cache:${HOME}/.pixi
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
+
+  projectodyssey-ci:
+    volumes:
+      - .:/workspace
+      - workspace-pixi:/workspace/.pixi
+      - pixi-cache:${HOME}/.pixi
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
+
+volumes:
+  workspace-pixi:
+    driver: local
+```
+
+### CI Workflow Pattern (After Fix)
+
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v6
+
+  # NO setup-pixi step — Mojo runs inside Docker
+
+  - name: Install Just
+    uses: extractions/setup-just@v3
+
+  - name: Build
+    run: just build  # Routes through Docker via _run recipe
+```
+
+### Related Mojo Import Fix
+
+When a Mojo package has circular references (e.g., `extensor.mojo` importing from `shape.mojo` which imports `ExTensor`), always use relative imports:
+
+```mojo
+# WRONG — creates separate type identity
+from shared.core.shape import split as split_fn
+
+# CORRECT — same type identity
+from .shape import split as split_fn
+```


### PR DESCRIPTION
## Summary

Documents fix for Docker container Mojo stdlib failures caused by host `.pixi/` bind-mount contamination in CI pipelines.

- Named Docker volumes shadow bind-mount subdirectories, preventing host environment leakage into containers
- CI workflows that route through Docker via justfile should NOT use `setup-pixi` or `NATIVE=1`
- Mojo relative imports prevent type identity splits in circular package references

## Key Findings

**What Worked**:
- Adding a `workspace-pixi` named volume at `/workspace/.pixi` to shadow the host's bind-mounted `.pixi/`
- Entrypoint script that runs `pixi install` on first container start to populate the named volume
- Removing `setup-pixi` from all CI jobs that route through Docker
- Using relative imports (`from .shape import ...`) instead of absolute imports in Mojo packages

**What Failed**:
- Adding `NATIVE=1` to bypass Docker → defeats container isolation purpose
- Keeping `setup-pixi` alongside Docker volume fix → wastes CI time, still creates host `.pixi/`
- Using absolute Mojo imports within a package → creates separate type identities via `__init__.mojo`

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
