### PR TITLE
feat: add parallel-test-fix-orchestration skill

### DIFF
--- a/skills/ci-cd/parallel-test-fix-orchestration/.claude-plugin/plugin.json
+++ b/skills/ci-cd/parallel-test-fix-orchestration/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "parallel-test-fix-orchestration",
+  "version": "1.0.0",
+  "description": "Orchestrate mass parallel test fixes using worktree-isolated agents, each producing its own PR. Use when: (1) CI has many (10+) failing test files across categories, (2) failures are independent and can be fixed in parallel, (3) each fix should be a separate PR for clean review.",
+  "category": "ci-cd",
+  "date": "2026-03-18"
+}

--- a/skills/ci-cd/parallel-test-fix-orchestration/references/notes.md
+++ b/skills/ci-cd/parallel-test-fix-orchestration/references/notes.md
@@ -1,0 +1,66 @@
+# Session Notes: Parallel Test Fix Orchestration
+
+## Date: 2026-03-18
+
+## Context
+
+ProjectOdyssey main branch had 45 failing test files in CI comprehensive tests (run ID 23274508817).
+Failures spanned compile errors, runtime errors, and permission issues across shared/core, shared/training,
+shared/testing, models, and configs test directories.
+
+## Approach
+
+1. Used an Explore agent to map all current source APIs before launching fix agents
+2. Read key __init__.mojo files to understand export paths
+3. Categorized all 45 failures into 3 categories (compile/runtime/permission)
+4. Launched agents in waves: Wave 0 (Docker fix), Waves 1-9 (test fixes)
+5. Each agent worked in its own worktree with isolation="worktree"
+6. All agents ran in background with run_in_background=True
+
+## Key Decisions
+
+- **Fix tests vs fix source**: Default to fixing tests. Only fix source for clear bugs
+  (runtime assertion failures that indicate real logic errors)
+- **Docker permissions**: Created Wave 0 to fix entrypoint.sh, then Wave 9 agents just
+  changed test paths to /tmp
+- **Wave sizing**: 5-10 agents per wave to avoid overwhelming git/CI
+
+## Common Mojo Test Failure Patterns Observed
+
+1. **Import path drift**: Module reorganization moves symbols but tests keep old paths
+2. **full() type tightening**: fill_value now requires Float64, not Int/Bool
+3. **List constructor**: Mojo 0.26.1 doesn't support List[T](a,b,c) variadic constructor
+4. **Docstring linting**: Summary must start with capital, descriptions must end with . or backtick
+5. **assert_value_at arg order**: 4th positional arg is tolerance (Float64), not message (String)
+6. **C-style ternary**: Mojo uses `x if cond else y`, not `cond ? x : y`
+7. **Missing `escaping` keyword**: Closures passed to higher-order functions need `escaping`
+8. **Missing `raises` keyword**: Functions calling raising functions need `raises`
+
+## Source Bugs Found
+
+### 1. ExTensor._set_float64/_set_float32 (PR #4965)
+- Missing else branch for integer dtypes
+- Values silently discarded when setting float on int tensor
+- Fix: Added else → _set_int64(index, Int64(value))
+
+### 2. ExTensor.__getitem__(*slices) step support (PR #4973)
+- Multi-dim slicing completely ignored Slice.step field
+- t[::2, :] returned same as t[:, :]
+- Fix: Extract step, validate step!=0, multiply out_idx*step
+
+### 3. ExTensor.__getitem__(Int) stride awareness (PR #4974)
+- Used raw memory offset for flat indexing
+- Wrong for non-contiguous views (transpose, axis>0 slice)
+- Fix: Convert flat index → nd coords → stride-aware offset
+
+### 4. TrainingLoop.run_epoch stub (PR #4967)
+- Accepted PythonObject, was a no-op stub
+- Fix: Changed to accept DataLoader, added real batch iteration
+
+## PR List (45 total)
+
+#4931, #4932, #4933, #4934, #4935, #4936, #4937, #4938, #4939, #4940,
+#4941, #4942, #4943, #4944, #4945, #4946, #4947, #4948, #4949, #4950,
+#4951, #4952, #4953, #4954, #4955, #4956, #4957, #4958, #4959, #4960,
+#4961, #4962, #4963, #4964, #4965, #4966, #4967, #4968, #4969, #4970,
+#4971, #4972, #4973, #4974, #4975

--- a/skills/ci-cd/parallel-test-fix-orchestration/skills/parallel-test-fix-orchestration/SKILL.md
+++ b/skills/ci-cd/parallel-test-fix-orchestration/skills/parallel-test-fix-orchestration/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: parallel-test-fix-orchestration
+description: "Orchestrate mass parallel test fixes using worktree-isolated agents with one PR per fix. Use when: CI has many independent test failures that need systematic resolution."
+category: ci-cd
+date: 2026-03-18
+user-invocable: false
+---
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Scope** | Mass CI test failure resolution |
+| **Scale** | 10-50+ failing test files per session |
+| **Parallelism** | Up to 10 concurrent worktree agents |
+| **Output** | One PR per failing test file, auto-merge enabled |
+| **Duration** | 5-15 minutes for 45 agents (wall clock) |
+
+## When to Use
+
+- CI comprehensive test suite has 10+ failing test files
+- Failures span multiple categories (compile errors, runtime errors, permission issues)
+- Each test file can be fixed independently (no shared source file conflicts)
+- You want clean, reviewable, single-purpose PRs rather than one mega-PR
+- Test failures are caused by API drift, not fundamental architectural issues
+
+## Verified Workflow
+
+### Quick Reference
+
+```
+1. Explore source APIs to build a "current truth" reference
+2. Categorize failures (compile vs runtime vs permission vs source bug)
+3. Launch agents in waves of 5-10, each in isolation: worktree
+4. Each agent: branch → read test → read source → fix → commit → push → PR → auto-merge
+5. Monitor completions, verify PR count matches failure count
+```
+
+### Step 1: Build API Reference
+
+Before launching any agents, read the current source modules that tests depend on. This prevents agents from guessing at APIs.
+
+Key files to read:
+- Package `__init__.mojo` files (show what's exported and from where)
+- Core type definitions (constructors, method signatures)
+- Test assertion helpers (parameter order, types)
+
+### Step 2: Categorize Failures
+
+Group failures into categories to write better agent prompts:
+
+| Category | Typical Fix | Agent Complexity |
+|----------|-------------|-----------------|
+| **Wrong import path** | Change `from X import Y` → `from Z import Y` | Simple (~30s) |
+| **API signature change** | Add missing arg, wrap type, reorder params | Simple (~60s) |
+| **Docstring formatting** | Capitalize, add periods | Trivial (~20s) |
+| **Missing import** | Add import line | Trivial (~20s) |
+| **Constructor change** | Update call pattern | Medium (~90s) |
+| **Removed method** | Rewrite test using current API | Complex (~3min) |
+| **Runtime assertion failure** | Investigate source vs test expectations | Complex (~5min) |
+| **Source bug** | Fix source code, not test | Complex (~10min) |
+| **Permission denied** | Change paths to /tmp/ | Simple (~30s) |
+
+### Step 3: Launch Agents in Waves
+
+```
+Agent(
+  subagent_type="general-purpose",
+  isolation="worktree",
+  run_in_background=True,
+  prompt="""
+  Fix failing test: <path>
+  Error: <exact error message>
+  Root cause: <your analysis from Step 1>
+  Current API: <signatures from Step 1>
+
+  Workflow:
+  1. git checkout -b fix/<N>-<name> main
+  2. Read the test file
+  3. Read the source module
+  4. Fix the test (or source if it's a bug)
+  5. Commit, push, create PR with --label testing
+  6. gh pr merge --auto --rebase
+  """
+)
+```
+
+**Critical**: Include the current API signatures in each agent prompt. Agents without this context will waste time re-discovering what you already know.
+
+### Step 4: Monitor and Verify
+
+- Agents report PR URLs on completion
+- Check for duplicate PR numbers (agents may accidentally reuse branches)
+- Verify all agents completed: count completed notifications vs launched count
+- Check `gh pr list --state open --label testing` for the full list
+
+### Step 5: Post-Merge Verification
+
+```bash
+# After all PRs merge, verify CI passes
+gh run list --branch main --limit 1
+# Clean up worktrees
+git worktree prune
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Launch all 45 agents simultaneously | Tried launching all agents at once in a single message | Tool call limits and context pressure; some agents got minimal context | Launch in waves of 5-10 to give each agent adequate prompt detail |
+| Fix tests without reading source first | Early agents tried fixing tests based only on error messages | Agents guessed wrong APIs, produced incorrect fixes | Always explore source APIs first and include signatures in agent prompts |
+| Assume all failures are test-only | Categorized all failures as "fix the test" | 4 were real source bugs (missing else branch, ignored step field, wrong offset, stub method) | Read source carefully; runtime assertion failures often indicate real source bugs |
+| Single agent prompt template | Used identical prompt structure for all categories | Simple import fixes got over-detailed prompts; complex bugs got under-detailed | Tailor prompt complexity to failure category |
+| Letting agents investigate Docker setup independently | Each permission-error agent investigated Dockerfile/entrypoint independently | Duplicated investigation work across 7 agents | Fix shared infrastructure (Docker entrypoint) as Wave 0 prerequisite, then verify in later wave |
+
+## Results & Parameters
+
+### Session Results
+
+- **45 PRs created** in ~15 minutes wall clock
+- **30 compile error fixes** (import paths, type casts, missing args, docstrings)
+- **8 runtime/source bug fixes** (4 real source bugs discovered)
+- **7 permission/environment fixes** (Docker paths → /tmp)
+- **0 failures** — all agents completed successfully
+
+### Agent Configuration
+
+```yaml
+agent_type: general-purpose
+isolation: worktree          # Each agent gets isolated git worktree
+run_in_background: true      # Non-blocking, notified on completion
+wave_size: 5-10              # Concurrent agents per wave
+```
+
+### Source Bugs Discovered
+
+These were categorized as "test failures" but were actually source code bugs:
+
+1. **ExTensor._set_float64/_set_float32**: Missing `else` branch — integer dtype values silently discarded
+2. **ExTensor.__getitem__(*slices)**: Step field from Slice objects completely ignored
+3. **ExTensor.__getitem__(Int)**: Used raw memory offset instead of stride-aware for non-contiguous views
+4. **TrainingLoop.run_epoch**: Was a PythonObject stub, never iterated batches
+
+### Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Total agents launched | 45 |
+| Success rate | 100% |
+| Avg agent duration (simple) | 45-90 seconds |
+| Avg agent duration (complex) | 3-12 minutes |
+| Longest agent (conv gradient) | ~12 minutes |
+| PRs with source fixes | 4 |
+| PRs with test-only fixes | 41 |


### PR DESCRIPTION
## Summary

Documents orchestrating mass parallel test fixes (45 failing test files) using worktree-isolated agents, each producing its own PR with auto-merge enabled.

- Systematic approach: explore APIs first, categorize failures, launch in waves
- Discovered 4 real source bugs while fixing "test failures"
- 100% success rate across 45 parallel agents

## Key Findings

**What Worked**:
- Exploring source APIs upfront and including signatures in agent prompts — agents resolved fixes in 30-90s instead of 3-5min
- Launching in waves of 5-10 with `isolation: worktree` and `run_in_background: true`
- Categorizing failures (compile/runtime/permission) to tailor prompt complexity
- Wave 0 (Docker fix) as prerequisite for permission-error tests

**What Failed**:
- Identical prompts for all categories → simple fixes got over-detailed, complex ones under-detailed
- Assuming all failures were test-only → missed 4 real source bugs
- Agents without API context wasted time re-discovering module structure

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
