### PR TITLE
feat: add logging-context-deduplication skill

### DIFF
--- a/skills/debugging/logging-context-deduplication/.claude-plugin/plugin.json
+++ b/skills/debugging/logging-context-deduplication/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "logging-context-deduplication",
+  "version": "1.0.0",
+  "description": "Fix duplicated context prefixes in structured logging pipelines. Use when: (1) log lines show the same tier/subtest/run info twice, (2) logging filters inject context that message f-strings also include, (3) empty context renders as [//] or similar artifacts.",
+  "category": "debugging",
+  "date": "2026-03-18"
+}

--- a/skills/debugging/logging-context-deduplication/references/notes.md
+++ b/skills/debugging/logging-context-deduplication/references/notes.md
@@ -1,0 +1,48 @@
+# Session Notes: Logging Context Deduplication
+
+## Date: 2026-03-18
+
+## Context
+
+ProjectScylla's E2E experiment runner uses a hierarchical state machine (experiment -> tier -> subtest -> run) with parallel execution via ThreadPoolExecutor. Logging uses Python's standard `logging` module with a `ContextFilter` that injects thread-local tier/subtest/run context into every log record.
+
+## Problem 1: Duplicated prefixes
+
+The `ContextFilter` in `log_context.py` injects `tier_id`, `subtest_id`, and `run_num` into log records. The format string in `manage_experiment.py` renders these as `[T5/12/1]`. But the state machine code ALSO manually prefixed every log message with `[T5/12/run_01]` via f-strings. Result: both appeared on every line.
+
+### Files with manual prefixes removed
+
+- `state_machine.py`: 5 log messages (debug, info with timing, until-target, shutdown-interrupted, error)
+- `subtest_state_machine.py`: 5 log messages (debug, info with timing, until-target, until-halt, shutdown-interrupted)
+- `tier_state_machine.py`: 5 log messages (debug, info with timing, until-target, shutdown-interrupted, rate-limit)
+- `experiment_state_machine.py`: 3 log messages (debug, info with timing, until-target)
+
+## Problem 2: [//] artifact
+
+When log messages are emitted outside of any tier/subtest scope (e.g., experiment-level messages, startup), all three context fields are empty strings. The format `[%(tier_id)s/%(subtest_id)s/%(run_num)s]` renders as `[//]`.
+
+### Fix: composite log_context_tag
+
+Added a computed `log_context_tag` field to `ContextFilter.filter()`:
+- When any context is set: ` [T5/12/1]` (with leading space for formatting)
+- When no context is set: `""` (empty string, nothing rendered)
+
+The format string uses `%(log_context_tag)s` instead of the static `[%(tier_id)s/%(subtest_id)s/%(run_num)s]`.
+
+Smart part-omission: if `run_num` is None but `tier_id`/`subtest_id` are set, renders ` [T5/12]` (no trailing slash).
+
+## Problem 3: Thread ID readability
+
+`%(thread)d` renders as `[T:134028120278720]` — a raw memory address from `threading.get_ident()`. Changed to `%(threadName)s` which renders as `[MainThread]`, `[Thread-1]`, etc.
+
+## Problem 4: Signal handling (separate fix in same session)
+
+`os.setpgrp()` at `manage_experiment.py:898` created a new process group, detaching from the terminal's foreground group. Ctrl+C (SIGINT) and Ctrl+Z (SIGTSTP) go to the terminal's foreground group, which no longer included the Python process.
+
+Fix: Removed `os.setpgrp()` (children already use `start_new_session=True`), simplified `_kill_group` to `_force_exit` (calls `restore_terminal()` + `os._exit()`), moved SIGTSTP registration before batch-mode early return.
+
+## Test verification
+
+- 171 unit tests pass (58 state machine + 113 manage_experiment)
+- 6 log_context tests pass (updated assertions for `log_context_tag`)
+- Pre-commit hooks pass on all modified files

--- a/skills/debugging/logging-context-deduplication/skills/logging-context-deduplication/SKILL.md
+++ b/skills/debugging/logging-context-deduplication/skills/logging-context-deduplication/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: logging-context-deduplication
+description: "Fix duplicated context prefixes in structured logging pipelines. Use when: log lines show the same context twice, or empty context renders as [//]."
+category: debugging
+date: 2026-03-18
+user-invocable: false
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Log lines show duplicated context (e.g., `[T5/12/1]` from filter AND `[T5/12/run_01]` from f-string) |
+| **Root Cause** | Logging filter injects fields into records, but message f-strings also manually prefix the same info |
+| **Secondary Bug** | When no context is set, format string renders `[//]` instead of being omitted |
+| **Scope** | 4 state machine files, 1 logging filter, 1 format string |
+
+## When to Use
+
+- Log output contains the same tier/subtest/run identifier twice per line
+- A `logging.Filter` injects context fields that message strings also include manually
+- Log lines outside of a scoped context show empty delimiters like `[//]` or `[/]`
+- Thread ID fields show raw memory addresses (e.g., `[T:134028120278720]`) instead of human-readable names
+
+## Verified Workflow
+
+### Quick Reference
+
+| Layer | What to change | Pattern |
+|-------|---------------|---------|
+| Filter | Add composite `log_context_tag` field | Empty when no context, ` [T0/00/1]` when set |
+| Format string | Use `%(log_context_tag)s` | Replaces `[%(tier_id)s/...]` |
+| Log messages | Remove manual `[tier/sub/run]` prefixes | Keep only the message content |
+| Thread field | `%(threadName)s` not `%(thread)d` | Human-readable names |
+
+### Step 1: Identify the duplication sources
+
+Trace the logging pipeline to find where context is injected:
+
+1. **Filter-level injection**: A `ContextFilter` (or similar `logging.Filter`) that sets `record.tier_id`, `record.subtest_id`, `record.run_num` from thread-local storage
+2. **Format string**: `"%(tier_id)s/%(subtest_id)s/%(run_num)s"` in `logging.basicConfig()` format
+3. **Message-level prefixes**: f-strings in log calls like `logger.info(f"[{tier_id}/{subtest_id}/run_{run_num:02d}] ...")`
+
+### Step 2: Remove manual prefixes from log messages
+
+Strip the `[tier/subtest/run]` prefix from all f-string log messages in state machine code. The filter already handles this.
+
+**Before:**
+```python
+logger.info(
+    f"[{tier_id}/{subtest_id}/run_{run_num:02d}] "
+    f"{current.value} -> {transition.to_state.value}: {transition.description} ({elapsed:.1f}s)"
+)
+```
+
+**After:**
+```python
+logger.info(
+    f"{current.value} -> {transition.to_state.value}: {transition.description} ({elapsed:.1f}s)"
+)
+```
+
+### Step 3: Fix empty-context rendering with composite tag
+
+Replace the always-rendered format field with a composite tag that is empty when no context is set:
+
+**In the ContextFilter:**
+```python
+def filter(self, record):
+    tier_id = getattr(_context, "tier_id", "")
+    subtest_id = getattr(_context, "subtest_id", "")
+    run_num = getattr(_context, "run_num", None)
+
+    record.tier_id = tier_id
+    record.subtest_id = subtest_id
+    record.run_num = str(run_num) if run_num is not None else ""
+
+    if tier_id or subtest_id or run_num is not None:
+        parts = [tier_id, subtest_id]
+        if run_num is not None:
+            parts.append(str(run_num))
+        record.log_context_tag = " [" + "/".join(parts) + "]"
+    else:
+        record.log_context_tag = ""
+    return True
+```
+
+**In the format string:**
+```python
+# Before: " [%(tier_id)s/%(subtest_id)s/%(run_num)s]"  -> renders "[//]" when empty
+# After:  "%(log_context_tag)s"                          -> renders "" when empty
+format="%(asctime)s [%(levelname)s] [%(threadName)s]%(log_context_tag)s %(name)s: %(message)s"
+```
+
+### Step 4: Use threadName instead of thread ID
+
+Replace `%(thread)d` with `%(threadName)s` for human-readable thread identification:
+- `[T:134028120278720]` becomes `[MainThread]` or `[Thread-1]`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Keep manual prefixes, remove filter | Would require updating every log call site to include context | Hundreds of log sites across the codebase; filter approach is the right abstraction | Use filters for cross-cutting concerns, not per-message formatting |
+| Conditional format string with `%(tier_id)s` | Format string is static; can't conditionally include/exclude sections | Python's `logging.Formatter` doesn't support conditional sections | Build the conditional logic in the Filter, emit a single composite field |
+| Use `os.setpgrp()` for signal handling | Creates new process group, detaching from terminal's foreground group | Kernel sends Ctrl+C/Ctrl+Z to terminal's foreground group, which is now empty | Child processes already use `start_new_session=True`; parent doesn't need its own group |
+
+## Results & Parameters
+
+### Log output comparison
+
+**Before:**
+```
+2026-03-18 20:10:16 [INFO] [T:136414484813504] [//] scylla.e2e.runner: Experiment completed
+2026-03-18 20:10:16 [INFO] [T:136414484813504] [T5/12/1] scylla.e2e.state_machine: [T5/12/run_01] dir_structure_created -> worktree_created: Create git worktree (2.8s)
+```
+
+**After:**
+```
+2026-03-18 20:10:16 [INFO] [MainThread] scylla.e2e.runner: Experiment completed
+2026-03-18 20:10:16 [INFO] [Thread-1] [T5/12/1] scylla.e2e.state_machine: dir_structure_created -> worktree_created: Create git worktree (2.8s)
+```
+
+### Files modified
+
+| File | Change |
+|------|--------|
+| `scylla/e2e/log_context.py` | Added composite `log_context_tag` field to ContextFilter |
+| `scripts/manage_experiment.py` | Updated format string to use `%(log_context_tag)s` and `%(threadName)s` |
+| `scylla/e2e/state_machine.py` | Removed `[tier/sub/run]` prefixes from 5 log messages |
+| `scylla/e2e/subtest_state_machine.py` | Removed `[tier/sub]` prefixes from 5 log messages |
+| `scylla/e2e/tier_state_machine.py` | Removed `[tier]` prefixes from 5 log messages |
+| `scylla/e2e/experiment_state_machine.py` | Removed `[experiment]` prefixes from 3 log messages |


### PR DESCRIPTION
## Summary

Documents how to fix duplicated context prefixes in structured logging pipelines using Python's `logging.Filter` pattern.

- Remove manual f-string prefixes when a `ContextFilter` already injects the same fields
- Use a composite `log_context_tag` field to conditionally render context (empty when no scope is active)
- Replace `%(thread)d` with `%(threadName)s` for human-readable thread identification

## Key Findings

**What Worked**:
- Composite tag field in the Filter for conditional rendering (empty vs populated)
- Stripping manual prefixes from 18 log messages across 4 state machine files

**What Failed**:
- Conditional format strings → Python's `logging.Formatter` doesn't support conditionals
- Removing the filter in favor of manual prefixes → too many call sites to maintain

## Test Plan

- [ ] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
