### PR TITLE
feat: add podman-nextjs-ci-container skill

### DIFF
--- a/skills/ci-cd/podman-nextjs-ci-container/.claude-plugin/plugin.json
+++ b/skills/ci-cd/podman-nextjs-ci-container/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "podman-nextjs-ci-container",
+  "version": "1.0.0",
+  "description": "Build Podman/Docker dev containers for Next.js projects with full CI simulation. Use when: (1) creating a Containerfile for a Node.js/Next.js project, (2) running test/lint/typecheck/build inside a container, (3) debugging container build failures with native modules.",
+  "category": "ci-cd",
+  "date": "2026-03-19"
+}

--- a/skills/ci-cd/podman-nextjs-ci-container/references/notes.md
+++ b/skills/ci-cd/podman-nextjs-ci-container/references/notes.md
@@ -1,0 +1,71 @@
+# Session Notes: Podman Dev Container for AI Maestro
+
+## Date: 2026-03-19
+
+## Context
+
+User wanted to: (1) run all testing, linting, build, and typecheck for AI Maestro and fix any issues found, then (2) create a Podman dev container so the entire repo can be built and tested inside a container.
+
+## Phase 1: Host CI Simulation
+
+All 4 checks passed on host without code fixes needed:
+- `yarn test` — 486 tests pass
+- `yarn lint` — warnings only (no errors)
+- `npx tsc --noEmit` — clean
+- `yarn build` — passes (stale `.next` cache was only issue, fixed by `rm -rf .next`)
+
+## Phase 2: Container Creation
+
+### Iteration 1: node:20.18.3
+- Failed: vite 7.3.1 requires >=20.19.0
+- Error: engine incompatibility during build
+
+### Iteration 2: node:20.19.2 + npm install -g yarn
+- Failed: yarn already installed in node:20 image
+- Fix: removed the yarn install step
+
+### Iteration 3: groupadd -g 1000 for node user
+- Failed: GID 1000 already taken by existing `node` user
+- Fix: use existing `node` user directly
+
+### Iteration 4: Short image name `node:20.19.2-bookworm-slim`
+- Failed: Podman can't resolve short names
+- Fix: use `docker.io/library/node:20.19.2-bookworm-slim`
+
+### Iteration 5: Sequential CI without .next cleanup
+- Failed: build step hangs due to stale .next cache
+- Fix: `(rm -rf .next || true)` before build
+
+### Iteration 6: Default heap size
+- Failed: OOM during Next.js production build
+- Fix: `NODE_OPTIONS="--max-old-space-size=4096"`
+
+### Final: Working Containerfile
+- All tests pass (486)
+- Lint clean (warnings only)
+- tsc clean
+- Build succeeds (53 pages)
+
+## Phase 3: GitHub Issue + Patch
+
+- Created issue #296 on 23blocks-OS/ai-maestro
+- Could not push (no write access to upstream)
+- Created gist with `git format-patch` and attached to issue via comment
+- Updated gist after yarn.lock fix
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `Containerfile` | Created |
+| `.containerignore` | Created |
+| `package.json` | Modified (6 container:* scripts) |
+| `yarn.lock` | Updated (lockfile sync after version bump) |
+
+## Skills Registry Patterns Applied
+
+- dockerfile-layer-caching: COPY package.json+yarn.lock before source
+- dockerfile-dep-pin: pinned node:20.19.2-bookworm-slim
+- fix-docker-platform: --platform linux/amd64
+- fix-docker-shell-tty: -it flags on container:shell
+- build-run-local: matches container:ci approach

--- a/skills/ci-cd/podman-nextjs-ci-container/skills/podman-nextjs-ci-container/SKILL.md
+++ b/skills/ci-cd/podman-nextjs-ci-container/skills/podman-nextjs-ci-container/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: podman-nextjs-ci-container
+description: "Build Podman/Docker dev containers for Next.js projects with full CI simulation. Use when: creating Containerfiles for Node.js/Next.js, running CI in containers, debugging native module builds."
+category: ci-cd
+date: 2026-03-19
+user-invocable: false
+---
+
+# Podman Next.js CI Container
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Objective** | Create a Podman dev container that runs the full CI pipeline (test, lint, typecheck, build) for a Next.js project with native Node modules |
+| **Stack** | Next.js 14, Vitest, ESLint, TypeScript, node-pty, Podman |
+| **Base Image** | `docker.io/library/node:20.19.2-bookworm-slim` |
+| **Result** | 486 tests pass, lint clean, tsc clean, build succeeds — all inside container |
+
+## When to Use
+
+- Creating a `Containerfile` or `Dockerfile` for a Next.js project
+- Setting up containerized CI that includes test, lint, typecheck, and build steps
+- Debugging Podman/Docker build failures involving native Node.js modules (node-pty, cozo-node)
+- Needing reproducible builds across different developer machines
+- Running sequential CI steps (test → lint → tsc → build) in a single container
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Build
+podman build -t ai-maestro-dev -f Containerfile .
+
+# Run individual checks
+podman run --rm ai-maestro-dev yarn test
+podman run --rm ai-maestro-dev yarn lint
+podman run --rm ai-maestro-dev yarn build
+
+# Full CI chain
+podman run --rm ai-maestro-dev sh -c 'yarn test && yarn lint && npx tsc --noEmit && (rm -rf .next || true) && yarn build'
+
+# Interactive shell
+podman run --rm -it ai-maestro-dev bash
+```
+
+### Step 1: Choose the Right Base Image
+
+Use a specific pinned version of Node that satisfies all dependency requirements:
+
+```dockerfile
+FROM docker.io/library/node:20.19.2-bookworm-slim
+```
+
+**Critical:** Always use the fully-qualified `docker.io/library/` prefix — Podman fails with short names.
+
+### Step 2: Install System Dependencies for Native Modules
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+`build-essential` + `python3` are required for native module compilation (node-gyp).
+
+### Step 3: Layer-Cache Dependencies
+
+```dockerfile
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile && yarn cache clean
+COPY . .
+```
+
+Copy manifests before source so dependency installation is cached unless package.json/yarn.lock change.
+
+**Critical:** If you modify package.json (e.g., adding scripts), you MUST run `yarn install` on the host first to update yarn.lock. Otherwise `--frozen-lockfile` will fail.
+
+### Step 4: Non-Root User and Memory Settings
+
+```dockerfile
+RUN chown -R node:node /app
+USER node
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+```
+
+- The `node` user already exists in the base image (UID/GID 1000) — don't try to create it
+- 4GB heap is required for Next.js production builds in containers
+
+### Step 5: Container Ignore File
+
+Create `.containerignore`:
+```
+node_modules
+.next
+.git
+*.md
+!package.json
+marketing/
+docs/images/
+.env*
+.DS_Store
+```
+
+### Step 6: Package.json Scripts
+
+```json
+{
+  "container:build": "podman build -t ai-maestro-dev -f Containerfile .",
+  "container:test": "podman run --rm ai-maestro-dev yarn test",
+  "container:lint": "podman run --rm ai-maestro-dev yarn lint",
+  "container:build-app": "podman run --rm ai-maestro-dev yarn build",
+  "container:shell": "podman run --rm -it ai-maestro-dev bash",
+  "container:ci": "podman run --rm ai-maestro-dev sh -c 'yarn test && yarn lint && npx tsc --noEmit && (rm -rf .next || true) && yarn build'"
+}
+```
+
+### Step 7: Stale .next Cache Fix
+
+When running build after other steps sequentially, the `.next` directory from a previous build can cause hangs. Always clean it:
+
+```bash
+(rm -rf .next || true) && yarn build
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| node:20.18.3 base image | Used older Node LTS | vite 7.3.1 requires >=20.19.0, build failed with engine incompatibility | Always check vite/next engine requirements before picking Node version |
+| `npm install -g yarn` in Dockerfile | Tried installing yarn globally | yarn is pre-installed in official node images, command fails | Check what's already in the base image before adding install steps |
+| `groupadd -g 1000 node` | Tried creating node user with GID 1000 | GID 1000 already taken by existing `node` user in base image | Use the existing `node` user — it's already set up correctly |
+| Short image names (`node:20.19.2`) | Used Docker-style short names | Podman requires fully-qualified names, fails to resolve | Always prefix with `docker.io/library/` for Podman compatibility |
+| Sequential test+lint+tsc+build without .next cleanup | Ran all CI steps in sequence | Build step hangs due to stale `.next` cache from previous runs | Add `rm -rf .next` before the build step in CI chains |
+| Default Node heap size | Ran Next.js build without memory override | OOM crash during production build in constrained container | Set `NODE_OPTIONS="--max-old-space-size=4096"` for Next.js builds |
+
+## Results & Parameters
+
+### Containerfile (Complete)
+
+```dockerfile
+# AI Maestro Dev Container
+FROM docker.io/library/node:20.19.2-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile && yarn cache clean
+COPY . .
+
+RUN chown -R node:node /app
+USER node
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+CMD ["yarn", "test"]
+```
+
+### Verified CI Results (in container)
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Tests | `yarn test` | 486 tests pass, 13 test files |
+| Lint | `yarn lint` | Warnings only, no errors |
+| Typecheck | `npx tsc --noEmit` | Clean |
+| Build | `yarn build` | 53 pages generated |
+| Full CI | `container:ci` script | All 4 steps pass sequentially |
+
+### Key Configuration
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| Node version | 20.19.2 | Minimum for vite 7.3.1 |
+| Base image | bookworm-slim | Minimal Debian with native build support |
+| Heap size | 4096 MB | Required for Next.js production builds |
+| User | `node` (existing) | Non-root, pre-configured in base image |
+| yarn flag | `--frozen-lockfile` | Reproducible installs, fails if lockfile stale |


### PR DESCRIPTION
## Summary

Documents how to create Podman dev containers for Next.js projects with full CI simulation (test, lint, typecheck, build).

- Containerfile recipe for Node.js + native modules (node-pty, cozo-node)
- Layer caching, non-root execution, memory tuning for Next.js builds
- 6 package.json scripts for container-based CI workflow

## Key Findings

**What Worked**:
- `docker.io/library/node:20.19.2-bookworm-slim` with build-essential + python3
- COPY package.json+yarn.lock before source for layer caching
- Existing `node` user (UID/GID 1000) — no need to create one
- `NODE_OPTIONS="--max-old-space-size=4096"` for Next.js production builds
- `rm -rf .next` before build step in sequential CI chains

**What Failed**:
- node:20.18.3 → vite 7.3.1 requires >=20.19.0
- `npm install -g yarn` → already pre-installed in node images
- `groupadd -g 1000` → GID 1000 already taken by existing `node` user
- Short image names → Podman requires `docker.io/library/` prefix
- Sequential CI without .next cleanup → build hangs on stale cache
- Default heap size → OOM during Next.js production build

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
