### PR TITLE
feat: add docker-to-podman-migration skill

### DIFF
--- a/skills/ci-cd/docker-to-podman-migration/.claude-plugin/plugin.json
+++ b/skills/ci-cd/docker-to-podman-migration/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "docker-to-podman-migration",
+  "version": "1.0.0",
+  "description": "Migrate CI/CD infrastructure from Docker to Podman for container builds, test execution, and GHCR publishing. Use when: (1) replacing Docker with Podman in GitHub Actions workflows, (2) eliminating NATIVE=1 workarounds by running tests inside containers, (3) rewriting GHCR publish workflows from docker/* actions to raw podman commands.",
+  "category": "ci-cd",
+  "date": "2026-03-19"
+}

--- a/skills/ci-cd/docker-to-podman-migration/references/notes.md
+++ b/skills/ci-cd/docker-to-podman-migration/references/notes.md
@@ -1,0 +1,88 @@
+# Docker to Podman Migration - Session Notes
+
+## Context
+
+ProjectOdyssey had `NATIVE=1` added to CI workflows as a workaround to bypass Docker container
+execution. The user wanted this removed entirely — ALL Mojo commands must run inside Podman
+containers in CI.
+
+## Migration Scope
+
+### Phase 1: Core infrastructure (14 files)
+
+- justfile: Full rewrite from Docker to Podman
+  - `docker_service` → `podman_service`
+  - `_run` helper: Docker detection → Podman detection
+  - All `docker-*` recipes → `podman-*`
+  - Removed old standalone Podman section (was separate from Docker section)
+  - GHCR recipes: `docker build` → `podman build --format docker`
+  - CI recipes: removed `docker buildx`, simplified
+
+- docker-compose.yml:
+  - `:delegated` → `:Z` (SELinux label for rootless Podman)
+  - `${HOME}/.gitconfig` → `${HOME:-.}/.gitconfig` (CI safety)
+
+- New setup-container composite action:
+  - `touch "$HOME/.gitconfig"` (prevents bind-mount failure)
+  - Export `USER_ID`/`GROUP_ID` to `GITHUB_ENV`
+  - `actions/cache` on `~/.local/share/containers`
+  - `podman compose build` + `up -d`
+  - 30-second retry loop for container readiness
+
+- 3 main test workflows:
+  - comprehensive-tests.yml (8 jobs)
+  - build-validation.yml
+  - training-tests-weekly.yml
+
+- GHCR publish: docker.yml → container-publish.yml
+  - Removed: docker/setup-qemu-action, docker/setup-buildx-action, docker/login-action,
+    docker/metadata-action, docker/build-push-action
+  - Added: shell-based tag generation, `podman build/push`, `actions/cache`
+
+- release.yml: `publish-docker` → `publish-container`
+
+### Phase 2: Remaining workflows (7 files)
+
+Discovered during audit that 9 additional jobs ran Mojo commands:
+- release.yml: `build` + `test` jobs
+- benchmark.yml: `benchmark-execution` + `simd-benchmarks`
+- model-e2e-tests-weekly.yml
+- paper-validation.yml: `validate-implementation` + `validate-reproducibility`
+- simd-benchmarks-weekly.yml
+- validate-configs.yml: `validate-paper-reproducibility`
+- mojo-version-check.yml
+
+Pattern: `pixi run mojo ...` → `podman compose exec -T <service> bash -c 'pixi run mojo ...'`
+
+### Mojo compilation fixes (on main)
+
+- test_shape_part3.mojo: Duplicate 5-arg `assert_value_at` calls (signature is 4-arg: tensor, flat_index, expected, message)
+- SimpleMLP2 in models.mojo: Missing `train()`, `set_inference_mode()`, `parameters()` returned empty list instead of 4 tensors
+
+## Key Reference URLs
+
+- https://oneuptime.com/blog/post/2026-03-18-use-github-container-registry-podman/view
+- https://oneuptime.com/blog/post/2026-01-27-podman-cicd/view
+- https://github.com/ibm-cloud-architecture/refarch-cloudnative-devops-kubernetes/blob/master/docs/podman.md
+
+## Critical Learnings
+
+1. **`--format docker` is mandatory** for GHCR pushes. Without it, Podman uses OCI format
+   which some tools don't handle correctly.
+
+2. **`actions/cache` on `~/.local/share/containers`** replaces Docker's `type=gha` cache.
+   Key by Dockerfile hash + dependency lockfiles.
+
+3. **Host file operations stay on host** — the workspace bind mount means `mkdir -p` on host
+   creates dirs visible in container and vice versa.
+
+4. **Always audit ALL workflows** — `grep -r 'pixi run mojo' .github/workflows/` before
+   declaring migration complete. Easy to miss infrequently-run workflows (weekly, manual-only).
+
+5. **Non-Mojo jobs can keep setup-pixi** — pre-commit, docs, security scanning, smoke tests
+   that only use Python/shell don't need the container overhead.
+
+6. **`podman compose` reads `docker-compose.yml` natively** — no need to rename the file.
+
+7. **`:Z` volume label** — required for rootless Podman SELinux relabeling, harmless no-op
+   on systems without SELinux.

--- a/skills/ci-cd/docker-to-podman-migration/skills/docker-to-podman-migration/SKILL.md
+++ b/skills/ci-cd/docker-to-podman-migration/skills/docker-to-podman-migration/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: docker-to-podman-migration
+description: "Migrate CI/CD from Docker to Podman for container builds, test execution, and GHCR publishing. Use when: replacing Docker with Podman in GitHub Actions, eliminating NATIVE=1 workarounds, rewriting GHCR publish workflows."
+category: ci-cd
+date: 2026-03-19
+user-invocable: false
+---
+
+# Docker to Podman CI/CD Migration
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-19 |
+| **Objective** | Replace Docker with Podman as the sole container engine for local dev, CI test execution, and GHCR publishing |
+| **Outcome** | Successfully migrated 17 CI jobs across 10 workflow files, eliminated all NATIVE=1 workarounds |
+| **Scope** | GitHub Actions workflows, justfile recipes, docker-compose.yml, GHCR publishing, documentation |
+
+## When to Use
+
+Invoke this skill when:
+
+1. **Migrating from Docker to Podman** in a project's CI/CD infrastructure
+2. **Eliminating `NATIVE=1` workarounds** that bypass container-based test execution
+3. **Rewriting GHCR publish workflows** from `docker/*` GitHub Actions to raw `podman` commands
+4. **Creating a `setup-container` composite action** for Podman compose in CI
+5. **Ubuntu-latest runners** already have Podman pre-installed and you want to leverage it
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# Composite action: .github/actions/setup-container/action.yml
+# 1. touch $HOME/.gitconfig (prevents bind-mount failure on CI)
+# 2. Export USER_ID/GROUP_ID to GITHUB_ENV
+# 3. actions/cache on ~/.local/share/containers
+# 4. podman compose build <service>
+# 5. podman compose up -d <service>
+# 6. Wait + verify with podman compose exec -T <service> pixi run mojo --version
+```
+
+### Step 1: Create setup-container composite action
+
+```yaml
+name: Set Up Podman Container
+runs:
+  using: composite
+  steps:
+    - name: Ensure .gitconfig exists
+      shell: bash
+      run: touch "$HOME/.gitconfig"
+
+    - name: Export runner UID/GID
+      shell: bash
+      run: |
+        echo "USER_ID=$(id -u)" >> "$GITHUB_ENV"
+        echo "GROUP_ID=$(id -g)" >> "$GITHUB_ENV"
+
+    - name: Cache Podman storage
+      uses: actions/cache@v5
+      with:
+        path: ~/.local/share/containers
+        key: podman-${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+        restore-keys: podman-
+
+    - name: Build and start container
+      shell: bash
+      run: |
+        podman compose build projectodyssey-dev
+        podman compose up -d projectodyssey-dev
+```
+
+### Step 2: Migrate workflow jobs
+
+For each job that runs Mojo commands:
+
+1. Replace `uses: ./.github/actions/setup-pixi` with `uses: ./.github/actions/setup-container`
+2. Remove `NATIVE=1` prefix from all `just` calls
+3. Wrap direct `pixi run mojo ...` calls:
+
+```yaml
+# Before (native execution)
+- run: pixi run mojo test -I . tests/
+
+# After (container execution via justfile _run helper)
+- run: just test-group "tests/shared/core" "test_*.mojo"
+
+# After (direct container execution for non-justfile commands)
+- run: |
+    podman compose exec -T projectodyssey-dev bash -c \
+      'pixi run mojo test -I . tests/'
+```
+
+### Step 3: Rewrite GHCR publish workflows
+
+Replace Docker-specific GitHub Actions with raw Podman commands:
+
+```yaml
+# Login
+- run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+# Build (--format docker is critical for GHCR compatibility)
+- run: |
+    podman build --format docker -f Dockerfile.ci --target production \
+      -t ghcr.io/$IMAGE_NAME:$VERSION .
+
+# Push
+- run: podman push ghcr.io/$IMAGE_NAME:$VERSION
+
+# Cache (replaces type=gha Docker cache)
+- uses: actions/cache@v5
+  with:
+    path: ~/.local/share/containers
+    key: podman-ci-${{ hashFiles('Dockerfile.ci') }}
+```
+
+### Step 4: Update docker-compose.yml for Podman
+
+```yaml
+volumes:
+  - .:/workspace:Z          # :Z for SELinux (was :delegated for Docker)
+  - ${HOME:-.}/.gitconfig:/home/dev/.gitconfig:ro  # ${HOME:-.} fallback for CI
+```
+
+### Step 5: Update justfile _run helper
+
+```just
+_run cmd:
+    #!/usr/bin/env bash
+    set -e
+    if [[ "${NATIVE:-}" == "1" ]]; then
+        eval "{{cmd}}"
+    elif command -v podman &>/dev/null && \
+        podman compose ps -q {{podman_service}} 2>/dev/null \
+        | xargs -r podman inspect -f '{{.State.Running}}' 2>/dev/null \
+        | grep -q true; then
+        podman compose exec -T {{podman_service}} bash -c "{{cmd}}"
+    else
+        echo "Error: Podman compose container not running."
+        exit 1
+    fi
+```
+
+### Step 6: Audit ALL workflows for completeness
+
+```bash
+# Find ALL jobs that still use setup-pixi
+grep -rn 'setup-pixi' .github/workflows/*.yml
+
+# Verify ZERO NATIVE=1 in any workflow
+grep -r 'NATIVE=1' .github/workflows/*.yml
+
+# For each setup-pixi job, classify: does it run Mojo?
+# If yes → migrate to setup-container
+# If no (Python-only, shell-only) → keep setup-pixi
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Migrating only the 3 main test workflows | Assumed comprehensive-tests, build-validation, training-weekly were the only Mojo-executing workflows | 9 additional jobs across 6 other workflows also ran `pixi run mojo` (release, benchmark, paper-validation, etc.) | Always audit ALL workflows with `grep -r 'pixi run mojo'` before declaring migration complete |
+| Using `docker/login-action` with Podman | Docker-specific GitHub Actions don't work with Podman | These actions assume Docker daemon is running | Use raw `podman login` via shell `run:` steps instead |
+| Using `type=gha` Docker cache with Podman | Docker buildx cache strategies are Docker-specific | Podman doesn't support buildx or GHA cache type | Use `actions/cache` on `~/.local/share/containers` keyed by Dockerfile hash |
+| Keeping `:delegated` volume mount | Docker-only volume consistency option | Podman ignores `:delegated` and may warn | Use `:Z` for SELinux label (no-op without SELinux) |
+| Single grep for unwrapped `pixi run mojo` | Grepped individual lines for `pixi run mojo` not inside `podman compose exec` | False positives: heredoc templates and multi-line `podman compose exec` blocks where the `pixi run` is on a separate line | Verify in context — check surrounding lines, not just the matching line |
+
+## Results & Parameters
+
+### Key Podman CI Parameters
+
+```yaml
+# Podman build for GHCR (MUST use --format docker)
+podman build --format docker -f Dockerfile.ci --target <target> -t <tag> .
+
+# Podman login
+echo "$TOKEN" | podman login ghcr.io --username "$ACTOR" --password-stdin
+
+# Cache path for Podman storage
+~/.local/share/containers
+
+# Cache key pattern
+podman-${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+
+# Container exec pattern (non-interactive for CI)
+podman compose exec -T <service> bash -c '<command>'
+
+# Volume mount for rootless Podman
+.:/workspace:Z
+
+# docker-compose.yml filename: keep as-is (podman compose reads it natively)
+```
+
+### Files Typically Modified
+
+| File | Change |
+|------|--------|
+| `.github/actions/setup-container/action.yml` | **NEW** — Podman compose setup for CI |
+| `.github/workflows/*.yml` | `setup-pixi` → `setup-container` for Mojo jobs |
+| `justfile` | `docker-*` → `podman-*` recipes, `_run` helper |
+| `docker-compose.yml` | `:delegated` → `:Z`, gitconfig mount fix |
+| `scripts/run_mojo.sh` | Remove Docker fallback |
+| `CLAUDE.md` / docs | Docker → Podman references |
+
+### ubuntu-latest Podman Availability
+
+- Ubuntu 24.04 (ubuntu-latest as of 2026): Podman 4.x pre-installed
+- No need to install Podman in CI
+- `podman compose` available (uses podman-compose or docker-compose backend)
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4991 | Full Docker→Podman migration, 17 CI jobs, GHCR publishing |


### PR DESCRIPTION
## Summary

Documents the complete Docker-to-Podman migration pattern for CI/CD infrastructure in GitHub Actions workflows, including GHCR publishing, container-based test execution, and justfile recipe migration.

- Covers setup-container composite action creation
- GHCR publishing with raw podman commands (replacing docker/* actions)
- Workflow migration pattern (setup-pixi → setup-container)
- Volume mount and caching strategies for Podman CI

## Key Findings

**What Worked**:
- `podman build --format docker` for GHCR compatibility
- `actions/cache` on `~/.local/share/containers` for Podman storage caching
- setup-container composite action with health check retry loop
- `:Z` SELinux volume label (no-op without SELinux)
- Keeping `docker-compose.yml` filename (podman compose reads it natively)

**What Failed**:
- Docker-specific GitHub Actions (buildx, login-action, build-push-action) → don't work with Podman
- `:delegated` volume mount → Docker-only, use `:Z` instead
- `type=gha` cache → Docker buildx-specific, use `actions/cache` on containers dir
- Only migrating main test workflows → missed 9 additional Mojo-executing jobs

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears in /advise searches
- [ ] Check skill activation with "docker to podman" or "container migration" queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
