### PR TITLE
feat: add fix-podman-rootless-ci skill

### DIFF
--- a/skills/ci-cd/fix-podman-rootless-ci/.claude-plugin/plugin.json
+++ b/skills/ci-cd/fix-podman-rootless-ci/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fix-podman-rootless-ci",
+  "version": "1.0.0",
+  "description": "Fix rootless Podman CI failures including Dockerfile ARG scoping across multi-stage builds, workspace UID mapping permissions, and compose provider compatibility. Use when: (1) Podman compose builds fail with 'can't find uid for user' in multi-stage Dockerfiles, (2) bind-mounted workspace files have Permission denied inside containers on CI, (3) docker-compose CLI plugin doesn't support Podman-specific features like userns_mode.",
+  "category": "ci-cd",
+  "date": "2026-03-20"
+}

--- a/skills/ci-cd/fix-podman-rootless-ci/references/notes.md
+++ b/skills/ci-cd/fix-podman-rootless-ci/references/notes.md
@@ -1,0 +1,58 @@
+# Session Notes: Fix All Failing CI Workflows on Main
+
+## Date: 2026-03-20
+
+## Context
+
+All 3 CI workflows on ProjectOdyssey's `main` branch were failing since commit `59fa92b`.
+The project uses rootless Podman with docker-compose CLI plugin on GitHub Actions ubuntu-latest runners.
+
+## Failures Encountered
+
+### 1. Pre-commit Checks — pixi lockfile channel mismatch
+- `pixi.lock` was generated against `https://conda.modular.com/max-nightly/`
+- `pixi.toml` specifies `https://conda.modular.com/max`
+- `pixi install --locked` requires exact channel match
+- **Fix**: `pixi install` to regenerate lockfile
+
+### 2. Comprehensive Tests — Container build failure
+- **Layer 1**: Podman socket not started on GH Actions → `systemctl --user start podman.socket`
+- **Layer 2**: `USER_NAME` ARG empty in development/production Dockerfile stages
+  - Error: `can't find uid for user :`
+  - Root cause: ARGs don't persist across FROM boundaries in Docker/Podman
+  - Fix: Re-declare `ARG USER_NAME=dev` in each stage
+- **Layer 3**: `Permission denied` writing to bind-mounted workspace
+  - Root cause: Rootless Podman UID namespace mapping
+  - Container UID 1001 maps to host subuid ~101001, not host UID 1001
+  - Host files (owned by host UID 1001) appear as root-owned inside container
+  - Fix: `chmod -R a+rwX .` on host before container use
+- **Layer 4**: `_ensure_build_dir` created dirs on host that container couldn't write to
+  - Fix: Removed host-side mkdir; `_build-inner` already does `mkdir -p` inside container
+- **Layer 5**: `_build-inner` always used "debug" mode regardless of argument
+  - Root cause: `MODE="${1:-debug}"` uses bash `$1` which is empty in justfile
+  - Fix: `MODE="{{mode}}"` uses just template substitution
+
+### 3. Container Build and Publish — SBOM auth failure
+- `anchore/sbom-action` tried to pull image from GHCR to scan it
+- Syft couldn't authenticate (doesn't inherit Podman login credentials)
+- **Fix**: Export image to tarball with `podman save`, scan the tarball
+
+## Key Debugging Observations
+
+- `podman compose` on GH Actions ubuntu-latest delegates to `/usr/libexec/docker/cli-plugins/docker-compose`
+- This means Podman-specific compose extensions (userns_mode, etc.) are NOT supported
+- The docker-compose plugin connects to Podman via the Docker API socket
+- Multiple failures were layered — fixing one revealed the next
+- Pre-existing Mojo test failures were hidden by the container build failure
+
+## Timeline
+
+1. Commit 1: pixi.lock + Podman socket + SBOM tarball → Pre-commit & Container Publish fixed
+2. Commit 2: Dockerfile ARG re-declaration → Container build fixed
+3. Commit 3: chmod workspace + remove host mkdir + fix justfile mode → Build Validation & Package Compilation fixed
+
+## Approaches That Failed
+
+1. `userns_mode: keep-id` in docker-compose.yml — docker-compose CLI plugin ignores it
+2. `PODMAN_USERNS=keep-id` env var — unreliable through docker-compose API
+3. `chown` inside container — overcomplicated for CI use case

--- a/skills/ci-cd/fix-podman-rootless-ci/skills/fix-podman-rootless-ci/SKILL.md
+++ b/skills/ci-cd/fix-podman-rootless-ci/skills/fix-podman-rootless-ci/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: fix-podman-rootless-ci
+description: "Fix rootless Podman CI failures: Dockerfile ARG scoping, workspace UID mapping, compose provider compatibility. Use when: container builds fail with empty ARG values across FROM boundaries, bind-mounted files have Permission denied, or docker-compose doesn't support Podman extensions."
+category: ci-cd
+date: 2026-03-20
+user-invocable: false
+---
+
+# Fix Podman Rootless CI
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Rootless Podman on GitHub Actions introduces multiple failure modes not seen with Docker or rootful Podman |
+| **Scope** | Multi-stage Dockerfiles, docker-compose.yml, CI composite actions, justfile build recipes |
+| **Environment** | GitHub Actions `ubuntu-latest` runners with rootless Podman + docker-compose CLI plugin |
+| **Impact** | All container-dependent CI jobs fail (builds, tests, SBOM generation) |
+
+## When to Use
+
+- Container builds fail with `can't find uid for user :` or empty `${VAR}` in COPY --chown
+- `Permission denied` when creating files/dirs inside bind-mounted workspace in CI containers
+- `podman compose` delegates to docker-compose CLI plugin and Podman-specific compose options are ignored
+- SBOM tools (Syft/anchore) fail to authenticate to GHCR to scan pushed images
+- Justfile recipes create directories on the host that are then non-writable inside the container
+
+## Verified Workflow
+
+### Quick Reference
+
+| Issue | Root Cause | Fix |
+|-------|-----------|-----|
+| `can't find uid for user :` | Docker ARGs don't persist across FROM | Re-declare `ARG` in each stage |
+| `Permission denied` on workspace files | Rootless Podman UID namespace mapping | `chmod -R a+rwX .` on host before container use |
+| docker-compose ignores `userns_mode` | docker-compose CLI plugin, not Podman compose | Don't use Podman-specific compose extensions |
+| SBOM scan auth failure | Syft can't authenticate to GHCR | Export image to tarball, scan locally |
+| Build mode always "debug" | Justfile `$1` vs `{{mode}}` parameter | Use `{{mode}}` template substitution |
+| Host-created dirs non-writable in container | `_ensure_build_dir` runs on host, not in container | Remove host-side mkdir; inner recipes already do it |
+
+### Step 1: Dockerfile ARG Scoping
+
+Docker/Podman `ARG` declarations are scoped to a single build stage. They do NOT persist across `FROM` boundaries.
+
+**Symptom**: `COPY --chown=${USER_NAME}:${USER_NAME}` fails with `can't find uid for user :`
+
+**Fix**: Re-declare the ARG in every stage that uses it:
+
+```dockerfile
+# Stage 1
+FROM ubuntu:24.04 AS base
+ARG USER_NAME=dev
+# ... uses USER_NAME ...
+
+# Stage 2 - MUST re-declare
+FROM base AS development
+ARG USER_NAME=dev          # <-- Required! Without this, USER_NAME is empty
+USER ${USER_NAME}
+COPY --chown=${USER_NAME}:${USER_NAME} . .
+
+# Stage 3 inheriting from development - ARG inherited
+FROM development AS ci
+# USER_NAME is available (inherited from development)
+
+# Stage 4 - from base, MUST re-declare
+FROM base AS production
+ARG USER_NAME=dev          # <-- Required again
+COPY --from=development /home/${USER_NAME}/.pixi /home/${USER_NAME}/.pixi
+```
+
+### Step 2: Rootless Podman Workspace Permissions
+
+In rootless Podman, the user namespace maps UIDs:
+- Container UID 0 (root) -> Host user (e.g., UID 1001)
+- Container UID 1001 -> Host subuid range (e.g., 101001)
+
+Bind-mounted host files (owned by host UID 1001) appear as owned by container root (UID 0). The container application user (UID 1001) cannot write to them.
+
+**Fix**: Make the workspace world-writable on the host before the container uses it:
+
+```yaml
+# In CI composite action, after starting container:
+- name: Fix workspace permissions
+  shell: bash
+  run: |
+    chmod -R a+rwX . || true
+```
+
+This is safe because CI runners are ephemeral single-use VMs.
+
+**Do NOT try**:
+- `userns_mode: keep-id` in docker-compose.yml (docker-compose CLI plugin ignores it)
+- `PODMAN_USERNS=keep-id` env var (unreliable through docker-compose API)
+- `chown` inside the container (overcomplicated and may not work with UID mapping)
+
+### Step 3: SBOM Generation Without Registry Auth
+
+SBOM tools like Syft/anchore need to read the container image. If the image was pushed to GHCR, Syft may not inherit Podman login credentials.
+
+**Fix**: Export the image to a tarball and scan locally:
+
+```yaml
+- name: Export image for SBOM
+  run: |
+    podman save -o /tmp/image.tar "$REGISTRY/$IMAGE:$TAG"
+
+- name: Generate SBOM
+  uses: anchore/sbom-action@v0
+  with:
+    image: /tmp/image.tar
+```
+
+### Step 4: Justfile Parameter Passing
+
+In justfile, recipe parameters are template-substituted with `{{param}}`. They are NOT passed as bash positional parameters (`$1`, `$2`).
+
+```just
+# WRONG - $1 is always empty in justfile bash blocks
+_build-inner mode="debug":
+    #!/usr/bin/env bash
+    MODE="${1:-debug}"    # Always "debug"!
+
+# CORRECT - use just template substitution
+_build-inner mode="debug":
+    #!/usr/bin/env bash
+    MODE="{{mode}}"       # Correctly receives the argument
+```
+
+### Step 5: Host vs Container Directory Creation
+
+When using `podman compose exec` to run builds inside a container with bind-mounted workspace:
+
+- Directories created on the **host** (before exec) are owned by the host user
+- In rootless Podman, these appear as root-owned inside the container
+- The container application user cannot write to them
+
+**Fix**: Don't create build output directories on the host. Let the inner build script create them inside the container where the user has appropriate permissions.
+
+### Step 6: Podman Socket on GitHub Actions
+
+GitHub Actions `ubuntu-latest` runners have Podman installed but the socket is not activated by default. `podman compose` delegates to docker-compose which needs the socket.
+
+```yaml
+- name: Start Podman socket
+  shell: bash
+  run: |
+    systemctl --user start podman.socket || true
+    echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `userns_mode: keep-id` in docker-compose.yml | Add Podman-specific user namespace mapping to compose file | `podman compose` on GH Actions delegates to `docker-compose` CLI plugin, which doesn't understand Podman extensions | Check what compose provider is actually used (`/usr/libexec/docker/cli-plugins/docker-compose`) before using Podman-specific features |
+| `PODMAN_USERNS=keep-id` env var | Set env var so Podman applies keep-id to all containers | Unreliable when containers are created through the Docker API by docker-compose, not directly by Podman CLI | Podman CLI env vars may not be honored when docker-compose creates containers via the API |
+| `chown` inside container as root | Run `podman compose exec -u 0 -T` to chown workspace to container user | Overcomplicated; in rootless Podman, root inside container IS the host user, but chown to non-root UID involves subuid mapping complexities | Prefer simpler host-side solutions (`chmod`) over in-container ownership changes |
+| Initial plan missing Dockerfile ARG issue | Original CI fix plan addressed 3 issues but missed the ARG scoping bug | The Dockerfile's `USER_NAME` ARG was only declared in the `base` stage; development/production stages silently used empty string | Always check `ARG` declarations across ALL stages in multi-stage Dockerfiles — empty ARGs cause silent failures, not build errors |
+| Assuming CI test failures were new regressions | 4 test groups failed after container fixes | These tests were previously **skipped** because the container build itself failed; fixing infrastructure made pre-existing test bugs visible | When fixing infrastructure, expect to uncover pre-existing failures that were hidden by earlier-stage breaks |
+
+## Results & Parameters
+
+### Configuration
+
+```yaml
+# GitHub Actions runner
+runner: ubuntu-latest (Ubuntu 24.04, GLIBC 2.39)
+podman_version: rootless (default on ubuntu-latest)
+compose_provider: /usr/libexec/docker/cli-plugins/docker-compose
+container_user: dev (UID 1001)
+runner_user: runner (UID 1001)
+
+# Key files modified
+files:
+  - Dockerfile                                    # ARG re-declaration
+  - .github/actions/setup-container/action.yml    # Socket + chmod
+  - .github/workflows/container-publish.yml       # SBOM tarball
+  - justfile                                      # {{mode}} fix
+  - pixi.lock                                     # Channel regeneration
+```
+
+### Verification Commands
+
+```bash
+# Check Podman compose provider
+podman compose version
+
+# Check if rootless
+podman info --format '{{.Host.Security.Rootless}}'
+
+# Test bind-mount permissions
+podman compose exec -T service ls -la /workspace
+
+# Verify ARG values in build
+podman build --build-arg USER_NAME=dev -f Dockerfile --target development . 2>&1 | grep "STEP.*COPY.*chown"
+```


### PR DESCRIPTION
## Summary

Documents fixing rootless Podman CI failures on GitHub Actions, covering 5 layered issues that caused all 3 CI workflows to fail on the ProjectOdyssey main branch.

- Dockerfile ARG scoping across multi-stage builds (empty USER_NAME)
- Rootless Podman UID namespace mapping causing Permission denied on bind mounts
- docker-compose CLI plugin ignoring Podman-specific extensions

## Key Findings

**What Worked**:
- Re-declaring `ARG USER_NAME=dev` in each Dockerfile stage that uses it
- `chmod -R a+rwX .` on the host checkout before container use (safe on ephemeral CI runners)
- Exporting images to tarball for SBOM scanning instead of pulling from registry
- Using just `{{mode}}` template substitution instead of bash `$1` for recipe parameters
- Removing host-side `_ensure_build_dir` so dirs are created inside the container

**What Failed**:
- `userns_mode: keep-id` in docker-compose.yml → docker-compose CLI plugin ignores Podman extensions
- `PODMAN_USERNS=keep-id` env var → unreliable when docker-compose creates containers via API
- `chown` inside container as root → overcomplicated; host-side chmod is simpler
- Initial plan missed the Dockerfile ARG scoping issue → always audit ARGs across all stages

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
