### PR TITLE
feat: add batch-subprocess-signal-hang skill

### DIFF
--- a/skills/debugging/batch-subprocess-signal-hang/.claude-plugin/plugin.json
+++ b/skills/debugging/batch-subprocess-signal-hang/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "batch-subprocess-signal-hang",
+  "version": "1.0.0",
+  "description": "Debugging batch mode hangs caused by subprocess stdin blocking, signal group isolation, and worker-thread terminal calls. Use when: (1) batch/parallel workers hang on exit, (2) Ctrl+C stops working after os.setpgrp(), (3) subprocess.run blocks waiting for stdin.",
+  "category": "debugging",
+  "date": "2026-03-20"
+}

--- a/skills/debugging/batch-subprocess-signal-hang/references/notes.md
+++ b/skills/debugging/batch-subprocess-signal-hang/references/notes.md
@@ -1,0 +1,51 @@
+# Session Notes: Batch Subprocess & Signal Hang Debugging
+
+## Date: 2026-03-20
+
+## Context
+ProjectScylla E2E experiment runner had three interacting bugs that caused:
+1. Process hangs in batch mode (ThreadPoolExecutor workers never exit)
+2. Ctrl+C completely non-functional
+3. ~15s delay per tier due to redundant subprocess pre-flight checks
+
+## Timeline
+
+### Phase 1: Initial Plan Implementation
+- Removed per-tier `check_api_rate_limit_status()` from `tier_action_builder.py`
+- Added single pre-flight check in `runner.py:_action_exp_repo_cloned()`
+- Added `set_log_context()` calls at tier and subtest entry points
+- Removed SIGTSTP `_kill_group` handler from `manage_experiment.py`
+- Updated stale transition descriptions in `tier_state_machine.py`
+
+### Phase 2: Discovered Batch Mode Hang
+- Running with `--threads 1` still caused process to hang
+- Sub-agent exploration traced the call chain:
+  - `cmd_run()` → `_run_batch()` → `ThreadPoolExecutor` → `run_one_test()` → `terminal_guard()` → `restore_terminal()` → `stty sane`
+- Root cause: `restore_terminal()` calls `subprocess.run(["stty", "sane"], stdin=sys.stdin)` from worker threads
+- Fix: Added `threading.current_thread() is not threading.main_thread()` guard
+
+### Phase 3: Discovered Ctrl+C Not Working
+- User reported Ctrl+C still hangs (many ^C characters with no effect)
+- Root cause: `os.setpgrp()` at line 873 of `manage_experiment.py` moved process to new process group
+- Terminal sends SIGINT to foreground process group — process was no longer in it
+- Fix: Removed `os.setpgrp()` entirely, along with the now-dead `_kill_group` handler and unused imports
+
+### Phase 4: Also Fixed subprocess stdin blocking
+- `check_api_rate_limit_status()` spawns `claude --print ping` without `stdin=subprocess.DEVNULL`
+- Claude CLI waits for stdin, causing 3-30s delay
+- Fix: Added `stdin=subprocess.DEVNULL` to the subprocess.run() call
+
+## Key Debugging Insights
+
+### Pipe buffering masks real behavior
+When debugging with `command | tail -30` or `command | grep pattern`, pipe buffering causes output to appear stuck even when the process is running fine. Use `PYTHONUNBUFFERED=1` or redirect to a file instead.
+
+### os.setpgrp() is a footgun in interactive tools
+It was originally added to enable `os.killpg()` for killing child processes. But it breaks ALL terminal signal delivery (SIGINT, SIGTSTP, SIGQUIT). The correct approach is to use signal handlers for graceful shutdown and let the OS handle process group management.
+
+### Three bugs interacted to create one symptom
+The user saw "process hangs" but the root causes were:
+1. stty blocking from worker thread (hang on exit)
+2. os.setpgrp() preventing SIGINT (can't interrupt)
+3. Per-tier subprocess check adding latency (appears slow)
+Each individually would cause problems; together they made the tool unusable.

--- a/skills/debugging/batch-subprocess-signal-hang/skills/batch-subprocess-signal-hang/SKILL.md
+++ b/skills/debugging/batch-subprocess-signal-hang/skills/batch-subprocess-signal-hang/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: batch-subprocess-signal-hang
+description: "Debugging batch mode hangs caused by subprocess stdin blocking, signal group isolation, and worker-thread terminal calls. Use when: (1) batch/parallel workers hang on exit, (2) Ctrl+C stops working after os.setpgrp(), (3) subprocess.run blocks waiting for stdin."
+category: debugging
+date: 2026-03-20
+user-invocable: false
+---
+
+# Batch Subprocess & Signal Hang Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Python batch runners hang indefinitely or ignore Ctrl+C |
+| **Root Causes** | 3 distinct bugs: stdin blocking, process group isolation, worker-thread stty |
+| **Languages** | Python 3.10+ |
+| **Key Tools** | subprocess, threading, signal, os |
+
+## When to Use
+
+- ThreadPoolExecutor workers hang on exit even though work completed
+- `Ctrl+C` has no effect (SIGINT not delivered)
+- `subprocess.run()` blocks for seconds waiting for input
+- `stty sane` called from non-main thread blocks or corrupts terminal
+- Process hangs after calling `os.setpgrp()` or `os.setsid()`
+
+## Verified Workflow
+
+### Bug 1: subprocess.run() blocks waiting for stdin
+
+**Symptom**: A subprocess call like `subprocess.run(["claude", "--print", "ping"])` blocks for 3-30 seconds.
+
+**Root Cause**: The CLI tool waits for stdin. Without `stdin=subprocess.DEVNULL`, it inherits the parent's stdin and blocks.
+
+**Fix**:
+```python
+# BEFORE (blocks)
+result = subprocess.run(["claude", "--print", "ping"], capture_output=True, text=True, timeout=30)
+
+# AFTER (returns immediately)
+result = subprocess.run(["claude", "--print", "ping"], capture_output=True, text=True, timeout=30, stdin=subprocess.DEVNULL)
+```
+
+**Rule**: Always pass `stdin=subprocess.DEVNULL` to non-interactive subprocess calls, especially in batch/background contexts.
+
+### Bug 2: os.setpgrp() breaks Ctrl+C
+
+**Symptom**: Pressing Ctrl+C has no effect. The process ignores SIGINT entirely.
+
+**Root Cause**: `os.setpgrp()` moves the process into a new process group. The terminal sends SIGINT to the **foreground process group** only. Since the process is no longer in it, SIGINT never arrives.
+
+**Fix**: Remove `os.setpgrp()`. If you need to kill child processes on exit, use `signal.signal(SIGINT, handler)` to propagate signals manually, or use `os.killpg()` only as a second-signal force-kill handler.
+
+**Rule**: Never call `os.setpgrp()` or `os.setsid()` in interactive CLI tools unless you also set up explicit signal forwarding. The process will become invisible to terminal job control.
+
+### Bug 3: stty from worker threads hangs
+
+**Symptom**: ThreadPoolExecutor workers hang on cleanup. The program never exits after all work completes.
+
+**Root Cause**: A `terminal_guard()` context manager calls `subprocess.run(["stty", "sane"], stdin=sys.stdin)` in its `__finally__` block. When called from a worker thread (not the main thread), the `stty` process blocks trying to access the controlling terminal.
+
+**Fix**: Guard terminal restoration with a main-thread check:
+```python
+import threading
+
+def restore_terminal() -> None:
+    with contextlib.suppress(Exception):
+        if threading.current_thread() is not threading.main_thread():
+            return  # Only main thread owns the controlling terminal
+        if sys.stdin.isatty():
+            subprocess.run(["stty", "sane"], stdin=sys.stdin, check=False)
+```
+
+**Rule**: Never call `stty` or other terminal-manipulation commands from worker threads. The controlling terminal is owned by the main thread only.
+
+### Diagnostic Checklist
+
+1. **Hang on exit?** → Check for non-daemon threads, stty calls from workers, ThreadPoolExecutor not shutting down
+2. **Ctrl+C ignored?** → Check for `os.setpgrp()`, `os.setsid()`, or signal handlers that swallow SIGINT
+3. **Subprocess slow?** → Check for missing `stdin=subprocess.DEVNULL`
+4. **Per-iteration slowness?** → Check for redundant subprocess pre-flight checks that should run once
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Move rate limit check from per-tier to once-per-experiment only | Initial fix removed per-tier check but didn't add stdin=DEVNULL | The subprocess still blocked for 3s waiting for stdin even when called once | Always add stdin=subprocess.DEVNULL for non-interactive subprocesses |
+| Remove SIGTSTP handler only, keep os.setpgrp() | Thought SIGTSTP kill handler was the only signal problem | os.setpgrp() itself was the root cause — it isolated the process from terminal SIGINT delivery | os.setpgrp() affects ALL signals from terminal, not just the ones you handle |
+| Add noqa comment to unused import instead of removing it | Tried to keep rate_limit imports in tier_action_builder.py with noqa:F401 | Unnecessary complexity — the import should just be removed when the function call is removed | Clean up imports immediately when removing call sites |
+| Debug with piped output (grep/tail) | Used `command 2>&1 \| tail -30` and `\| grep` to filter output | Pipe buffering made it appear the process was hung when it was actually running fine | Always use PYTHONUNBUFFERED=1 or redirect to file when debugging hangs |
+
+## Results & Parameters
+
+### Environment
+- Python 3.10+ with ThreadPoolExecutor for parallel batch execution
+- CLI subprocess calls (`claude --print ping`) for rate limit pre-flight checks
+- `stty sane` for terminal restoration after agent runs
+
+### Configuration Pattern
+```python
+# Safe subprocess call (non-interactive)
+subprocess.run(
+    ["command", "--flag", "arg"],
+    capture_output=True,
+    text=True,
+    timeout=30,
+    stdin=subprocess.DEVNULL,  # ALWAYS for non-interactive
+)
+
+# Safe terminal restoration (main thread only)
+def restore_terminal():
+    if threading.current_thread() is not threading.main_thread():
+        return
+    if sys.stdin.isatty():
+        subprocess.run(["stty", "sane"], stdin=sys.stdin, check=False)
+
+# Signal handling (no process group isolation)
+# Do NOT call os.setpgrp() in interactive CLI tools
+signal.signal(signal.SIGINT, graceful_handler)   # First Ctrl+C
+signal.signal(signal.SIGTERM, graceful_handler)   # systemd/docker stop
+```
+
+### Files Modified (ProjectScylla)
+- `scylla/utils/terminal.py` — main-thread guard for stty
+- `scylla/e2e/rate_limit.py` — stdin=subprocess.DEVNULL
+- `scylla/e2e/runner.py` — single pre-flight rate limit check
+- `scylla/e2e/tier_action_builder.py` — removed per-tier rate limit check
+- `scripts/manage_experiment.py` — removed os.setpgrp() and dead signal handlers


### PR DESCRIPTION
## Summary

Documents debugging three interacting bugs that caused Python batch runners to hang indefinitely and ignore Ctrl+C.

- `os.setpgrp()` isolates process from terminal foreground group, preventing SIGINT delivery
- `stty sane` called from ThreadPoolExecutor workers blocks on stdin access
- `subprocess.run()` without `stdin=subprocess.DEVNULL` blocks waiting for input

## Key Findings

**What Worked**:
- Main-thread guard (`threading.current_thread() is not threading.main_thread()`) prevents stty from worker threads
- `stdin=subprocess.DEVNULL` for all non-interactive subprocess calls
- Removing `os.setpgrp()` entirely — signal handlers handle graceful/forceful shutdown

**What Failed**:
- Removing only SIGTSTP handler while keeping os.setpgrp() → SIGINT still not delivered
- Debugging with piped output (`| tail`, `| grep`) → pipe buffering masked real behavior
- Adding noqa to unused imports instead of removing them → unnecessary complexity

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
