### PR TITLE
fix: correct skills-registry-commands source path in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7752,7 +7752,7 @@
       "name": "skills-registry-commands",
       "description": "Complete skills registry system with 4 components: (1) /advise command - search skills before starting work, (2) /retrospective command - capture session learnings as new skills, (3) documentation-patterns skill - how to write effective skill docs, (4) validation-workflow skill - CI/CD for plugin validation. Use when setting up team knowledge capture or implementing the Sionic AI skills pattern.",
       "version": "1.0.0",
-      "source": "https://github.com/HomericIntelligence/ProjectMnemosyne/tree/main/plugins/tooling/skills-registry-commands",
+      "source": "./plugins/tooling/skills-registry-commands",
       "category": "tooling",
       "tags": [
         "advise",


### PR DESCRIPTION
## Summary

Fix marketplace schema validation error by correcting the source path format for the skills-registry-commands plugin.

## Problem

The skills-registry-commands plugin was using an absolute GitHub URL format for its source field:
```
https://github.com/HomericIntelligence/ProjectMnemosyne/tree/main/plugins/tooling/skills-registry-commands
```

This caused marketplace validation to fail with:
```
plugins.944.source: Invalid input
```

The marketplace schema expects all plugin sources to use consistent relative path formatting, matching the format used by all 974 skills.

## Solution

Changed the source path to match the standard relative format:
```
./plugins/tooling/skills-registry-commands
```

This aligns with the marketplace schema expectations while correctly pointing to the plugin directory.

## Changes

- `.claude-plugin/marketplace.json`: Updated skills-registry-commands source path from absolute URL to relative path

## Validation

- ✅ Marketplace schema validation passes
- ✅ All 975 plugins properly indexed
- ✅ Plugin source paths consistent across marketplace
- ✅ skills-registry-commands now discoverable in marketplace

## Testing

The marketplace has been tested and successfully:
- Removed and re-added to Claude Code
- Loads without schema validation errors
- All plugins appear in marketplace list
- Ready for plugin discovery and updates

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>