### PR TITLE
feat: add mojo-setitem-lvalue-semantics skill

### DIFF
--- a/skills/mojo-setitem-lvalue-semantics.md
+++ b/skills/mojo-setitem-lvalue-semantics.md
@@ -1,0 +1,159 @@
+---
+name: mojo-setitem-lvalue-semantics
+description: "Documents Mojo subscript assignment semantics: obj[i]=val uses __getitem__ lvalue, not __setitem__. Use when: (1) debugging 'cannot implicitly convert' errors on ExTensor/subscript assignments, (2) designing subscript APIs in Mojo structs, (3) encountering 'cannot call function that may raise' after wrapping subscript assignments."
+category: debugging
+date: 2026-03-21
+version: "1.0.0"
+user-invocable: false
+tags: [mojo, type-errors, subscript, setitem, getitem, lvalue, ExTensor, Float32, Float64, Float16]
+---
+
+# Mojo __setitem__ Lvalue Semantics
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-21 |
+| **Objective** | Fix 314 type errors after replacing bitcast UAF writes with subscript assignment |
+| **Outcome** | All errors resolved; discovered Mojo `obj[i]=val` uses lvalue, not `__setitem__` |
+| **Mojo Version** | 0.26.1 |
+
+## When to Use
+
+- Debugging `cannot implicitly convert 'Float64' value to 'Float32'` errors on subscript assignments
+- Designing Mojo structs that need to accept multiple types via subscript assignment
+- Migrating from direct pointer writes (`bitcast[T]()[i] = val`) to safe assignment APIs
+- Encountering `cannot call function that may raise in a context that cannot raise` after wrapping subscript assignments in type constructors
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+Problem:  tensor[i] = Float64(x)  -> ERROR: cannot convert Float64 to Float32
+Fix 1:    tensor[i] = Float32(x)  -> OK (matches __getitem__ return type)
+Fix 2:    tensor.set(i, Float64(x))  -> OK (explicit method call with overloads)
+Fix 3:    tensor._set_float64(i, Float64(x))  -> OK (for non-raising contexts)
+```
+
+### Step 1: Understand the Semantics
+
+In Mojo, `obj[i] = val` is syntactic sugar for lvalue assignment through `__getitem__`, NOT a call to `__setitem__`. The compiler:
+
+1. Calls `__getitem__(i)` to get an lvalue reference
+2. Assigns `val` to that reference
+3. Since `__getitem__` returns `Float32`, `val` must be `Float32`
+
+This means `__setitem__` overloads for `Float64`, `Float16`, `Int64`, etc. are **dead code** -- they are never invoked via `obj[i] = val` syntax.
+
+### Step 2: Choose the Right Fix Pattern
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| RHS is same type as `__getitem__` return | Direct assignment | `result[i] = Float32(expr)` |
+| RHS is different type, in `raises` context | `set()` method | `result.set(i, Float64(expr))` |
+| Inside `@parameter fn` / `parallelize[]` closure | Direct pointer write | `result._set_float64(i, Float64(expr))` |
+| Accumulating with mixed types | Cast before arithmetic | `Float64(tensor[i]) + float64_val` |
+
+### Step 3: Implement the `set()` Method
+
+Add overloaded `set()` methods that delegate to `__setitem__`:
+
+```mojo
+@always_inline
+fn set(mut self, index: Int, value: Float64) raises:
+    self.__setitem__(index, value)
+
+@always_inline
+fn set(mut self, index: Int, value: Float32) raises:
+    self.__setitem__(index, Float64(value))
+
+@always_inline
+fn set(mut self, index: Int, value: Float16) raises:
+    self.__setitem__(index, Float64(Float32(value)))
+
+@always_inline
+fn set(mut self, index: Int, value: Int) raises:
+    self.__setitem__(index, Float64(value))
+# ... more overloads for Int64, Int32, Int16, Int8, UInt8, etc.
+```
+
+### Step 4: Handle Non-Raising Contexts
+
+`parallelize[]` closures use `@parameter fn` which cannot raise. In these contexts:
+
+```mojo
+# ERROR: .set() raises, can't use in @parameter fn
+@parameter
+fn parallel_work(b: Int) capturing:
+    output.set(idx, val)  # Cannot call function that may raise
+
+# FIX: Use internal non-raising method
+@parameter
+fn parallel_work(b: Int) capturing:
+    output._set_float64(idx, Float64(val))  # Does not raise
+```
+
+### Step 5: Fix Mixed-Type Arithmetic
+
+When `__getitem__` returns Float32 but you need Float64 arithmetic:
+
+```mojo
+# ERROR: Float32 + Float64 -> __add__ type mismatch
+grad_beta.set(f, grad_beta[f] + grad_out)  # grad_beta[f] is Float32, grad_out is Float64
+
+# FIX: Cast __getitem__ result to match
+grad_beta.set(f, Float64(grad_beta[f]) + grad_out)
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Add `__setitem__` overloads | Added 9 new `__setitem__` overloads for Float16, Int, Int8, etc. | Mojo never dispatches `obj[i] = val` to `__setitem__` -- these are dead code | `__setitem__` in Mojo is not called via subscript assignment syntax |
+| Wrap all RHS in `Float32()` | Changed `result[i] = Float64(x)` to `result[i] = Float32(x)` everywhere | Introduced "cannot call function that may raise" errors in `@parameter fn` closures | `Float32()` constructor raises; can't use in non-raising contexts like `parallelize[]` |
+| Delegate to sub-agents (round 1) | Launched 8 parallel agents to fix all files | Agents only fixed ~60% of errors; missed Float16 paths and arithmetic mismatches | Sub-agents need explicit error line numbers and all error categories enumerated |
+| Use `.set()` in `parallelize[]` | Replaced direct writes with `.set()` in parallel computation functions | `.set()` raises but `@parameter fn` closures cannot raise | Need separate non-raising internal method (`_set_float64`) for parallel contexts |
+
+## Results & Parameters
+
+### Error Distribution
+
+```text
+267 errors: cannot implicitly convert 'Float64' to 'Float32'
+ 24 errors: cannot implicitly convert 'Float16' to 'Float32'
+ 16 errors: invalid call to '__add__' (Float64/Float32 mismatch)
+  6 errors: cannot implicitly convert 'Int64' to 'Float32'
+  1 error:  cannot call function that may raise
+```
+
+### Fix Pattern Distribution
+
+```text
+~200 sites: result[i] = Float32(expr)        -- simple same-type cast
+ ~40 sites: result.set(i, expr)              -- explicit method for non-Float32 values
+  ~8 sites: result._set_float64(i, expr)     -- for parallelize[] closures
+  ~8 sites: Float64(tensor[i]) + expr        -- arithmetic type promotion
+  ~5 sites: self._set_float64/int64()        -- internal constructors
+```
+
+### Files Affected
+
+```text
+shared/core/extensor.mojo       -- Added set() overloads, fixed constructors
+shared/core/activation.mojo     -- 74 lines changed
+shared/core/attention.mojo      -- 34 lines changed
+shared/core/conv.mojo           -- 22 lines changed
+shared/core/dropout.mojo        -- 26 lines changed
+shared/core/dtype_cast.mojo     -- 18 lines changed
+shared/core/layers/dropout.mojo -- 24 lines changed
+shared/core/normalization.mojo  -- 187 lines changed (largest, most complex)
+shared/core/pooling.mojo        -- 12 lines changed
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4996 follow-up fix | Fixed 314 type errors across 9 files after bitcast UAF migration |

--- a/skills/mojo-setitem-lvalue-semantics.notes.md
+++ b/skills/mojo-setitem-lvalue-semantics.notes.md
@@ -1,0 +1,54 @@
+# Session Notes: Mojo __setitem__ Lvalue Semantics
+
+## Context
+
+PR #4996 replaced `tensor._data.bitcast[T]()[i] = val` (bitcast UAF writes) with
+`tensor[i] = Float64(val)` (using `__setitem__`). CI reported 314+ type errors because
+Mojo's `obj[i] = val` does not dispatch to `__setitem__`.
+
+## Discovery Process
+
+1. Initial plan assumed adding `__setitem__` overloads would fix the errors
+2. Added 9 overloads (Float16, Int, Int8/16/32, UInt8/16/32/64) -- all dead code
+3. Created minimal test to confirm: `v[1] = Float64(2.0)` fails even with matching `__setitem__`
+4. Root cause: Mojo treats `obj[i]` as an lvalue via `__getitem__` (returns Float32)
+5. Solution: `set()` method with explicit overloads + `_set_float64` for non-raising contexts
+
+## Minimal Reproduction
+
+```mojo
+struct MyVec:
+    var data: UnsafePointer[Float32]
+    fn __getitem__(self, i: Int) -> Float32: return self.data[i]
+    fn __setitem__(mut self, i: Int, val: Float64): self.data[i] = Float32(val)
+
+fn main():
+    var v = MyVec(...)
+    v[0] = Float64(1.0)  # ERROR: cannot implicitly convert Float64 to Float32
+    # __setitem__ is NEVER called -- Mojo uses __getitem__ lvalue
+```
+
+## Three Fix Patterns
+
+1. **Float32 cast** -- `result[i] = Float32(expr)` -- works in raising contexts
+2. **set() method** -- `result.set(i, expr)` -- works for any type, raises
+3. **_set_float64()** -- `result._set_float64(i, Float64(expr))` -- for parallelize closures
+
+## Parallelization Strategy
+
+- Round 1: 8 agents for initial Float64->Float32 conversion (fixed ~60%)
+- Round 2: 4 agents for remaining errors using .set() pattern (fixed ~35%)
+- Manual fixes: parallelize closures, arithmetic type mismatches (~5%)
+
+## Files Modified
+
+- `shared/core/extensor.mojo` -- Added `set()` overloads, fixed constructors
+- `shared/core/activation.mojo` -- 74 lines changed
+- `shared/core/attention.mojo` -- 34 lines changed
+- `shared/core/conv.mojo` -- 22 lines changed
+- `shared/core/dropout.mojo` -- 26 lines changed
+- `shared/core/dtype_cast.mojo` -- 18 lines changed
+- `shared/core/layers/dropout.mojo` -- 24 lines changed
+- `shared/core/normalization.mojo` -- 187 lines changed (largest, most complex)
+- `shared/core/pooling.mojo` -- 12 lines changed
+- `docs/adr/ADR-009-heap-corruption-workaround.md` -- Fixed broken blog link


### PR DESCRIPTION
## Summary

Documents that Mojo's `obj[i] = val` syntax uses `__getitem__` as an lvalue (not `__setitem__`), causing type errors when the RHS type differs from the return type.

- Discovered while fixing 314 type errors across 9 files in ProjectOdyssey
- Three fix patterns: Float32 cast, `set()` method overloads, `_set_float64()` for non-raising contexts
- Documents 4 failed approaches and why they failed

## Key Findings

**What Worked**:
- Adding `set(index, value)` method with overloads for all numeric types (Float64, Float32, Float16, Int, Int64, etc.)
- Using `_set_float64()` directly inside `parallelize[]` closures that can't raise
- Casting `Float64(tensor[i])` before arithmetic with Float64 operands

**What Failed**:
- Adding `__setitem__` overloads → dead code, never dispatched via `[i]=`
- Wrapping everything in `Float32()` → introduces "cannot raise" errors in `@parameter fn`
- First round of 8 sub-agents → only fixed 60% of errors, missed Float16/Float64 paths

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/` (979/979 valid)
- [ ] Install plugin and verify skill appears in search
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
