### PR TITLE
feat: add e2e-resource-exhaustion skill

### DIFF
--- a/skills/optimization/e2e-resource-exhaustion/.claude-plugin/plugin.json
+++ b/skills/optimization/e2e-resource-exhaustion/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "e2e-resource-exhaustion",
+  "version": "1.0.0",
+  "description": "Diagnose and fix machine crashes from memory/disk exhaustion during parallel E2E experiment runs. Use when: (1) experiment runner hangs or crashes the machine, (2) WSL2 VM gets killed during batch runs, (3) disk fills up with uncleaned workspaces.",
+  "category": "optimization",
+  "date": "2026-03-22"
+}

--- a/skills/optimization/e2e-resource-exhaustion/references/notes.md
+++ b/skills/optimization/e2e-resource-exhaustion/references/notes.md
@@ -1,0 +1,47 @@
+# Session Notes: E2E Resource Exhaustion Fix
+
+## Date: 2026-03-22
+
+## Context
+- haiku-2 experiment run at ~/fullruns/haiku-2/
+- 7 tests (test-001 through test-007), 6 Mojo + 1 Python
+- run_tests.sh with --threads 15, 3 phases (agent, diff, judge)
+- Machine: WSL2, 16GB RAM, 1TB disk (77% used)
+
+## Raw Findings
+
+### Workspace Analysis
+- 2,737 workspace directories across 7 tests
+- Total: 187GB
+- test-001 (Python/Hello-World): 92MB, 577 workspaces
+- test-002 (Mojo/modular): 57GB, 360 workspaces
+- test-003..007 (Mojo/ProjectOdyssey): 18-44GB each, 360 workspaces each
+- ProjectOdyssey repo: 1.4GB, each worktree checkout: ~1.2GB
+
+### Run State Analysis
+- test-001: 600 runs, 23 judged (worktree_cleaned), 571 at diff_captured
+- test-002: 360 runs, 65 judged, 294 at diff_captured
+- test-003,004,006: 360 runs each, 0 judged, all at diff_captured
+- test-005: 360 runs, mixed states (some still at agent_complete/replay_generated)
+- test-007: 360 runs, mostly at replay_generated (earliest stage)
+
+### Crash Pattern
+- run.log ends with heartbeat messages only (process hung)
+- No OOM traces in dmesg (WSL2 VM killed by Windows host)
+- All model validation attempts timed out (haiku, sonnet, opus)
+- Experiment was in Phase 3 (judging) when crash occurred
+
+### Architecture
+- Batch: ThreadPoolExecutor(max_workers=threads) in manage_experiment.py
+- Per-experiment: tiers sequential, subtests sequential (run_tier_subtests_parallel is actually sequential)
+- Agent: subprocess.Popen (claude CLI via replay.sh)
+- Judge: subprocess.run (claude CLI with --allowedTools Read,Glob,Grep)
+- Build pipeline: under _pipeline_lock (threading.Lock, serializes mojo build)
+- Workspace: git worktree add (1.2GB per Mojo checkout)
+
+### Key Code Paths
+- stages.py:stage_create_worktree -> workspace_setup.py:_setup_workspace -> git worktree add
+- stages.py:stage_execute_agent -> Popen(["bash", replay_script])
+- stage_finalization.py:stage_execute_judge -> _call_judge_with_retry -> llm_judge.py:_call_claude_judge -> subprocess.run(["claude", ...])
+- stage_finalization.py:stage_cleanup_worktree -> workspace_manager.cleanup_worktree (only for passing runs!)
+- stages.py:stage_run_judge_pipeline -> build_pipeline.py:_run_build_pipeline (under _pipeline_lock)

--- a/skills/optimization/e2e-resource-exhaustion/skills/e2e-resource-exhaustion/SKILL.md
+++ b/skills/optimization/e2e-resource-exhaustion/skills/e2e-resource-exhaustion/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: e2e-resource-exhaustion
+description: "Diagnose and fix machine crashes from memory/disk exhaustion during parallel E2E experiment runs. Use when: experiment runner hangs, WSL2 VM crashes, or disk fills with uncleaned workspaces."
+category: optimization
+date: 2026-03-22
+user-invocable: false
+---
+
+# E2E Resource Exhaustion: Diagnosis and Fix
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Machine crashes during parallel E2E experiment runs due to memory/disk exhaustion |
+| **Root Cause** | Unbounded workspace accumulation + unbounded concurrent `claude` CLI processes |
+| **Environment** | WSL2 (16GB RAM), 7 concurrent Mojo tests, 120 subtests x 3-5 runs each |
+| **Impact** | 2,737 uncleaned workspaces totaling 187GB; 7+ concurrent 500MB processes |
+| **Fix** | Eager workspace cleanup, semaphore-based concurrency limits, resource monitoring |
+
+## When to Use
+
+- Machine hangs or crashes during `manage_experiment.py run --threads N`
+- WSL2 VM gets killed silently (no OOM traces in `dmesg`)
+- `du -sh` on results directory shows >100GB of workspace directories
+- Run log ends with only heartbeat messages (process hung)
+- `checkpoint.json` shows `tier_state=complete` but `subtest_states` are `runs_in_progress` (not `aggregated`)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Check workspace accumulation
+find ~/fullruns/<run>/ -name "workspace" -type d -maxdepth 5 | wc -l
+
+# Check disk usage per test
+for d in ~/fullruns/<run>/2026-*; do du -sh "$d"; done
+
+# Check memory
+free -h
+
+# Check run state breakdown per test
+python3 -c "
+import json
+cp = json.load(open('<test>/checkpoint.json'))
+rs = cp.get('run_states', {})
+counts = {}
+for tier in rs:
+    for sub in rs[tier]:
+        for run, state in rs[tier][sub].items():
+            counts[state] = counts.get(state, 0) + 1
+print(counts)
+"
+```
+
+### Step 1: Diagnose the Resource Consumers
+
+Three things consume resources during E2E runs:
+
+1. **Git worktree workspaces** (~1.2GB each for Mojo repos): Created in `stage_create_worktree`, only cleaned for passing runs in `stage_cleanup_worktree`. Failed runs keep workspaces forever.
+
+2. **`claude` CLI subprocesses** (~200-500MB each): Spawned by `stage_execute_agent` (via `replay.sh`) and `stage_execute_judge` (via `_call_claude_judge`). With `--threads 15`, up to 7 concurrent processes.
+
+3. **Build pipeline processes** (`mojo build`, `bazel`, `pixi`): Run under `_pipeline_lock` (serialized), but each can use 1-2GB.
+
+### Step 2: Check checkpoint.json State
+
+```python
+# Understand run pipeline stages
+# replay_generated -> agent_complete -> diff_captured -> judge_pipeline_run
+# -> judge_prompt_built -> judged -> worktree_cleaned
+```
+
+Runs stuck at `diff_captured` = agent work done, workspace still exists, judging not started.
+Runs at `worktree_cleaned` = fully complete, workspace removed.
+
+### Step 3: Apply Resource Guards
+
+**Fix 1 - Eager workspace cleanup**: Remove the `run_passed` guard in `stage_cleanup_worktree`. Clean up ALL workspaces after judging. Add `--keep-failed-workspaces` flag for debugging.
+
+**Fix 2 - Workspace semaphore**: `threading.Semaphore` in `stage_create_worktree` / `stage_cleanup_worktree` to limit concurrent live workspaces (default: `cpu_count * 2`).
+
+**Fix 3 - Agent semaphore**: `threading.Semaphore` around `stage_execute_agent` and `stage_execute_judge` to limit concurrent `claude` CLI processes (default: `min(threads, cpu_count)`).
+
+**Fix 4 - Judge optimization**: Remove `--allowedTools Read,Glob,Grep` from judge CLI command. All context is already in the prompt (workspace state, git diff, pipeline results). This eliminates workspace dependency and reduces memory overhead.
+
+**Fix 5 - Resource monitoring**: Log RAM/disk at startup, warn if low. Periodic checks in heartbeat thread.
+
+### Step 4: Update run_tests.sh
+
+```bash
+pixi run python scripts/manage_experiment.py run \
+  --threads 15 --until agent_complete \
+  --max-concurrent-agents 6 "${COMMON_ARGS[@]}"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running with `--threads 15` unguarded | Let all 7 tests run with unbounded concurrency | 7 concurrent `claude` processes + 2700+ workspaces exhausted 16GB RAM and 1TB disk | Always limit concurrent subprocesses to `min(threads, cpu_count)` |
+| Checking `dmesg` for OOM killer | Expected Linux OOM traces | WSL2 VM gets killed by Windows host silently - no kernel logs survive | On WSL2, memory exhaustion kills the VM, not individual processes |
+| Relying on `_pipeline_lock` alone | Lock serializes build pipeline (`mojo build`) | Lock only covers build pipeline, not `claude` CLI processes which are the main RAM consumers | Need separate semaphores for different resource types |
+| Keeping failed workspaces for debugging | `stage_cleanup_worktree` only cleaned passing runs | Failed runs (majority) accumulated 187GB of 1.2GB workspaces | Workspace diff is captured at `DIFF_CAPTURED` stage - workspace is no longer needed after judging |
+
+## Results & Parameters
+
+### Resource Limits (recommended for 16GB machine)
+
+```yaml
+# run_tests.sh settings
+threads: 15                    # batch thread pool size
+max_concurrent_agents: 6       # claude CLI process limit
+max_concurrent_workspaces: null # auto: cpu_count * 2
+
+# Per-test resource footprint (Mojo repos)
+workspace_size: ~1.2GB         # per git worktree checkout
+claude_cli_memory: ~200-500MB  # per process
+mojo_build_memory: ~1-2GB      # serialized under _pipeline_lock
+```
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `scylla/e2e/stages.py` | `_workspace_semaphore`, `_agent_semaphore`, `configure_resource_limits()` |
+| `scylla/e2e/stage_finalization.py` | `stage_cleanup_worktree()` (eager cleanup), `stage_execute_judge()` (agent semaphore) |
+| `scylla/e2e/health.py` | `log_resource_preflight()`, `_log_resource_usage()` |
+| `scylla/e2e/llm_judge.py` | `_call_claude_judge()` (no tools, no workspace) |
+| `config/judge/system_prompt.md` | "Do NOT run any tests" instruction |
+| `scylla/e2e/models.py` | `keep_failed_workspaces`, `max_concurrent_workspaces`, `max_concurrent_agents` |
+| `scripts/manage_experiment.py` | CLI flags for resource limits |
+
+### Diagnostic Commands
+
+```bash
+# Count live workspaces
+find ~/fullruns/<run>/ -name "workspace" -type d -maxdepth 5 | wc -l
+
+# Total disk usage
+du -sh ~/fullruns/<run>/
+
+# Check if repo is modular monorepo (uses bazel, very memory-hungry)
+test -f <repo>/bazelw && echo "modular monorepo" || echo "standalone"
+
+# Check run completion status
+python3 -c "
+import json
+for tier in ['T0','T1','T2','T3','T4','T5','T6']:
+    cp = json.load(open('<test>/checkpoint.json'))
+    rs = cp['run_states'].get(tier, {})
+    counts = {}
+    for sub in rs:
+        for run, state in rs[sub].items():
+            counts[state] = counts.get(state, 0) + 1
+    print(f'{tier}: {counts}')
+"
+```


### PR DESCRIPTION
## Summary

Documents diagnosis and fix for machine crashes during parallel E2E experiment runs caused by memory/disk exhaustion on a 16GB WSL2 machine.

- 2,737 uncleaned workspace directories totaling 187GB (failed runs never cleaned up)
- Unbounded concurrent `claude` CLI processes consuming 200-500MB each
- WSL2 VM silently killed by Windows host (no OOM traces in dmesg)

## Key Findings

**What Worked**:
- Eager workspace cleanup for ALL runs (not just passing) after diff capture + judging
- `threading.Semaphore` to limit concurrent workspaces and claude CLI processes
- Removing judge tool access (`--allowedTools`) — all context already in prompt
- Pre-flight resource checks and periodic monitoring in heartbeat thread

**What Failed**:
- Running `--threads 15` unguarded → 7 concurrent tests exhausted 16GB RAM
- Checking `dmesg` for OOM → WSL2 VM crash leaves no kernel logs
- Relying on `_pipeline_lock` alone → only serializes build pipeline, not claude processes
- Keeping failed workspaces for debugging → 187GB accumulation from 1.2GB Mojo worktrees

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/ plugins/`
- [ ] Install plugin and verify skill appears
- [ ] Check skill activation with relevant triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
