### PR TITLE
feat: add pypi-trusted-publishing-setup skill

### DIFF
--- a/skills/pypi-trusted-publishing-setup.md
+++ b/skills/pypi-trusted-publishing-setup.md
@@ -1,0 +1,129 @@
+---
+name: pypi-trusted-publishing-setup
+description: "Configure PyPI trusted publishing (OIDC) with GitHub Actions for namespace packages. Use when: (1) setting up OIDC trusted publishing for a new PyPI project, (2) debugging 403/400 errors during PyPI upload, (3) publishing namespace packages like Org-Project to PyPI."
+category: ci-cd
+date: 2026-03-22
+version: "1.0.0"
+user-invocable: false
+---
+
+# PyPI Trusted Publishing Setup
+
+## Overview
+
+| Date | Objective | Outcome |
+|------|-----------|---------|
+| 2026-03-22 | Configure OIDC trusted publishing for HomericIntelligence-Hephaestus | Successfully published v0.4.0 after fixing distribution name, environment, and pending publisher |
+
+## When to Use
+
+- Setting up OIDC trusted publishing for a **new** PyPI project
+- Debugging `403 Forbidden` or `400 Non-user identities cannot create new projects` during PyPI upload
+- Migrating from `secrets.PYPI_API_TOKEN` to trusted publishing
+- Publishing namespace packages (e.g., `OrgName-ProjectName`) to PyPI
+- Changing a PyPI distribution name while keeping the Python import name unchanged
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# .github/workflows/release.yml
+permissions:
+  contents: write
+  id-token: write  # REQUIRED for OIDC
+
+jobs:
+  build-and-publish:
+    environment: pypi  # Must match PyPI trusted publisher config
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true  # Enable during setup, disable after confirmed working
+```
+
+### Step 1: Configure pyproject.toml
+
+The `name` field MUST exactly match the PyPI project name:
+
+```toml
+[project]
+name = "OrgName-ProjectName"  # Distribution name on PyPI
+
+[tool.hatch.build.targets.wheel]
+packages = ["projectname"]  # Python import name (can differ)
+```
+
+Wheel filenames are normalized to lowercase: `orgname_projectname-*.whl` (PEP 625).
+
+### Step 2: Configure GitHub Environment
+
+Repository Settings → Environments → create `pypi`:
+- Deployment branches and tags: "Selected branches and tags", add `v*` tag pattern
+- Required reviewers (optional): Add reviewer for manual approval gate
+
+### Step 3: Workflow permissions
+
+Must have `id-token: write` at top level of workflow.
+
+### Step 4: Register on PyPI
+
+**For NEW projects** (doesn't exist on PyPI yet): Add a **pending publisher** at https://pypi.org/manage/account/publishing/ — OIDC cannot create new projects.
+
+**For EXISTING projects**: Add trusted publisher at project settings → Publishing.
+
+### Step 5: Update dependent files
+
+When changing distribution name, also update:
+- `pixi.toml` pypi-dependencies key (lowercase)
+- Regenerate `pixi.lock`
+- Integration test wheel globs (must be lowercase)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Hardcoded SHA for pypi-publish | `pypa/gh-action-pypi-publish@76f52bc...` | SHA was invalid/not found | Use `@release/v1` branch ref |
+| Protected branches only on env | GitHub env `protected_branches: true` | Tags are not protected branches | Use "Selected branches and tags" with `v*` pattern |
+| Distribution name mismatch | `pyproject.toml` name `hephaestus`, PyPI project `HomericIntelligence` | `403 OIDC scoped token not valid for project` | Distribution name must EXACTLY match PyPI project |
+| Trusted publisher for new project | Added trusted publisher, not pending publisher | `400 Non-user identities cannot create new projects` | New projects need **pending publisher** first |
+| Uppercase wheel glob | `HomericIntelligence_Hephaestus-*.whl` | File not found | PEP 625: wheels are always lowercase |
+| Changed pyproject.toml only | Forgot pixi.toml/pixi.lock | `lock-file not up-to-date` | Must update pixi.toml dep name and regen lock |
+| Non-verbose publish action | Default `verbose: false` | Only got `403 Forbidden` with no detail | Always enable `verbose: true` when debugging |
+
+## Results & Parameters
+
+### Working release workflow
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  build-and-publish:
+    environment: pypi
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+```
+
+### Namespace package pattern
+
+| Repo | PyPI Name | Import | Wheel |
+|------|-----------|--------|-------|
+| ProjectHephaestus | `HomericIntelligence-Hephaestus` | `import hephaestus` | `homericintelligence_hephaestus-*.whl` |
+| ProjectKeystone | `HomericIntelligence-Keystone` | `import keystone` | `homericintelligence_keystone-*.whl` |
+
+### Debugging checklist
+
+1. Enable `verbose: true` on publish action
+2. Check HTML error body in logs
+3. Verify `id-token: write` permission
+4. Verify environment name matches (case-sensitive)
+5. Verify distribution name matches PyPI project
+6. New projects: use pending publisher

--- a/skills/pypi-trusted-publishing-setup.notes.md
+++ b/skills/pypi-trusted-publishing-setup.notes.md
@@ -1,0 +1,26 @@
+# Session Notes: PyPI Trusted Publishing Setup
+
+## Date: 2026-03-22
+
+## Context
+- Repository: HomericIntelligence/ProjectHephaestus
+- Issues: #36, #37, #38
+- Goal: Publish v0.4.0 to PyPI using OIDC trusted publishing
+
+## Timeline
+
+1. GitHub `pypi` environment had `protected_branches: true` — already fixed by user
+2. v0.3.2 tag had broken workflow (hardcoded SHA + API token) — skipped, v0.4.0 supersedes
+3. v0.4.0 triggered, got 403 Forbidden — added verbose logging via PR
+4. Verbose revealed distribution name mismatch: `hephaestus` vs PyPI `HomericIntelligence`
+5. User wanted namespace packages: changed to `HomericIntelligence-Hephaestus`
+6. Had to update pixi.toml, pixi.lock, integration test wheel glob (lowercase), mypy issue
+7. Got `400 Non-user identities cannot create new projects` — needed pending publisher
+8. After pending publisher registered, v0.4.0 published successfully
+
+## Key Insight
+PyPI error messages are HTML-formatted and only visible with `verbose: true`. Without it you only get bare `403 Forbidden` or `400 Bad Request`.
+
+## PRs Created
+- #39: Enable verbose PyPI publish
+- #40: Change distribution name + fix CI


### PR DESCRIPTION
## Summary

Documents configuring PyPI OIDC trusted publishing with GitHub Actions, specifically for namespace packages (OrgName-ProjectName pattern).

- Complete workflow from pyproject.toml setup to pending publisher registration
- Debugging guide for 403/400 errors during PyPI upload
- Namespace package naming conventions and PEP 625 wheel normalization

## Key Findings

**What Worked**:
- OIDC trusted publishing with `pypa/gh-action-pypi-publish@release/v1`
- Pending publisher registration for new PyPI projects
- Namespace pattern: `HomericIntelligence-Hephaestus` on PyPI, `import hephaestus` in Python

**What Failed**:
- Distribution name mismatch → 403 Forbidden (OIDC token scoped to wrong project)
- Trusted publisher on new project → 400 (OIDC can't create new projects, need pending publisher)
- Uppercase wheel globs → file not found (PEP 625 normalizes to lowercase)
- Changing pyproject.toml name without updating pixi.toml → stale lock file

## Test Plan

- [x] Validate plugin with `python3 scripts/validate_plugins.py skills/`
- [ ] Check skill appears in marketplace.json after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
