### PR TITLE
fix: add .pixi/ and .pytest_cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ worktrees/
 
 # build artifacts
 build/
+
+# Pixi environment
+.pixi/
+
+# Pytest cache
+.pytest_cache/


### PR DESCRIPTION
## Summary
- Added `.pixi/` entry to .gitignore for pixi environment management
- Added `.pytest_cache/` entry for pytest cache files

Closes #912

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>