### PR TITLE
feat: add .editorconfig and pre-commit config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 4
+
+[*.{md,yml,yaml,json,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files


### PR DESCRIPTION
## Summary
- Added `.editorconfig` for consistent formatting across editors (LF line endings, UTF-8 charset, trailing whitespace trimming, per-filetype indent settings, markdown trailing whitespace preserved)
- Added `.pre-commit-config.yaml` with basic quality hooks (trailing whitespace, EOF fixer, YAML/JSON validation, large file check)

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)