### PR TITLE
fix: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
- Pinned all GitHub Actions to immutable SHA hashes instead of mutable version tags
- Added version comments for readability
- Prevents supply chain attacks via tag mutation

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)