### PR TITLE
fix: remove ~/.agent-brain cleanup from commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,6 @@ Save learnings after a session (auto-creates PR).
 5. Create branch: `skill/<name>`
 6. Commit and push
 7. Create PR with summary
-8. After PR created, clean up worktree at `$HOME/.agent-brain/ProjectMnemosyne/`
 
 **Auto-trigger**: UserPromptSubmit hook reminds about retrospective when you type session-ending keywords.
 

--- a/plugins/tooling/skills-registry-commands/commands/advise.md
+++ b/plugins/tooling/skills-registry-commands/commands/advise.md
@@ -14,6 +14,8 @@ Search the skills registry for relevant prior learnings before starting work.
 Single shared clone in user's home directory. Automatically updated before searches.
 Automatically skipped if already running in the ProjectMnemosyne repository.
 
+> **Note**: Never delete ~/.agent-brain/. This is a persistent shared location that caches repository clones across sessions for faster access.
+
 ## Instructions
 
 When the user invokes this command:

--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -12,8 +12,10 @@ Capture session learnings and create a new flat-format skill file in the Project
 **Base branch**: `main`
 **Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Single shared clone in user's home directory. Automatically cleaned after PR creation.
+Single shared clone in user's home directory. Persists across sessions for faster access.
 Automatically skipped if already running in the ProjectMnemosyne repository.
+
+> **Note**: Never delete ~/.agent-brain/. This is a persistent shared location that caches repository clones across sessions for faster access.
 
 ## Instructions
 
@@ -39,11 +41,9 @@ When the user invokes this command:
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
      # Already in ProjectMnemosyne - work in current directory
      MNEMOSYNE_DIR="."
-     NEED_CLEANUP=false
    else
-     # Use shared home directory location
+     # Use shared home directory location (persistent cache)
      MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
-     NEED_CLEANUP=true
 
      if [ ! -d "$MNEMOSYNE_DIR" ]; then
        # Clone fresh
@@ -205,14 +205,6 @@ Documents <brief description of what was learned>.
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
    ```
 
-8. **Cleanup** (if cloned to $HOME/.agent-brain):
-   ```bash
-   if [ "$NEED_CLEANUP" = true ]; then
-     # After PR created, remove the worktree clone
-     rm -rf "$HOME/.agent-brain/ProjectMnemosyne"
-   fi
-   ```
-
 ## Common Issues & Solutions
 
 ### Top Validation Failures
@@ -239,15 +231,6 @@ git push -u origin skill/<name>
 
 # OR update existing PR
 git push origin skill/<name>
-```
-
-### Issue: Cleanup directory
-
-**Cause**: Shared clone at `$HOME/.agent-brain/ProjectMnemosyne` takes up disk space.
-
-**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/retrospective`:
-```bash
-rm -rf $HOME/.agent-brain/ProjectMnemosyne
 ```
 
 ## Required Sections


### PR DESCRIPTION
## Summary
- Removed automatic cleanup step (step 8) from `/retrospective` that deleted `~/.agent-brain/ProjectMnemosyne`
- Removed `NEED_CLEANUP` variable and all references
- Removed the "Cleanup directory" troubleshooting section that encouraged manual deletion
- Added persistence note to both `/retrospective` and `/advise` commands
- Updated CLAUDE.md to remove step 8 reference from /retrospective workflow
- `~/.agent-brain/` is a persistent shared location that should never be deleted

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)