### PR TITLE
fix: migrate retrospective command to git worktrees

### DIFF
--- a/ADVISE_RETROSPECTIVE_UPDATED.md
+++ b/ADVISE_RETROSPECTIVE_UPDATED.md
@@ -40,10 +40,10 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
    - Example: `training-grpo-external-vllm-setup.md`
    - Auto-detect category from conversation context
 
-2. **Clone Location**
-   - Before: `<ProjectRoot>/build/<PID>/ProjectMnemosyne/` (isolated)
-   - After: `$HOME/.agent-brain/ProjectMnemosyne/` (shared)
-   - Automatic cleanup after PR creation
+2. **Work Isolation**
+   - Before: `<ProjectRoot>/build/<PID>/ProjectMnemosyne/` (isolated clone per session)
+   - After: Git worktrees from base repo (isolated per branch, cleaned up after PR)
+   - Base repo: current directory if in ProjectMnemosyne, else persistent cache at `$HOME/.agent-brain/ProjectMnemosyne/`
 
 3. **File Structure**
    - Before:
@@ -108,12 +108,12 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 
 **After**:
 ```
-1. Clone to shared $HOME/.agent-brain
+1. Create git worktree from base repo for branch isolation
 2. Auto-generate skill filename (no user input!)
 3. Create single flat skills/<name>.md file + optional notes
 4. Validate (simpler, single command)
 5. Commit and create PR
-6. Auto-cleanup (remove clone)
+6. Clean up worktree (git worktree remove + prune)
 ```
 
 ## Key Improvements
@@ -122,7 +122,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 1. **No manual metadata entry** — filename auto-generated from conversation
 2. **Simpler file structure** — single .md file instead of nested directories
 3. **Faster retrospective** — skip the prompt dialogs
-4. **Auto-cleanup** — no accumulating build directories
+4. **Worktree cleanup** — `git worktree remove` after each PR, no stale directories
 
 ### For System
 1. **Reduced disk usage** — shared clone instead of PID-scoped copies
@@ -140,7 +140,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 - [ ] Skill file created in correct format (YAML frontmatter + markdown)
 - [ ] Validation passes with `python3 scripts/validate_plugins.py`
 - [ ] PR created with correct title and body
-- [ ] Clone auto-cleaned after PR creation
+- [ ] Worktree cleaned up after PR creation (`git worktree remove`)
 - [ ] Re-running `/advise` uses cached clone and updates it
 
 ## Migration Complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,18 +49,20 @@ Save learnings after a session (auto-creates PR).
 1. Read entire conversation history
 2. Extract: objective, steps taken, successes, failures, parameters
 3. Auto-generate skill filename: `<topic>-<subtopic>-<short-4-word-summary>`
-4. Generate skill file from template:
+4. Create git worktree for branch isolation (all work done in worktree, not base repo)
+5. Generate skill file from template:
    - `skills/<name>.md` with YAML frontmatter + all required sections
    - Optional `skills/<name>.notes.md` for raw session details
-5. Create branch: `skill/<name>`
-6. Commit and push
-7. Create PR with summary
+6. Create branch: `skill/<name>`
+7. Commit and push
+8. Create PR with summary
+9. Clean up worktree with `git worktree remove`
 
 **Auto-trigger**: UserPromptSubmit hook reminds about retrospective when you type session-ending keywords.
 
 **Format notes**:
 - Category/name are auto-generated (no user prompting)
-- Clone location: `$HOME/.agent-brain/ProjectMnemosyne/`
+- Work isolation: git worktrees (auto-created per branch, cleaned up after PR)
 - Single flat `.md` file with YAML frontmatter
 - Branch name: `skill/<name>`
 

--- a/plugins/tooling/skills-registry-commands/commands/advise.md
+++ b/plugins/tooling/skills-registry-commands/commands/advise.md
@@ -9,12 +9,9 @@ Search the skills registry for relevant prior learnings before starting work.
 ## Target Repository
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
-**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
+**Cache location**: `$HOME/.agent-brain/ProjectMnemosyne/` (persistent read-only cache)
 
-Single shared clone in user's home directory. Automatically updated before searches.
-Automatically skipped if already running in the ProjectMnemosyne repository.
-
-> **Note**: Never delete ~/.agent-brain/. This is a persistent shared location that caches repository clones across sessions for faster access.
+Automatically updated before searches. Skipped if already running in the ProjectMnemosyne repository.
 
 ## Instructions
 

--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -10,12 +10,14 @@ Capture session learnings and create a new flat-format skill file in the Project
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
 **Base branch**: `main`
-**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
+**Work isolation**: Git worktrees (auto-created per branch, cleaned up after PR creation)
 
-Single shared clone in user's home directory. Persists across sessions for faster access.
-Automatically skipped if already running in the ProjectMnemosyne repository.
+All skill creation work MUST be done in an isolated git worktree. The base repository
+(either the current directory or a persistent cache at `$HOME/.agent-brain/ProjectMnemosyne/`)
+is used only to spawn worktrees — never work directly in it.
 
-> **Note**: Never delete ~/.agent-brain/. This is a persistent shared location that caches repository clones across sessions for faster access.
+> **Important**: Always use `git worktree add` for branch isolation and `git worktree remove`
+> for cleanup. Never use `rm -rf` on repository directories.
 
 ## Instructions
 
@@ -34,33 +36,34 @@ When the user invokes this command:
    - Filename: `<topic>-<subtopic>-<short-4-word-summary>` (kebab-case)
    - Auto-detect category from conversation context (training, evaluation, optimization, debugging, architecture, tooling, ci-cd, testing, documentation)
 
-3. **Setup repository**:
+3. **Setup repository and create worktree**:
    ```bash
    # Detect if already in ProjectMnemosyne
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
-     # Already in ProjectMnemosyne - work in current directory
-     MNEMOSYNE_DIR="."
+     # Already in ProjectMnemosyne - use current repo as base
+     MNEMOSYNE_BASE="$(git rev-parse --show-toplevel)"
    else
-     # Use shared home directory location (persistent cache)
-     MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     # Use persistent cache as base repo for worktree creation
+     MNEMOSYNE_BASE="$HOME/.agent-brain/ProjectMnemosyne"
 
-     if [ ! -d "$MNEMOSYNE_DIR" ]; then
+     if [ ! -d "$MNEMOSYNE_BASE" ]; then
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_BASE"
      fi
-
-     # Always update to latest main before starting
-     git -C "$MNEMOSYNE_DIR" fetch origin
-     git -C "$MNEMOSYNE_DIR" checkout main
-     git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
-
-     cd "$MNEMOSYNE_DIR"
    fi
 
-   # Create branch from origin/main (clean state)
-   git checkout -b skill/<name> origin/main
+   # Ensure we have latest main
+   git -C "$MNEMOSYNE_BASE" fetch origin
+   git -C "$MNEMOSYNE_BASE" checkout main 2>/dev/null || true
+   git -C "$MNEMOSYNE_BASE" pull --ff-only origin main 2>/dev/null || true
+
+   # Create an isolated worktree for the new skill branch
+   WORKTREE_DIR="/tmp/mnemosyne-skill-<name>"
+   git -C "$MNEMOSYNE_BASE" worktree add "$WORKTREE_DIR" -b skill/<name> origin/main
+
+   cd "$WORKTREE_DIR"
    ```
 
 4. **Generate skill file** as flat `skills/<name>.md`:
@@ -205,6 +208,16 @@ Documents <brief description of what was learned>.
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
    ```
 
+8. **Clean up worktree** (REQUIRED after PR creation):
+   ```bash
+   # Return to the base repo directory first
+   cd "$MNEMOSYNE_BASE" 2>/dev/null || cd -
+
+   # Remove the worktree
+   git -C "$MNEMOSYNE_BASE" worktree remove "$WORKTREE_DIR"
+   git -C "$MNEMOSYNE_BASE" worktree prune
+   ```
+
 ## Common Issues & Solutions
 
 ### Top Validation Failures
@@ -218,6 +231,17 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 | "Failed Attempts table missing required columns" | Table format incorrect | Use: \| Attempt \| What Was Tried \| Why It Failed \| Lesson Learned \| |
 | "Quick Reference should use ###" | Using `## Quick Reference` instead of `###` | Demote to `### Quick Reference` (subsection of Verified Workflow) |
 | Skill not in marketplace | File not committed or in wrong location | Verify in `skills/<name>.md` (root of skills dir, not nested) |
+
+### Issue: Stale worktree
+
+**Cause**: Worktree from a previous failed `/retrospective` was not cleaned up.
+
+**Solution**: List and remove stale worktrees:
+```bash
+git worktree list
+git worktree remove /tmp/mnemosyne-skill-<name>
+git worktree prune
+```
 
 ### Issue: PR already exists
 


### PR DESCRIPTION
## Summary

Replace the `.agent-brain` clone+checkout workflow in `/retrospective` with proper git worktree isolation:

- **retrospective.md**: New step 3 uses `git worktree add` for branch isolation, new step 8 uses `git worktree remove` for cleanup
- **advise.md**: Remove "Never delete ~/.agent-brain/" note, clarify as read-only cache
- **CLAUDE.md**: Update workflow steps to include worktree creation and cleanup
- **ADVISE_RETROSPECTIVE_UPDATED.md**: Update workflow comparison to reflect worktree pattern

## Key Changes

- All skill creation work now happens in `/tmp/mnemosyne-skill-<name>` worktrees
- Base repo (current dir or `$HOME/.agent-brain/ProjectMnemosyne/`) is only used to spawn worktrees
- Explicit `git worktree remove` + `git worktree prune` cleanup mandated
- Added "Stale worktree" troubleshooting section
- No more `rm -rf` on any repository directories

## Test Plan

- [ ] Verify `/retrospective` creates worktree correctly
- [ ] Verify worktree cleanup after PR creation
- [ ] Verify `/advise` still works with persistent cache
- [ ] Verify no `rm -rf.*agent-brain` patterns remain

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>