### PR TITLE
feat: add nats-jetstream-sync-codebase-integration skill

### DIFF
--- a/skills/tooling-justfile-pixi-ecosystem-wrapping.md
+++ b/skills/tooling-justfile-pixi-ecosystem-wrapping.md
@@ -99,7 +99,7 @@ pixi run test-shell
    - Verify `just --list` succeeds
    - Verify expected recipes are present (test, lint, format, typecheck, etc.)
    - Regression guard: no heredocs in justfile (`grep -cE '<<\s*[A-Z_]'`)
-   - **Sync test**: parse `[tasks]` from pixi.toml and verify each has a matching just recipe (skip utility-only tasks like `plan-issues`)
+   - **Sync test**: parse `[tasks]` from `pixi.toml` and verify each has a matching just recipe (skip utility-only tasks like `plan-issues`)
 
 6. **Update project docs** (e.g., CLAUDE.md) with a Quick Start section showing justfile commands.
 


### PR DESCRIPTION
## Summary

Documents integrating NATS JetStream into a synchronous Python codebase using daemon threads with isolated asyncio event loops.

- Async-in-sync bridge pattern for wrapping nats-py in threading.Thread
- Optional dependency guard with try/except ImportError at point of use
- Config integration checklist across 5 files (Pydantic model + YAML + JSON schema + loader + CLI)
- mypy strict mode compliance patterns

## Key Findings

**What Worked**:
- Daemon thread with `asyncio.new_event_loop()` inside `run()` cleanly isolates async nats-py from sync codebase
- `threading.Event` for shutdown coordination between signal handler and subscriber thread
- Exponential backoff reconnection (1s initial, 2x multiplier, 60s max) for NATS connection failures
- `try/except ImportError` at point of use (inside async method) rather than module level

**What Failed**:
- `dict[str, object]` as type for Pydantic `**kwargs` unpacking → use `dict[str, Any]`
- `logging.LogCaptureFixture` for pytest caplog → use `pytest.LogCaptureFixture`
- Testing pre-set stop event then asserting loop created → thread exits before entering loop

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1019/1019 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>