### PR TITLE
feat: amend generate-changelog skill (v2.0.0)

### DIFF
--- a/skills/generate-changelog.history
+++ b/skills/generate-changelog.history
@@ -1,0 +1,99 @@
+# generate-changelog — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** Issue #33 — pipe delimiter bug fix in ProjectHephaestus `hephaestus/git/changelog.py`
+**Verification:** verified-local
+
+### What changed
+- Added critical bug documentation: `|` delimiter in git log `--pretty=format` breaks when commit subjects contain pipe characters
+- Added fix: use `%x09` (tab) as delimiter instead of `|`, since tabs never appear in git commit subjects
+- Added nested parentheses scope parsing fix (`index()`/`rindex()` instead of chained `split()`)
+- Added Failed Attempts entries documenting the pipe delimiter and scope parsing pitfalls
+- Added edge-case test patterns for `parse_commit()` and `categorize_commits()`
+- Updated Quick Reference with correct format string
+- Upgraded verification level to `verified-local`
+- Bumped version to 2.0.0
+
+### Why
+Previous version (v1.0.0) was a generic workflow description. This session discovered and fixed a real bug where `git log --pretty=format:%h|%s|%an` produces garbled output when commit subjects contain `|` characters (e.g. `feat: add A|B toggle`). The `split("|", 2)` in `parse_commit()` would incorrectly split the subject. Additionally, chained `split("(")[1].split(")")[0]` for scope extraction broke on nested parentheses like `feat(core(sub)): msg`.
+
+### Previous version (v1.0.0) snapshot
+---
+name: generate-changelog
+description: Create changelog from git commits. Use when preparing release notes.
+category: tooling
+date: '2026-03-19'
+version: 1.0.0
+mcp_fallback: none
+tier: 2
+---
+# Generate Changelog
+
+## Overview
+
+| Item | Details |
+|------|---------|
+| Date | N/A |
+| Objective | Automatically extract commit messages and generate formatted changelog entries for release notes and version history. |
+| Outcome | Operational |
+
+
+Automatically extract commit messages and generate formatted changelog entries for release notes and version history.
+
+## When to Use
+
+- Preparing release notes
+- Documenting version history
+- Creating user-facing change summaries
+- Generating development notes
+
+### Quick Reference
+
+```bash
+# Extract commits since last tag
+git log v1.0.0..HEAD --pretty=format:"%h - %s (%an) %d"
+
+# Group by conventional commit type
+git log --pretty=format:"%h %s" | grep -E "^[a-f0-9]+ (feat|fix|docs|refactor|test):"
+
+# Generate markdown changelog
+git log --reverse --pretty=format:"- %s (%h)" > CHANGELOG.md
+```
+
+## Verified Workflow
+
+1. **Extract commits**: Get commit messages since last release
+2. **Parse convention**: Identify conventional commit types (feat, fix, docs, etc.)
+3. **Categorize changes**: Group into sections (Features, Fixes, Documentation, etc.)
+4. **Format output**: Create readable markdown or text format
+5. **Add context**: Include version number, date, and links
+
+## Output Format
+
+Changelog entry:
+
+- Version number and release date
+- Features section (new capabilities)
+- Fixes section (bug fixes)
+- Documentation section (doc updates)
+- Breaking changes (if any)
+- Contributors
+- Version links (GitHub compare)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | Direct approach worked | N/A | Solution was straightforward |
+## Results & Parameters
+
+N/A — this skill describes a workflow pattern.
+
+## References
+
+- See `doc-update-blog` skill for blog post updates
+- See git documentation for commit message conventions
+- See <https://keepachangelog.com/> for changelog format standards
+
+---

--- a/skills/generate-changelog.md
+++ b/skills/generate-changelog.md
@@ -1,76 +1,136 @@
 ---
 name: generate-changelog
-description: Create changelog from git commits. Use when preparing release notes.
+description: "Generate changelog from git commits with safe delimiter handling. Use when: (1) writing git log format strings that parse fields, (2) parsing conventional commit messages, (3) extracting scope from commit prefixes."
 category: tooling
-date: '2026-03-19'
-version: 1.0.0
-mcp_fallback: none
-tier: 2
+date: '2026-03-25'
+version: "2.0.0"
+user-invocable: false
+verification: verified-local
+history: generate-changelog.history
+tags:
+  - git
+  - changelog
+  - parsing
+  - conventional-commits
 ---
+
 # Generate Changelog
 
 ## Overview
 
-| Item | Details |
-|------|---------|
-| Date | N/A |
-| Objective | Automatically extract commit messages and generate formatted changelog entries for release notes and version history. |
-| Outcome | Operational |
-
-
-Automatically extract commit messages and generate formatted changelog entries for release notes and version history.
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Generate formatted changelogs from git commit history using safe delimiter parsing |
+| **Outcome** | Operational — delimiter bug fixed, edge-case tests added |
+| **Verification** | verified-local |
+| **History** | [changelog](./generate-changelog.history) |
 
 ## When to Use
 
-- Preparing release notes
-- Documenting version history
-- Creating user-facing change summaries
-- Generating development notes
+- Writing `git log --pretty=format` strings that split output into fields
+- Parsing conventional commit messages (`type(scope): message`)
+- Extracting scope from commit prefixes that may contain nested parentheses
+- Generating changelogs or release notes from commit history
+- Testing commit parsers for edge cases (pipes, colons, nested parens)
+
+## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# Extract commits since last tag
-git log v1.0.0..HEAD --pretty=format:"%h - %s (%an) %d"
+# CORRECT: Use %x09 (tab) as field delimiter — tabs never appear in commit subjects
+git log v1.0.0..HEAD --pretty=format:"%h%x09%s%x09%an" --no-merges
 
-# Group by conventional commit type
-git log --pretty=format:"%h %s" | grep -E "^[a-f0-9]+ (feat|fix|docs|refactor|test):"
+# WRONG: Pipe delimiter breaks if subject contains | characters
+# git log --pretty=format:"%h|%s|%an"  # DO NOT USE
 
-# Generate markdown changelog
-git log --reverse --pretty=format:"- %s (%h)" > CHANGELOG.md
+# Parse in Python:
+# parts = line.split("\t", 2)  # NOT split("|", 2)
 ```
 
-## Verified Workflow
+### Detailed Steps
 
-1. **Extract commits**: Get commit messages since last release
-2. **Parse convention**: Identify conventional commit types (feat, fix, docs, etc.)
-3. **Categorize changes**: Group into sections (Features, Fixes, Documentation, etc.)
-4. **Format output**: Create readable markdown or text format
-5. **Add context**: Include version number, date, and links
+1. **Use tab delimiter in git log format**: Replace `%h|%s|%an` with `%h%x09%s%x09%an`. The `%x09` is git's hex escape for tab. Tabs cannot appear in git commit subjects, making the split reliable.
 
-## Output Format
+2. **Split on tab in parser**: `commit_line.split("\t", 2)` instead of `split("|", 2)`. The `maxsplit=2` ensures the author field captures any remaining content.
 
-Changelog entry:
+3. **Parse conventional commit prefix**: Split subject on first colon only (`subject.split(":", 1)`) to preserve colons in the message body (e.g., `fix: url: handle https://`).
 
-- Version number and release date
-- Features section (new capabilities)
-- Fixes section (bug fixes)
-- Documentation section (doc updates)
-- Breaking changes (if any)
-- Contributors
-- Version links (GitHub compare)
+4. **Extract scope with index/rindex for nested parens**: Instead of `prefix.split("(")[1].split(")")[0]`, use:
+   ```python
+   open_paren = prefix.index("(")
+   close_paren = prefix.rindex(")")
+   scope = prefix[open_paren + 1 : close_paren].strip()
+   ```
+   This correctly handles `feat(core(sub)): msg` → scope = `core(sub)`.
+
+5. **Test edge cases**: Always test parsers with:
+   - Pipe characters in subject: `"abc\tfeat: add A|B toggle\tAuthor"`
+   - Multiple colons: `"abc\tfix: url: handle https://example.com\tAuthor"`
+   - Nested parentheses in scope: `"abc\tfeat(core(sub)): msg\tAuthor"`
+   - Empty input: `""`
+   - Incomplete fields (missing author): `"abc\tsubject"`
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| Pipe delimiter | `--pretty=format:%h\|%s\|%an` with `split("\|", 2)` | Commit subjects containing `\|` (e.g., "add A\|B toggle") produce garbled fields — the split finds 4+ parts instead of 3 | Use a character that cannot appear in commit subjects. Tab (`%x09`) is ideal since git strips tabs from subjects |
+| Chained split for scope | `prefix.split("(")[1].split(")")[0]` | Breaks on nested parentheses like `feat(core(sub))` — `split("(")[1]` returns `core` and `split(")")[0]` returns `core`, losing the inner parens entirely | Use `index("(")`/`rindex(")")` to grab everything between the outermost parentheses |
+| Split on all colons | `subject.split(":")` without maxsplit | Loses everything after the second colon in messages like `fix: url: handle https://` | Always use `split(":", 1)` to split only on the first colon |
+
 ## Results & Parameters
 
-N/A — this skill describes a workflow pattern.
+```python
+# Correct parse_commit implementation pattern:
+def parse_commit(commit_line: str) -> tuple[str, str, str, str]:
+    parts = commit_line.split("\t", 2)
+    if len(parts) != 3:
+        return ("", "other", "", commit_line)
+
+    commit_hash, subject, _author = parts
+    commit_type = "other"
+    scope = ""
+    message = subject
+
+    if ":" in subject:
+        prefix, rest = subject.split(":", 1)
+        message = rest.strip()
+
+        if "(" in prefix and ")" in prefix:
+            commit_type = prefix.split("(")[0].strip().lower()
+            open_paren = prefix.index("(")
+            close_paren = prefix.rindex(")")
+            scope = prefix[open_paren + 1 : close_paren].strip()
+        else:
+            commit_type = prefix.strip().lower()
+
+    return (commit_hash, commit_type, scope, message)
+```
+
+```python
+# Edge-case test patterns (pytest):
+@pytest.mark.parametrize("commit_line,expected", [
+    ("abc\tfeat: add A|B toggle\tAuthor", ("abc", "feat", "", "add A|B toggle")),
+    ("abc\tfix: url: handle https://x.com\tA", ("abc", "fix", "", "url: handle https://x.com")),
+    ("abc\tfeat(core(sub)): msg\tA", ("abc", "feat", "core(sub)", "msg")),
+    ("", ("", "other", "", "")),
+    ("abc\tsubject", ("", "other", "", "abc\tsubject")),
+])
+def test_parse_commit_edge_cases(commit_line, expected):
+    assert parse_commit(commit_line) == expected
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #33 — pipe delimiter bug fix | 38 changelog tests pass, 401 total unit tests pass (82.14% coverage) |
 
 ## References
 
 - See `doc-update-blog` skill for blog post updates
 - See git documentation for commit message conventions
 - See <https://keepachangelog.com/> for changelog format standards
+- ProjectHephaestus PR #71: https://github.com/HomericIntelligence/ProjectHephaestus/pull/71


### PR DESCRIPTION
## Summary

Amends existing `generate-changelog` skill from v1.0.0 to v2.0.0.

Documents the pipe delimiter bug fix and scope parsing hardening discovered in ProjectHephaestus issue #33 (PR #71).

- Git log `--pretty=format:%h|%s|%an` breaks when commit subjects contain `|` characters
- Tab delimiter (`%x09`) is safe since tabs never appear in git commit subjects
- Chained `split("(")[1].split(")")[0]` breaks on nested parentheses; `index()`/`rindex()` is correct

## Verification Level

**verified-local**

All 38 changelog tests and 401 total unit tests pass locally in ProjectHephaestus. CI validation pending on ProjectHephaestus PR #71.

## Key Findings

**What Worked**:
- Using `%x09` (tab) as git log field delimiter — tabs cannot appear in commit subjects
- Using `index("(")`/`rindex(")")` for scope extraction to handle nested parentheses
- Testing with parametrized edge cases (pipes, multiple colons, nested parens, empty input)

**What Failed**:
- Pipe (`|`) as delimiter → breaks when subjects contain pipes (e.g., `feat: add A|B toggle`)
- Chained `split()` for scope → breaks on nested parentheses like `feat(core(sub)): msg`
- `split(":")` without maxsplit → loses content after second colon

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1049/1049 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>