### PR TITLE
refactor: rename /retrospective to /learn, update mnemosyne: prefix

### DIFF
--- a/plugins/tooling/mnemosyne/commands/advise.md
+++ b/plugins/tooling/mnemosyne/commands/advise.md
@@ -104,7 +104,7 @@ If the user wants more detail, read the full skill `.md` file and its `.history`
 for the most relevant matches.
 
 > **Note**: If the user's goal involves **creating or fixing skills**, remind them to run
-> `/retrospective` which captures session learnings and creates or amends a skill file.
+> `/learn` which captures session learnings and creates or amends a skill file.
 
 ## Output Format
 
@@ -150,7 +150,7 @@ param1: value1
 ### Invocation
 
 ```bash
-/skills-registry-commands:advise training a model with GRPO
+/mnemosyne:advise training a model with GRPO
 ```
 
 ### Output

--- a/plugins/tooling/mnemosyne/commands/learn.md
+++ b/plugins/tooling/mnemosyne/commands/learn.md
@@ -2,7 +2,7 @@
 description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
 ---
 
-# /retrospective
+# /learn
 
 Capture session learnings and create or amend a skill file in the ProjectMnemosyne marketplace.
 
@@ -396,7 +396,7 @@ git push origin skill/<name>
 
 **Cause**: Shared clone at `$HOME/.agent-brain/ProjectMnemosyne` takes up disk space.
 
-**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/retrospective`:
+**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/learn`:
 ```bash
 rm -rf $HOME/.agent-brain/ProjectMnemosyne
 ```
@@ -415,7 +415,7 @@ rm -rf $HOME/.agent-brain/ProjectMnemosyne
 ## Example
 
 ```
-/skills-registry-commands:retrospective
+/mnemosyne:learn
 ```
 
 Claude will analyze the session, check for existing skills to amend, and either update an existing skill (with history) or create a new one.


### PR DESCRIPTION
## Summary

- Renames `retrospective.md` → `learn.md` command file
- Updates heading `# /retrospective` → `# /learn`
- Updates all invocations from `skills-registry-commands:` → `mnemosyne:`
- Updates cross-references in `advise.md`

Part of the mnemosyne consolidation effort (follows PR #1046 plugin rename).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>