### PR TITLE
refactor: rename skills-registry-commands to mnemosyne, /retrospective to /learn

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7662,7 +7662,7 @@
     },
     {
       "name": "retrospective-integration",
-      "description": "Integrate /retrospective skill into automation pipelines to automatically capture session learnings",
+      "description": "Integrate /learn skill into automation pipelines to automatically capture session learnings",
       "version": "1.0.0",
       "source": "./skills/retrospective-integration.md",
       "category": "tooling",
@@ -7749,14 +7749,14 @@
       "tags": []
     },
     {
-      "name": "skills-registry-commands",
-      "description": "Complete skills registry system with 4 components: (1) /advise command - search skills before starting work, (2) /retrospective command - capture session learnings as new skills, (3) documentation-patterns skill - how to write effective skill docs, (4) validation-workflow skill - CI/CD for plugin validation. Use when setting up team knowledge capture or implementing the Sionic AI skills pattern.",
+      "name": "mnemosyne",
+      "description": "Complete skills registry system with 4 components: (1) /advise command - search skills before starting work, (2) /learn command - capture session learnings as new skills, (3) documentation-patterns skill - how to write effective skill docs, (4) validation-workflow skill - CI/CD for plugin validation. Use when setting up team knowledge capture or implementing the Sionic AI skills pattern.",
       "version": "1.0.0",
-      "source": "./plugins/tooling/skills-registry-commands",
+      "source": "./plugins/tooling/mnemosyne",
       "category": "tooling",
       "tags": [
         "advise",
-        "retrospective",
+        "learn",
         "skills",
         "registry",
         "documentation"

--- a/.claude/hooks/learn-trigger.py
+++ b/.claude/hooks/learn-trigger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Hook triggered on UserPromptSubmit when user types session-ending keywords.
-Adds context reminding about /retrospective - does not block.
+Adds context reminding about /learn - does not block.
 
 Receives JSON input with:
 - prompt: The user's prompt text
@@ -43,8 +43,8 @@ def main():
                 "hookSpecificOutput": {
                     "hookEventName": "UserPromptSubmit",
                     "additionalContext": (
-                        "[Retrospective Reminder] Before ending this session, "
-                        "consider running /retrospective to capture any learnings."
+                        "[Learn Reminder] Before ending this session, "
+                        "consider running /learn to capture any learnings."
                     ),
                 }
             }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
             "timeout": 5
           }
         ]

--- a/ADVISE_RETROSPECTIVE_UPDATED.md
+++ b/ADVISE_RETROSPECTIVE_UPDATED.md
@@ -1,8 +1,8 @@
-# Advise & Retrospective Commands - Updated for Flat Files
+# Advise & Learn Commands - Updated for Flat Files
 
 ## Summary
 
-Both `/advise` and `/retrospective` commands have been updated to work with the new flat-format skill structure.
+Both `/advise` and `/learn` commands have been updated to work with the new flat-format skill structure.
 
 **Completed**: 2026-03-19
 
@@ -29,8 +29,8 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
    - Unchanged: still searches marketplace.json, presents findings
    - Focus sections: Failed Attempts, When to Use, Results & Parameters
 
-### /retrospective Command
-**File**: `plugins/tooling/mnemosyne/commands/retrospective.md`
+### /learn Command
+**File**: `plugins/tooling/mnemosyne/commands/learn.md`
 
 #### Key Updates:
 1. **Auto-Generate Filename** (Major Change!)
@@ -94,7 +94,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 4. Present findings
 ```
 
-### Retrospective - Before vs After
+### Learn - Before vs After
 
 **Before**:
 ```
@@ -134,7 +134,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 
 - [ ] `/advise <query>` reads from flat `skills/*.md` files
 - [ ] Marketplace.json is correctly parsed with `source: ./skills/<name>.md`
-- [ ] `/retrospective` auto-generates filename from conversation
+- [ ] `/learn` auto-generates filename from conversation
 - [ ] Auto-generated filename follows `<topic>-<subtopic>-<4words>` pattern
 - [ ] Category is auto-detected (not prompted)
 - [ ] Skill file created in correct format (YAML frontmatter + markdown)
@@ -146,7 +146,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 ## Migration Complete
 
 ✅ All 930 skills converted to flat format
-✅ Advise and retrospective commands updated
+✅ Advise and learn commands updated
 ✅ Validation and marketplace generation updated
 ✅ CI workflows updated
 ✅ Documentation (CLAUDE.md) updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Renamed `skills-registry-commands` plugin to `mnemosyne`.
+- Renamed `/retrospective` command to `/learn`.
+
 ### Added
 - `CONTRIBUTING.md` with skill contribution guidelines, quality standards, and PR process.
 - `CHANGELOG.md` in Keep a Changelog format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Save learnings after a session (auto-creates PR).
 8. Create PR with summary
 9. Clean up worktree with `git worktree remove`
 
-**Auto-trigger**: UserPromptSubmit hook reminds about retrospective when you type session-ending keywords.
+**Auto-trigger**: UserPromptSubmit hook reminds about `/learn` when you type session-ending keywords.
 
 **Format notes**:
 - Category/name are auto-generated (no user prompting)
@@ -77,7 +77,7 @@ skills/<name>.notes.md       # (Optional) Additional context from development se
 
 All skills are now flat files in the `skills/` directory. Metadata is stored as YAML frontmatter in each `.md` file.
 
-**Exception**: `plugins/tooling/mnemosyne/` stays in `plugins/` — it's the command infrastructure (advise, retrospective), not a skill.
+**Exception**: `plugins/tooling/mnemosyne/` stays in `plugins/` — it's the command infrastructure (advise, learn), not a skill.
 
 ### Required Fields
 

--- a/plugins/tooling/mnemosyne/hooks/learn-trigger.py
+++ b/plugins/tooling/mnemosyne/hooks/learn-trigger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Hook triggered on UserPromptSubmit when user types session-ending keywords.
-Adds context reminding about /retrospective - does not block.
+Adds context reminding about /learn - does not block.
 
 Receives JSON input with:
 - prompt: The user's prompt text
@@ -43,8 +43,8 @@ def main():
                 "hookSpecificOutput": {
                     "hookEventName": "UserPromptSubmit",
                     "additionalContext": (
-                        "[Retrospective Reminder] Before ending this session, "
-                        "consider running /retrospective to capture any learnings."
+                        "[Learn Reminder] Before ending this session, "
+                        "consider running /learn to capture any learnings."
                     ),
                 }
             }

--- a/plugins/tooling/mnemosyne/hooks/settings.json.example
+++ b/plugins/tooling/mnemosyne/hooks/settings.json.example
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
             "timeout": 5
           }
         ]

--- a/plugins/tooling/mnemosyne/references/notes.md
+++ b/plugins/tooling/mnemosyne/references/notes.md
@@ -1,4 +1,4 @@
-# Skills Registry Commands - Complete Setup
+# Mnemosyne - Complete Setup
 
 A complete skills registry system for Claude agents, including commands, hooks, validation, and documentation patterns.
 
@@ -8,11 +8,11 @@ A complete skills registry system for Claude agents, including commands, hooks, 
 mnemosyne/
 ├── skills/
 │   ├── advise/SKILL.md              # /advise command
-│   ├── retrospective/SKILL.md       # /learn command
+│   ├── learn/SKILL.md               # /learn command
 │   ├── documentation-patterns/SKILL.md  # How to write good skills
 │   └── validation-workflow/SKILL.md     # CI/CD setup
 ├── hooks/
-│   ├── retrospective-trigger.py     # SessionEnd hook
+│   ├── learn-trigger.py             # SessionEnd hook
 │   └── settings.json.example        # Hook configuration
 ├── scripts/
 │   ├── validate_plugins.py          # PR validation
@@ -34,7 +34,7 @@ cp -r plugins/tooling/mnemosyne your-project/plugins/tooling/
 ```bash
 mkdir -p your-project/.claude/hooks
 
-cp plugins/tooling/mnemosyne/hooks/retrospective-trigger.py \
+cp plugins/tooling/mnemosyne/hooks/learn-trigger.py \
    your-project/.claude/hooks/
 
 cp plugins/tooling/mnemosyne/hooks/settings.json.example \
@@ -99,7 +99,7 @@ mkdir -p plugins/{training,evaluation,optimization,debugging,architecture,toolin
 | `/learn` | Capture learnings after sessions |
 | `documentation-patterns` | How to write discoverable skills |
 | `validation-workflow` | CI/CD for quality enforcement |
-| `retrospective-trigger.py` | Auto-prompt on session end |
+| `learn-trigger.py` | Auto-prompt on session end |
 | `validate_plugins.py` | PR validation script |
 | `generate_marketplace.py` | Marketplace index generator |
 

--- a/plugins/tooling/mnemosyne/skills/learn/SKILL.md
+++ b/plugins/tooling/mnemosyne/skills/learn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: retrospective
+name: learn
 description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
 user-invocable: false
 ---

--- a/skills/claude-code-v21-adoption.md
+++ b/skills/claude-code-v21-adoption.md
@@ -169,12 +169,12 @@ Update `CLAUDE.md` with new field usage:
   - `agent`: Optional agent type (e.g., mojo-specialist)
 ```
 
-### 7. Create Retrospective
+### 7. Create Learn
 
 After completing all PRs:
 
 ```text
-/retrospective
+/learn
 ```
 
 Capture the workflow for future version upgrades.

--- a/skills/claude-code-v21-adoption.notes.md
+++ b/skills/claude-code-v21-adoption.notes.md
@@ -34,7 +34,7 @@ Updated sub-skills:
 - ci-failure-workflow: analyze, fix
 - gh-pr-review-workflow: fix-feedback, get-comments, reply-comment
 - git-worktree-workflow: cleanup, create, switch, sync
-- mnemosyne: advise, documentation-patterns, retrospective, validation-workflow
+- mnemosyne: advise, documentation-patterns, learn, validation-workflow
 
 ### PR #71: Agent hooks + tool blocking
 **Branch**: `feature/agent-hooks`
@@ -87,8 +87,8 @@ git commit -m "feat(...): ..."
 gh pr create --title "..." --label "enhancement"
 gh pr merge --auto --rebase
 
-# Retrospective
-/retrospective
+# Learn
+/learn
 ```
 
 ## Stats

--- a/skills/claude-plugin-format.notes.md
+++ b/skills/claude-plugin-format.notes.md
@@ -61,7 +61,7 @@ version: 1.0.0
 ### Deleted
 - `/marketplace.json` (wrong location)
 - `/.claude/skills/advise/` (duplicate)
-- `/.claude/skills/retrospective/` (duplicate)
+- `/.claude/skills/learn/` (duplicate)
 
 ### Updated
 - `.claude-plugin/marketplace.json` - moved from root, updated with current 4 plugins
@@ -72,13 +72,13 @@ version: 1.0.0
 - `plugins/training/grpo-external-vllm/.claude-plugin/plugin.json` - removed tags
 - `plugins/training/spec-driven-experimentation/.claude-plugin/plugin.json` - removed tags
 - `plugins/tooling/mnemosyne/skills/advise/SKILL.md` - removed category, invokedBy
-- `plugins/tooling/mnemosyne/skills/retrospective/SKILL.md` - removed category, invokedBy
+- `plugins/tooling/mnemosyne/skills/learn/SKILL.md` - removed category, invokedBy
 - `plugins/tooling/mnemosyne/skills/documentation-patterns/SKILL.md` - removed category, source, date
 - `plugins/tooling/mnemosyne/skills/validation-workflow/SKILL.md` - removed category, source, date
 
 ### Added
 - `plugins/tooling/mnemosyne/commands/advise.md` - slash command
-- `plugins/tooling/mnemosyne/commands/retrospective.md` - slash command
+- `plugins/tooling/mnemosyne/commands/learn.md` - slash command
 
 ## Commits Created
 
@@ -88,7 +88,7 @@ version: 1.0.0
 4. `db4f54d` - fix: remove tags from plugin.json (not in official schema)
 5. `e55f911` - feat: add advise and retrospective as slash commands
 6. `c2e4c9c` - fix: remove non-standard frontmatter fields from SKILL.md files
-7. `af63c35` - fix: add target repository to /retrospective command
+7. `af63c35` - fix: add target repository to /learn command
 
 ## Key Documentation References
 

--- a/skills/consolidate-skills-directory.md
+++ b/skills/consolidate-skills-directory.md
@@ -89,7 +89,7 @@ find skills -maxdepth 1 -mindepth 1 -type d | grep -v -E "^skills/(architecture|
 
 - `.github/workflows/validate-plugins.yml`: trigger on `skills/**` + `plugins/**`, pass both to script
 - `.github/workflows/update-marketplace.yml`: same
-- `plugins/tooling/mnemosyne/commands/retrospective.md`: generate into `skills/<category>/<name>/`
+- `plugins/tooling/mnemosyne/commands/learn.md`: generate into `skills/<category>/<name>/`
 - `CLAUDE.md`, `README.md`, `.claude/shared/plugin-standards.md`: update Required Structure section
 
 ### 6. Add YAML frontmatter to migrated legacy SKILL.md files

--- a/skills/persist-automation-logs.md
+++ b/skills/persist-automation-logs.md
@@ -156,7 +156,7 @@ Add `state_dir.mkdir()` and save failure output:
 
 ```python
 def _run_retrospective(self, session_id: str, worktree_path: Path, issue_number: int) -> None:
-    """Resume Claude session to run /retrospective."""
+    """Resume Claude session to run /learn."""
     self.state_dir.mkdir(parents=True, exist_ok=True)  # Ensure directory exists
     log_file = self.state_dir / f"retrospective-{issue_number}.log"
 

--- a/skills/retrospective-hook-integration.md
+++ b/skills/retrospective-hook-integration.md
@@ -87,7 +87,7 @@ Update `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
             "timeout": 120,
             "once": true
           }
@@ -101,13 +101,13 @@ Update `.claude/settings.json`:
 ### 3. Copy Hook Script
 
 ```bash
-cp /path/to/ProjectMnemosyne/.claude/hooks/retrospective-trigger.py .claude/hooks/
+cp /path/to/ProjectMnemosyne/.claude/hooks/learn-trigger.py .claude/hooks/
 ```
 
 ### 4. Commit and Create PR
 
 ```bash
-git add .claude/settings.json .claude/hooks/retrospective-trigger.py
+git add .claude/settings.json .claude/hooks/learn-trigger.py
 git commit -m "feat(hooks): add SessionEnd hook for retrospective prompts"
 git push -u origin retrospective-hook
 gh pr create --title "feat(hooks): add SessionEnd hook" --body "..."
@@ -142,7 +142,7 @@ After marketplace registration:
       "hooks": [
         {
           "type": "command",
-          "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+          "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
           "timeout": 120,
           "once": true
         }

--- a/skills/retrospective-hook-integration.notes.md
+++ b/skills/retrospective-hook-integration.notes.md
@@ -59,7 +59,7 @@ The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
 
 **Changes**:
 - Added SessionEnd hook to `.claude/settings.json`
-- Copied `retrospective-trigger.py` to `.claude/hooks/`
+- Copied `learn-trigger.py` to `.claude/hooks/`
 - Used worktree workflow to avoid conflicts
 
 ### 4. Created PRs
@@ -96,7 +96,7 @@ The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
             "timeout": 120
           }
         ]
@@ -106,7 +106,7 @@ The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
 }
 ```
 
-### retrospective-trigger.py
+### learn-trigger.py
 
 - Reads JSON input from stdin
 - Triggers only on `"exit"` or `"clear"` reasons

--- a/skills/retrospective-integration.md
+++ b/skills/retrospective-integration.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective-integration
-description: Integrate /retrospective skill into automation pipelines to automatically
+description: Integrate /learn skill into automation pipelines to automatically
   capture session learnings
 category: tooling
 date: 2026-02-13
@@ -41,7 +41,7 @@ except (json.JSONDecodeError, AttributeError):
 
 **Key**: Use `.get()` for graceful None return, log warnings but never fail pipeline
 
-### 2. Resume Session to Run Retrospective with Proper Permissions
+### 2. Resume Session to Run Learn with Proper Permissions
 
 **Critical**: When resuming a session to run `/learn`, you MUST provide tool permissions for git and gh commands:
 

--- a/skills/skill-audit-and-merge.notes.md
+++ b/skills/skill-audit-and-merge.notes.md
@@ -56,7 +56,7 @@ Added tags to these plugin.json files:
 - claude-plugin-format: plugin, validation, schema, claude-code, format
 - claude-plugin-marketplace: marketplace, registry, plugin, claude-code, installation
 - verify-issue-before-work: github, issues, workflow, verification, duplicate-prevention
-- mnemosyne: skills, advise, retrospective, knowledge-capture, team-learning
+- mnemosyne: skills, advise, learn, knowledge-capture, team-learning
 - grpo-external-vllm: ml, training, llm, vllm, grpo, reinforcement-learning
 - spec-driven-experimentation: ml, training, methodology, experiments, ablation, hyperparameters
 

--- a/skills/spec-driven-experimentation.md
+++ b/skills/spec-driven-experimentation.md
@@ -133,7 +133,7 @@ workflow:
   2. Run /advise to check prior work
   3. Generate experiments from spec
   4. Execute priority-ordered
-  5. /retrospective to save findings
+  5. /learn to save findings
   6. Update TECHSPEC with results
 
 # Anti-patterns

--- a/skills/tooling-parallel-worktree-bulk-issue-execution.md
+++ b/skills/tooling-parallel-worktree-bulk-issue-execution.md
@@ -64,7 +64,7 @@ gh issue list --repo ORG/REPO --state open --limit 100 --json number,title,body,
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Content filter on CODE_OF_CONDUCT.md | Sub-agent tried to write Contributor Covenant text | API content filtering policy blocked the output (twice) | Governance documents with conduct/harassment language may trigger content filters — handle these in the main session where you can write shorter, adapted versions |
-| Sub-agent retrospective | Asked completed agents to run /retrospective | Agents are one-shot — once they return results, their context is gone | Sub-agents cannot run follow-up commands after completion; capture learnings from the main session instead |
+| Sub-agent retrospective | Asked completed agents to run /learn | Agents are one-shot — once they return results, their context is gone | Sub-agents cannot run follow-up commands after completion; capture learnings from the main session instead |
 | Branch already exists from failed agent | Retry agent tried to create same branch name | Previous failed agent had already pushed the branch | Use `-v2` suffix or delete remote branch before retrying with same name |
 
 ## Results & Parameters

--- a/skills/tooling-pr-auto-merge-worktree-command-migration.md
+++ b/skills/tooling-pr-auto-merge-worktree-command-migration.md
@@ -16,14 +16,14 @@ tags: [auto-merge, rebase, worktree, retrospective, advise, agent-brain, pr-mana
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Enable auto-merge on 14 open PRs, rebase all against main, and migrate /retrospective and /advise commands from clone+rm-rf pattern to git worktree isolation |
+| **Objective** | Enable auto-merge on 14 open PRs, rebase all against main, and migrate /learn and /advise commands from clone+rm-rf pattern to git worktree isolation |
 | **Outcome** | 13/14 PRs merged (1 auto-merging), worktree migration PR merged |
 | **Verification** | verified-ci |
 
 ## When to Use
 
 - Multiple open PRs need auto-merge enabled and rebasing against main
-- Command files (advise.md, retrospective.md) reference `rm -rf` on shared directories like `$HOME/.agent-brain/`
+- Command files (advise.md, learn.md) reference `rm -rf` on shared directories like `$HOME/.agent-brain/`
 - Migrating any clone-based workflow to git worktree isolation
 - Need to replace "Never delete X" guardrails with proper worktree lifecycle management
 
@@ -42,7 +42,7 @@ git -C /tmp/rebase-pr-<number> rebase origin/main
 git -C /tmp/rebase-pr-<number> push --force-with-lease origin <branch>
 git worktree remove /tmp/rebase-pr-<number>
 
-# Worktree pattern for /retrospective
+# Worktree pattern for /learn
 MNEMOSYNE_BASE="$(git rev-parse --show-toplevel)"
 git -C "$MNEMOSYNE_BASE" worktree add /tmp/mnemosyne-skill-<name> -b skill/<name> origin/main
 cd /tmp/mnemosyne-skill-<name>
@@ -109,7 +109,7 @@ success_rate: 100%
 ### Files Modified for Worktree Migration
 
 ```
-plugins/tooling/mnemosyne/commands/retrospective.md  # Primary: new worktree setup + cleanup
+plugins/tooling/mnemosyne/commands/learn.md  # Primary: new worktree setup + cleanup
 plugins/tooling/mnemosyne/commands/advise.md          # Minor: remove "Never delete" note
 CLAUDE.md                                                            # Update workflow description
 ADVISE_RETROSPECTIVE_UPDATED.md                                      # Update workflow comparison

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -16,7 +16,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Merge 16 duplicate adr009-* skills into 3 consolidated skills, and add semver rules to the /retrospective command |
+| **Objective** | Merge 16 duplicate adr009-* skills into 3 consolidated skills, and add semver rules to the /learn command |
 | **Outcome** | 16 skills merged to 3 (net -13), 35 unique Failed Attempts preserved, semver rules added |
 | **Verification** | verified-ci |
 
@@ -100,7 +100,7 @@ lines_after: 864
 unique_lessons_preserved: 35 Failed Attempts rows
 ```
 
-### Semver Rules for /retrospective
+### Semver Rules for /learn
 
 | Change Type | Bump | When |
 |-------------|------|------|


### PR DESCRIPTION
## Summary

Renames the plugin and commands for cleaner invocation:

| Element | Old | New |
|---------|-----|-----|
| Plugin directory | `plugins/tooling/skills-registry-commands/` | `plugins/tooling/mnemosyne/` |
| Plugin name | `skills-registry-commands` | `mnemosyne` |
| Command | `/retrospective` | `/learn` |
| Hook | `retrospective-trigger.py` | `learn-trigger.py` |
| Invocation | `/skills-registry-commands:retrospective` | `/mnemosyne:learn` |
| Invocation | `/skills-registry-commands:advise` | `/mnemosyne:advise` |

41 files changed across plugin config, documentation, settings, hooks, and skill files.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes (1049/1049 valid)
- [x] Zero remaining `skills-registry-commands` references (except CHANGELOG history)
- [x] Zero remaining `retrospective-trigger` references
- [x] Plugin directory exists at `plugins/tooling/mnemosyne/`
- [ ] `/mnemosyne:advise` and `/mnemosyne:learn` work correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>