### PR TITLE
chore: enable hephaestus@ProjectHephaestus plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "hephaestus@ProjectHephaestus": true
   }
 }


### PR DESCRIPTION
## Summary
- Add `hephaestus@ProjectHephaestus` to `enabledPlugins` in `.claude/settings.json`
- Part of org-wide rollout of the Hephaestus plugin across all HomericIntelligence repos

## Test plan
- [ ] Verify `.claude/settings.json` contains `hephaestus@ProjectHephaestus: true`
- [ ] Start a Claude Code session and confirm `/hephaestus:advise` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)