### PR TITLE
fix(ci): add missing pyyaml dependency to update-marketplace workflow

### DIFF
--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: pip install pyyaml
+
       - name: Generate marketplace.json
         run: python3 scripts/generate_marketplace.py .claude-plugin/marketplace.json
 


### PR DESCRIPTION
## Summary
- The `update-marketplace.yml` workflow was failing with `ModuleNotFoundError: No module named 'yaml'`
- Added `pip install pyyaml` step, matching the pattern already used in `validate-plugins.yml`

## Test plan
- [ ] Verify the `Validate Plugins` CI check passes on this PR
- [ ] After merge, confirm the `Update Marketplace` workflow succeeds on the next skills push

🤖 Generated with [Claude Code](https://claude.com/claude-code)