### PR TITLE
feat: amend tooling-skill-deduplication-semver-versioning skill (v1.2.0)

### DIFF
--- a/skills/tooling-skill-deduplication-semver-versioning.history
+++ b/skills/tooling-skill-deduplication-semver-versioning.history
@@ -1,5 +1,45 @@
 # tooling-skill-deduplication-semver-versioning -- History
 
+## v1.2.0 (2026-03-28)
+
+**Changed by:** PR #1079 -- consolidate preflight/verify-before-work skills (9->2)
+**Verification:** verified-ci
+
+### What changed
+
+- Added new deduplication result: preflight cluster (9->2, 78% reduction)
+- Added sub-grouping heuristic: "manual workflow vs automation patterns" split axis
+- Added Failed Attempts row: `gh pr merge --auto --squash` fails if squash disabled
+- Updated "Top Duplicate Clusters Remaining" to remove `preflight-*` count
+- Added new Verified On entry for PR #1079
+
+### Why
+
+The preflight cluster (9 files) split cleanly along a "manual vs automation" axis rather
+than being pure duplicates. This validates a new sub-grouping heuristic: when a cluster
+contains both "how to do X manually" and "how to build automation for X", split into two
+consolidated files rather than forcing a single merge. Also discovered that
+`gh pr merge --auto --squash` fails silently when the repo disables squash merging;
+the fallback is `--rebase`.
+
+### Previous version (v1.1.0) snapshot
+
+---
+name: tooling-skill-deduplication-semver-versioning
+description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
+category: tooling
+date: 2026-03-27
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: tooling-skill-deduplication-semver-versioning.history
+tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
+---
+
+See v1.1.0 entry below for full content snapshot.
+
+---
+
 ## v1.1.0 (2026-03-27)
 
 **Changed by:** PR #1075 -- consolidate Mojo test splitting skills (10->1)

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -2,8 +2,8 @@
 name: tooling-skill-deduplication-semver-versioning
 description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
 category: tooling
-date: 2026-03-27
-version: "1.1.0"
+date: 2026-03-28
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: tooling-skill-deduplication-semver-versioning.history
@@ -16,9 +16,9 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-27 |
+| **Date** | 2026-03-28 |
 | **Objective** | Merge duplicate skill clusters into consolidated skills, with semantic versioning for amendments |
-| **Outcome** | Two rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9). Semver rules added. |
+| **Outcome** | Three rounds: 16 adr009-* -> 3 (net -13); 10 mojo-test-* -> 1 (net -9); 9 preflight-* -> 2 (net -7). Semver rules added. |
 | **Verification** | verified-ci |
 | **History** | [changelog](./tooling-skill-deduplication-semver-versioning.history) |
 
@@ -54,6 +54,7 @@ done
 1. List all skill names, extract 2-part prefixes, count occurrences
 2. Focus on clusters with 3+ skills sharing a prefix
 3. Read descriptions to sub-group within each cluster (e.g., adr009-* split into: test-splitting, CI-patterns, audit)
+4. Apply the "manual vs automation" heuristic: if some skills describe how to do X manually and others describe how to automate X, split into two consolidated files rather than forcing a single merge
 
 **Phase 2: Merge each sub-group**
 
@@ -91,6 +92,7 @@ For multiple clusters, launch parallel agents (one per group) in the same worktr
 | Merging by exact text dedup | Tried deduplicating Failed Attempts by exact row match | Different skills describe the same lesson with different wording | Deduplicate by lesson/concept, not by exact text match |
 | Splitting into multiple consolidated files | Planned 10 mojo-test-* files into 2-3 sub-groups | All 10 files covered the same core workflow with minor variations | When content is truly redundant, even large clusters (10 files) can consolidate to 1 |
 | Forgetting .notes.md files | Deleted .md files but forgot accompanying .notes.md | Orphaned .notes.md files clutter the skills directory | Always delete both .md and .notes.md when removing source skills |
+| `gh pr merge --auto --squash` on repos with squash disabled | Ran `gh pr merge --auto --squash <PR>` to enable auto-merge | GraphQL error: "Merge method squash merging is not allowed on this repository" | Try `--rebase` as fallback: `gh pr merge --auto --rebase <PR>` |
 
 ## Results & Parameters
 
@@ -119,6 +121,19 @@ unique_lessons_preserved: 12 Failed Attempts rows, 17 Verified On entries
 files_deleted: 20 (10 .md + 10 .notes.md)
 ```
 
+**Round 3: Preflight/verify-before-work cluster (2026-03-28)**
+
+```yaml
+skills_before: 9
+skills_after: 2
+net_reduction: 7 skills (-78%)
+split_axis: "manual verification patterns vs script automation patterns"
+files_deleted: 14 (9 .md + 5 .notes.md)
+consolidated_to:
+  - preflight-verify-before-implementing (git log + PR status, decision matrix, stale TODO search)
+  - preflight-script-integration-patterns (exit codes, set -uo pipefail, closingIssuesReferences)
+```
+
 ### Semver Rules for /learn
 
 | Change Type | Bump | When |
@@ -143,6 +158,7 @@ files_deleted: 20 (10 .md + 10 .notes.md)
 ```
 
 Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1).
+Note: `preflight-*` cluster (was 9) resolved in PR #1079 (9->2).
 
 ## Verified On
 
@@ -150,3 +166,4 @@ Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1).
 |---------|---------|---------|
 | ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session |
 | ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session |
+| ProjectMnemosyne | PR #1079, merged 9 preflight-* skills into 2 | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `tooling-skill-deduplication-semver-versioning` from v1.1.0 to v1.2.0.

Documents round 3 of preflight/verify-before-work skill deduplication (9 skills -> 2).

- New deduplication round: 9 preflight-* skills consolidated to 2 using manual/automation split axis
- New sub-grouping heuristic: when a cluster has "how to do X manually" vs "how to automate X" skills, split into 2 files rather than forcing a single merge
- New Failed Attempts row: `gh pr merge --auto --squash` fails if squash merging is disabled in the repo — use `--rebase` as fallback
- Updated Top Duplicate Clusters Remaining table

## Verification Level

**verified-ci** — PR #1079 passed CI

## Key Findings

**What Worked**:
- Split preflight cluster by concern: manual verification patterns (6 skills) + automation patterns (3 skills) = 2 consolidated files
- `gh pr merge --auto --rebase` works when `--squash` is disabled

**What Failed**:
- `gh pr merge --auto --squash` → GraphQL error if squash merging disabled in repo settings

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 1034/1034 valid
- [x] History file updated with v1.2.0 entry and v1.1.0 snapshot

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>