### PR TITLE
feat: amend tooling-skill-deduplication-semver-versioning (v1.3.0)

### DIFF
--- a/skills/tooling-skill-deduplication-semver-versioning.history
+++ b/skills/tooling-skill-deduplication-semver-versioning.history
@@ -1,5 +1,35 @@
 # tooling-skill-deduplication-semver-versioning -- History
 
+## v1.3.0 (2026-03-28)
+
+**Changed by:** PR #1080 -- consolidate conv2d gradient checking skills (9->3)
+**Verification:** verified-ci
+
+### What changed
+- Added Round 4 deduplication result: conv2d-gradient-* cluster (9->3, 67% reduction)
+- Added 2 new Failed Attempts rows: over-splitting subtopics; depthwise mixed with standard conv2d
+- Updated "Top Duplicate Clusters Remaining" note to reflect conv2d-gradient-* is resolved
+- Added new Verified On entry for PR #1080
+
+### Why
+Nine overlapping conv2d gradient testing skills were identified as a consolidation target.
+Unlike prior rounds (10->1), this cluster warranted 3 outputs because the source skills covered
+three genuinely distinct scenarios: standard conv2d finite-difference checks, depthwise-specific
+API quirks (different kernel shape, field names, tolerance API), and analytical-value tests using
+all-ones configurations. Merging depthwise into the standard skill would have buried critical
+API differences (`.grad_weights` not `.grad_kernel`; `tolerance:` not `rtol`/`atol`).
+
+### Previous version (v1.2.0) snapshot
+date: 2026-03-28
+version: "1.2.0"
+Outcome: Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added.
+Verified On:
+- ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session
+- ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session
+- ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session
+
+---
+
 ## v1.2.0 (2026-03-28)
 
 **Changed by:** PR #1077 -- consolidate deprecated file cleanup skills (6->1)

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -3,7 +3,7 @@ name: tooling-skill-deduplication-semver-versioning
 description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
 category: tooling
 date: 2026-03-28
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: tooling-skill-deduplication-semver-versioning.history
@@ -18,7 +18,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 |-------|-------|
 | **Date** | 2026-03-28 |
 | **Objective** | Merge duplicate skill clusters into consolidated skills, with semantic versioning for amendments |
-| **Outcome** | Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added. |
+| **Outcome** | Four rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 9 conv2d-gradient-* merged to 3 (net -6). Semver rules added. |
 | **Verification** | verified-ci |
 | **History** | [changelog](./tooling-skill-deduplication-semver-versioning.history) |
 
@@ -92,6 +92,8 @@ For multiple clusters, launch parallel agents (one per group) in the same worktr
 | Splitting into multiple consolidated files | Planned 10 mojo-test-* files into 2-3 sub-groups | All 10 files covered the same core workflow with minor variations | When content is truly redundant, even large clusters (10 files) can consolidate to 1 |
 | Forgetting .notes.md files | Deleted .md files but forgot accompanying .notes.md | Orphaned .notes.md files clutter the skills directory | Always delete both .md and .notes.md when removing source skills |
 | Cross-category consolidation | Source skills had mismatched categories (e.g., one marked `documentation`, rest `tooling`) | Category was set per-skill rather than reflecting the actual content topic | When consolidating, pick the most accurate category for the merged skill's actual function, not just the majority |
+| Over-splitting subtopics | Planned 9 conv2d skills into more than 3 groups | Content analysis showed clear 3-way split: finite-difference checks, depthwise-specific quirks, analytical-value tests | Group by actual usage scenario (how the tests are written), not by file naming pattern |
+| Depthwise mixed with standard conv2d | Considered merging depthwise into the standard conv2d finite-differences skill | Depthwise has critical API differences (kernel shape, field names, tolerance API) that warrant a dedicated skill | Even when topics are adjacent, separate skills when the API contract differs significantly |
 
 ## Results & Parameters
 
@@ -131,6 +133,22 @@ unique_lessons_preserved: 8 Failed Attempts rows
 consolidated_into: deprecated-file-stub-cleanup
 ```
 
+**Round 4: Conv2D gradient testing cluster (2026-03-28)**
+
+```yaml
+skills_before: 9
+skills_after: 3
+net_reduction: 6 skills (-67%)
+files_deleted: 18 (9 .md + 9 .notes.md)
+lines_deleted: 2136
+lines_added: 712
+split_into:
+  - conv2d-gradient-checking-finite-differences (standard conv2d: padding, stride, multi-channel)
+  - depthwise-conv2d-gradient-checking-tests (depthwise-specific API quirks)
+  - conv2d-backward-analytical-value-tests (exact expected values, batch accumulation, border pixel formula)
+key_insight: topic-adjacent skills with different APIs warrant separate skills even in same domain
+```
+
 ### Semver Rules for /learn
 
 | Change Type | Bump | When |
@@ -154,7 +172,7 @@ consolidated_into: deprecated-file-stub-cleanup
 5  batch-pr-*
 ```
 
-Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1).
+Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1). `conv2d-gradient-*` cluster (was 9) resolved in PR #1080 (9->3).
 
 ## Verified On
 
@@ -163,3 +181,4 @@ Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-fi
 | ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session |
 | ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session |
 | ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session |
+| ProjectMnemosyne | PR #1080, merged 9 conv2d-gradient-* skills into 3 | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `tooling-skill-deduplication-semver-versioning` from v1.2.0 to v1.3.0.

Documents Round 4 of the skills deduplication effort: 9 conv2d gradient testing skills consolidated into 3.

- Round 4 results: `conv2d-gradient-*` cluster (9→3, 67% reduction, 18 files deleted)
- Key new insight: adjacent-topic skills with distinct APIs warrant separate skills — forced 10→1 is not always right
- 2 new Failed Attempts rows: over-splitting subtopics; merging depthwise with standard conv2d

## Verification Level

**verified-ci** — PR #1080 (the conv2d consolidation itself) passed CI and was auto-merged before this amendment.

## Key Findings

**What Worked**:
- Grouping by usage scenario (how tests are written) rather than file naming pattern
- Keeping depthwise-conv2d separate due to distinct kernel shape `(channels,1,kH,kW)`, `.grad_weights` field, and `tolerance:` API

**What Failed**:
- Over-splitting 9 skills into more sub-groups → 3 was the natural split
- Merging depthwise into standard conv2d → would have buried critical API differences

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes: 1028/1028 valid
- [x] History file updated with v1.3.0 entry and v1.2.0 snapshot

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>