### PR TITLE
feat: amend tooling-skill-deduplication-semver-versioning (v1.3.0)

### DIFF
--- a/skills/tooling-skill-deduplication-semver-versioning.history
+++ b/skills/tooling-skill-deduplication-semver-versioning.history
@@ -1,5 +1,32 @@
 # tooling-skill-deduplication-semver-versioning -- History
 
+## v1.3.0 (2026-03-28)
+
+**Changed by:** PR #1085 -- consolidate CI failure triage skills (18->3)
+**Verification:** verified-ci
+
+### What changed
+- Added Round 4 deduplication result: CI-failure-triage cluster (18->3, 83% reduction)
+- New finding: large clusters with clear topic sub-divisions benefit from splitting by topic (not forcing to 1)
+- Updated "Top Duplicate Clusters Remaining" to note CI failure triage cluster resolved
+- Added new Verified On entry for PR #1085
+
+### Why
+18 CI failure triage skills were identified across ci-*, diagnose-*, fix-ci-*, pre-existing-*, verify-ci-*
+prefixes. Unlike prior rounds where a single merged skill worked, these 18 files contained 3 distinct
+topics: (1) log reading/diagnosis, (2) concrete fix patterns, (3) pre-existing failure triage. Splitting
+into 3 focused skills preserved the topic separation and prevented one monolithic skill from becoming
+too broad. Key new learning: when a cluster spans clear sub-domains, split by topic even if it means
+3 output files instead of 1.
+
+### Previous version (v1.2.0) snapshot
+date: 2026-03-28
+version: "1.2.0"
+Outcome: Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added.
+Verified On: PR #1040, PR #1075, PR #1077
+
+---
+
 ## v1.2.0 (2026-03-28)
 
 **Changed by:** PR #1077 -- consolidate deprecated file cleanup skills (6->1)

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -3,7 +3,7 @@ name: tooling-skill-deduplication-semver-versioning
 description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
 category: tooling
 date: 2026-03-28
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: tooling-skill-deduplication-semver-versioning.history
@@ -18,7 +18,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 |-------|-------|
 | **Date** | 2026-03-28 |
 | **Objective** | Merge duplicate skill clusters into consolidated skills, with semantic versioning for amendments |
-| **Outcome** | Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added. |
+| **Outcome** | Four rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 18 CI-failure-triage-* merged to 3 (net -15). Semver rules added. |
 | **Verification** | verified-ci |
 | **History** | [changelog](./tooling-skill-deduplication-semver-versioning.history) |
 
@@ -131,6 +131,23 @@ unique_lessons_preserved: 8 Failed Attempts rows
 consolidated_into: deprecated-file-stub-cleanup
 ```
 
+**Round 4: CI failure triage cluster (2026-03-28)**
+
+```yaml
+skills_before: 18
+skills_after: 3
+net_reduction: 15 skills (-83%)
+files_deleted: 35 (18 .md + 17 .notes.md)
+lines_deleted: 4303
+lines_added: 1034
+unique_lessons_preserved: 25+ Failed Attempts rows across 3 skills
+consolidated_into:
+  - ci-cd-failure-diagnosis-log-analysis (7 sources)
+  - ci-cd-failure-fix-patterns (6 sources)
+  - ci-cd-preexisting-failure-triage (5 sources)
+split_strategy: by_topic_not_prefix (3 distinct topics within ci-* prefix)
+```
+
 ### Semver Rules for /learn
 
 | Change Type | Bump | When |
@@ -154,7 +171,7 @@ consolidated_into: deprecated-file-stub-cleanup
 5  batch-pr-*
 ```
 
-Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1).
+Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1). CI failure triage cluster (was 18+) resolved in PR #1085 (18->3).
 
 ## Verified On
 
@@ -163,3 +180,4 @@ Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-fi
 | ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session |
 | ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session |
 | ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session |
+| ProjectMnemosyne | PR #1085, merged 18 CI-failure-triage-* skills into 3 | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `tooling-skill-deduplication-semver-versioning` from v1.2.0 to v1.3.0.

Records Round 4 of skill deduplication: 18 CI failure triage skills consolidated into 3 focused skills in PR #1085.

- 18 source skills across ci-*, diagnose-*, fix-ci-*, pre-existing-*, verify-ci-* prefixes
- Split into 3 focused outputs by topic (diagnosis/log-analysis, fix-patterns, preexisting-triage)
- 4303 lines deleted, 1034 lines of consolidated content added

## Verification Level

**verified-ci** — PR #1085 merged successfully

## Key Findings

**What Worked**:
- Splitting by topic (not forcing to 1) when a cluster spans clear sub-domains
- All 18 source files + 17 .notes.md files deleted cleanly

**New Learning**:
- Large clusters with 3 distinct topics should split into 3 focused files, not 1 monolithic skill

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes: 1003/1003 valid
- [x] History file updated with v1.3.0 entry

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>