### PR TITLE
feat: amend tooling-skill-deduplication-semver-versioning (v1.3.0)

### DIFF
--- a/skills/tooling-skill-deduplication-semver-versioning.history
+++ b/skills/tooling-skill-deduplication-semver-versioning.history
@@ -1,5 +1,33 @@
 # tooling-skill-deduplication-semver-versioning -- History
 
+## v1.3.0 (2026-03-28)
+
+**Changed by:** PR #1083 -- consolidate 15 worktree-* skills into 4 (functional grouping)
+**Verification:** verified-ci
+
+### What changed
+- Added Round 4 deduplication result: 15 worktree-* skills into 4 (net -11, 73% reduction)
+- Added new "When to Use" trigger: lifecycle-phase skills belonging together
+- Added Phase 5 to workflow: functional-role grouping strategy
+- Added 2 new Failed Attempts rows: grouping-only-by-prefix, deleting .history files
+- Updated "Top Duplicate Clusters Remaining" list with current state
+- Added new Verified On entry for PR #1083
+
+### Why
+15 overlapping worktree-operation skills were consolidated into 4 functional groups. Key insight:
+prefix-based grouping alone was insufficient — `parallel-rebase-agent-worktree-isolation` would
+not appear under `worktree-*` prefix. Functional role grouping (lifecycle / cleanup / parallel /
+migration+testing) produced more discoverable consolidated skills.
+
+### Previous version (v1.2.0) snapshot
+---
+name: tooling-skill-deduplication-semver-versioning
+version: "1.2.0"
+date: 2026-03-28
+Outcome: Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added.
+Verified On: PR #1040, PR #1075, PR #1077
+---
+
 ## v1.2.0 (2026-03-28)
 
 **Changed by:** PR #1077 -- consolidate deprecated file cleanup skills (6->1)

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -3,7 +3,7 @@ name: tooling-skill-deduplication-semver-versioning
 description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
 category: tooling
 date: 2026-03-28
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: tooling-skill-deduplication-semver-versioning.history
@@ -18,16 +18,17 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 |-------|-------|
 | **Date** | 2026-03-28 |
 | **Objective** | Merge duplicate skill clusters into consolidated skills, with semantic versioning for amendments |
-| **Outcome** | Three rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5). Semver rules added. |
+| **Outcome** | Four rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 15 worktree-* merged to 4 (net -11). Semver rules added. |
 | **Verification** | verified-ci |
 | **History** | [changelog](./tooling-skill-deduplication-semver-versioning.history) |
 
 ## When to Use
 
-- Multiple skills share a common prefix (e.g., `adr009-*`, `pr-review-*`, `mojo-test-*`)
+- Multiple skills share a common prefix (e.g., `adr009-*`, `pr-review-*`, `mojo-test-*`, `worktree-*`)
 - `/advise` returns redundant or contradictory advice for the same topic
 - Need to identify duplicate clusters in a large skills registry (1000+ skills)
 - Updating `/learn` versioning rules to use semantic versioning
+- Skills cover same lifecycle phases that should be treated as a single reference (e.g., create+switch+sync+path+stale-detection all belong in one worktree lifecycle skill)
 
 ## Verified Workflow
 
@@ -82,6 +83,18 @@ python3 scripts/validate_plugins.py
 
 For multiple clusters, launch parallel agents (one per group) in the same worktree. Each agent reads its group's skills and writes the merged output.
 
+**Phase 5: Grouping strategy for lifecycle-phase skills**
+
+When skills cover sequential lifecycle phases (e.g., create → switch → sync → cleanup → parallel),
+group by **functional role** rather than just prefix:
+
+- Group 1 (Lifecycle): create + switch + sync + path-awareness + stale-detection
+- Group 2 (Cleanup): cleanup + branch-cleanup + bulk-artifact-cleanup
+- Group 3 (Parallel): all parallel/batch agent execution patterns
+- Group 4 (Migration/Testing): migration-from-clone + integration-test-patterns
+
+This functional grouping is more discoverable than topic-prefix grouping alone.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -92,6 +105,8 @@ For multiple clusters, launch parallel agents (one per group) in the same worktr
 | Splitting into multiple consolidated files | Planned 10 mojo-test-* files into 2-3 sub-groups | All 10 files covered the same core workflow with minor variations | When content is truly redundant, even large clusters (10 files) can consolidate to 1 |
 | Forgetting .notes.md files | Deleted .md files but forgot accompanying .notes.md | Orphaned .notes.md files clutter the skills directory | Always delete both .md and .notes.md when removing source skills |
 | Cross-category consolidation | Source skills had mismatched categories (e.g., one marked `documentation`, rest `tooling`) | Category was set per-skill rather than reflecting the actual content topic | When consolidating, pick the most accurate category for the merged skill's actual function, not just the majority |
+| Grouping only by prefix | Used 2-part prefix matching to find all clusters | `worktree-*` cluster had 7 skills but many were from different functional areas; some parallel-agent skills (e.g., `parallel-rebase-agent-worktree-isolation`) had different prefixes but belonged in the same group | Cross-reference by content topic, not just prefix — read descriptions and group by functional role (lifecycle, cleanup, parallel, migration) |
+| Deleting .history files for consolidated skills | Removed source `.history` files along with `.notes.md` | Lost audit trail from source skills | When source skills have `.history` files, extract key entries into the consolidated skill's notes, then delete the source history |
 
 ## Results & Parameters
 
@@ -131,6 +146,25 @@ unique_lessons_preserved: 8 Failed Attempts rows
 consolidated_into: deprecated-file-stub-cleanup
 ```
 
+**Round 4: Worktree operations cluster (2026-03-28)**
+
+```yaml
+skills_before: 15
+skills_after: 4
+net_reduction: 11 skills (-73%)
+files_deleted: 23 (15 .md + 7 .notes.md + 1 .history)
+lines_deleted: 2822
+lines_added: 1125
+unique_lessons_preserved: 30+ Failed Attempts rows across 4 groups
+consolidated_into:
+  - worktree-lifecycle-create-switch-sync
+  - worktree-cleanup-branches-artifacts
+  - worktree-parallel-agent-execution
+  - worktree-migration-testing-patterns
+grouping_strategy: functional-role (not prefix-only)
+validation: 1044/1044 skills pass validate_plugins.py
+```
+
 ### Semver Rules for /learn
 
 | Change Type | Bump | When |
@@ -142,19 +176,21 @@ consolidated_into: deprecated-file-stub-cleanup
 ### Top Duplicate Clusters Remaining (for future merges)
 
 ```
-9  pr-review-*
-7  skill-fix-*
-7  pre-commit-*
-7  mojo-hash-*
-7  mojo-extensor-*
-7  github-actions-*
-7  git-worktree-*
-5  mojo-jit-*
-5  mass-pr-*
-5  batch-pr-*
+11  ci-cd-*
+9   pr-review-*
+7   skill-fix-*
+7   pre-commit-*
+7   mojo-hash-*
+7   mojo-extensor-*
+7   git-worktree-*   (separate from worktree-* — git-worktree-* prefix)
+7   github-actions-*
+5   mojo-test-*      (reduced from 10 but still 5 remaining)
+5   mass-pr-*
+5   fix-ci-*
+5   batch-pr-*
 ```
 
-Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1).
+Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1, but 5 new ones created). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1). `worktree-*` cluster resolved in PR #1083 (15->4).
 
 ## Verified On
 
@@ -163,3 +199,4 @@ Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-fi
 | ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session |
 | ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session |
 | ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session |
+| ProjectMnemosyne | PR #1083, merged 15 worktree-* skills into 4 (functional grouping) | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `tooling-skill-deduplication-semver-versioning` from v1.2.0 to v1.3.0.

Documents Round 4: 15 worktree-operation skills consolidated into 4 functional groups (PR #1083).

- Round 4: 15 worktree-* skills -> 4 consolidated skills (73% reduction, net -11)
- New workflow phase: functional-role grouping strategy (not just prefix-matching)
- 2 new Failed Attempts: grouping-only-by-prefix, deleting source .history files

## Verification Level

**verified-ci** — PR #1083 passed CI with 1044/1044 valid skills

## Key Findings

**What Worked**:
- Functional grouping (lifecycle / cleanup / parallel / migration+testing) more discoverable than prefix-only
- Single orchestrating agent reading all 15 files then writing 4 consolidated files

**What Failed**:
- Prefix-only grouping misses cross-prefix skills (parallel-rebase-agent-worktree-isolation belongs with worktree-parallel group but doesn't share worktree-* prefix)

## Test Plan

- [x] python3 scripts/validate_plugins.py passes 1028/1028
- [x] History file updated with v1.2.0 snapshot

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>