### PR TITLE
learn(ci-mojo): 5 skills for UAF bitcast, exotic dtype, Docker rate limit, benchmark path, mkdocs link

### DIFF
--- a/skills/ci-benchmark-host-container-path-mismatch.md
+++ b/skills/ci-benchmark-host-container-path-mismatch.md
@@ -1,0 +1,149 @@
+---
+name: ci-benchmark-host-container-path-mismatch
+description: "Fix GitHub Actions benchmark workflow failures where mkdir runs on host but
+  benchmark output is written inside a container. Use when: (1) benchmark CI step fails
+  to write output files, (2) workflow uses 'podman compose exec' or 'docker exec' for the
+  benchmark run but creates output dirs on the host, (3) directory exists on host but is
+  not accessible inside the container due to volume/UID mismatch."
+category: ci-cd
+date: 2026-03-27
+version: "1.0.0"
+user-invocable: false
+tags:
+  - ci
+  - benchmark
+  - podman
+  - docker
+  - container
+  - volume-mount
+  - filesystem-mismatch
+---
+
+# CI Benchmark Host/Container Path Mismatch
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-27 |
+| **Objective** | Fix benchmark workflow where output directory created on host is not accessible inside container |
+| **Outcome** | Successful — create output directory inside the container exec command |
+
+## When to Use
+
+- Benchmark CI step fails with permission denied or file-not-found writing output
+- Workflow creates output directory with `mkdir -p benchmark-results` on the host runner
+- The actual benchmark runs via `podman compose exec -T dev bash -c "..."` or `docker exec`
+- The container mounts the workspace via a volume with different UID mapping
+- Output directory convention mismatch: host has `benchmark-results/` but container expects
+  `builds/benchmarks/`
+
+## Root Cause
+
+`mkdir -p benchmark-results` on the **GitHub Actions host runner** creates a directory owned
+by the runner UID. The `podman compose exec` command runs inside the **container** where
+`/workspace` is a volume-mounted directory. The container process (running as a different UID
+due to rootless Podman's UID remapping) cannot write to a directory created by the host.
+
+Additionally, the output path convention may differ between host and container.
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# BROKEN: mkdir on host, benchmark runs inside container
+- name: Run benchmarks
+  run: |
+    mkdir -p benchmark-results
+    podman compose exec -T dev bash -c "pixi run python run.py --output benchmark-results/out.json"
+
+# FIXED: create output dir inside container exec, also create on host for fallback
+- name: Run benchmarks
+  run: |
+    mkdir -p builds/benchmarks
+    podman compose exec -T dev bash -c "mkdir -p builds/benchmarks && pixi run python run.py --output builds/benchmarks/out.json"
+```
+
+### Detailed Steps
+
+1. **Identify the failure** — look for permission denied or missing file errors in the
+   benchmark step output.
+
+2. **Determine where the command runs** — any step using `podman compose exec`, `docker exec`,
+   or `podman run` runs inside the container; `mkdir` or `run:` steps without these run on
+   the host.
+
+3. **Check volume mount UID mapping** — rootless Podman maps container UIDs to a sub-UID
+   range; files created by the host runner UID are not writable by the container UID.
+
+4. **Fix**: move `mkdir` inside the `exec` call:
+
+   ```yaml
+   podman compose exec -T dev bash -c "mkdir -p builds/benchmarks && pixi run python run.py --output builds/benchmarks/out.json"
+   ```
+
+5. **Also create on host** (for artifact upload steps that run on host):
+
+   ```yaml
+   mkdir -p builds/benchmarks
+   podman compose exec -T dev bash -c "mkdir -p builds/benchmarks && ..."
+   ```
+
+6. **Verify output path convention** — ProjectOdyssey uses `builds/benchmarks/` (not
+   `benchmark-results/`, not `build/`).
+
+### ProjectOdyssey Output Directory Convention
+
+| Purpose | Directory | Notes |
+|---------|-----------|-------|
+| Benchmark results | `builds/benchmarks/` | JSON output files |
+| Build artifacts | `builds/` | Compiled binaries |
+| Test results | `test-results/` | JUnit XML, coverage |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `mkdir -p benchmark-results` on host | Created output dir before exec call | Host dir not accessible by container process due to UID remapping | Create the dir inside the container exec, not on the host |
+| Using `benchmark-results/` path | Used non-standard output dir name | Project convention is `builds/benchmarks/` | Check project output dir conventions before hardcoding paths |
+
+## Results & Parameters
+
+### UID Remapping in Rootless Podman
+
+```bash
+# Host runner UID (typically 1001 in GitHub Actions)
+id  # uid=1001(runner) gid=1001(runner)
+
+# Container UID (mapped to subuid range)
+podman compose exec dev id  # uid=1000(dev) -- different from host
+
+# Directory created on host by UID 1001 is owned by different UID than container's 1000
+# -> permission denied when container tries to write
+```
+
+### Workflow Pattern (Copy-Paste)
+
+```yaml
+- name: Run benchmarks
+  run: |
+    mkdir -p builds/benchmarks
+    podman compose exec -T dev bash -c \
+      "mkdir -p builds/benchmarks && \
+       pixi run python scripts/run_benchmark.py \
+         --output builds/benchmarks/results.json"
+
+- name: Upload benchmark results
+  uses: actions/upload-artifact@v4
+  with:
+    name: benchmark-results
+    path: builds/benchmarks/
+    if-no-files-found: warn
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | CI benchmark workflow | PR #5177 (unverified) |

--- a/skills/ci-docker-hub-rate-limit-mcr-mirror.md
+++ b/skills/ci-docker-hub-rate-limit-mcr-mirror.md
@@ -1,0 +1,152 @@
+---
+name: ci-docker-hub-rate-limit-mcr-mirror
+description: "Fix Docker Hub anonymous pull rate limit failures in GitHub Actions CI by switching
+  ubuntu base image to MCR mirror. Use when: (1) CI container build fails with 'toomanyrequests'
+  pulling ubuntu:24.04, (2) multiple parallel build variants exhaust the 100 pulls/6h
+  anonymous limit, (3) no Docker Hub credentials are configured."
+category: ci-cd
+date: 2026-03-27
+version: "1.0.0"
+user-invocable: false
+tags:
+  - ci
+  - docker
+  - podman
+  - rate-limit
+  - mcr
+  - ubuntu
+  - base-image
+---
+
+# CI Docker Hub Rate Limit — Use MCR Mirror
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-27 |
+| **Objective** | Fix Docker Hub anonymous pull rate limit failures during parallel container builds |
+| **Outcome** | Successful — MCR mirror has no pull limits and stays current with upstream Ubuntu |
+
+## When to Use
+
+- CI fails with `toomanyrequests: You have reached your pull rate limit` pulling `ubuntu:24.04`
+- Multiple container build variants (runtime, CI, prod) run in parallel on the same runner IP
+- Anonymous Docker Hub pull limit (100/6h per IP) is exhausted by shared runner IP pools
+- No Docker Hub authentication is configured in the workflow
+- `FROM ubuntu:24.04` is used in `Dockerfile` or `Dockerfile.ci`
+
+## Root Cause
+
+GitHub Actions runners on hosted infrastructure share IP addresses. Docker Hub's anonymous pull
+rate limit is 100 pulls per 6 hours per IP. When a workflow triggers 3+ parallel container
+builds (e.g., runtime, CI, prod variants) each pulling `ubuntu:24.04`, the shared runner IP
+can exhaust the quota — especially during busy periods when other orgs' workflows are also
+pulling from the same IP.
+
+The Microsoft Container Registry (MCR) mirror at `mcr.microsoft.com/mirror/docker/library/ubuntu`
+mirrors Docker Hub's official images with no pull limits and no authentication required.
+
+## Verified Workflow
+
+### Quick Reference
+
+```dockerfile
+# BEFORE -- pulls from Docker Hub, subject to rate limits
+FROM ubuntu:24.04 AS builder
+
+# AFTER -- uses MCR mirror, no rate limits, same image
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS builder
+```
+
+Apply to ALL `FROM` lines in ALL Dockerfiles (including `Dockerfile.ci`, multi-stage builds):
+
+```bash
+# Find all ubuntu base image references
+grep -rn "FROM ubuntu:" Dockerfile Dockerfile.ci
+
+# Replace
+sed -i 's|FROM ubuntu:|FROM mcr.microsoft.com/mirror/docker/library/ubuntu:|g' Dockerfile Dockerfile.ci
+```
+
+### Detailed Steps
+
+1. **Confirm rate limit is the cause** — look for this error in CI build logs:
+
+   ```text
+   Error response from daemon: toomanyrequests: You have reached your pull rate limit.
+   You may increase the limit by authenticating and upgrading:
+   https://www.docker.com/increase-rate-limit
+   ```
+
+2. **Count parallel builds** — check the workflow for matrix strategies or multiple jobs
+   that each start a container build. If 3+ jobs all pull `ubuntu:24.04`, they compete for
+   the same rate limit bucket.
+
+3. **Replace in all Dockerfiles**:
+
+   ```dockerfile
+   FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS builder
+   FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS runtime
+   ```
+
+4. **Verify multi-stage builds** — check every `FROM` line, not just the first.
+
+5. **Note**: The MCR mirror only covers Docker Hub's official library images (`library/`).
+   For other images use the same mirror prefix:
+   - `mcr.microsoft.com/mirror/docker/library/python:3.11-slim`
+   - `mcr.microsoft.com/mirror/docker/library/node:20-alpine`
+
+### MCR Mirror URL Pattern
+
+```text
+mcr.microsoft.com/mirror/docker/library/<image>:<tag>
+
+Examples:
+  mcr.microsoft.com/mirror/docker/library/ubuntu:24.04
+  mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
+  mcr.microsoft.com/mirror/docker/library/python:3.11-slim
+  mcr.microsoft.com/mirror/docker/library/node:20-alpine
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Adding Docker Hub credentials | Considered authenticating to Docker Hub for higher limits | Adds secret management overhead; MCR mirror is simpler and free | Use MCR mirror — no auth required, no cost, no rate limits |
+| Serializing builds | Considered running builds sequentially to avoid concurrent pulls | Increases CI wall time significantly | MCR mirror is better — parallel builds are fine |
+
+## Results & Parameters
+
+### MCR Mirror Properties
+
+| Property | Value |
+|----------|-------|
+| URL | `mcr.microsoft.com/mirror/docker/library/` |
+| Authentication | None required |
+| Rate limit | None |
+| Image sync | Stays current with Docker Hub upstream |
+| Scope | Docker Hub official library images only |
+| Cost | Free |
+
+### Identifying Affected Workflows
+
+```bash
+# Find all Dockerfile references in GitHub Actions workflows
+grep -rn "docker build\|podman build\|Dockerfile" .github/workflows/
+
+# Find all ubuntu base images in Dockerfiles
+grep -rn "FROM ubuntu" Dockerfile* */Dockerfile*
+```
+
+### Note on GHCR Published Images
+
+The rate limit issue affects base image **pulls during build**, not published image pushes.
+If the workflow publishes final images to GHCR (`ghcr.io/org/image`), those pushes are
+unaffected. Only the `FROM ubuntu:24.04` base image pull at build time is rate-limited.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Dockerfile and Dockerfile.ci | PR #5177 (unverified) |

--- a/skills/mkdocs-nav-cleanup.md
+++ b/skills/mkdocs-nav-cleanup.md
@@ -1,14 +1,16 @@
 ---
 name: mkdocs-nav-cleanup
-description: 'Fix MkDocs build failures caused by nav entries referencing deleted
-  documentation files. Use when: (1) CI ''Deploy Documentation'' job fails after deleting
-  doc stubs, (2) mkdocs build --strict reports missing files, (3) PR deletes placeholder
-  docs but mkdocs.yml nav still references them.'
+description: 'Fix MkDocs build failures from nav referencing deleted files or relative
+  links escaping the docs/ tree. Use when: (1) CI ''Deploy Documentation'' job fails
+  after deleting doc stubs, (2) mkdocs build --strict reports missing files, (3) PR
+  deletes placeholder docs but mkdocs.yml nav still references them, (4) --strict
+  rejects a relative link like ../../docs/dev/file.md that escapes the docs/ root.'
 category: ci-cd
-date: 2026-03-05
-version: 1.0.0
+date: 2026-03-27
+version: 1.1.0
 user-invocable: false
 ---
+
 ## Overview
 
 | Field | Value |
@@ -23,41 +25,52 @@ user-invocable: false
 - A PR deletes placeholder/stub documentation files and CI "Deploy Documentation" fails
 - `mkdocs build --strict` reports "Documentation file 'X.md' specified in nav is not found"
 - A remaining markdown file contains a relative link to a now-deleted file
-- Pre-existing link-check failures (root-relative paths) are conflated with PR-caused failures — need to distinguish which CI failures are in-scope
+- Pre-existing link-check failures (root-relative paths) conflated with PR-caused failures
+- A relative link uses `../../docs/dev/` from inside `docs/adr/` — escaping the mkdocs
+  `docs/` root under `--strict`
 
 ## Verified Workflow
 
 1. **Identify deleted files** — check the PR diff for removed `.md` files
 2. **Audit mkdocs.yml nav** — find all nav entries referencing the deleted files
 3. **Audit remaining docs for cross-links** — grep for relative links pointing to deleted files:
+
    ```bash
    grep -r "deleted-file-name" docs/ mkdocs.yml
    ```
-4. **Remove nav entries** from `mkdocs.yml` — delete the entries (and their parent section if now empty)
-5. **Remove broken relative links** from remaining docs — remove or update bullet points referencing deleted files
+
+4. **Remove nav entries** from `mkdocs.yml` — delete the entries (and their parent section
+   if now empty)
+5. **Remove broken relative links** from remaining docs — remove or update bullet points
+   referencing deleted files
 6. **Verify no remaining references**:
+
    ```bash
    grep -r "deleted-file1\|deleted-file2" docs/ mkdocs.yml
    ```
+
 7. **Run pre-commit on changed files**:
+
    ```bash
    pre-commit run --files mkdocs.yml docs/path/to/changed.md
    ```
+
 8. **Commit** with message format `fix: Address review feedback for PR #<N>`
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Removing entire section blocks at once | Used Edit to replace multi-line nav blocks covering Core + Advanced + Development | Initially included Release Process (a surviving file) in the removal | Always check which files in a nav section still exist before removing the whole block — keep entries for surviving files |
+| Removing entire section blocks at once | Used Edit to replace multi-line nav blocks covering Core + Advanced + Development | Initially included Release Process (a surviving file) in the removal | Always check which files in a nav section still exist before removing the whole block |
 | Treating link-check failures as in-scope | Considered fixing 20 root-relative path errors in CLAUDE.md, docs/adr/, notebooks/README.md | These were pre-existing on main, unrelated to the PR | Verify pre-existing CI failures with `gh run list --branch main --workflow "Check Markdown Links"` before scoping fixes |
 
 ## Results & Parameters
 
 **What was fixed (PR #3308, issue #3142):**
 
-- `mkdocs.yml`: Removed `Core` section (8 entries), 6 `Advanced` entries, 3 `Development` entries — all referencing deleted placeholder stubs
-- `docs/advanced/benchmarking.md:666`: Removed `[SIMD Integration Guide](integration.md)` bullet — relative link to deleted stub
+- `mkdocs.yml`: Removed `Core` section (8 entries), 6 `Advanced` entries, 3 `Development`
+  entries — all referencing deleted placeholder stubs
+- `docs/advanced/benchmarking.md:666`: Removed `[SIMD Integration Guide](integration.md)` bullet
 
 **Verification command:**
 
@@ -69,5 +82,28 @@ Expected output: empty (no matches).
 
 **Key distinction — two independent CI failure types:**
 
-1. **In-scope**: `build-docs` fails because nav references deleted files → fix mkdocs.yml and cross-links
-2. **Out-of-scope (pre-existing)**: `link-check` fails on root-relative paths (e.g. `/.claude/shared/`) → do not fix in this PR; confirm with `gh run list --branch main --workflow "..."` that it was already failing before the PR
+1. **In-scope**: `build-docs` fails because nav references deleted files → fix mkdocs.yml
+   and cross-links
+2. **Out-of-scope (pre-existing)**: `link-check` fails on root-relative paths (e.g.
+   `/.claude/shared/`) → do not fix in this PR; confirm with
+   `gh run list --branch main --workflow "..."` that it was already failing before the PR
+
+### Relative Link Escaping the docs/ Root
+
+`mkdocs --strict` rejects relative links that resolve outside the `docs/` directory:
+
+```markdown
+# WRONG — from docs/adr/ADR-014.md, this goes to repo-root then docs/dev/
+[link](../../docs/dev/mojo-jit-crash-workaround.md)
+
+# CORRECT — from docs/adr/, ../dev/ stays within docs/
+[link](../dev/mojo-jit-crash-workaround.md)
+```
+
+**Rule**: Count `../` hops from the file location. From `docs/adr/file.md`:
+
+- `../` goes to `docs/` (safe)
+- `../../` goes to repo root (escapes docs/, rejected by --strict)
+
+**Diagnosis**: `mkdocs build --strict` error:
+`"path '../../docs/dev/...' is not within the documentation directory"`

--- a/skills/mojo-bitcast-always-inline-crash-fix.md
+++ b/skills/mojo-bitcast-always-inline-crash-fix.md
@@ -1,9 +1,13 @@
 ---
 name: mojo-bitcast-always-inline-crash-fix
-description: "Fix Mojo runtime crashes from bitcast pointer access by adding @always_inline. Use when: (1) libKGENCompilerRTShared.so crash in CI, (2) heap corruption after bitcast operations, (3) ASAP destruction invalidating pointers."
+description: "Fix Mojo 0.26.1 UAF crashes from bitcast pointer writes. Use when: (1)
+  libKGENCompilerRTShared.so crash in CI showing 3 fixed frames (0x3cb78b/0x3c93c6/0x3cc397),
+  (2) heap corruption after bitcast writes in dtype conversion functions, (3) ASAP
+  destruction invalidating pointers before write completes, (4) ADR-009 workaround marked
+  Resolved but source still has UAF writes."
 category: debugging
-date: '2026-03-25'
-version: "1.0.0"
+date: '2026-03-27'
+version: "1.1.0"
 user-invocable: false
 tags:
   - mojo
@@ -11,99 +15,164 @@ tags:
   - always-inline
   - heap-corruption
   - asap-destruction
+  - uaf
+  - asan
 ---
 
-# Mojo Bitcast @always_inline Crash Fix
+# Mojo Bitcast UAF / @always_inline Crash Fix
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-25 |
-| **Objective** | Fix intermittent CI crashes in gradient checking tests caused by bitcast pointer access |
-| **Outcome** | Successful — added @always_inline to 7 runtime-dtype accessor methods |
+| **Date** | 2026-03-27 |
+| **Objective** | Fix Mojo 0.26.1 use-after-free crashes in bitcast write paths and dtype conversion functions |
+| **Outcome** | Successful — two fix patterns: @always_inline on accessor methods; pointer arithmetic for direct UAF writes |
 
 ## When to Use
 
-- CI crashes with `libKGENCompilerRTShared.so` stack traces after bitcast operations
+- CI crashes with `libKGENCompilerRTShared.so` stack traces showing the 3-frame fingerprint
 - Heap corruption errors (`libc.so.6+0x45330` fortify_fail_abort) in Mojo code
-- Methods that use `ptr.bitcast[T]()` to read/write tensor data crash intermittently
+- Methods that use `ptr.bitcast[T]()` to write tensor data crash intermittently
 - Working `load[dtype]`/`store[dtype]` methods have `@always_inline` but similar methods without it crash
+- Dtype conversion functions (`to_int8`, `to_fp8`, block packing functions) crash
+- ADR-009 was marked "Resolved" but crashes persist — fix may have been applied to test callers, not source
 
 ## Verified Workflow
 
-### Quick Reference
+### Quick Reference — Two Fix Patterns
+
+**Pattern 1: @always_inline for accessor methods**
 
 ```mojo
 # BAD: Without @always_inline, ASAP destruction may destroy `self`
 # before the bitcast pointer write completes
 fn _set_float64(self, index: Int, value: Float64):
     var ptr = (self._data + offset).bitcast[Float32]()
-    ptr[] = value.cast[DType.float32]()  # ← self may be destroyed here
+    ptr[] = value.cast[DType.float32]()  # self may be destroyed here
 
 # GOOD: @always_inline keeps self alive through the bitcast
 @always_inline
 fn _set_float64(self, index: Int, value: Float64):
     var ptr = (self._data + offset).bitcast[Float32]()
-    ptr[] = value.cast[DType.float32]()  # ← self guaranteed alive
+    ptr[] = value.cast[DType.float32]()  # self guaranteed alive
+```
+
+**Pattern 2: Pointer arithmetic for direct UAF writes**
+
+```mojo
+# UNSAFE write — triggers ASAN abort (UAF)
+tensor._data.bitcast[T]()[i] = value
+
+# SAFE read — OK
+var v = tensor._data.bitcast[T]()[i]
+
+# SAFE write — pointer arithmetic separates lifetime from write
+var ptr = (tensor._data + offset).bitcast[T]()
+ptr[] = value
+
+# Also safe: use internal setters
+tensor._set_float32(index, value)
+tensor._set_int64(index, Int64(value))
 ```
 
 ### Detailed Steps
 
-1. **Identify the crash pattern** — Look for `libKGENCompilerRTShared.so` stack traces with no symbols. The crash occurs in heap management code (malloc/free)
+1. **Identify the crash pattern** — Look for `libKGENCompilerRTShared.so` stack traces
+   with no symbols. The crash occurs in heap management code (malloc/free).
 
-2. **Check if bitcast methods lack `@always_inline`** — Compare crashing methods against working ones. In this case:
+2. **Check the UAF write fingerprint** — The 3-frame ASAN signature is:
+
+   ```text
+   #0 ...libKGENCompilerRTShared.so+0x3cb78b
+   #1 ...libKGENCompilerRTShared.so+0x3c93c6
+   #2 ...libKGENCompilerRTShared.so+0x3cc397
+   #3 ...libc.so.6+0x45330  -- __fortify_fail / heap corruption
+   ```
+
+3. **Audit ALL instances** — Do not just fix the test callers. Search the **source files**
+   for UAF writes:
+
+   ```bash
+   grep -rn '._data.bitcast\[' shared/ tests/
+   ```
+
+   Common locations: dtype conversion functions (`to_int8`, `to_int16`, `to_int32`,
+   `to_uint8/16/32/64`, `to_fp8`, `to_bf8`, `mxfp4`/`nvfp4` block packing).
+
+4. **Check if bitcast methods lack `@always_inline`** — Compare crashing methods against
+   working ones:
    - `load[dtype]`/`store[dtype]` had `@always_inline` and worked
    - `_get_float64`/`_set_float64` lacked it and crashed
 
-3. **Add `@always_inline` to all bitcast accessor methods**:
+5. **Add `@always_inline` to all bitcast accessor methods**:
    - `_get_float64()`, `_set_float64()`
    - `_get_float32()`, `_set_float32()`
    - `_get_int64()`, `_set_int64()`
    - `_get_dtype_size()` (helper called by all accessors)
 
-4. **Replace any local deep-copy functions** with `AnyTensor.clone()` to avoid duplicate bitcast code paths
+6. **Replace direct UAF writes** in source and test code with pointer arithmetic or
+   internal setters.
+
+7. **Replace any local deep-copy functions** with `AnyTensor.clone()` to avoid duplicate
+   bitcast code paths.
+
+### ADR-009 "Resolved" Trap
+
+If ADR-009 is marked "Resolved" but crashes persist:
+
+- The fix was likely applied only to **test callers**, not the **source functions**
+- Source files like `any_tensor.mojo` can have 20+ UAF write sites in dtype conversion
+- Test files can have direct `_data.bitcast[Float32]()[i] = value` writes in helpers
+- Always audit the source, not just the test wrappers
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Removing debug_assert | Removed debug_assert from load/store/data_ptr (commit dbc94176c) | Fixed JIT buffer overflow but not the bitcast crash — different root cause | debug_assert removal and @always_inline fix address different crash mechanisms |
-| ADR-009 file splitting | Split test files to ≤10 fn test_ functions | Reduced frequency but didn't eliminate crashes — the real issue is pointer lifetime, not file size | File splitting is a workaround, not a root cause fix for bitcast crashes |
+| ADR-009 file splitting | Split test files to 10 fn test_ functions | Reduced frequency but did not eliminate crashes — real issue is pointer lifetime | File splitting is a workaround, not a root cause fix |
 | Local reproduction | Ran tests 20+ times locally to reproduce | All passed locally — crash is CI-only due to different JIT optimization levels | Mojo JIT behavior differs between local and CI environments |
+| Fixing test callers only | Applied UAF fixes to test code while source functions still had the UAF writes | Source `any_tensor.mojo` had ~20 UAF writes in dtype conversion functions | Always search source files for UAF writes — do not trust "Resolved" ADR status |
+| Retrying CI runs | Rerunning failed CI jobs | Retrying masks root causes; crashes recur on subsequent runs | Investigate and fix the actual UAF write site |
 
 ## Results & Parameters
 
 ### The ASAP destruction mechanism
 
-Mojo uses "As Soon As Possible" destruction — objects are destroyed as soon as they're last used. In a method like:
+Mojo uses "As Soon As Possible" destruction — objects are destroyed as soon as they are
+last used. In a method like:
 
 ```mojo
 fn _set_float64(self, index: Int, value: Float64):
     var offset = index * self._get_dtype_size()
     var ptr = (self._data + offset).bitcast[Float32]()
-    # ← Mojo may destroy `self` here since it's no longer referenced
-    ptr[] = value.cast[DType.float32]()  # ← writing to freed memory!
+    # Mojo may destroy `self` here since it's no longer referenced
+    ptr[] = value.cast[DType.float32]()  # writing to freed memory!
 ```
 
-The JIT compiler may determine that `self` is no longer needed after computing the pointer, and destroy it (freeing `self._data`) before the write through `ptr` completes.
+The JIT compiler may determine that `self` is no longer needed after computing the pointer,
+and destroy it (freeing `self._data`) before the write through `ptr` completes.
 
-`@always_inline` prevents this by inlining the function body into the caller's scope, where `self` remains alive for the duration of the call.
+`@always_inline` prevents this by inlining the function body into the caller's scope,
+where `self` remains alive for the duration of the call.
 
 ### Crash signature
 
-```
-#0 0x00007fc7f5dcb78b (/workspace/.pixi/envs/default/lib/libKGENCompilerRTShared.so+0x3cb78b)
-#1 0x00007fc7f5dc93c6 (/workspace/.pixi/envs/default/lib/libKGENCompilerRTShared.so+0x3c93c6)
-#2 0x00007fc7f5dcc397 (/workspace/.pixi/envs/default/lib/libKGENCompilerRTShared.so+0x3cc397)
-#3 0x00007fc7fe633330 (/lib/x86_64-linux-gnu/libc.so.6+0x45330)
+```text
+#0 0x00007fc7f5dcb78b (libKGENCompilerRTShared.so+0x3cb78b)
+#1 0x00007fc7f5dc93c6 (libKGENCompilerRTShared.so+0x3c93c6)
+#2 0x00007fc7f5dcc397 (libKGENCompilerRTShared.so+0x3cc397)
+#3 0x00007fc7fe633330 (libc.so.6+0x45330)
 ```
 
-The `libc.so.6+0x45330` offset corresponds to `__fortify_fail` / `__stack_chk_fail`, indicating heap corruption from use-after-free.
+The `libc.so.6+0x45330` offset corresponds to `__fortify_fail` / `__stack_chk_fail`,
+indicating heap corruption from use-after-free.
 
 ### Methods that need @always_inline
 
 Any method on AnyTensor that:
+
 1. Accesses `self._data` via bitcast
 2. Is NOT parametric (can't use `load[dtype]`/`store[dtype]` which require compile-time dtype)
 3. Is called in tight loops (gradient checking, element-wise operations)
@@ -112,4 +181,4 @@ Any method on AnyTensor that:
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | shared/tensor/any_tensor.mojo | [notes](./skills/mojo-bitcast-always-inline-crash-fix.notes.md) |
+| ProjectOdyssey | shared/tensor/any_tensor.mojo | [notes](./mojo-bitcast-always-inline-crash-fix.notes.md) |

--- a/skills/mojo-exotic-dtype-default-param-crash.md
+++ b/skills/mojo-exotic-dtype-default-param-crash.md
@@ -1,0 +1,154 @@
+---
+name: mojo-exotic-dtype-default-param-crash
+description: "Fix Mojo 0.26.1 ASAN abort at module load from exotic dtype (E8M0, FP8) used
+  as default parameter values. Use when: (1) ASAN abort fires before any test body runs,
+  (2) code uses Scalar[E8M0](1.0) or Scalar[FP8](1.0) as a default param, (3) E8M0/FP8
+  float-conversion path is triggered at module load time."
+category: debugging
+date: 2026-03-27
+version: "1.0.0"
+user-invocable: false
+tags:
+  - mojo
+  - asan
+  - dtype
+  - e8m0
+  - fp8
+  - default-param
+  - module-load
+---
+
+# Mojo Exotic Dtype Default Parameter Crash
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-27 |
+| **Objective** | Fix ASAN abort caused by using exotic float dtypes (E8M0, FP8) as default parameter values |
+| **Outcome** | Successful — replace default params with bitcast-safe construction helpers |
+
+## When to Use
+
+- CI test file crashes at ASAN abort before any test body executes
+- Code contains `Scalar[E8M0](1.0)` or `Scalar[FP8](1.0)` as a **default parameter value**
+- `E8M0 = DType.float8_e8m0fnu` — exponent-only, no mantissa, no sign, no valid float conversion
+- `FP8 = DType.float8_e4m3fn` — less exotic but same crash risk when used as a default param
+- The crash signature is the same 3-frame ASAN fingerprint as UAF bitcast crashes but fires
+  at module load, not during a write operation
+
+## Root Cause
+
+Default parameter values in Mojo are evaluated **when the module is loaded**, before any test
+function runs. The float-to-exotic-dtype cast path (`Scalar[E8M0](1.0)`) triggers an ASAN abort
+during this module initialization.
+
+- `E8M0` has no mantissa and no sign bit — it represents exponents only (used in microscaling
+  formats). There is no valid path from a Float64 literal to E8M0.
+- Even `FP8` (`float8_e4m3fn`) can crash as a default param if the cast path is not safe
+  at module-load time.
+
+Runtime calls to `Scalar[FP8](1.0)` inside function bodies are fine — only **default params**
+are affected because they run at module scope.
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+# CRASHES: evaluated at module load, no valid float->E8M0 conversion
+fn some_func(val: Scalar[E8M0] = Scalar[E8M0](1.0)):
+    ...
+
+# CRASHES: same for FP8
+fn other_func(val: Scalar[FP8] = Scalar[FP8](1.0)):
+    ...
+
+# SAFE for E8M0: exponent 127 = 1.0 in E8M0 representation
+fn _e8m0_from_exponent(exp: UInt8) -> Scalar[E8M0]:
+    return bitcast[E8M0, 1](SIMD[DType.uint8, 1](exp))[0]
+
+alias E8M0_ONE = _e8m0_from_exponent(127)
+
+# SAFE for FP8: 0x3C is the bit pattern for 1.0 in float8_e4m3fn
+alias FP8_ONE = bitcast[FP8, 1](SIMD[DType.uint8, 1](0x3C))[0]
+```
+
+### Detailed Steps
+
+1. **Identify the module-load crash** — if the crash occurs before any test body runs
+   (crash on the first `fn test_*` entry with no test logic executed), look for default
+   parameter values using exotic dtypes.
+
+2. **Search for all exotic dtype default params**:
+
+   ```bash
+   grep -rn 'Scalar\[E8M0\]\|Scalar\[FP8\]\|float8_e8m0\|float8_e4m3' shared/ tests/ | grep '='
+   ```
+
+3. **Replace E8M0 defaults** with a bitcast-safe helper:
+
+   ```mojo
+   fn _e8m0_from_exponent(exp: UInt8) -> Scalar[DType.float8_e8m0fnu]:
+       return bitcast[DType.float8_e8m0fnu, 1](SIMD[DType.uint8, 1](exp))[0]
+
+   # E8M0 encoding: biased exponent (bias=127), 1.0 = exponent field 127
+   alias E8M0_ONE = _e8m0_from_exponent(127)
+   ```
+
+4. **Replace FP8 defaults** using the bit pattern for 1.0:
+
+   ```mojo
+   # float8_e4m3fn bit pattern: sign=0, exp=0111(7), mantissa=000 -> 0x3C
+   alias FP8_ONE = bitcast[DType.float8_e4m3fn, 1](SIMD[DType.uint8, 1](0x3C))[0]
+   ```
+
+5. **Files affected in ProjectOdyssey**:
+   - `shared/tensor/mxfp4.mojo` line 290 — default param with `Scalar[E8M0](1.0)`
+   - `shared/tensor/nvfp4.mojo` line 271 — default param with `Scalar[FP8](1.0)`
+   - `shared/tensor/nvfp4.mojo` line 671 — constructor body with `Scalar[FP8](1.0)` (runtime)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Retrying CI | Rerunning the failed test group | ASAN abort is deterministic — not flaky infrastructure | This crash always reproduces; do not retry |
+| Treating as UAF | Assuming 3-frame ASAN signature always means bitcast write UAF | The same ASAN abort fires for module-load default-param crashes | Distinguish by crash timing: pre-test-body = module load; mid-test = bitcast write UAF |
+
+## Results & Parameters
+
+### E8M0 Bit Encoding Reference
+
+```text
+E8M0 = float8_e8m0fnu:
+  - 8 bits: all exponent, no mantissa, no sign
+  - Biased exponent with bias=127
+  - 1.0 = exponent 127 = 0x7F
+  - No valid float cast path -- must use bitcast from UInt8
+```
+
+### FP8 (float8_e4m3fn) Bit Encoding Reference
+
+```text
+FP8 = float8_e4m3fn:
+  - Sign: 1 bit
+  - Exponent: 4 bits, bias=7
+  - Mantissa: 3 bits
+  - 1.0 = 0 0111 000 = 0x3C
+  - Runtime Scalar[FP8](1.0) is safe; only default params crash
+```
+
+### Diagnostic Pattern: Module-Load vs. Mid-Test Crash
+
+| Indicator | Module-Load Crash | Mid-Test UAF Crash |
+|-----------|------------------|--------------------|
+| When crash fires | Before first test body | During test execution |
+| Stack shows | Module init frames | Test function + write ops |
+| Root cause | Exotic dtype default param | `tensor._data.bitcast[T]()[i] = value` |
+| Fix | Replace default param with alias | @always_inline or pointer arithmetic |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | shared/tensor/mxfp4.mojo, shared/tensor/nvfp4.mojo | PR #5177 (unverified) |


### PR DESCRIPTION
## Summary

Session learnings from diagnosing root causes of ProjectOdyssey CI failures (PR #5177).
All 5 files validated with `python3 scripts/validate_plugins.py`.

### New skills (3)

- **mojo-exotic-dtype-default-param-crash**: ASAN abort at module load when `Scalar[E8M0](1.0)`
  or `Scalar[FP8](1.0)` is used as a default parameter value. Includes E8M0/FP8 bit encoding
  reference and diagnostic table distinguishing module-load crash from mid-test UAF crash.
- **ci-benchmark-host-container-path-mismatch**: `mkdir` on host runner vs. `podman compose exec`
  inside container causing permission denied. Fix: create output dir inside the exec call.
  ProjectOdyssey output dir convention: `builds/benchmarks/`.
- **ci-docker-hub-rate-limit-mcr-mirror**: 3+ parallel container builds exhaust Docker Hub's
  100/6h anonymous pull limit. Fix: `FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04`.

### Amended skills (2, v1.0.0 -> v1.1.0)

- **mojo-bitcast-always-inline-crash-fix**: Added Pattern 2 (pointer arithmetic for direct UAF
  writes), ADR-009 "Resolved" trap warning, grep audit command, 2 new failed attempts (fixing
  test callers only; retrying CI runs).
- **mkdocs-nav-cleanup**: Added relative link escaping the `docs/` root under `--strict`
  (`../../docs/dev/` from `docs/adr/` is wrong; `../dev/` is correct).

## Verification level

`unverified` — PR #5177 was opened but CI results not yet available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)