### PR TITLE
feat: amend tooling-skill-deduplication-semver-versioning (v1.5.0)

### DIFF
--- a/skills/tooling-skill-deduplication-semver-versioning.history
+++ b/skills/tooling-skill-deduplication-semver-versioning.history
@@ -1,5 +1,39 @@
 # tooling-skill-deduplication-semver-versioning -- History
 
+## v1.5.0 (2026-03-28)
+
+**Changed by:** PR #1097 -- consolidate 4 adr009-* skills into 1 with OBSOLETE notice
+**Verification:** verified-ci
+
+### What changed
+- Added Round 6 deduplication result: 4 adr009-* skills -> 1 (ADR-009 declared OBSOLETE)
+- Added "Special case: OBSOLETE topics" guidance to Verified Workflow
+- Added Failed Attempts row: stopping at 3 when topic is OBSOLETE
+- Added new trigger: skill covers a topic that is now OBSOLETE
+- Updated "Top Duplicate Clusters Remaining" to note PR #1097
+- Added new Verified On entry for PR #1097
+
+### Why
+After Round 5 consolidated 12 adr009 skills into 3 well-organized sub-skills, the ADR-009
+workaround was declared fixed at the compiler/runtime level. The user requirement to add a
+prominent OBSOLETE notice motivated further consolidation from 3 to 1: splitting the notice
+across 3 separate skill files would fragment the OBSOLETE message. A single canonical skill
+with the OBSOLETE notice immediately after the Overview table was the correct design.
+Also merged adr009-ci-pattern-updates.md (4th file) into the same consolidated skill.
+
+### Previous version (v1.4.0) snapshot
+date: 2026-03-28
+version: "1.4.0"
+Outcome: Five rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 9 conv2d-gradient-* merged to 3 (net -6); 12 adr009-test-splitting-* merged to 3 (net -9). Semver rules added.
+Verified On:
+- ProjectMnemosyne | PR #1040, merged 16 adr009 skills + added semver | 2026-03-25 session
+- ProjectMnemosyne | PR #1075, merged 10 mojo-test-* skills into 1 | 2026-03-27 session
+- ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session
+- ProjectMnemosyne | PR #1080, merged 9 conv2d-gradient-* skills into 3 | 2026-03-28 session
+- ProjectMnemosyne | PR #1086, re-consolidated 12 adr009-test-splitting-* skills into 3 | 2026-03-28 session
+
+---
+
 ## v1.4.0 (2026-03-28)
 
 **Changed by:** PR #1086 -- re-consolidate ADR-009 test splitting skills (12->3, second pass)

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -3,7 +3,7 @@ name: tooling-skill-deduplication-semver-versioning
 description: "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes."
 category: tooling
 date: 2026-03-28
-version: "1.4.0"
+version: "1.5.0"
 user-invocable: false
 verification: verified-ci
 history: tooling-skill-deduplication-semver-versioning.history
@@ -18,7 +18,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 |-------|-------|
 | **Date** | 2026-03-28 |
 | **Objective** | Merge duplicate skill clusters into consolidated skills, with semantic versioning for amendments |
-| **Outcome** | Five rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 9 conv2d-gradient-* merged to 3 (net -6); 12 adr009-test-splitting-* merged to 3 (net -9). Semver rules added. |
+| **Outcome** | Six rounds: 16 adr009-* merged to 3 (net -13); 10 mojo-test-* merged to 1 (net -9); 6 deprecated-file-cleanup-* merged to 1 (net -5); 9 conv2d-gradient-* merged to 3 (net -6); 12 adr009-test-splitting-* merged to 3 (net -9); 4 adr009-* merged to 1 with OBSOLETE notice (net -3). |
 | **Verification** | verified-ci |
 | **History** | [changelog](./tooling-skill-deduplication-semver-versioning.history) |
 
@@ -28,6 +28,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 - `/advise` returns redundant or contradictory advice for the same topic
 - Need to identify duplicate clusters in a large skills registry (1000+ skills)
 - Updating `/learn` versioning rules to use semantic versioning
+- A skill covers a topic that is now OBSOLETE and needs a prominent deprecation notice before all other content
 
 ## Verified Workflow
 
@@ -72,6 +73,31 @@ For each sub-group of duplicates:
 4. No `.history` file needed — this is a new v1.0.0 skill, not an amendment
 5. If another agent may have already deleted some files, skip them silently (`git rm` will error on missing files)
 
+**Special case: OBSOLETE topics**
+
+When the underlying topic is no longer applicable (e.g., a bug was fixed at the compiler level),
+consolidate ALL related skills into a single historical reference with a prominent obsolescence
+notice immediately after the Overview table:
+
+```markdown
+## <Topic> Status: OBSOLETE
+
+> **<Topic> has been fixed.** <Brief explanation of why the workaround is no longer needed.>
+>
+> **Do NOT use this skill to implement <workaround> on new code.**
+>
+> For <the actual problem>, use **<preferred solution>** instead:
+> - <Preferred solution detail 1>
+> - <Preferred solution detail 2>
+>
+> This skill is preserved for historical reference and for understanding existing code
+> that has not yet been updated.
+```
+
+Key difference from regular consolidation: even well-organized 3-file clusters warrant
+further consolidation to 1 when a prominent OBSOLETE notice is the primary requirement,
+because splitting the obsolescence notice across 3 files fragments the message.
+
 **Phase 3: Validate**
 
 ```bash
@@ -95,6 +121,7 @@ For multiple clusters, launch parallel agents (one per group) in the same worktr
 | Over-splitting subtopics | Planned 9 conv2d skills into more than 3 groups | Content analysis showed clear 3-way split: finite-difference checks, depthwise-specific quirks, analytical-value tests | Group by actual usage scenario (how the tests are written), not by file naming pattern |
 | Depthwise mixed with standard conv2d | Considered merging depthwise into the standard conv2d finite-differences skill | Depthwise has critical API differences (kernel shape, field names, tolerance API) that warrant a dedicated skill | Even when topics are adjacent, separate skills when the API contract differs significantly |
 | Assuming one-time merges are durable | Merged adr009-* cluster in Round 1 (16->3), assumed stable | /learn calls after the merge created 9 new duplicate skills covering the same adr009 split topic | Deduplication is not permanent; re-duplication occurs organically — schedule periodic re-consolidation passes |
+| Stopping at 3 when topic is OBSOLETE | Round 5 consolidated 12 adr009 skills to 3 sub-skills | When the underlying topic (ADR-009 workaround) was declared OBSOLETE, the 3-file structure fragmented the OBSOLETE notice | When a topic is OBSOLETE, consolidate further to 1 file — the obsolescence notice is the dominant content |
 
 ## Results & Parameters
 
@@ -150,6 +177,18 @@ split_into:
 key_insight: prior round merged these to 3, but subsequent /learn calls recreated 9 more duplicates — re-consolidation needed
 ```
 
+**Round 6: ADR-009 OBSOLETE consolidation (2026-03-28)**
+
+```yaml
+skills_before: 4
+skills_after: 1
+net_reduction: 3 skills (-75%)
+files_deleted: 3 (adr009-split-audit-recovery.md, adr009-desplit-merge-workflow.md, adr009-ci-pattern-updates.md)
+motivation: ADR-009 was fixed at compiler level; needed single skill with prominent OBSOLETE notice
+key_insight: when a topic is OBSOLETE, consolidate to 1 even if subtopics were well-organized into 3
+obsolete_notice_position: immediately after Overview table (before "When to Use")
+```
+
 **Round 4: Conv2D gradient testing cluster (2026-03-28)**
 
 ```yaml
@@ -189,7 +228,7 @@ key_insight: topic-adjacent skills with different APIs warrant separate skills e
 5  batch-pr-*
 ```
 
-Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1). `conv2d-gradient-*` cluster (was 9) resolved in PR #1080 (9->3). ADR-009 second pass (12 re-duplicated) resolved in PR #1086 (12->3).
+Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-file-*` cluster (was 6) resolved in PR #1077 (6->1). `conv2d-gradient-*` cluster (was 9) resolved in PR #1080 (9->3). ADR-009 second pass (12 re-duplicated) resolved in PR #1086 (12->3). ADR-009 OBSOLETE pass resolved in PR #1097 (4->1).
 
 ## Verified On
 
@@ -200,3 +239,4 @@ Note: `mojo-test-*` cluster (was 8) resolved in PR #1075 (10->1). `deprecated-fi
 | ProjectMnemosyne | PR #1077, merged 6 deprecated-file-cleanup-* skills into 1 | 2026-03-28 session |
 | ProjectMnemosyne | PR #1080, merged 9 conv2d-gradient-* skills into 3 | 2026-03-28 session |
 | ProjectMnemosyne | PR #1086, re-consolidated 12 adr009-test-splitting-* skills into 3 (cluster re-duplicated after prior merge) | 2026-03-28 session |
+| ProjectMnemosyne | PR #1097, consolidated 4 adr009-* skills to 1 with prominent OBSOLETE notice (ADR-009 fixed at compiler level) | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `tooling-skill-deduplication-semver-versioning` from v1.4.0 to v1.5.0.

- Adds Round 6 deduplication result: 4 adr009-* skills consolidated into 1 (PR #1097)
- Adds new pattern: when a topic is OBSOLETE, consolidate to 1 file with prominent notice
- Adds OBSOLETE topic workflow guidance with template
- Adds new Failed Attempts row and When to Use trigger

## Verification Level

**verified-ci** — PR #1097 already merged to main.

## Key Findings

**What Worked**:
- Single historical reference with OBSOLETE notice at top (after Overview, before When to Use)
- All content from 4 source files preserved in 1 consolidated skill (4->1, 75% reduction)
- `python3 scripts/validate_plugins.py` passes (971/971 valid)

**New Learning**:
- When a topic is OBSOLETE, consolidate further to 1 even if prior round created a well-organized 3-file structure — splitting the OBSOLETE notice fragments the message

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes (971/971)
- [x] History log updated with v1.5.0 entry and v1.4.0 snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)