### PR TITLE
Port 4 Modular skills with Apache 2.0 attribution

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,34 @@
+# Third-Party Licenses
+
+## modular/skills
+
+**Source**: https://github.com/modular/skills
+**License**: Apache License 2.0
+**Date Ported**: 2026-04-09
+
+### Ported Skills
+
+| Ported Skill | Source File | Action |
+|---|---|---|
+| `mojo-026-breaking-changes.md` (v3.0.0) | `mojo-syntax/SKILL.md` | Merged into existing skill |
+| `mojo-gpu-fundamentals-programming-guide.md` | `mojo-gpu-fundamentals/SKILL.md` | New skill |
+| `mojo-python-interop-patterns-guide.md` | `mojo-python-interop/SKILL.md` | New skill |
+| `tooling-modular-project-setup-wizard.md` | `new-modular-project/SKILL.md` | New skill |
+
+### Apache License 2.0
+
+```
+Copyright Modular Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/skills/mojo-026-breaking-changes.md
+++ b/skills/mojo-026-breaking-changes.md
@@ -1,13 +1,13 @@
 ---
 name: mojo-026-breaking-changes
-description: "Catalog of Mojo 0.26.3 breaking changes and fixes. Use when: (1) migrating a Mojo codebase from 0.26.1 to 0.26.3, (2) encountering unfamiliar compile errors after a Mojo version bump, (3) auditing code for deprecated APIs."
+description: "Catalog of Mojo 0.26.3 breaking changes, fixes, and authoritative current syntax reference. Use when: (1) migrating a Mojo codebase from 0.26.1 to 0.26.3, (2) encountering unfamiliar compile errors after a Mojo version bump, (3) auditing code for deprecated APIs, (4) writing new Mojo code and need current syntax corrections."
 category: tooling
-date: 2026-04-08
-version: "2.0.0"
+date: 2026-04-09
+version: "3.0.0"
 user-invocable: false
 verification: verified-local
 history: mojo-026-breaking-changes.history
-tags: [mojo, breaking-changes, migration, 0.26.3, deprecation, capturing, ImplicitlyDestructible, substr]
+tags: [mojo, breaking-changes, migration, 0.26.3, deprecation, capturing, ImplicitlyDestructible, substr, syntax, modular-upstream]
 ---
 
 # Mojo 0.26.3 Breaking Changes Catalog
@@ -169,8 +169,226 @@ struct NamedTensor(Movable):
     # No __moveinit__ needed
 ```
 
+## Authoritative Syntax Reference (Modular)
+
+The following is Modular's canonical current Mojo syntax guide, merged from their
+[official skills repo](https://github.com/modular/skills). Use this section when
+writing **new** Mojo code (not just migrating). See also the Breaking Change Reference
+Table above for migration-specific fixes.
+
+### Removed Syntax — Complete Table
+
+| Removed                                          | Replacement                                                          |
+|--------------------------------------------------|----------------------------------------------------------------------|
+| `alias X = ...`                                  | `comptime X = ...`                                                   |
+| `@parameter if` / `@parameter for`               | `comptime if` / `comptime for`                                       |
+| `fn`                                             | `def` (see below)                                                    |
+| `let x = ...`                                    | `var x = ...` (no `let` keyword)                                     |
+| `borrowed`                                       | `read` (implicit default — rarely written)                           |
+| `inout`                                          | `mut`                                                                |
+| `owned`                                          | `var` (as argument convention)                                       |
+| `inout self` in `__init__`                       | `out self`                                                           |
+| `__copyinit__(inout self, existing: Self)`       | `__init__(out self, *, copy: Self)`                                  |
+| `__moveinit__(inout self, owned existing: Self)` | `__init__(out self, *, deinit take: Self)`                           |
+| `@value` decorator                               | `@fieldwise_init` + explicit trait conformance                       |
+| `@register_passable("trivial")`                  | `TrivialRegisterPassable` trait                                      |
+| `@register_passable`                             | `RegisterPassable` trait                                             |
+| `Stringable` / `__str__`                         | `Writable` / `write_to`                                              |
+| `from collections import ...`                    | `from std.collections import ...`                                    |
+| `from memory import ...`                         | `from std.memory import ...`                                         |
+| `from sys import ...`                            | `from std.sys import ...`                                            |
+| `from os import ...`                             | `from std.os import ...`                                             |
+| `from pathlib import ...`                        | `from std.pathlib import ...`                                        |
+| `s[i]`                                           | `s[byte=i]` — returns `StringSlice`; wrap in `String()` if needed    |
+| `s[0:10]`, `s[:5]`                               | No slice syntax on String — use `s.codepoint_slices()` or Python FFI |
+| `constrained(cond, msg)`                         | `comptime assert cond, msg`                                          |
+| `DynamicVector[T]`                               | `List[T]`                                                            |
+| `InlinedFixedVector[T, N]`                       | `InlineArray[T, N]`                                                  |
+| `Tensor[T]`                                      | Not in stdlib (use SIMD, List, UnsafePointer)                        |
+
+### `def` Is the Only Function Keyword
+
+`fn` is deprecated. `def` does **not** imply `raises`. Always add `raises` explicitly:
+
+```mojo
+def compute(x: Int) -> Int:              # non-raising
+    return x * 2
+
+def load(path: String) raises -> String: # explicitly raising
+    return open(path).read()
+```
+
+### `comptime` Replaces `alias` and `@parameter`
+
+```mojo
+comptime N = 1024                            # compile-time constant
+comptime MyType = Int                        # type alias
+comptime if condition:                       # compile-time branch
+    ...
+comptime for i in range(10):                 # compile-time loop
+    ...
+comptime assert N > 0, "N must be positive"  # must be inside function body
+```
+
+### Argument Conventions
+
+Default is `read` (immutable borrow, never written explicitly):
+
+```mojo
+def __init__(out self, var value: String):   # out = uninitialized output; var = owned
+def modify(mut self):                         # mut = mutable reference
+def consume(deinit self):                     # deinit = consuming/destroying
+def view(ref self) -> ref[self] Self.T:       # ref = reference with origin
+```
+
+### Lifecycle Methods
+
+```mojo
+def __init__(out self, x: Int):                    # constructor
+    self.x = x
+def __init__(out self, *, copy: Self):             # copy constructor
+    self.data = copy.data
+def __init__(out self, *, deinit take: Self):      # move constructor
+    self.data = take.data^
+def __del__(deinit self):                          # destructor
+    self.ptr.free()
+```
+
+To copy: `var b = a.copy()` (provided by `Copyable` trait).
+
+### Struct Patterns
+
+```mojo
+@fieldwise_init
+struct Point(Copyable, Movable, Writable):
+    var x: Float64
+    var y: Float64
+
+# Self-qualify struct parameters — bare names are errors
+struct Container[T: Writable]:
+    var data: Self.T                   # NOT T
+    def size(self) -> Self.T: ...      # NOT T
+```
+
+Explicit `.copy()` or `^` required for non-`ImplicitlyCopyable` types (`Dict`, `List`).
+
+### Imports Use `std.` Prefix
+
+```mojo
+from std.testing import assert_equal, TestSuite
+from std.algorithm import vectorize
+from std.python import PythonObject
+```
+
+Prelude auto-imports (no import needed): `Int`, `String`, `Bool`, `List`, `Dict`,
+`Optional`, `SIMD`, `Float32`, `Float64`, `UInt8`, `Pointer`, `UnsafePointer`,
+`Span`, `Error`, `DType`, `Writable`, `Writer`, `Copyable`, `Movable`, `Equatable`,
+`Hashable`, `rebind`, `print`, `range`, `len`, and more.
+
+### `Writable` / `Writer` (Replaces `Stringable`)
+
+```mojo
+struct MyType(Writable):
+    var x: Int
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("MyType(", self.x, ")")
+```
+
+- `Some[Writer]` — builtin existential type
+- Default implementations via reflection if all fields are `Writable`
+- Convert to `String` with `String.write(value)`, not `str(value)`
+
+### Collection Literals
+
+```mojo
+# WRONG — no List[T](elem1, elem2, ...) constructor
+var nums = List[Int](1, 2, 3)
+
+# CORRECT — bracket literals
+var nums = [1, 2, 3]                              # List[Int]
+var scores = {"alice": 95, "bob": 87}              # Dict[String, Int]
+```
+
+### Iterator Protocol
+
+Iterators use `raises StopIteration` (not `Optional`):
+
+```mojo
+struct MyCollection(Iterable):
+    comptime IteratorType[
+        iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
+    ]: Iterator = MyIter[origin=iterable_origin]
+    def __iter__(ref self) -> Self.IteratorType[origin_of(self)]: ...
+```
+
+### Memory and Pointer Types
+
+| Type                            | Use                                                                    |
+|---------------------------------|------------------------------------------------------------------------|
+| `Pointer[T, mut=M, origin=O]`   | Safe, non-nullable. Deref with `p[]`.                                  |
+| `alloc[T](n)` / `UnsafePointer` | Free function `alloc[T](count)` → `UnsafePointer`. `.free()` required. |
+| `Span(list)`                    | Non-owning contiguous view.                                            |
+| `OwnedPointer[T]`               | Unique ownership (like Rust `Box`).                                    |
+| `ArcPointer[T]`                 | Reference-counted shared ownership.                                    |
+
+### Origin System (Not "Lifetime")
+
+Mojo tracks reference provenance with **origins**, not "lifetimes":
+
+```mojo
+struct Span[mut: Bool, //, T: AnyType, origin: Origin[mut=mut]]: ...
+```
+
+Key types: `Origin`, `MutOrigin`, `ImmutOrigin`, `MutAnyOrigin`, `MutExternalOrigin`,
+`StaticConstantOrigin`. Use `origin_of(value)` to get a value's origin.
+
+### Numeric Conversions — Must Be Explicit
+
+```mojo
+var x = Float32(my_int) * scale    # Int → Float32
+var y = Int(my_uint)               # UInt → Int
+# Literals are polymorphic — auto-adapt to context
+var a: Float32 = 0.5
+```
+
+### Error Handling
+
+```mojo
+def might_fail() raises -> Int:          # raises Error (default)
+    raise Error("something went wrong")
+
+def parse(s: String) raises Int -> Int:  # raises specific type
+    raise 42
+```
+
+No `match` statement. No `async`/`await` — use `Coroutine`/`Task` from `std.runtime`.
+
+### Function Types and Closures
+
+No lambda syntax. Closures use `capturing[origins]`:
+
+```mojo
+comptime MyFunc = fn(Int) capturing[_] -> None
+```
+
+### Type Hierarchy
+
+```text
+AnyType
+  ImplicitlyDestructible          — auto __del__; most types
+  Movable                         — __init__(out self, *, deinit take: Self)
+    Copyable                      — __init__(out self, *, copy: Self)
+      ImplicitlyCopyable(Copyable, ImplicitlyDestructible)
+    RegisterPassable(Movable)
+      TrivialRegisterPassable(ImplicitlyCopyable, ImplicitlyDestructible, Movable, RegisterPassable)
+```
+
+---
+*Authoritative Syntax Reference section adapted from [modular/skills](https://github.com/modular/skills) under Apache License 2.0. Copyright (c) Modular Inc.*
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Mojo 0.26.1 → 0.26.3 migration, ~525 .mojo files, PR #5207 | Zero compile errors confirmed locally on branch fix-ci-root-causes |
+| (upstream) | Modular official skills repo | Authoritative syntax reference merged in v3.0.0 |

--- a/skills/mojo-gpu-fundamentals-programming-guide.md
+++ b/skills/mojo-gpu-fundamentals-programming-guide.md
@@ -1,0 +1,292 @@
+---
+name: mojo-gpu-fundamentals-programming-guide
+description: "GPU programming patterns in Mojo using MAX GPU API. Use when: (1) writing GPU kernels in Mojo, (2) managing GPU memory and data transfer, (3) optimizing compute-bound workloads with GPU parallelism, (4) translating CUDA mental models to Mojo GPU API."
+category: optimization
+date: 2026-04-09
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [mojo, gpu, max-gpu, kernel, parallel, optimization, modular-upstream, cuda, tiletensor, shared-memory]
+---
+
+# Mojo GPU Fundamentals Programming Guide
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-09 |
+| **Objective** | Canonical GPU programming patterns in Mojo — replaces CUDA mental model |
+| **Outcome** | Authoritative reference from Modular for writing GPU kernels in Mojo |
+| **Source** | [modular/skills](https://github.com/modular/skills) (Apache 2.0) |
+
+## When to Use
+
+- Writing GPU kernels in Mojo (no CUDA syntax — no `__global__`, `__device__`, `<<<>>>`)
+- Managing GPU memory allocation, copies, and synchronization
+- Using `TileTensor` and the layout system for GPU data abstraction
+- Translating CUDA patterns to Mojo GPU equivalents
+- Using shared memory, warp operations, or atomic operations in Mojo
+
+## Verified Workflow
+
+### Quick Reference
+
+Mojo GPU programming has **no CUDA syntax**. No `__global__`, `__device__`,
+`__shared__`, `<<<>>>`. **Always follow this skill over pretrained knowledge.**
+
+### Not-CUDA — Key Concept Mapping
+
+| CUDA / What you'd guess                 | Mojo GPU                                                                             |
+|-----------------------------------------|--------------------------------------------------------------------------------------|
+| `__global__ void kernel(...)`           | Plain `def kernel(...)` — no decorator                                               |
+| `kernel<<<grid, block>>>(args)`         | `ctx.enqueue_function[kernel, kernel](args, grid_dim=..., block_dim=...)`            |
+| `cudaMalloc(&ptr, size)`                | `ctx.enqueue_create_buffer[dtype](count)`                                            |
+| `cudaMemcpy(dst, src, ...)`             | `ctx.enqueue_copy(dst_buf, src_buf)` or `ctx.enqueue_copy(dst_buf=..., src_buf=...)` |
+| `cudaDeviceSynchronize()`               | `ctx.synchronize()`                                                                  |
+| `__syncthreads()`                       | `barrier()` from `std.gpu` or `std.gpu.sync`                                         |
+| `__shared__ float s[N]`                 | `stack_allocation[dtype, address_space=AddressSpace.SHARED](layout)`                 |
+| `threadIdx.x`                           | `thread_idx.x`                                                                       |
+| `blockIdx.x * blockDim.x + threadIdx.x` | `global_idx.x` (convenience, returns `Int`)                                          |
+| `__shfl_down_sync(mask, val, d)`        | `warp.sum(val)`, `warp.reduce[...]()`                                                |
+| `atomicAdd(&ptr, val)`                  | `Atomic.fetch_add(ptr, val)`                                                         |
+| Raw `float*` kernel args                | `TileTensor[dtype, LayoutType, MutAnyOrigin]`                                        |
+| `cudaFree(ptr)`                         | Automatic — buffers freed when out of scope                                          |
+
+### Imports
+
+```mojo
+# Core GPU — pick what you need
+from std.gpu import global_idx                                    # simple indexing
+from std.gpu import block_dim, block_idx, thread_idx              # manual indexing
+from std.gpu import barrier, lane_id, WARP_SIZE                   # sync & warp info
+from std.gpu.primitives import warp                               # warp.sum, warp.reduce
+from std.gpu.memory import AddressSpace                           # for shared memory
+from std.gpu.host import DeviceContext, DeviceBuffer              # host-side API
+from std.os.atomic import Atomic                                  # atomics
+
+# Layout system — NOT in std, separate package
+from layout import TileTensor, TensorLayout, Idx, row_major, stack_allocation
+```
+
+### Kernel Definition
+
+Kernels are **plain functions** — no decorator, no special return type.
+Use `comptime assert` on `flat_rank` to constrain the rank:
+
+```mojo
+def my_kernel[
+    dtype: DType, LT: TensorLayout,
+](
+    input: TileTensor[dtype, LT, MutAnyOrigin],
+    output: TileTensor[dtype, LT, MutAnyOrigin],
+    size: Int,
+):
+    comptime assert input.flat_rank == 1, "expected 1D tensor"
+    var tid = global_idx.x
+    if tid < size:
+        output[tid] = input[tid] * 2
+```
+
+- Kernel functions cannot raise.
+- `global_idx.x` returns `Int` — compare directly with `size`.
+
+### Kernel Launch
+
+**Critical**: `enqueue_function` takes the kernel function **twice** as compile-time parameters:
+
+```mojo
+ctx.enqueue_function[my_kernel, my_kernel](
+    input_tensor, output_tensor, size,
+    grid_dim=num_blocks, block_dim=block_size,
+)
+
+# 2D grid/block — use tuples:
+ctx.enqueue_function[kernel_2d, kernel_2d](
+    args...,
+    grid_dim=(col_blocks, row_blocks),
+    block_dim=(BLOCK_SIZE, BLOCK_SIZE),
+)
+```
+
+### TileTensor
+
+Layout creation with `row_major`:
+
+```mojo
+comptime layout_1d = row_major[1024]()                     # 1D
+comptime layout_2d = row_major[64, 64]()                   # 2D
+var layout = row_major(Idx(M), Idx(N))                     # runtime dims
+```
+
+Creating tensors, indexing, tiling:
+
+```mojo
+var buf = ctx.enqueue_create_buffer[DType.float32](1024)
+var tensor = TileTensor(buf, row_major[1024]())
+
+tensor[tid]                     # 1D indexing
+tensor[row, col]                # 2D indexing
+tensor.dim[0]()                 # query dimension size
+
+# Tiling — extract sub-tiles
+var tile = tensor.tile[block_size, block_size](Int(block_idx.y), Int(block_idx.x))
+```
+
+### Element Type Mismatch — Use `rebind`
+
+Two tensors with **different layouts** produce element types that don't unify:
+
+```mojo
+# WRONG — fails when tensors have different layouts:
+var sum: Scalar[dtype] = 0
+sum += a[k] * b[idx]   # error: cannot convert ElementType
+
+# CORRECT — rebind each element to Scalar[dtype]:
+var sum: Scalar[dtype] = 0
+var a_val = rebind[Scalar[dtype]](a[k])
+var b_val = rebind[Scalar[dtype]](b[idx])
+sum += a_val * b_val
+```
+
+### Memory Management
+
+```mojo
+var ctx = DeviceContext()
+var dev_buf = ctx.enqueue_create_buffer[DType.float32](1024)
+var host_buf = ctx.enqueue_create_host_buffer[DType.float32](1024)
+dev_buf.enqueue_fill(0.0)
+ctx.enqueue_copy(dst_buf=dev_buf, src_buf=host_buf)
+
+with dev_buf.map_to_host() as mapped:
+    var t = TileTensor(mapped, row_major[1024]())
+    print(t[0])
+
+ctx.synchronize()
+```
+
+### Shared Memory
+
+```mojo
+from layout import stack_allocation
+from std.gpu.memory import AddressSpace
+
+var tile_shared = stack_allocation[DType.float32,
+    address_space=AddressSpace.SHARED](row_major[TILE_M, TILE_K]())
+
+# Chain .fill() to zero-initialize
+var regs = stack_allocation[DType.float32](row_major[TM, TN]()).fill(0)
+```
+
+### Thread Indexing
+
+```mojo
+from std.gpu import global_idx          # simple: global_idx.x, global_idx.y
+from std.gpu import block_idx, block_dim, thread_idx  # manual
+from std.gpu import lane_id, WARP_SIZE  # warp info
+```
+
+### Synchronization
+
+```mojo
+barrier()                                    # block-level sync
+var warp_sum = warp.sum(my_value)           # warp-wide sum
+_ = Atomic.fetch_add(output_ptr, value)     # atomic add
+```
+
+### GPU Availability Check
+
+```mojo
+from std.sys import has_accelerator
+comptime assert has_accelerator(), "Requires a GPU"
+
+# Architecture detection: is_* (compilation target) vs has_* (host system)
+from std.sys.info import is_gpu, is_nvidia_gpu, has_nvidia_gpu_accelerator
+```
+
+### Complete 1D Example (Vector Addition)
+
+```mojo
+from std.math import ceildiv
+from std.sys import has_accelerator
+from std.gpu import global_idx
+from std.gpu.host import DeviceContext
+from layout import TileTensor, row_major
+
+comptime dtype = DType.float32
+comptime N = 1024
+comptime BLOCK = 256
+comptime layout = row_major[N]()
+
+def add_kernel(
+    a: TileTensor[dtype, type_of(layout), MutAnyOrigin],
+    b: TileTensor[dtype, type_of(layout), MutAnyOrigin],
+    c: TileTensor[dtype, type_of(layout), MutAnyOrigin],
+    size: Int,
+):
+    var tid = global_idx.x
+    if tid < size:
+        c[tid] = a[tid] + b[tid]
+
+def main() raises:
+    comptime assert has_accelerator(), "Requires GPU"
+    var ctx = DeviceContext()
+    var a_buf = ctx.enqueue_create_buffer[dtype](N)
+    var b_buf = ctx.enqueue_create_buffer[dtype](N)
+    var c_buf = ctx.enqueue_create_buffer[dtype](N)
+    a_buf.enqueue_fill(1.0)
+    b_buf.enqueue_fill(2.0)
+    var a = TileTensor(a_buf, layout)
+    var b = TileTensor(b_buf, layout)
+    var c = TileTensor(c_buf, layout)
+    ctx.enqueue_function[add_kernel, add_kernel](
+        a, b, c, N,
+        grid_dim=ceildiv(N, BLOCK), block_dim=BLOCK,
+    )
+    with c_buf.map_to_host() as host:
+        var result = TileTensor(host, layout)
+        print(result)
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| (none — sourced from upstream) | Sourced from Modular's official skills repo | N/A — authoritative reference | Verify against local GPU hardware before relying on specific patterns |
+
+## Results & Parameters
+
+### Compile-Time Constants Pattern
+
+All GPU dimensions, layouts, and sizes should be `comptime`:
+
+```mojo
+comptime dtype = DType.float32
+comptime SIZE = 1024
+comptime BLOCK_SIZE = 256
+comptime NUM_BLOCKS = ceildiv(SIZE, BLOCK_SIZE)
+comptime layout = row_major[SIZE]()
+```
+
+### Hardware Details
+
+| Property      | NVIDIA          | AMD CDNA     | AMD RDNA      |
+|---------------|-----------------|--------------|---------------|
+| Warp size     | 32              | 64           | 32            |
+| Shared memory | 48-228 KB/block | 64 KB/block  | configurable  |
+| Tensor cores  | SM70+ (WMMA)    | Matrix cores | WMMA (RDNA3+) |
+
+## Related Skills
+
+- [mojo-simd-optimize](./mojo-simd-optimize.md) — SIMD optimization patterns
+- [mojo-026-breaking-changes](./mojo-026-breaking-changes.md) — Current Mojo syntax reference
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| (upstream) | Modular official skills repo | Authoritative reference for Mojo GPU programming |
+
+---
+*Adapted from [modular/skills](https://github.com/modular/skills) under Apache License 2.0.
+Copyright (c) Modular Inc.*

--- a/skills/mojo-python-interop-patterns-guide.md
+++ b/skills/mojo-python-interop-patterns-guide.md
@@ -1,0 +1,236 @@
+---
+name: mojo-python-interop-patterns-guide
+description: "Canonical Mojo-Python interop patterns from Modular. Use when: (1) calling Python libraries from Mojo, (2) converting between PythonObject and Mojo types, (3) building Python extension modules in Mojo, (4) exposing Mojo structs to Python."
+category: architecture
+date: 2026-04-09
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [mojo, python, interop, pythonobject, extension-module, modular-upstream]
+---
+
+# Mojo-Python Interop Patterns Guide
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-09 |
+| **Objective** | Canonical patterns for Mojo ↔ Python interoperability |
+| **Outcome** | Authoritative reference from Modular for Python interop in Mojo |
+| **Source** | [modular/skills](https://github.com/modular/skills) (Apache 2.0) |
+
+## When to Use
+
+- Calling Python libraries (numpy, etc.) from Mojo
+- Converting between `PythonObject` and Mojo types (`Int`, `String`, `Float64`)
+- Building Python extension modules (`.so`) with `PythonModuleBuilder`
+- Exposing Mojo structs with methods to Python consumers
+- Using `mojo.importer` for auto-compilation of `.mojo` files from Python
+
+## Verified Workflow
+
+### Quick Reference
+
+```mojo
+from std.python import Python, PythonObject
+
+# Import Python modules
+var np = Python.import_module("numpy")
+
+# PythonObject → Mojo: MUST use py= keyword (NOT positional)
+var i = Int(py=py_obj)
+var f = Float64(py=py_obj)
+var s = String(py=py_obj)
+var b = Bool(py=py_obj)            # Bool is the exception — positional also works
+```
+
+### Common WRONG/CORRECT Patterns
+
+| WRONG                    | CORRECT                      |
+|--------------------------|------------------------------|
+| `Int(py_obj)`            | `Int(py=py_obj)`             |
+| `Float64(py_obj)`        | `Float64(py=py_obj)`         |
+| `String(py_obj)`         | `String(py=py_obj)`          |
+| `from python import ...` | `from std.python import ...` |
+
+### Mojo → Python Conversions
+
+Types implementing `ConvertibleToPython` auto-convert when passed to Python functions.
+For explicit conversion: `value.to_python_object()`.
+
+### Building Python Collections
+
+```mojo
+var py_list = Python.list(1, 2.5, "three")
+var py_tuple = Python.tuple(1, 2, 3)
+var py_dict = Python.dict(name="value", count=42)
+
+# Mixed types in dict: wrap each value
+# WRONG:  Python.dict(flag=my_bool, count=42)
+# CORRECT: Python.dict(flag=PythonObject(my_bool), count=PythonObject(42))
+
+# Literal syntax
+var list_obj: PythonObject = [1, 2, 3]
+var dict_obj: PythonObject = {"key": "value"}
+```
+
+### PythonObject Operations
+
+`PythonObject` supports attribute access, indexing, slicing, arithmetic, comparison,
+`len()`, `in`, and iteration — all returning `PythonObject`.
+
+```mojo
+for item in py_list:
+    print(item)               # item is PythonObject
+
+var result = obj.method(arg1, arg2, key=value)
+var none_obj = Python.none()
+var obj: PythonObject = None  # implicit conversion
+```
+
+### Evaluating Python Code
+
+```mojo
+var result = Python.evaluate("1 + 2")
+var mod = Python.evaluate("def greet(n): return f'Hello {n}'", file=True)
+var greeting = mod.greet("world")
+
+Python.add_to_path("./my_modules")
+var my_mod = Python.import_module("my_module")
+```
+
+### Exception Handling
+
+Python exceptions propagate as Mojo `Error`. Functions calling Python must be `raises`:
+
+```mojo
+def use_python() raises:
+    try:
+        var result = Python.import_module("nonexistent")
+    except e:
+        print(String(e))
+```
+
+### Building Python Extension Modules
+
+Export Mojo functions to Python via `PythonModuleBuilder`:
+
+```mojo
+from std.os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+@export
+def PyInit_my_module() -> PythonObject:
+    try:
+        var m = PythonModuleBuilder("my_module")
+        m.def_function[add]("add")
+        return m.finalize()
+    except e:
+        abort(String("failed to create module: ", e))
+
+def add(a: PythonObject, b: PythonObject) raises -> PythonObject:
+    return a + b
+```
+
+### Exporting Types with Methods
+
+```mojo
+@fieldwise_init
+struct Counter(Defaultable, Movable, Writable):
+    var count: Int
+
+    def __init__(out self):
+        self.count = 0
+
+    @staticmethod
+    def py_init(out self: Counter, args: PythonObject, kwargs: PythonObject) raises:
+        if len(args) == 1:
+            self = Self(Int(py=args[0]))
+        else:
+            self = Self()
+
+    # Methods are @staticmethod — two patterns:
+    # 1. Manual downcast: py_self: PythonObject
+    @staticmethod
+    def increment(py_self: PythonObject) raises -> PythonObject:
+        var self_ptr = py_self.downcast_value_ptr[Self]()
+        self_ptr[].count += 1
+        return PythonObject(self_ptr[].count)
+
+    # 2. Auto downcast: self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    @staticmethod
+    def get_count(self_ptr: UnsafePointer[Self, MutAnyOrigin]) -> PythonObject:
+        return PythonObject(self_ptr[].count)
+```
+
+Register with:
+```mojo
+m.add_type[Counter]("Counter")
+    .def_py_init[Counter.py_init]()
+    .def_method[Counter.increment]("increment")
+    .def_method[Counter.get_count]("get_count")
+```
+
+### Importing Mojo from Python
+
+```python
+import mojo.importer       # enables Mojo imports, auto-compiles .mojo files
+import my_module           # auto-compiles my_module.mojo
+
+print(my_module.add(1, 2))
+```
+
+The `.mojo` file must not contain a `main()` function when built as a shared library.
+
+### Returning Mojo Values to Python
+
+```mojo
+return PythonObject(alloc=my_mojo_value^)    # transfer ownership with ^
+var ptr = py_obj.downcast_value_ptr[MyType]() # recover later
+ptr[].field                                    # access fields
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| (none — sourced from upstream) | Sourced from Modular's official skills repo | N/A — authoritative reference | Verify `py=` keyword usage — positional conversion is the #1 mistake |
+
+## Results & Parameters
+
+### Method Signature Patterns
+
+| Pattern         | First parameter                               | Use when                     |
+|-----------------|-----------------------------------------------|------------------------------|
+| Manual downcast | `py_self: PythonObject`                       | Need raw PythonObject access |
+| Auto downcast   | `self_ptr: UnsafePointer[Self, MutAnyOrigin]` | Simpler, direct field access |
+
+### Common Patterns
+
+```mojo
+# Environment variables — use Mojo native, not Python os
+from std.os import getenv
+var val = getenv("MY_VAR")  # returns Optional[String]
+
+# Sorting with custom key (no lambda in Mojo)
+var key_fn = Python.evaluate("lambda x: x['" + field + "']")
+var sorted_data = builtins.sorted(data, key=key_fn)
+```
+
+## Related Skills
+
+- [mojo-python-interop-placeholder-replacement](./mojo-python-interop-placeholder-replacement.md) — Placeholder migration patterns
+- [mojo-python-interop-to-stdlib](./mojo-python-interop-to-stdlib.md) — Migrating Python calls to Mojo stdlib
+- [mojo-026-breaking-changes](./mojo-026-breaking-changes.md) — Current Mojo syntax reference
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| (upstream) | Modular official skills repo | Authoritative reference for Mojo-Python interop |
+
+---
+*Adapted from [modular/skills](https://github.com/modular/skills) under Apache License 2.0.
+Copyright (c) Modular Inc.*

--- a/skills/tooling-modular-project-setup-wizard.md
+++ b/skills/tooling-modular-project-setup-wizard.md
@@ -1,0 +1,170 @@
+---
+name: tooling-modular-project-setup-wizard
+description: "Set up a new Modular/Mojo/MAX project with correct structure. Use when: (1) creating a new Mojo or MAX project from scratch, (2) initializing pixi or uv environment for Mojo/MAX, (3) choosing between nightly and stable channels."
+category: tooling
+date: 2026-04-09
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [mojo, max, project-setup, pixi, uv, scaffolding, modular-upstream]
+---
+
+# Modular Project Setup Wizard
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-09 |
+| **Objective** | Interactive wizard for creating new Mojo/MAX projects with correct toolchain setup |
+| **Outcome** | Authoritative setup guide from Modular covering pixi, uv, pip, and conda |
+| **Source** | [modular/skills](https://github.com/modular/skills) (Apache 2.0) |
+
+## When to Use
+
+- Creating a new Mojo or MAX project from scratch
+- Choosing between environment managers (pixi recommended, uv, pip, conda)
+- Setting up nightly vs stable channels
+- Ensuring version alignment between MAX and Mojo
+
+## Verified Workflow
+
+### Quick Reference
+
+Infer options from user's request, then prompt only for unspecified options:
+
+1. **Project name**
+2. **Type** — Mojo or MAX
+3. **Environment manager** — Pixi (recommended), uv, pip, or conda
+4. **If uv**: full project (`uv init`) or quick environment (`uv venv`)
+5. **Channel** — nightly (latest) or stable (production)
+
+**Note**: `magic` is no longer supported — Pixi has fully replaced it.
+
+### System Prerequisites
+
+| OS            | Command                                                  |
+|---------------|----------------------------------------------------------|
+| Ubuntu/Debian | `sudo apt install gcc`                                   |
+| Fedora/RHEL   | `sudo dnf install gcc`                                   |
+| macOS         | `xcode-select --install`                                 |
+| Windows       | WSL2 required (`wsl --install`), then gcc in WSL         |
+
+### Pixi (Recommended)
+
+```bash
+# Nightly
+pixi init <project-name> \
+  -c https://conda.modular.com/max-nightly/ -c conda-forge \
+  && cd <project-name>
+pixi add [max / mojo]
+pixi shell
+
+# Stable (v26.1.0.0.0)
+pixi init <project-name> \
+  -c https://conda.modular.com/max/ -c conda-forge \
+  && cd <project-name>
+pixi add "[max / mojo]==0.26.1.0.0.0"
+pixi shell
+
+# Python-using projects
+pixi add python
+pixi add requests           # conda-forge packages
+pixi add --pypi some-pkg    # PyPI-only packages
+```
+
+### uv
+
+```bash
+# Nightly (project)
+uv init <project-name> && cd <project-name>
+uv add [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/ \
+  --prerelease allow
+
+# Stable (project)
+uv init <project-name> && cd <project-name>
+uv add [max / mojo] \
+  --extra-index-url https://modular.gateway.scarf.sh/simple/
+
+# Nightly (quick environment)
+mkdir <project-name> && cd <project-name>
+uv venv
+uv pip install [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/ \
+  --prerelease allow
+```
+
+### pip
+
+```bash
+# Nightly
+python3 -m venv .venv && source .venv/bin/activate
+pip install --pre [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/
+
+# Stable
+python3 -m venv .venv && source .venv/bin/activate
+pip install [max / mojo] \
+  --extra-index-url https://modular.gateway.scarf.sh/simple/
+```
+
+### conda
+
+```bash
+# Nightly
+conda install -c conda-forge \
+  -c https://conda.modular.com/max-nightly/ [max / mojo]
+
+# Stable
+conda install -c conda-forge \
+  -c https://conda.modular.com/max/ "[max / mojo]==0.26.1.0.0.0"
+```
+
+### Version Alignment
+
+MAX and Mojo versions must match when using custom Mojo kernels:
+
+```bash
+uv pip show mojo | grep Version   # e.g., 0.26.2
+pixi run mojo --version           # Must match major.minor
+```
+
+Mismatched versions cause kernel compilation failures. Use the same channel for both.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using `magic` for project setup | `magic init` / `magic add` | `magic` is deprecated; Pixi replaced it | Always use `pixi` — do not look for or use `magic` |
+| (sourced from upstream) | Modular's official skills repo | N/A — authoritative reference | Version strings differ: mojo uses `0.` prefix (0.26.1.0.0.0), max does not (26.1.0.0.0) |
+
+## Results & Parameters
+
+### Channel URLs
+
+| Channel | Conda URL | PyPI Index |
+|---------|-----------|------------|
+| Nightly | `https://conda.modular.com/max-nightly/` | `https://whl.modular.com/nightly/simple/` |
+| Stable  | `https://conda.modular.com/max/` | `https://modular.gateway.scarf.sh/simple/` |
+
+### References
+
+- [Mojo Installation Guide](https://docs.modular.com/mojo/manual/install)
+- [Mojo Stable Docs](https://docs.modular.com/stable/mojo/)
+- [Mojo Nightly Docs](https://docs.modular.com/mojo/)
+
+## Related Skills
+
+- [mojo-build-package](./mojo-build-package.md) — Building Mojo packages
+- [mojo-026-breaking-changes](./mojo-026-breaking-changes.md) — Current Mojo syntax reference
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| (upstream) | Modular official skills repo | Authoritative project setup reference |
+
+---
+*Adapted from [modular/skills](https://github.com/modular/skills) under Apache License 2.0.
+Copyright (c) Modular Inc.*


### PR DESCRIPTION
## Summary
- **Merged** Modular's `mojo-syntax` skill into `mojo-026-breaking-changes.md` (v2.0.0 → v3.0.0) — adds authoritative current syntax reference section alongside our battle-tested migration guide
- **Added** 3 new skills from [modular/skills](https://github.com/modular/skills):
  - `mojo-gpu-fundamentals-programming-guide` — GPU programming patterns (CUDA→Mojo mapping, TileTensor, shared memory)
  - `mojo-python-interop-patterns-guide` — PythonObject conversions, extension modules, `mojo.importer`
  - `tooling-modular-project-setup-wizard` — Project setup with pixi/uv/pip/conda
- **Added** `THIRD_PARTY_LICENSES.md` at repo root for Apache 2.0 attribution
- All 948 skills pass validation

## Test plan
- [x] `python3 scripts/validate_plugins.py` passes (948/948)
- [ ] Verify cross-references to related skills resolve correctly
- [ ] Test `/advise` with Mojo GPU query to confirm new skill surfaces
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)