### PR TITLE
Add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` configuring automated dependency update checks
- **pip** ecosystem: weekly checks on `requirements.txt`, max 5 open PRs
- **github-actions** ecosystem: weekly checks on `.github/workflows/`, max 5 open PRs

Closes #941

## Test plan
- [x] `python3 -m pytest tests/ -v` — 39 passed
- [x] `python3 scripts/validate_plugins.py` — all 953 skills valid
- [ ] Verify Dependabot picks up the config after merge (check Security > Dependabot tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)