### PR TITLE
Add test coverage measurement (pytest-cov)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,4 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--cov=scripts --cov-report=term-missing --cov-report=html"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest==8.3.5
 mypy==1.14.1
 types-PyYAML
+pytest-cov==6.1.1


### PR DESCRIPTION
## Summary
- Added `pytest-cov==6.1.1` to `requirements-dev.txt`
- Created `pyproject.toml` with `[tool.pytest.ini_options]` configuring coverage on `scripts/` with term-missing and HTML reports
- No changes needed to `justfile` or CI workflow since pyproject.toml addopts are picked up automatically

Closes #1107

## Test plan
- [x] `python3 -m pytest tests/ -v` passes all 39 tests with coverage report
- [x] `python3 scripts/validate_plugins.py` passes (953/953 valid)
- [ ] CI pipeline runs successfully with coverage enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)