### PR TITLE
fix: add pyproject.toml and pixi.toml for packaging

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 # ProjectMnemosyne command runner — wraps Python scripts for consistent developer experience.
 # All path variables are configurable at the top of the file.
+# Note: equivalent tasks are also defined in pixi.toml for pixi users.
 
 # Directory containing skill markdown files
 skills_dir := "skills"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,22 @@
+[project]
+name = "project-mnemosyne"
+version = "0.1.0"
+description = "Skills marketplace for the HomericIntelligence agentic ecosystem"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.9"
+pyyaml = ">=6.0"
+
+[feature.dev.dependencies]
+pytest = ">=8.3"
+
+[environments]
+default = { features = ["dev"] }
+
+[tasks]
+validate = "python3 scripts/validate_plugins.py"
+test = "python3 -m pytest tests/"
+check = { depends-on = ["validate", "test"] }
+generate-marketplace = "python3 scripts/generate_marketplace.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "project-mnemosyne"
+version = "0.1.0"
+description = "Skills marketplace for the HomericIntelligence agentic ecosystem"
+requires-python = ">=3.9"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with project metadata, dependencies (pyyaml), dev dependencies (pytest), and pytest config
- Add `pixi.toml` with conda-forge channel, platform targets, dependencies, and task definitions mirroring the justfile
- Update `justfile` with a note about pixi.toml availability for pixi users

Closes #927, Closes #911, Closes #918

## Test plan
- [x] `python3 -m pytest tests/ -v` — 39/39 passed
- [x] `python3 scripts/validate_plugins.py` — 953/953 valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)