### PR TITLE
Add marketplace.json integrity tests

### DIFF
--- a/tests/test_generate_marketplace.py
+++ b/tests/test_generate_marketplace.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
 """
-Tests for marketplace statistics in generate_marketplace.py.
+Tests for marketplace statistics and integrity in generate_marketplace.py.
 
 Verifies that:
 - total_plugins count matches the number of plugin entries
 - categories dict has correct per-category counts
 - last_updated is a valid ISO 8601 timestamp
 - stdout summary is printed during generation
+- Schema validation (required top-level and plugin fields)
+- No duplicate plugin names or source paths
+- Source paths resolve to existing files and match expected pattern
+- Category validation against allowed set
+- Date format is valid ISO 8601
 """
 
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -138,6 +144,256 @@ class TestMarketplaceStatistics:
         result = generate_marketplace()
 
         assert result["total_plugins"] == 1
+
+
+ALLOWED_CATEGORIES = {
+    "training",
+    "evaluation",
+    "optimization",
+    "debugging",
+    "architecture",
+    "tooling",
+    "ci-cd",
+    "testing",
+    "documentation",
+}
+
+REQUIRED_TOP_LEVEL_FIELDS = {
+    "name",
+    "owner",
+    "description",
+    "version",
+    "total_plugins",
+    "categories",
+    "last_updated",
+    "plugins",
+}
+
+REQUIRED_PLUGIN_FIELDS = {"name", "description", "version", "source", "category"}
+
+
+class TestSchemaValidation:
+    """Tests that marketplace output conforms to the expected schema."""
+
+    def test_required_top_level_fields_present(self, tmp_path, monkeypatch):
+        """Marketplace JSON must contain all required top-level fields."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+
+        result = generate_marketplace()
+
+        missing = REQUIRED_TOP_LEVEL_FIELDS - set(result.keys())
+        assert not missing, f"Missing top-level fields: {missing}"
+
+    def test_each_plugin_has_required_fields(self, tmp_path, monkeypatch):
+        """Every plugin entry must contain all required fields."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+
+        result = generate_marketplace()
+
+        for plugin in result["plugins"]:
+            missing = REQUIRED_PLUGIN_FIELDS - set(plugin.keys())
+            assert not missing, (
+                f"Plugin '{plugin.get('name', '?')}' missing fields: {missing}"
+            )
+
+    def test_total_plugins_matches_plugins_length(self, tmp_path, monkeypatch):
+        """total_plugins must equal len(plugins)."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+        _make_skill_file(tmp_path, "skill-c", "tooling")
+
+        result = generate_marketplace()
+
+        assert result["total_plugins"] == len(result["plugins"])
+
+    def test_empty_marketplace_has_required_fields(self, tmp_path, monkeypatch):
+        """Even an empty marketplace must have all required top-level fields."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "skills").mkdir()
+
+        result = generate_marketplace()
+
+        missing = REQUIRED_TOP_LEVEL_FIELDS - set(result.keys())
+        assert not missing, f"Missing top-level fields: {missing}"
+        assert result["total_plugins"] == 0
+        assert result["plugins"] == []
+
+
+class TestDeduplication:
+    """Tests that no duplicate plugin names or source paths exist."""
+
+    def test_no_duplicate_plugin_names(self, tmp_path, monkeypatch):
+        """Plugin names must be unique."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+        _make_skill_file(tmp_path, "skill-c", "tooling")
+
+        result = generate_marketplace()
+
+        names = [p["name"] for p in result["plugins"]]
+        assert len(names) == len(set(names)), (
+            f"Duplicate plugin names found: "
+            f"{[n for n in names if names.count(n) > 1]}"
+        )
+
+    def test_no_duplicate_source_paths(self, tmp_path, monkeypatch):
+        """Source paths must be unique."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+
+        result = generate_marketplace()
+
+        sources = [p["source"] for p in result["plugins"]]
+        assert len(sources) == len(set(sources)), (
+            f"Duplicate source paths found: "
+            f"{[s for s in sources if sources.count(s) > 1]}"
+        )
+
+    def test_duplicate_name_in_frontmatter_is_deduplicated(
+        self, tmp_path, monkeypatch
+    ):
+        """If two files declare the same name, only one should appear."""
+        monkeypatch.chdir(tmp_path)
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir(exist_ok=True)
+
+        # Two files with the same frontmatter name
+        (skills_dir / "file-one.md").write_text(
+            "---\nname: duplicate-name\ndescription: first\n"
+            "category: training\ndate: 2026-01-01\nversion: '1.0.0'\n---\n"
+        )
+        (skills_dir / "file-two.md").write_text(
+            "---\nname: duplicate-name\ndescription: second\n"
+            "category: debugging\ndate: 2026-01-01\nversion: '1.0.0'\n---\n"
+        )
+
+        result = generate_marketplace()
+
+        names = [p["name"] for p in result["plugins"]]
+        assert names.count("duplicate-name") == 1
+
+
+class TestPathResolution:
+    """Tests that source paths are valid and follow the expected pattern."""
+
+    def test_source_paths_point_to_existing_files(self, tmp_path, monkeypatch):
+        """Every source path must resolve to an existing file."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+
+        result = generate_marketplace()
+
+        for plugin in result["plugins"]:
+            source = plugin["source"]
+            resolved = tmp_path / source.lstrip("./")
+            assert resolved.exists(), (
+                f"Source path '{source}' does not resolve to an existing file "
+                f"(checked {resolved})"
+            )
+
+    def test_source_paths_match_skills_pattern(self, tmp_path, monkeypatch):
+        """Source paths must match ./skills/<name>.md pattern."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "debugging")
+
+        result = generate_marketplace()
+
+        pattern = re.compile(r"^\./skills/[a-z0-9][a-z0-9\-]*\.md$")
+        for plugin in result["plugins"]:
+            source = plugin["source"]
+            assert pattern.match(source), (
+                f"Source path '{source}' does not match expected "
+                f"pattern ./skills/<name>.md"
+            )
+
+
+class TestCategoryValidation:
+    """Tests that categories are valid and counts are accurate."""
+
+    def test_all_categories_in_allowed_set(self, tmp_path, monkeypatch):
+        """Every plugin category must be in the allowed categories set."""
+        monkeypatch.chdir(tmp_path)
+        for cat in ["training", "debugging", "tooling", "evaluation"]:
+            _make_skill_file(tmp_path, f"skill-{cat}", cat)
+
+        result = generate_marketplace()
+
+        for plugin in result["plugins"]:
+            assert plugin["category"] in ALLOWED_CATEGORIES, (
+                f"Plugin '{plugin['name']}' has invalid category "
+                f"'{plugin['category']}'"
+            )
+
+    def test_category_counts_match_actual_plugin_counts(
+        self, tmp_path, monkeypatch
+    ):
+        """Category counts dict must match actual per-category plugin counts."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+        _make_skill_file(tmp_path, "skill-b", "training")
+        _make_skill_file(tmp_path, "skill-c", "debugging")
+        _make_skill_file(tmp_path, "skill-d", "tooling")
+
+        result = generate_marketplace()
+
+        # Count categories from plugin entries
+        actual_counts: dict[str, int] = {}
+        for plugin in result["plugins"]:
+            cat = plugin["category"]
+            actual_counts[cat] = actual_counts.get(cat, 0) + 1
+
+        assert result["categories"] == actual_counts
+
+    def test_categories_dict_has_no_extra_keys(self, tmp_path, monkeypatch):
+        """categories dict must not contain categories absent from plugins."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+
+        result = generate_marketplace()
+
+        plugin_categories = {p["category"] for p in result["plugins"]}
+        extra = set(result["categories"].keys()) - plugin_categories
+        assert not extra, f"Extra categories in counts dict: {extra}"
+
+
+class TestDateFormat:
+    """Tests that date fields are valid ISO 8601."""
+
+    def test_last_updated_is_valid_iso8601(self, tmp_path, monkeypatch):
+        """last_updated must be a valid ISO 8601 UTC timestamp ending in Z."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+
+        result = generate_marketplace()
+
+        ts = result["last_updated"]
+        assert ts.endswith("Z"), f"Timestamp '{ts}' does not end with Z"
+        # Must parse without error
+        parsed = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+        assert parsed.year >= 2026
+
+    def test_last_updated_matches_iso8601_regex(self, tmp_path, monkeypatch):
+        """last_updated must match the YYYY-MM-DDTHH:MM:SSZ pattern."""
+        monkeypatch.chdir(tmp_path)
+        _make_skill_file(tmp_path, "skill-a", "training")
+
+        result = generate_marketplace()
+
+        pattern = re.compile(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+        )
+        assert pattern.match(result["last_updated"]), (
+            f"Timestamp '{result['last_updated']}' does not match "
+            f"ISO 8601 pattern"
+        )
 
 
 class TestMainSummaryOutput:


### PR DESCRIPTION
## Summary
- Add 5 new test classes (14 tests) to `tests/test_generate_marketplace.py` for marketplace.json integrity validation
- **Schema validation**: required top-level fields, required plugin-entry fields, total_plugins consistency, empty marketplace
- **Deduplication**: no duplicate plugin names, no duplicate source paths, frontmatter-level dedup
- **Path resolution**: source paths resolve to existing files, match `./skills/<name>.md` pattern
- **Category validation**: all categories in allowed set, counts match actual plugins, no extra keys
- **Date format**: ISO 8601 parsing and regex validation

## Test plan
- [x] `python3 -m pytest tests/ -v` -- all 53 tests pass (14 new + 39 existing)
- [x] `python3 scripts/validate_plugins.py` -- 953/953 valid

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)