### PR TITLE
Add mypy type checking to CI pipeline

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Validate flat-format skill files
         run: python3 scripts/validate_plugins.py
 
+      - name: Type check
+        run: mypy scripts/ --ignore-missing-imports
+
       - name: Run test suite
         run: pytest tests/ -v
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+python_version = 3.9
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = False
+check_untyped_defs = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 pytest==8.3.5
+mypy==1.14.1
+types-PyYAML

--- a/scripts/migrate_ecosystem_skills.py
+++ b/scripts/migrate_ecosystem_skills.py
@@ -118,7 +118,7 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
     fm_text = rest[:end_idx].strip()
     body = rest[end_idx + 4:].lstrip("\n")
 
-    frontmatter = {}
+    frontmatter: dict[str, object] = {}
     for line in fm_text.splitlines():
         line = line.rstrip()
         if not line or line.startswith("#"):
@@ -134,7 +134,8 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
                 val = val[1:-1]
             # Handle empty values
             if val == "":
-                val = None
+                frontmatter[key] = None
+                continue
             frontmatter[key] = val
 
     return frontmatter, body
@@ -391,7 +392,7 @@ def transform_skill(
 # Skill discovery
 # ---------------------------------------------------------------------------
 
-def discover_odyssey_skills() -> list[tuple[str, Path, None]]:
+def discover_odyssey_skills() -> list[tuple[str, Path, Optional[str]]]:
     """
     Discover skills from ProjectOdyssey.
     Format: <skill-name>/SKILL.md
@@ -401,7 +402,7 @@ def discover_odyssey_skills() -> list[tuple[str, Path, None]]:
     if not base.exists():
         return []
 
-    skills = []
+    skills: list[tuple[str, Path, Optional[str]]] = []
     for item in sorted(base.iterdir()):
         if not item.is_dir():
             continue
@@ -413,7 +414,7 @@ def discover_odyssey_skills() -> list[tuple[str, Path, None]]:
     return skills
 
 
-def discover_scylla_skills() -> list[tuple[str, Path, str]]:
+def discover_scylla_skills() -> list[tuple[str, Path, Optional[str]]]:
     """
     Discover skills from ProjectScylla.
     Format: <category>/<skill-name>/SKILL.md
@@ -423,7 +424,7 @@ def discover_scylla_skills() -> list[tuple[str, Path, str]]:
     if not base.exists():
         return []
 
-    skills = []
+    skills: list[tuple[str, Path, Optional[str]]] = []
     for category_dir in sorted(base.iterdir()):
         if not category_dir.is_dir():
             continue
@@ -454,7 +455,7 @@ def discover_scylla_skills() -> list[tuple[str, Path, str]]:
     return skills
 
 
-def discover_keystone_skills() -> list[tuple[str, Path, None]]:
+def discover_keystone_skills() -> list[tuple[str, Path, Optional[str]]]:
     """
     Discover skills from ProjectKeystone.
     Format: <skill-name>/SKILL.md (or <skill-name>/<sub>/SKILL.md for nested)
@@ -464,7 +465,7 @@ def discover_keystone_skills() -> list[tuple[str, Path, None]]:
     if not base.exists():
         return []
 
-    skills = []
+    skills: list[tuple[str, Path, Optional[str]]] = []
     for item in sorted(base.iterdir()):
         if not item.is_dir():
             continue
@@ -519,6 +520,7 @@ def build_skill_registry(
         sources_to_scan = [source_filter]
 
     for source in sources_to_scan:
+        candidates: list[tuple[str, Path, Optional[str]]] = []
         if source == "scylla":
             candidates = discover_scylla_skills()
         elif source == "keystone":

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -122,7 +122,7 @@ def validate_sections(body: str) -> List[str]:
 
 def validate_failed_attempts_table(body: str) -> List[str]:
     """Validate Failed Attempts table structure."""
-    errors = []
+    errors: List[str] = []
 
     # Find Failed Attempts section
     if "## Failed Attempts" not in body:


### PR DESCRIPTION
## Summary
- Added `mypy==1.14.1` and `types-PyYAML` to `requirements-dev.txt`
- Created `mypy.ini` with baseline config (Python 3.9, check_untyped_defs enabled)
- Added "Type check" step to `.github/workflows/validate-plugins.yml` running `mypy scripts/ --ignore-missing-imports`
- Fixed 6 mypy errors in `scripts/validate_plugins.py` and `scripts/migrate_ecosystem_skills.py` (missing type annotations, incompatible Optional types)

Closes #932

## Test plan
- [x] `mypy scripts/ --ignore-missing-imports` passes with no errors
- [x] `pytest tests/ -v` passes (39 tests)
- [x] `python3 scripts/validate_plugins.py` passes (953 skill files validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)