### PR TITLE
fix(docs): update CLAUDE.md ecosystem description to match architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,7 @@ organizes, and shares learnings from experiments, debugging sessions, and develo
 **Purpose**: Capture team knowledge so Claude can `/advise` before starting work and prevent
 repeated mistakes.
 
-**Ecosystem**: Works with ProjectOdyssey (training), ProjectKeystone (coordination), and
-ProjectScylla (testing).
+**Ecosystem**: Works with ProjectOdyssey (training), ProjectKeystone (DAG execution), ProjectScylla (testing), Myrmidons (agent provisioning), AchaeanFleet (agent images), and ProjectHephaestus (shared utilities).
 
 ## Commands
 
@@ -208,5 +207,5 @@ command infrastructure.
 ## References
 
 - [ProjectOdyssey](https://github.com/HomericIntelligence/ProjectOdyssey) - Training platform
-- [ProjectKeystone](https://github.com/HomericIntelligence/ProjectKeystone) - Coordination
+- [ProjectKeystone](https://github.com/HomericIntelligence/ProjectKeystone) - DAG execution and task coordination
 - [ProjectScylla](https://github.com/HomericIntelligence/ProjectScylla) - Testing


### PR DESCRIPTION
## Summary

- Updates the **Ecosystem** line (line 13) to reflect the full HomericIntelligence project set: ProjectOdyssey, ProjectKeystone, ProjectScylla, Myrmidons, AchaeanFleet, and ProjectHephaestus with accurate role descriptions
- Corrects ProjectKeystone's role from "coordination" to "DAG execution" in the one-liner
- Updates the References section entry for ProjectKeystone from "Coordination" to "DAG execution and task coordination"

## Test plan

- [ ] Verify line 13 of CLAUDE.md lists all six ecosystem projects with correct roles
- [ ] Verify the References section ProjectKeystone entry reads "DAG execution and task coordination"
- [ ] Confirm no other stale ecosystem references remain in CLAUDE.md

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)