### PR TITLE
feat: add Radiance frontend CI skills

### DIFF
--- a/skills/ci-cd-karma-playwright-chromium-launcher.md
+++ b/skills/ci-cd-karma-playwright-chromium-launcher.md
@@ -1,0 +1,104 @@
+---
+name: ci-cd-karma-playwright-chromium-launcher
+description: "Run Karma Angular tests in GitHub Actions with Playwright-managed Chromium instead of relying on system Chrome. Use when: (1) CI lacks a reliable Chrome binary, (2) you need deterministic Chromium setup for headless Karma jobs."
+category: ci-cd
+date: 2026-04-22
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [ci-cd, github-actions, playwright, karma, chromium]
+---
+
+# Karma Playwright Chromium Launcher
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-22 |
+| **Objective** | Make GitHub Actions frontend unit tests use Playwright-installed Chromium instead of depending on system Chrome discovery. |
+| **Outcome** | Successful locally. Karma continued using the Chrome launcher API, but the actual browser binary came from Playwright Chromium through `CHROME_BIN`. |
+| **Verification** | verified-local |
+
+Verified locally only — CI validation was pending during capture.
+
+## When to Use
+
+- An Angular/Karma workflow fails because GitHub Actions runner Chrome sandboxing or browser discovery is inconsistent.
+- You want a deterministic Chromium install path in CI without depending on `google-chrome`, `chromium`, or `chromium-browser` being preinstalled.
+- You need a headless Karma launcher that is clearly tied to Playwright-managed Chromium for reproducible frontend tests.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# CI step
+npm install --no-save playwright
+npx playwright install --with-deps chromium
+
+chrome_bin=$(node -e "console.log(require('playwright').chromium.executablePath())")
+cat > "$RUNNER_TEMP/chrome-headless-radiance" <<'EOF'
+#!/usr/bin/env bash
+exec "$chrome_bin" --no-sandbox --disable-dev-shm-usage "$@"
+EOF
+chmod +x "$RUNNER_TEMP/chrome-headless-radiance"
+echo "CHROME_BIN=$RUNNER_TEMP/chrome-headless-radiance" >> "$GITHUB_ENV"
+
+npm test -- --watch=false --browsers=PlaywrightChromiumHeadless
+```
+
+### Detailed Steps
+
+1. Install `playwright` in the CI job and download Chromium with `npx playwright install --with-deps chromium`.
+2. Resolve the Playwright Chromium executable path from Node instead of probing system Chrome locations.
+3. Wrap that executable in a small shell script that adds `--no-sandbox` and `--disable-dev-shm-usage`.
+4. Export the wrapper path through `CHROME_BIN` so Karma’s Chrome launcher API uses the Playwright binary.
+5. Rename the Karma custom launcher to something explicit like `PlaywrightChromiumHeadless` so the workflow contract reflects the real browser source.
+6. Keep in mind that Karma logs may still say `Starting browser ChromeHeadless` because the underlying launcher implementation comes from `karma-chrome-launcher`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| System Chrome discovery | Looked up `google-chrome`, `chromium`, or `chromium-browser` on the runner | This depends on runner image state and reintroduced exactly the environment variability the fix was trying to remove | Install and own the browser dependency inside the job |
+| Keeping the old launcher contract | Left the workflow and CI contract tests pinned to `ChromeHeadless` strings | The repo’s own CI contract tests then failed even though the browser source changed correctly | Update test contracts and workflow text together when renaming CI launchers |
+| Treating “Playwright” as a full Karma launcher replacement | Expected the runtime logs to stop mentioning `ChromeHeadless` entirely | Karma still uses the Chrome launcher plugin under the hood, so only the binary source changed | Distinguish between launcher API name and actual browser binary source |
+
+## Results & Parameters
+
+Observed stable setup:
+
+```text
+Browser provider: Playwright-installed Chromium
+Karma launcher name: PlaywrightChromiumHeadless
+Env var bridge: CHROME_BIN
+Required flags:
+- --no-sandbox
+- --disable-dev-shm-usage
+```
+
+Useful validation commands:
+
+```bash
+npm test -- --watch=false --browsers=PlaywrightChromiumHeadless \
+  --include src/services/radiance_run_service.spec.ts \
+  --include src/components/radiance_source_input/radiance_source_input.spec.ts \
+  --include src/components/visualizer/worker/graph_processor.spec.ts \
+  --include src/components/visualizer/worker/graph_layout.spec.ts
+
+pytest -q tests/backend/test_ci_contract.py
+```
+
+Expected local signal:
+
+```text
+TOTAL: 10 SUCCESS
+pytest: 6 passed
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Radiance | PR #110 rebase + frontend CI browser change | Rebased against `origin/master`, resolved workflow conflict in favor of Playwright Chromium, and updated the CI contract to match |

--- a/skills/ci-cd-packaged-frontend-functional-asset-validation.md
+++ b/skills/ci-cd-packaged-frontend-functional-asset-validation.md
@@ -1,0 +1,95 @@
+---
+name: ci-cd-packaged-frontend-functional-asset-validation
+description: "Validate packaged frontend outputs functionally instead of diffing generated bundle names. Use when: (1) CI checks packaged web assets after a rebuild, (2) hashed bundle filenames make git diff gates brittle."
+category: ci-cd
+date: 2026-04-22
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [ci-cd, github-actions, frontend, packaging, validation]
+---
+
+# Packaged Frontend Functional Asset Validation
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-22 |
+| **Objective** | Replace brittle packaged-asset drift checks with runtime validation of the shipped frontend surface. |
+| **Outcome** | Successful locally. Rebuild the packaged frontend, serve it from the packaged directory, and verify all discovered local assets return `200`. |
+| **Verification** | verified-local |
+
+Verified locally only — CI validation was pending during capture.
+
+## When to Use
+
+- A workflow rebuilds packaged frontend assets and currently fails on `git diff --exit-code` because hashed bundle filenames change.
+- You need to prove the packaged web app is actually servable instead of proving generated files stayed byte-for-byte stable.
+- A repo vendors a built frontend into a Python or server package and wants CI to validate the shipped output surface.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Rebuild packaged assets from the UI source tree
+cd vendor/model_explorer/src/ui
+npm ci
+npm run deploy
+
+# 2. Validate the packaged frontend runtime surface
+cd /path/to/repo
+python3 scripts/checks/validate_packaged_frontend.py
+```
+
+### Detailed Steps
+
+1. Rebuild the packaged frontend exactly the way the repository ships it, not just the development bundle.
+2. Serve the packaged `web_app` directory over a local loopback HTTP server inside the validator.
+3. Fetch `index.html` and parse local `script`, `stylesheet`, `icon`, and preload URLs dynamically instead of hardcoding hashed filenames.
+4. Fetch each discovered local asset and fail if any request is non-`200` or returns an empty body.
+5. Parse CSS asset bodies for `url(...)` references and verify those local assets as well.
+6. Run the validator from CI immediately after `npm run deploy` so the workflow proves the shipped package is internally consistent.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Hardcoded drift gate | Used `git diff --exit-code` after `npm run deploy` | Rebuilds legitimately changed hashed bundle names like `main-*.js`, which made CI fail even when the packaged app still worked | Generated filename drift is not a functional failure; validate runtime reachability instead |
+| Narrow `index.html` diff inspection | Looked only at `index.html` script-tag rewrites | That explains why CI failed, but it does not prove the packaged frontend is healthy or complete | Turn diagnosis into an executable validator that checks all discovered local assets |
+| Generic `urllib.request.urlopen` in validator | Used `urlopen()` for convenience in the functional validator | Bandit flagged it as `B310` because it accepts broader URL schemes than necessary | Keep the validator on an explicit trust boundary and fetch only loopback `http://127.0.0.1:<port>` assets |
+
+## Results & Parameters
+
+Recommended validator behavior:
+
+```text
+Input root: vendor/model_explorer/src/server/package/src/model_explorer/web_app
+Server bind: 127.0.0.1 on ephemeral port
+Accepted URLs: only http://127.0.0.1:<ephemeral>/...
+Validation surface:
+- index.html
+- local script assets
+- local stylesheet assets
+- local icon/preload assets
+- local CSS url(...) assets
+Failure conditions:
+- non-200 response
+- empty response body
+- no local assets discovered in index.html
+```
+
+Observed useful command sequence:
+
+```bash
+npm run deploy
+python3 scripts/checks/validate_packaged_frontend.py
+bandit -q -r radiance scripts --severity-level medium --confidence-level medium
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Radiance | PR #110 CI remediation | Replaced the packaged frontend `git diff` gate with a runtime asset validator and confirmed it locally before pushing |


### PR DESCRIPTION
## Summary

Adds two new CI/CD skills from the Radiance PR #110 remediation work.

- functional packaged frontend validation instead of brittle generated-file diffs
- Playwright-managed Chromium setup for Karma tests in GitHub Actions
- explicit notes on Bandit-safe loopback-only asset fetching and CI contract alignment

## Verification Level

**verified-local**

Validated in the source repo locally and validated in ProjectMnemosyne with `python3 scripts/validate_plugins.py`.

## Key Findings

**What Worked**:
- Serving packaged frontend assets locally and validating every discovered local asset URL
- Using Playwright Chromium via `CHROME_BIN` for deterministic Karma CI browser setup

**What Failed**:
- `git diff --exit-code` after frontend rebuilds -> hashed bundle filenames changed without indicating a real runtime failure
- Generic `urlopen()` in the validator -> Bandit flagged it as an overly broad fetch surface

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Verify skill files pass repository pytest/pre-push checks
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
