### PR TITLE
learn(ci-cd): github-actions bot protected-branch push → PR pattern

### DIFF
--- a/skills/ci-cd-github-actions-bot-protected-branch-push.md
+++ b/skills/ci-cd-github-actions-bot-protected-branch-push.md
@@ -1,0 +1,175 @@
+---
+name: ci-cd-github-actions-bot-protected-branch-push
+description: "Use when: (1) a GitHub Actions workflow regenerates an artifact (marketplace.json, lockfile, generated code) and tries to push it directly to a protected branch, (2) you see GH006 Protected Branch Update Failed in CI logs, (3) an auto-commit workflow is failing because branch protection requires PRs and status checks, (4) you need loop-safe auto-update CI with no manual intervention"
+category: ci-cd
+date: 2026-04-22
+version: "1.0.0"
+user-invocable: true
+tags: [github-actions, protected-branch, GH006, auto-commit, create-pull-request, loop-prevention, marketplace, auto-merge]
+---
+
+# GitHub Actions Bot: Protected Branch Push → PR Pattern
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-22 |
+| **Objective** | Fix GitHub Actions workflow that regenerates `marketplace.json` and pushed directly to `main`, hitting branch protection (GH006) |
+| **Outcome** | Successful — replaced direct push with `peter-evans/create-pull-request` + auto-merge + three-layer loop prevention |
+
+## When to Use
+
+- A workflow regenerates a file (marketplace index, lockfile, generated docs) and tries `git push origin main` as `github-actions[bot]`
+- CI log contains: `remote: error: GH006: Protected branch update failed for refs/heads/main`
+- Branch protection requires PRs and required status checks on `main`
+- You need the update to land automatically without manual review (idempotent, low-risk artifact)
+
+## Verified Workflow
+
+### Quick Reference
+
+Replace the direct-push step in your workflow with:
+
+```yaml
+- name: Create PR for marketplace update
+  uses: peter-evans/create-pull-request@v7.0.8  # pin to exact version or SHA
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    commit-message: "chore: regenerate marketplace.json [skip ci]"
+    branch: chore/update-marketplace
+    title: "chore: update marketplace.json"
+    body: "Auto-generated: marketplace index regenerated from skills."
+    labels: automated
+    delete-branch: true
+
+- name: Enable auto-merge
+  if: steps.cpr.outputs.pull-request-operation == 'created'
+  run: gh pr merge --auto --squash chore/update-marketplace
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+And add this path filter to the workflow trigger so the squash-merge never re-triggers the workflow:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "plugins/**"
+      - "!.claude-plugin/marketplace.json"   # ← exclude the artifact itself
+```
+
+### Detailed Steps
+
+1. **Identify the error**: look for `GH006` in CI logs on the push-to-main step.
+2. **Remove the direct-push step**: delete any `git push origin main` or `git push origin HEAD:main` in the workflow.
+3. **Add `peter-evans/create-pull-request`**: use the copy-paste snippet above. Pin the action to a specific tag or SHA.
+4. **Add auto-merge step**: gate it on `pull-request-operation == 'created'` so it only runs when a new PR is opened, not on updates.
+5. **Add the path-exclusion filter** to `on.push.paths`: this is the primary loop-prevention guard. The squash-merge commit only touches `marketplace.json`, which is now excluded, so the workflow never re-fires.
+6. **Add `[skip ci]` to the commit message**: secondary guard — suppresses CI on the `chore/update-marketplace` branch itself.
+7. **Add a "Check for changes" gate** before `create-pull-request`: only run the step when the file actually changed (idempotency fallback — prevents spurious open PRs).
+
+```yaml
+- name: Check for changes
+  id: diff
+  run: |
+    git diff --quiet .claude-plugin/marketplace.json || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+- name: Create PR for marketplace update
+  if: steps.diff.outputs.changed == 'true'
+  uses: peter-evans/create-pull-request@v7.0.8
+  # ... (rest of config above)
+```
+
+8. **Set `strict: true` on required status checks** in branch protection settings: ensures the `chore/update-marketplace` PR must be up-to-date with `main` before merging, avoiding stale-base merge failures.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Exclude chore branch in trigger | Added `!chore/update-marketplace` to `branches:` filter | Irrelevant — `branches` already only matches `main`; the chore branch never matched `branches: [main]` anyway. Pure noise. | Path exclusion (`!artifact-file`) is the correct tool, not branch exclusion |
+| `[skip ci]` on squash-merge commit | Tried to put `[skip ci]` on the squash-merge commit message | Not possible — GitHub controls the squash-merge commit message; you cannot inject tokens into it reliably | Use path filter as the primary guard; `[skip ci]` only helps on the branch commit, not the merge commit |
+| `Validate Plugins` regenerate and commit back to PR branches | Considered having the validate workflow regenerate and push to the source PR branch | Requires write access to forks (security risk) and creates race conditions | Bot-generated artifact updates should live on a dedicated bot branch (`chore/update-marketplace`), not back-patched onto contributor branches |
+
+## Results & Parameters
+
+### Configuration
+
+Full workflow trigger + loop-prevention config:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "plugins/**"
+      - "!.claude-plugin/marketplace.json"   # PRIMARY loop guard
+
+jobs:
+  update-marketplace:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Regenerate marketplace
+        run: python3 scripts/generate_marketplace.py .claude-plugin/marketplace.json skills/ plugins/
+
+      - name: Check for changes
+        id: diff
+        run: git diff --quiet .claude-plugin/marketplace.json || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR for marketplace update
+        id: cpr
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: regenerate marketplace.json [skip ci]"
+          branch: chore/update-marketplace
+          title: "chore: update marketplace.json"
+          body: "Auto-generated: marketplace index regenerated from merged skills."
+          labels: automated
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --squash chore/update-marketplace
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Three-Layer Loop Prevention Summary
+
+| Layer | Mechanism | Guards Against |
+|-------|-----------|----------------|
+| 1 (primary) | `!.claude-plugin/marketplace.json` in `paths` trigger | Squash-merge commit touching only that file never re-triggers workflow |
+| 2 (secondary) | `[skip ci]` in branch commit message | Suppresses CI runs on the `chore/update-marketplace` branch itself |
+| 3 (fallback) | "Check for changes" gate before PR creation | Skips PR creation when `marketplace.json` is unchanged (idempotency) |
+
+### Expected Output
+
+- First run after a skill merge: `chore/update-marketplace` PR opened, auto-merge enabled
+- Subsequent runs where marketplace unchanged: workflow exits early at "Check for changes" step
+- After `chore/update-marketplace` squash-merges: workflow does NOT re-fire (path filter prevents it)
+- No `GH006` errors
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | PR opened, CI not yet confirmed end-to-end (`verified-precommit`) | `.github/workflows/update-marketplace.yml` |
+
+## References
+
+- [peter-evans/create-pull-request action](https://github.com/peter-evans/create-pull-request)
+- [GitHub branch protection docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitHub Actions path filters](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)


### PR DESCRIPTION
## Summary

- Adds skill `ci-cd-github-actions-bot-protected-branch-push` documenting the fix for GH006 branch-protection failures when a GitHub Actions bot tries to push directly to `main`
- Captures the three-layer loop-prevention pattern: path-exclusion trigger filter (primary), `[skip ci]` commit message (secondary), and idempotency "check for changes" gate (fallback)
- Documents two failed approaches with lessons learned: excluding the chore branch from `branches:` filter (wrong tool), and injecting `[skip ci]` into the squash-merge commit (not possible)
- Includes copy-paste ready workflow snippet for `peter-evans/create-pull-request@v7.0.8` with auto-merge

## Test plan

- [ ] CI `validate` job passes (967 skills expected)
- [ ] `marketplace.json` update PR opens automatically after merge (end-to-end not yet verified — `verified-precommit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)