### PR TITLE
fix(ci): resolve duplicate Authorization header in update-marketplace workflow

### DIFF
--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0


### PR DESCRIPTION
The update-marketplace workflow fails with 'Duplicate header: Authorization' because both actions/checkout and peter-evans/create-pull-request configure git credentials.

Fix: add `persist-credentials: false` to the checkout step so peter-evans/create-pull-request exclusively manages credentials.

Fixes CI run 24870910168.