### PR TITLE
feat: amend 3 skills with Odysseus issue-closeout session learnings

### DIFF
--- a/skills/ci-cd-broken-main-parallel-fix-wave.history
+++ b/skills/ci-cd-broken-main-parallel-fix-wave.history
@@ -1,0 +1,35 @@
+# ci-cd-broken-main-parallel-fix-wave — History
+
+## v1.1.0 (2026-04-23)
+
+**Changed by:** Odysseus issue closeout session (Issues #76, #136) — NATS publishing feature + triage follow-ups
+**Verification:** verified-ci
+
+### What changed
+- Added Pattern 6: clang-format version mismatch — podman reformat fix using exact CI image (ubuntu:24.04, clang-format-18)
+- Added Monitor Noise Reduction Pattern — 60s interval for release builds, filter must include failure
+- Added 3 new Failed Attempts rows: local clang-format version, monitor filter success-only, 30s poll for release builds
+- Added `clang-format` to Agent Tier Selection Table
+- Updated description to mention clang-format violations
+- Updated verification from `verified-local` to `verified-ci` (PRs merged with CI passing)
+- Added `history` frontmatter field
+
+### Why
+During Odysseus issue #76 (hi.logs.* NATS publishing), parallel agents implementing the feature in
+ProjectAgamemnon and ProjectNestor both had clang-format violations detected by CI after
+build/test/tidy all passed. The agents used local clang-format-14 (Debian 11 dev host) instead
+of clang-format-18 (CI ubuntu-24.04). Fixed by using `podman run ubuntu:24.04` with the exact
+CI version. Monitor noise reduction learned from polling CI during the fix — 30s interval on a
+30-minute release build generated 60+ notifications.
+
+### Previous version (v1.0.0) snapshot
+
+See git history at commit 48c51481 — initial version dated 2026-04-24 with verification: verified-local.
+Key content: 5 CI failure patterns (conan, persist-credentials, dependabot-docker, BATS exit 127,
+Python import failures), 5-repo ecosystem fix wave, Haiku/Sonnet tier selection table.
+
+---
+
+## v1.0.0 (2026-04-24)
+
+**Initial version.**

--- a/skills/ci-cd-broken-main-parallel-fix-wave.md
+++ b/skills/ci-cd-broken-main-parallel-fix-wave.md
@@ -1,12 +1,13 @@
 ---
 name: ci-cd-broken-main-parallel-fix-wave
-description: "Triage and fix broken CI/main across multiple repos simultaneously using Agamemnon task registry + parallel myrmidon fix agents. Use when: (1) 3+ repos have broken main branch CI, (2) need to register tasks in Agamemnon before dispatching agents, (3) CI failures are diverse (conan profile, dependabot config, GitHub Actions auth, BATS helper, Python imports)."
+description: "Triage and fix broken CI/main across multiple repos simultaneously using Agamemnon task registry + parallel myrmidon fix agents. Use when: (1) 3+ repos have broken main branch CI, (2) need to register tasks in Agamemnon before dispatching agents, (3) CI failures are diverse (conan profile, dependabot config, GitHub Actions auth, BATS helper, Python imports, clang-format violations)."
 category: ci-cd
-date: 2026-04-24
-version: "1.0.0"
+date: 2026-04-23
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
-tags: [ci, broken-main, agamemnon, parallel-agents, myrmidon, conan, dependabot, bats, github-actions, fix-wave]
+verification: verified-ci
+history: ci-cd-broken-main-parallel-fix-wave.history
+tags: [ci, broken-main, agamemnon, parallel-agents, myrmidon, conan, dependabot, bats, github-actions, fix-wave, clang-format, monitor]
 ---
 
 # CI Broken-Main Parallel Fix Wave
@@ -15,10 +16,11 @@ tags: [ci, broken-main, agamemnon, parallel-agents, myrmidon, conan, dependabot,
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-24 |
+| **Date** | 2026-04-23 |
 | **Objective** | Use the HomericIntelligence agent mesh to fix broken CI/main across multiple repositories simultaneously — NATS + Agamemnon task registry + parallel Claude Code sub-agents as myrmidon workers |
-| **Outcome** | Successful — 5 repos triaged, tasks registered in Agamemnon, 5 parallel fix agents dispatched (mix of Haiku and Sonnet tiers) |
-| **Verification** | verified-local — tasks dispatched and agents running; PRs not yet merged at capture time |
+| **Outcome** | Successful — 5 repos triaged, tasks registered in Agamemnon, 5 parallel fix agents dispatched (mix of Haiku and Sonnet tiers); clang-format violations fixed via podman container |
+| **Verification** | verified-ci — PRs merged with CI passing |
+| **History** | [changelog](./ci-cd-broken-main-parallel-fix-wave.history) |
 
 ## When to Use
 
@@ -133,6 +135,9 @@ curl -s -X PATCH $AGAMEMNON/v1/teams/$TEAM_ID/tasks/fix-odysseus-conan-profile \
 | Dispatching all agents as Haiku | Used Haiku for BATS exit 127 and Python type error investigation | Haiku lacks the reasoning depth to investigate unknown root causes from log output alone | Escalate to Sonnet for failures where root cause is not already known before dispatch |
 | Running `conan` directly after `setup-pixi` | Assumed `setup-pixi` initialized conan profiles | Conan 2.x requires explicit `conan profile detect` — profiles don't auto-initialize | Always add `pixi run conan profile detect` as an explicit step after `setup-pixi`, before build scripts |
 | Dependabot docker block with no Dockerfiles | Kept `package-ecosystem: docker` in dependabot.yml despite no Dockerfiles | Dependabot fails hard with "dependency_file_not_found /Dockerfile" — no graceful skip | Remove `package-ecosystem: docker` blocks unless the repo actually contains Dockerfiles |
+| Running local clang-format on C++ PRs | Used system clang-format-14 on Debian 11 dev host to reformat before push | CI uses clang-format-18 on ubuntu-24.04; version differences produce divergent formatting decisions | Always use `podman run ubuntu:24.04` with the exact CI clang-format version — never the local system version |
+| Monitor filter emitting only on success | Set monitor `filter="conclusion == 'success'"` for CI polling | If the run fails, filter never emits — silence is indistinguishable from "still running" | Monitor filter MUST include failure: `conclusion == 'failure' OR conclusion == 'success'` |
+| 30s monitor poll for release builds | Used 30s poll interval for long-running C++ release CI | Generates 60+ noisy notifications during a 30-minute build; distracts from other work | Use 60s interval for release builds; 30s only for fast checks (lint, pre-commit) |
 
 ## Results & Parameters
 
@@ -222,6 +227,69 @@ curl -s -X PATCH $AGAMEMNON/v1/teams/$TEAM_ID/tasks/fix-odysseus-conan-profile \
 
 **Root cause**: Likely package structure issue — missing `__init__.py`, wrong module path, or stale pixi cache key causing 400 on cache fetch.
 
+---
+
+#### Pattern 6: clang-format Version Mismatch (C++ PRs after CI run)
+
+**Error**: CI reports `clang-format: would reformat <file>` after otherwise passing build/test/tidy steps.
+
+**Root cause**: Developer ran `clang-format` locally using a different version (e.g., clang-format-14 on Debian
+11) than CI (clang-format-18 on ubuntu-24.04). Version differences produce divergent formatting decisions.
+
+**Fix**: Use `podman run` with the exact CI base image to reformat:
+
+```bash
+# Install exact CI clang-format version via ubuntu-24.04 container
+podman run --rm -v $(pwd):/src ubuntu:24.04 bash -c "
+  apt-get update -qq && apt-get install -y clang-format-18 2>/dev/null
+  cd /src
+  clang-format-18 -i \$(git diff --name-only origin/main..HEAD | grep -E '\.(cpp|cc|h|hpp)$')
+"
+
+# Or shorter: from inside the repo
+podman run --rm -v $(pwd):/src -w /src ubuntu:24.04 \
+  bash -c 'apt-get update -qq && apt-get install -y clang-format-18 -qq && \
+           clang-format-18 -i $(git diff --name-only origin/main..HEAD)'
+
+# Commit the style fix and push to the existing branch
+git add -u
+git commit -m "style: apply clang-format to <feature-name>"
+git push  # No new PR needed — existing PR picks up the new commit
+```
+
+**Key rules:**
+- Identify the CI clang-format version from the workflow YAML (look for `ubuntu-24.04` → clang-format-18)
+- Run on all files changed in the PR (`git diff --name-only origin/main..HEAD`), not all files
+- Commit as a separate `style:` commit — do not squash into the feature commit (keeps blame clean)
+- Push to the existing branch — no new PR needed; auto-merge picks up the fix commit
+
+**Agent tier**: Haiku — once pattern is identified from CI logs, the fix is mechanical.
+
+---
+
+### Monitor Noise Reduction Pattern
+
+When polling CI status for long-running release builds, 30-second poll intervals cause excessive
+notifications. Recommended approach:
+
+```bash
+# Stop a noisy monitor
+TaskStop <monitor-id>
+
+# Re-arm with tighter filter (emit on FAILURE too, not just success)
+# and longer poll interval for release builds
+Monitor(
+    filter="conclusion == 'failure' OR conclusion == 'success'",
+    interval_seconds=60
+)
+```
+
+**Rules:**
+- Use 30s poll for fast checks (lint, pre-commit). Use 60s for release/build CI runs.
+- Monitor filter MUST emit on FAILURE too — `conclusion == 'success'` only causes silent misses
+  if the run fails. Silence does NOT mean "still running".
+- If a monitor produces too much noise: `TaskStop` the old one, re-arm with longer interval.
+
 ### Agent Tier Selection Table
 
 | Failure Type | Agent Tier | Why |
@@ -229,6 +297,7 @@ curl -s -X PATCH $AGAMEMNON/v1/teams/$TEAM_ID/tasks/fix-odysseus-conan-profile \
 | conan profile detect missing | Haiku | Exact fix known: add 1-line step to workflow YAML |
 | dependabot.yml docker block cleanup | Haiku | Exact fix known: remove block from YAML |
 | persist-credentials: false missing | Haiku | Exact fix known: add 1 attribute to checkout step |
+| clang-format violations | Haiku | Once CI version identified, fix is mechanical: podman reformat + `style:` commit |
 | BATS exit 127 (run_validate not found) | Sonnet | Root cause unknown — requires reading test file + load directives |
 | Python type errors + import failures | Sonnet | Root cause unknown — requires package structure investigation |
 | Pixi cache 400 errors | Sonnet | Environment-dependent, requires cache invalidation + diagnosis |
@@ -246,7 +315,7 @@ curl -s -X POST http://localhost:8080/v1/teams/$TEAM_ID/tasks \
     "priority": "high",
     "metadata": {
       "repo": "HomericIntelligence/<repo>",
-      "failure_type": "<conan-profile|persist-credentials|dependabot-docker|bats-exit-127|python-import>",
+      "failure_type": "<conan-profile|persist-credentials|dependabot-docker|bats-exit-127|python-import|clang-format>",
       "agent_tier": "<haiku|sonnet>"
     }
   }'

--- a/skills/close-issue-via-minimal-pr.history
+++ b/skills/close-issue-via-minimal-pr.history
@@ -1,0 +1,74 @@
+# close-issue-via-minimal-pr — History
+
+## v1.1.0 (2026-04-23)
+
+**Changed by:** Odysseus issue closeout session (Issues #102, #76, #136)
+**Verification:** verified-ci
+
+### What changed
+- Added "Closes part of #N does NOT auto-close" failure pattern to Failed Attempts table
+- Added GitHub auto-close keyword rules table to Results & Parameters
+- Added Step 5: Fallback — `gh issue close <N> --reason completed` for missed auto-close
+- Added new "When to Use" trigger: PR already merged but issue still open due to bad keyword
+- Updated PR body closing keyword warning (CRITICAL callout in Step 4)
+- Added `verification` and `history` frontmatter fields
+- Bumped date to 2026-04-23
+
+### Why
+During Odysseus issue #102 closeout, the PR body contained `"Closes part of #102"`. GitHub's
+auto-close parser does not recognize this phrase — it requires exact verb + `#N` with no
+intervening words. The issue remained open after merge and had to be closed manually with
+`gh issue close 102 --reason completed`. Added this pattern to prevent future confusion.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: close-issue-via-minimal-pr
+description: 'Close a GitHub issue when all code already exists on main but the issue
+  is still open. Use when: (1) a verification/CI-check issue has no outstanding code
+  changes, (2) the feature branch has zero diff from main, (3) you need a minimal
+  commit to create a PR that triggers CI and closes the issue.'
+category: ci-cd
+date: 2026-03-15
+version: 1.0.0
+user-invocable: false
+---
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Issue is still open but all code changes already landed on main; branch has no diff from main |
+| **Pattern** | Minimal docstring update in the primary file to create a substantive commit |
+| **Trigger** | `git diff main..HEAD` is empty; issue asks for "CI verification" of existing code |
+| **PR outcome** | CI runs against existing code; `Closes #N` in commit or PR body closes the issue |
+
+## When to Use
+
+- Issue title contains "verify", "run in CI", "confirm passes", "check CI"
+- Branch was created with `git checkout -b <N>-auto-impl` but has no code to add — all work was done in a previous PR
+- `git status` shows only untracked files (e.g., `.claude-prompt-N.md`), no modified tracked files
+- `git diff origin/main` is empty
+- The issue is a follow-up from a prior issue ("Follow-up from #XXXX")
+- CI glob pattern already covers the relevant test files (confirmed via `grep` on workflow YAML)
+
+## Verified Workflow
+
+### Quick Reference
+
+[...original content truncated for brevity — full content in git history at commit eb33b69d...]
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Create empty commit | `git commit --allow-empty` | GitHub still creates a PR but it's harder to justify; pre-commit hooks may reject it | A real docstring improvement is cleaner and more reviewable than an empty commit |
+| Use `.claude-prompt-N.md` as the commit file | Stage and commit the prompt file | Prompt files are ephemeral implementation details, not project files — staging them pollutes history | Only commit actual project files; leave prompt files untracked |
+| Look for missing implementation | Read test files expecting to find TODOs or stubs | Tests were fully implemented; the only missing piece was the PR | Always check `git diff origin/main` first before assuming code is missing |
+```
+
+---
+
+## v1.0.0 (2026-03-15)
+
+**Initial version.**

--- a/skills/close-issue-via-minimal-pr.md
+++ b/skills/close-issue-via-minimal-pr.md
@@ -3,11 +3,14 @@ name: close-issue-via-minimal-pr
 description: 'Close a GitHub issue when all code already exists on main but the issue
   is still open. Use when: (1) a verification/CI-check issue has no outstanding code
   changes, (2) the feature branch has zero diff from main, (3) you need a minimal
-  commit to create a PR that triggers CI and closes the issue.'
+  commit to create a PR that triggers CI and closes the issue, (4) a merged PR did
+  not auto-close the issue because the commit keyword was wrong.'
 category: ci-cd
-date: 2026-03-15
-version: 1.0.0
+date: 2026-04-23
+version: 1.1.0
 user-invocable: false
+verification: verified-ci
+history: close-issue-via-minimal-pr.history
 ---
 ## Overview
 
@@ -17,6 +20,8 @@ user-invocable: false
 | **Pattern** | Minimal docstring update in the primary file to create a substantive commit |
 | **Trigger** | `git diff main..HEAD` is empty; issue asks for "CI verification" of existing code |
 | **PR outcome** | CI runs against existing code; `Closes #N` in commit or PR body closes the issue |
+| **Verification** | verified-ci |
+| **History** | [changelog](./close-issue-via-minimal-pr.history) |
 
 ## When to Use
 
@@ -26,6 +31,7 @@ user-invocable: false
 - `git diff origin/main` is empty
 - The issue is a follow-up from a prior issue ("Follow-up from #XXXX")
 - CI glob pattern already covers the relevant test files (confirmed via `grep` on workflow YAML)
+- A PR already merged but the issue remained open because the closing keyword was wrong (e.g., "Closes part of #N")
 
 ## Verified Workflow
 
@@ -41,12 +47,17 @@ grep -n "test_<name>" .github/workflows/comprehensive-tests.yml
 # 3. Make minimal docstring update to primary file
 # (update module docstring to clarify scope + reference CI verification issue)
 
-# 4. Commit, push, create PR with Closes #N
+# 4. Commit, push, create PR with exact Closes #N keyword
 git add <file>
-git commit -m "ci(test): verify <name> passes in CI\n\nCloses #N"
+git commit -m "ci(test): verify <name> passes in CI
+
+Closes #N"
 git push -u origin <branch>
 gh pr create --title "..." --body "Closes #N"
 gh pr merge --auto --rebase <pr-number>
+
+# 5. If issue still open after PR merge (bad keyword in previous PR):
+gh issue close <N> --reason completed
 ```
 
 ### Step 1: Confirm the branch is empty
@@ -84,6 +95,10 @@ The change must be substantive (not just whitespace) and accurate. A good docstr
 
 ### Step 4: Commit, push, create PR
 
+**CRITICAL**: Use the exact auto-close keyword — `Closes #N`, `Fixes #N`, or `Resolves #N` — directly
+followed by `#N` with no intervening words. GitHub's parser will NOT auto-close for phrases like
+`"Closes part of #N"`, `"Closes some of #N"`, `"Addresses #N"`, or `"Related to #N"`.
+
 ```bash
 git add <file>
 git commit -m "$(cat <<'EOF'
@@ -94,9 +109,7 @@ verification environment (e.g., GLIBC constraint on dev host)>.
 
 Closes #N
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 EOF
 )"
 
@@ -130,6 +143,18 @@ EOF
 gh pr merge --auto --rebase <pr-number>
 ```
 
+### Step 5: Fallback — explicit issue close when auto-close missed
+
+If the issue remains open after a PR merges (because a prior PR used a partial keyword like
+"Closes part of #N"), close it programmatically:
+
+```bash
+gh issue close <N> --reason completed
+```
+
+This is also the correct approach when you close an issue programmatically as a result of
+a pin-bump or chore commit where no individual PR carries the `Closes #N` body.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -137,6 +162,7 @@ gh pr merge --auto --rebase <pr-number>
 | Create empty commit | `git commit --allow-empty` | GitHub still creates a PR but it's harder to justify; pre-commit hooks may reject it | A real docstring improvement is cleaner and more reviewable than an empty commit |
 | Use `.claude-prompt-N.md` as the commit file | Stage and commit the prompt file | Prompt files are ephemeral implementation details, not project files — staging them pollutes history | Only commit actual project files; leave prompt files untracked |
 | Look for missing implementation | Read test files expecting to find TODOs or stubs | Tests were fully implemented; the only missing piece was the PR | Always check `git diff origin/main` first before assuming code is missing |
+| "Closes part of #N" as PR body closing keyword | PR body contained `"Closes part of #N"` expecting GitHub to auto-close | GitHub parser requires exact verb immediately followed by `#N` — intervening words ("part of") break the pattern | Use only `Closes #N`, `Fixes #N`, or `Resolves #N` — no words between verb and `#N`; fall back to `gh issue close` |
 
 ## Results & Parameters
 
@@ -148,12 +174,29 @@ gh pr merge --auto --rebase <pr-number>
 # Change: module docstring clarification + CI verification note
 
 git add tests/shared/core/test_extensor_setitem.mojo
-git commit -m "ci(test): verify test_extensor_setitem passes in CI\n\nCloses #3840"
+git commit -m "ci(test): verify test_extensor_setitem passes in CI
+
+Closes #3840"
 git push -u origin 3840-auto-impl
 gh pr create --title "ci(test): verify test_extensor_setitem passes in CI" \
   --body "Closes #3840" --label "testing"
 gh pr merge --auto --rebase 4811
 ```
+
+### GitHub auto-close keyword rules
+
+| Phrase | Auto-closes? |
+|--------|-------------|
+| `Closes #N` | YES |
+| `Fixes #N` | YES |
+| `Resolves #N` | YES |
+| `closes #N` (lowercase) | YES |
+| `Closes part of #N` | NO — intervening words break parser |
+| `Addresses #N` | NO — not a recognized verb |
+| `Related to #N` | NO — not a recognized verb |
+| `See #N` | NO — not a recognized verb |
+
+When in doubt, use `gh issue close <N> --reason completed` after merge.
 
 ### CI coverage verification pattern
 
@@ -179,3 +222,4 @@ When the issue says "cannot verify locally due to GLIBC mismatch":
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Issue #3840, PR #4811 | [notes.md](../references/notes.md) |
+| Odysseus | Issue #102, PR #138 — "Closes part of #102" failed to auto-close; used `gh issue close 102 --reason completed` | 2026-04-23 |

--- a/skills/multi-repo-pr-orchestration-swarm-pattern.history
+++ b/skills/multi-repo-pr-orchestration-swarm-pattern.history
@@ -3,6 +3,31 @@
 # Each entry records what changed and why; full snapshots for major versions only.
 ---
 
+## v1.2.0 — 2026-04-23
+
+**Changed by**: Odysseus issue closeout session (Issues #102, #76, #136)
+**Session context**: Submodule pin bump, NATS publishing feature, Keystone pin audit — 2026-04-23
+
+### What Changed
+
+- Bumped version 1.1.0 → 1.2.0; date updated to 2026-04-23
+- Phase 3 (Wave 1b): added duplicate-commit auto-drop explanation (git patch-id detection)
+- Phase 3 (Wave 1b): added `mergeStateStatus: BLOCKED + empty statusCheckRollup` = transient state note with re-check commands
+- Phase 5 (Wave 2): expanded submodule pin section with pre-pin audit steps (verify open PRs first, check for stale branch pins, non-required CI checks explanation)
+- Failed Attempts: 3 new rows (BLOCKED transient state misinterpretation, pin before PRs merged, stale branch pin)
+- Updated description to mention duplicate-commit rebase and mergeStateStatus BLOCKED transient state
+- Added `pin-audit` and `duplicate-commit` tags
+
+### Key New Learnings
+
+1. **Duplicate-commit auto-drop**: `git rebase origin/main` uses git's patch-id detection to automatically drop commits whose patch is already applied upstream. After rebase, always verify with `git log --oneline origin/main..HEAD` and `git diff origin/main`. Empty diff + empty log = subsumed, close the PR.
+2. **BLOCKED + empty statusCheckRollup = transient**: Not a permanent block. CI takes 10-30s to queue after a force-push. Wait 60s, re-check with `gh pr view --json statusCheckRollup` before acting.
+3. **Pin audit order**: Verify `gh pr list --state open` is empty before bumping any submodule pin. Bumping too early makes the pin stale again immediately.
+4. **Stale branch pin detection**: Use `git branch -r --contains HEAD` on the submodule. If the current pin is on a feature branch (not `origin/main`), audit whether main has those changes and pin to main instead.
+5. **Non-required checks don't block**: Only required branch protection checks matter for merge and pinning. Non-required checks (pre-commit, docker scanning, security-report) can show FAILURE without blocking.
+
+---
+
 ## v1.1.0 — 2026-04-19
 
 **Changed by**: Claude Sonnet 4.6 (skill amendment session)

--- a/skills/multi-repo-pr-orchestration-swarm-pattern.md
+++ b/skills/multi-repo-pr-orchestration-swarm-pattern.md
@@ -1,12 +1,12 @@
 ---
 name: multi-repo-pr-orchestration-swarm-pattern
-description: "Orchestrate PR management across all HomericIntelligence repos using myrmidon swarm. Use when: (1) multiple repos have open PRs that need merging, conflict resolution, or CI fixes, (2) Odysseus submodule pins need updating after cross-repo PR merges, (3) coordinating parallel waves of agents across 5+ repos with sequential-within-repo merge ordering."
+description: "Orchestrate PR management across all HomericIntelligence repos using myrmidon swarm. Use when: (1) multiple repos have open PRs that need merging, conflict resolution, or CI fixes, (2) Odysseus submodule pins need updating after cross-repo PR merges, (3) coordinating parallel waves of agents across 5+ repos with sequential-within-repo merge ordering, (4) a PR branch has a duplicate commit that's already on main and needs rebase, (5) mergeStateStatus is BLOCKED but statusCheckRollup is empty — CI may not have started yet."
 category: ci-cd
-date: 2026-04-19
-version: "1.1.0"
+date: 2026-04-23
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
-tags: [multi-repo, PR, merge, submodule, myrmidon-swarm, cross-repo, orchestration, odysseus]
+tags: [multi-repo, PR, merge, submodule, myrmidon-swarm, cross-repo, orchestration, odysseus, duplicate-commit, pin-audit]
 history: multi-repo-pr-orchestration-swarm-pattern.history
 ---
 
@@ -142,6 +142,30 @@ git push --force-with-lease
 
 **Key pattern**: Always `git fetch origin` before rebasing to get the latest main after Wave 1 merges.
 
+**Duplicate-commit auto-drop**: When a branch contains a commit whose patch is already applied
+upstream (e.g., the same commit was cherry-picked or landed via another PR), `git rebase origin/main`
+silently drops it via git's patch-id detection. This is correct behavior — the PR branch will have
+fewer commits after rebase than before, but the diff will be clean. Always verify after rebase:
+
+```bash
+git log --oneline origin/main..HEAD  # Should show only the PR's unique commits
+git diff origin/main                  # Should show only the PR's intended changes
+```
+
+If the log is empty and diff is also empty, the PR is fully subsumed — close it.
+
+**mergeStateStatus: BLOCKED with empty statusCheckRollup**: This is a transient state that means
+CI hasn't started yet, NOT that the PR is permanently blocked. After a force-push (e.g., rebase),
+GitHub takes 10-30 seconds to queue CI. Always re-check after a minute before concluding a PR is blocked:
+
+```bash
+# Confirm CI queued (wait 60s after force-push before checking)
+gh pr view <PR> --json mergeStateStatus,statusCheckRollup
+# statusCheckRollup: [] → CI not started yet (transient)
+# statusCheckRollup: [{conclusion: null}] → CI queued/running
+# statusCheckRollup: [{conclusion: "success"}] → CI passed
+```
+
 **Subsumption check at scale**: At 87 PRs, ~15-20% of DIRTY PRs turn out to be fully subsumed by the merge cascade (their changes already landed via another PR). Always check before rebasing:
 ```bash
 # A PR is subsumed if its diff is empty against origin/main
@@ -195,7 +219,26 @@ gh pr merge $PR_NUM --repo HomericIntelligence/$REPO --rebase
 
 ### Phase 5: Wave 2 -- Update Odysseus Submodule Pins
 
-After all PRs are merged across repos, update the Odysseus meta-repo submodule pins:
+After all PRs are merged across repos, update the Odysseus meta-repo submodule pins.
+
+**Pre-pin audit** (CRITICAL — do this before bumping any pin):
+
+```bash
+# Step 1: Verify all open PRs are merged before bumping pin
+# If PRs are still open, the pin will become stale again immediately after they merge
+gh pr list --repo HomericIntelligence/<repo> --state open --json number,title
+# → Should be empty before bumping
+
+# Step 2: Check local pin vs origin/main
+git -C <submodule-path> rev-parse HEAD           # current pin
+git -C <submodule-path> rev-parse origin/main    # what main is at
+
+# Step 3: Check for stale branch pins
+# If current pin is on a feature branch (not origin/main), audit carefully
+git -C <submodule-path> branch -r --contains HEAD
+# If output shows "origin/<feature-branch>" not "origin/main", the pin is stale
+# Pin to origin/main if the feature branch changes are already in main
+```
 
 ```bash
 cd /home/mvillmow/Odysseus
@@ -213,10 +256,23 @@ git submodule foreach --quiet '
 
 # Stage and commit updated pins
 git add -A  # Only submodule refs change, safe here
-git commit -m "chore: update submodule pins after cross-repo PR merges"
+git commit -m "chore: update submodule pins after cross-repo PR merges
+
+Closes #N"   # Include Closes #N if this commit closes a tracking issue
 ```
 
-**Warning**: Only pin submodules whose `main` branch moved forward. Never pin to feature branch commits from unmerged PRs.
+**Warning**: Only pin submodules whose `main` branch moved forward. Never pin to feature branch commits
+from unmerged PRs. If the current pin points to a stale feature branch (e.g., `fix/spdlog-link-visibility`)
+and that branch's changes are already on `main`, pin to `origin/main` instead.
+
+**Non-required CI checks**: Submodule repos may have non-required checks (pre-commit, docker scanning,
+security-report) showing FAILURE in CI. Only required checks block merge — verify with:
+
+```bash
+gh api repos/HomericIntelligence/<repo>/branches/main --jq '.protection.required_status_checks.contexts'
+```
+
+A non-required check failing does NOT prevent pinning to that commit.
 
 ### Phase 6: Verification
 
@@ -244,6 +300,9 @@ git status
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Parallel PR merges within same repo | Merged PRs #4, #5, #6 in parallel targeting the same branch | PR #6 got conflicts because its base changed when #4 and #5 merged | Must merge sequentially within a repo (oldest-first); parallelize only across repos |
+| Treating BLOCKED+empty statusCheckRollup as permanent block | Saw `mergeStateStatus: BLOCKED` + `statusCheckRollup: []` and concluded PR was stuck | This is a transient state: CI hadn't started yet (10-30s after force-push). PR merged normally after CI queued | Wait 60s after force-push before concluding a PR is permanently blocked; re-check with `gh pr view --json statusCheckRollup` |
+| Bumping submodule pin before all open PRs merged | Updated pin to latest main immediately after one PR merged | A second PR merged 10 minutes later, making the pin stale again instantly | Always verify `gh pr list --state open` is empty for a repo before bumping its Odysseus pin |
+| Pinning to stale feature branch commit | Left submodule pinned to `fix/spdlog-link-visibility` branch SHA | main had moved 10+ commits ahead of the branch tip with additional coverage/CI fixes | Check `git branch -r --contains HEAD` on the submodule — if not on `origin/main`, audit and pin to main |
 | Using `--admin` flag to bypass CI | `gh pr merge --admin` to force-merge when branch protection blocks | User explicitly requested not using `--admin`, preferring proper CI flow | Respect CI gates; fix failures rather than bypassing them |
 | First attempt at Charybdis merge | Attempted merge with failing CI | clang-format, clang-tidy, and coverage checks were failing | Must spawn a Sonnet agent to investigate and fix CI before merge is possible |
 | Nestor PR rebase after other PRs merged | PR #3 in Nestor conflicted after other Nestor PRs merged to main | Base branch moved forward, invalidating the PR's diff | Always rebase onto fresh origin/main after each merge within the same repo |


### PR DESCRIPTION
## Summary

Amends 3 existing skills with learnings from the Odysseus Issues #102/#76/#136 closeout session:

- **close-issue-via-minimal-pr** (v1.0.0 → v1.1.0): GitHub auto-close keyword pitfall + explicit fallback
- **ci-cd-broken-main-parallel-fix-wave** (v1.0.0 → v1.1.0): clang-format podman fix + monitor noise reduction
- **multi-repo-pr-orchestration-swarm-pattern** (v1.1.0 → v1.2.0): duplicate-commit rebase + mergeStateStatus BLOCKED transient + submodule pin audit

## Verification Level

**verified-ci** — all patterns validated in the live Odysseus ecosystem with PRs merged and CI passing.

## Key Findings

**What Worked**:
- `podman run ubuntu:24.04` with exact CI clang-format version avoids version-divergence formatting failures
- `git rebase origin/main` auto-drops duplicate commits via patch-id detection — verify with `git log + git diff`
- `gh issue close <N> --reason completed` as fallback when PR missed the auto-close keyword
- Pre-pin audit (verify open PRs empty, check stale branch pins) prevents immediately-stale submodule pins

**What Failed**:
- `"Closes part of #N"` → GitHub parser does NOT auto-close; intervening words break the verb+#N pattern
- `mergeStateStatus: BLOCKED + statusCheckRollup: []` misread as permanent block; was transient (CI not started yet)
- Local clang-format-14 vs CI clang-format-18 divergent formatting → CI failure after local pre-check passed
- Monitor filter `conclusion == 'success'` only → silent misses on CI failure; 30s poll on 30-min builds = noise flood
- Pinning submodule to stale feature branch commit while main had 10+ additional commits ahead

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — all 3 skills pass
- [x] Verify skill files appear in `skills/` root (flat format)
- [x] History files created/updated for all 3 amended skills

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>