### PR TITLE
feat(skills): Add e2e-rate-limit-diagnosis-reset

### DIFF
--- a/skills/e2e-rate-limit-diagnosis-reset.md
+++ b/skills/e2e-rate-limit-diagnosis-reset.md
@@ -1,0 +1,249 @@
+---
+name: e2e-rate-limit-diagnosis-reset
+description: 'Diagnose experiment data quality issues caused by Anthropic API monthly
+  usage limits (HTTP 429) and reset affected runs for retry. Use when: experiment
+  results show unexplained failures in later tiers, runs have zero tokens/cost with
+  exit_code=1, or checkpoint marks rate-limited runs as successfully completed with
+  F grades.'
+category: debugging
+date: 2026-04-25
+version: 1.0.0
+user-invocable: false
+tags:
+- rate-limit
+- 429
+- experiment-diagnosis
+- checkpoint-reset
+- data-quality
+- e2e-testing
+---
+# E2E Rate Limit Diagnosis and Experiment Reset
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Problem** | Experiment results show "garbage data" in later tiers (T3-T6) -- all runs fail with zero tokens, zero cost, ~8-10s duration |
+| **Root cause** | Anthropic API monthly usage limit (HTTP 429) hit mid-experiment; later tiers disproportionately affected because they run after earlier tiers consume quota |
+| **Fix** | Diagnose via result.json inspection, then reset affected runs in checkpoint for retry using `scripts/reset_rate_limited_runs.py` |
+| **Language** | Python 3.10+ |
+| **Project** | ProjectScylla |
+
+## When to Use
+
+Use this skill when:
+
+1. **Experiment data shows a "cliff"** -- early tiers succeed but later tiers have mass failures
+2. **Runs have zero tokens and zero cost** -- `total_tokens=0, cost_usd=0.0, exit_code=1, duration ~8-10s`
+3. **Checkpoint marks failed runs as complete** -- `run_states="worktree_cleaned"` with `completed_runs="failed"` for rate-limited runs (the system treated them as valid F-grade results)
+4. **You suspect API quota exhaustion** rather than a code bug or tier design issue
+5. **You need to selectively reset runs** in a completed experiment without re-running everything
+
+**Key differentiator from `e2e-rate-limit-detection`**: That skill covers real-time detection/parsing of rate limits during execution. This skill covers post-hoc diagnosis when rate limits were NOT properly handled and corrupted experiment data.
+
+## Verified Workflow
+
+### Step 1: Identify the Failure Signature
+
+Start with aggregate data, not individual runs:
+
+```bash
+# Check summary statistics
+cat results/<experiment>/docs/arxiv/haiku/data/summary.json | python -m json.tool
+
+# Look at runs.csv for patterns
+# Key columns: tier, pass_rate, total_tokens, cost_usd, exit_code
+head -50 docs/arxiv/haiku/data/runs.csv
+```
+
+**Failure signature to look for**:
+- `exit_code=1` (agent crashed)
+- `api_calls=1` (only one API call before failure)
+- `total_tokens=0` (no tokens consumed)
+- `cost_usd=0.0` (no cost)
+- `duration` in 8-10 second range (just enough for one failed API roundtrip)
+- Concentrated in later tiers (T3 second half, T4, T5, T6)
+
+### Step 2: Confirm the Root Cause in result.json
+
+Do NOT assume the cause from aggregate data alone. Check actual error messages:
+
+```bash
+# Find a failed run and read its result.json
+cat results/<experiment>/T4/01/run_01/agent/result.json | python -m json.tool
+```
+
+**Confirmation**: Look for these fields in the JSON:
+```json
+{
+  "is_error": true,
+  "result": "You've hit your org's monthly usage limit",
+  "api_error_status": 429,
+  "total_cost_usd": 0,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
+}
+```
+
+**The `api_error_status: 429` field is definitive.** If you see this, the run failed due to rate limiting, not a code bug.
+
+### Step 3: Map the Failure Timeline
+
+Understand which tiers/subtests were affected:
+
+```bash
+# Check which tiers have rate-limited runs
+for tier in T0 T1 T2 T3 T4 T5 T6; do
+  echo "=== $tier ==="
+  grep -rl "api_error_status.*429\|monthly usage limit" \
+    results/<experiment>/$tier/*/run_*/agent/result.json 2>/dev/null | wc -l
+done
+```
+
+**Typical pattern for monthly quota exhaustion**:
+- T0-T2: Succeed (~$5-6 total cost)
+- T3/01-15: Succeed (~$3-4 additional)
+- T3/16-41: Rate limited (quota hit at ~$10 total)
+- T4: All rate limited (runs after T3)
+- T5: All rate limited (depends on T0-T4 completing first)
+- T6: All rate limited (depends on T5)
+
+### Step 4: Reset Affected Runs
+
+Use the reset script (or create one if it does not exist):
+
+```bash
+# Dry run first (default mode)
+pixi run python scripts/reset_rate_limited_runs.py \
+  --experiment-dir results/<experiment-dir>
+
+# Apply the reset
+pixi run python scripts/reset_rate_limited_runs.py \
+  --experiment-dir results/<experiment-dir> \
+  --apply
+```
+
+**What the reset script does**:
+1. Scans `completed/` directory for runs with 429 errors in `agent/result.json`
+2. Also checks `run_result.json` for judge failures on rate-limited agent output
+3. Cleans result artifacts: `run_result.json`, `report.json`, `report.md`, `judge/` contents
+4. Cleans subtest-level and experiment-level reports
+5. Updates `checkpoint.json`:
+   - Resets `run_states` from `"worktree_cleaned"` to `"pending"`
+   - Removes affected runs from `completed_runs`
+   - Cascades: sets affected subtest states and tier states back to `"pending"`
+   - Sets `experiment_state` back to `"tiers_running"`
+6. Backs up original checkpoint as `checkpoint.json.bak`
+
+### Step 5: Re-run Affected Tiers
+
+```bash
+pixi run python scripts/manage_experiment.py run \
+  --config <experiment_dir> \
+  --tiers T3 T4 T5 T6
+```
+
+The resume logic in `manage_experiment.py` will pick up only the `"pending"` runs.
+
+## Key Checkpoint Structure Facts
+
+Understanding these is critical for manual debugging or script development:
+
+```python
+# run_states uses string run numbers (NOT zero-padded)
+checkpoint["run_states"]["T3"]["16"]["1"]  # correct
+checkpoint["run_states"]["T3"]["16"]["01"]  # WRONG
+
+# completed_runs status values
+"passed"          # judge_passed=True (good grade)
+"failed"          # judge_passed=False (bad grade OR rate-limited -- ambiguous!)
+"agent_complete"  # agent ran, judge never evaluated
+
+# Terminal states that WON'T be auto-retried by manage_experiment.py:
+# - run_states="worktree_cleaned" -- considered DONE regardless of grade
+# The auto-reset in _reset_non_completed_runs() only resets:
+# - run_states="failed" (infra crash)
+# - run_states="rate_limited" (detected rate limit)
+# It does NOT reset "worktree_cleaned" runs that happened to be rate-limited
+# but were not detected as such (the detection gap this skill addresses)
+
+# Tier/subtest state cascade
+# When resetting runs, you MUST also reset:
+# - subtest_states[tier][subtest] -> "pending"
+# - tier_states[tier] -> "pending"
+# - experiment_state -> "tiers_running"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assumed tier design problem | Investigated whether T4-T6 tier configs were broken | Aggregate data alone does not reveal root cause | Always check actual error messages in `agent/result.json` before hypothesizing |
+| Assumed infrastructure crash | Looked for Docker/system errors | No infra errors present | Rate limits can masquerade as clean failures with exit_code=1 |
+| Checked only checkpoint state | Read checkpoint.json tier_states | Checkpoint said "failed" for T4 but actual pass rate was 97.3% on non-rate-limited runs | Checkpoint state does not always reflect data quality; inspect run-level data |
+
+## Pitfalls
+
+1. **Rate-limited runs look like valid F-grade results**: The checkpoint marks them as `worktree_cleaned` + `completed_runs="failed"`. The system treats this as "the agent ran and got a bad grade" rather than "the agent could not run at all."
+
+2. **T4 checkpoint "failed" vs actual data quality**: A tier can show `tier_states="failed"` in the checkpoint while the runs that DID complete have a 97%+ pass rate. The "failed" state reflects the presence of any failed runs, not the overall quality.
+
+3. **Dependency chain amplifies quota exhaustion**: T5 depends on T0-T4 completing; T6 depends on T5. If quota runs out during T3, everything downstream is guaranteed to fail.
+
+4. **Monthly vs per-minute rate limits**: Monthly quota (HTTP 429 with "monthly usage limit") is fundamentally different from per-minute rate limits (HTTP 429 with "Retry-After" header). The existing rate limit detection handles per-minute limits with pause/resume but does NOT handle monthly quota exhaustion (there is nothing to wait for).
+
+## Results & Parameters
+
+### Detection Patterns (Copy-Paste Ready)
+
+**Rate-limited run indicators in result.json**:
+```python
+# Definitive: API error status
+data.get("api_error_status") == 429
+
+# Supportive: error message
+"monthly usage limit" in data.get("result", "")
+"hit your org's monthly usage limit" in data.get("result", "")
+
+# Supportive: zero-cost signature
+data.get("total_cost_usd") == 0
+data.get("usage", {}).get("input_tokens") == 0
+data.get("usage", {}).get("output_tokens") == 0
+```
+
+### Reset Script Location
+
+`scripts/reset_rate_limited_runs.py` in ProjectScylla
+
+### Related Commands
+
+```bash
+# Check experiment cost before hitting limit
+grep -o '"cost_usd":[0-9.]*' results/<experiment>/*/run_result.json | \
+  awk -F: '{sum+=$2} END {printf "Total: $%.2f\n", sum}'
+
+# Count rate-limited vs successful runs per tier
+for tier in T0 T1 T2 T3 T4 T5 T6; do
+  total=$(find results/<experiment>/$tier -name result.json -path "*/agent/*" 2>/dev/null | wc -l)
+  limited=$(grep -rl "api_error_status.*429" results/<experiment>/$tier/*/run_*/agent/result.json 2>/dev/null | wc -l)
+  echo "$tier: $limited/$total rate-limited"
+done
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | test-001 experiment (2026-03-30) | T4-T6 garbage results diagnosed as monthly API quota exhaustion; reset script created and applied successfully |
+
+## Related Skills
+
+- `e2e-rate-limit-detection` -- Real-time rate limit detection during execution (code-level parsing fix)
+- `always-retry-infra-failures` -- Making retry logic unconditional; distinguishing infra crash vs bad grade
+- `batch-retry-errors-checkpoint-reset` -- Batch mode checkpoint reset for failed/rate-limited runs
+
+## Tags
+
+`debugging` `rate-limit` `429` `experiment-diagnosis` `checkpoint-reset` `data-quality` `e2e-testing` `monthly-quota` `api-errors`

--- a/skills/e2e-rate-limit-diagnosis-reset.notes.md
+++ b/skills/e2e-rate-limit-diagnosis-reset.notes.md
@@ -1,0 +1,162 @@
+# E2E Rate Limit Diagnosis and Reset - Raw Session Notes
+
+## Session Context
+
+**Date**: 2026-04-25
+**Project**: ProjectScylla
+**Initial Request**: Debug why test-001 experiment showed "garbage results" for T4-T6 tiers
+**Verification**: verified-local (script executed successfully, reset applied, rerun pending)
+
+## Problem Discovery
+
+### Initial Symptoms
+
+User observed a large data gap in test-001 experiment results:
+- T0-T2 tiers had normal results
+- T3 had partial results (subtests 01-15 OK, 16-41 failed)
+- T4-T6 showed near-total failure ("garbage results")
+
+### Investigation Steps
+
+**Step 1**: Analyzed aggregate data in `docs/arxiv/haiku/data/`
+- `runs.csv` showed the cliff pattern: pass rates dropping to near-zero for later tiers
+- `summary.json` confirmed the data quality issue
+
+**Step 2**: Traced to experiment results at `results/2026-03-30T04-09-50-test-001/`
+- Examined tier-level directories to understand the scope of failures
+
+**Step 3**: Read `agent/result.json` for individual failed runs
+- Found the definitive 429 error: `"api_error_status": 429`
+- Error message: `"You've hit your org's monthly usage limit"`
+
+**Step 4**: Confirmed the timeline by mapping costs:
+- T0-T2 succeeded: ~$5.53 total
+- T3/01-15 succeeded: ~$3.64 additional
+- Rate limit hit at approximately $10.28 total spend
+- Everything after that point failed with zero tokens
+
+### Key Finding
+
+The root cause was **Anthropic API monthly usage limit exhaustion**, not any code bug, tier design issue, or infrastructure problem.
+
+## Diagnosis Pitfalls (Time Wasted)
+
+1. **Initially assumed tier design problem**: Spent time investigating whether T4-T6 configurations were broken. The aggregate data pattern (later tiers fail) was misleading -- it looked like a tier complexity issue.
+
+2. **Assumed infrastructure crash**: Looked for Docker/system errors before checking the actual agent output. No infra errors were present.
+
+3. **Trusted checkpoint state**: The checkpoint showed `tier_states="failed"` for T4, but this was ambiguous -- it could mean "all runs failed with bad grades" or "runs couldn't execute at all." The actual data for T4 runs that DID complete showed 97.3% pass rate.
+
+**Lesson**: Always go to `agent/result.json` first when diagnosing unexpected failures. The actual error message is definitive; aggregate statistics and checkpoint states are not.
+
+## Reset Script Details
+
+### Created: `scripts/reset_rate_limited_runs.py`
+
+**Design decisions**:
+
+1. **Dry-run by default**: `--apply` flag required to actually make changes. This prevents accidental data loss.
+
+2. **Backup**: Original `checkpoint.json` saved as `checkpoint.json.bak` before modification.
+
+3. **Detection logic**: Checks both `agent/result.json` (for `api_error_status: 429`) and `run_result.json` (for judge failures on rate-limited agent output). Both need to be cleaned.
+
+4. **Artifact cleanup**: Removes `run_result.json`, `report.json`, `report.md`, and `judge/` directory contents. These contain invalid results from the rate-limited run.
+
+5. **Checkpoint cascade**: When resetting a run, must also reset:
+   - `run_states[tier][subtest][run]` -> `"pending"`
+   - Remove from `completed_runs[tier][subtest][run]`
+   - `subtest_states[tier][subtest]` -> `"pending"`
+   - `tier_states[tier]` -> `"pending"`
+   - `experiment_state` -> `"tiers_running"`
+
+6. **Run number format**: `run_states` uses string run numbers WITHOUT zero-padding: `"1"`, `"2"`, `"3"` -- NOT `"01"`, `"02"`, `"03"`.
+
+### Why manage_experiment.py resume doesn't handle this
+
+The `_reset_non_completed_runs()` function in `manage_experiment.py` only auto-resets runs in these states:
+- `run_states="failed"` (infra crash -- unhandled exception)
+- `run_states="rate_limited"` (detected rate limit with RateLimitError)
+
+It does NOT reset `run_states="worktree_cleaned"` runs. Rate-limited runs that were not detected as rate limits during execution end up at `worktree_cleaned` with `completed_runs="failed"` -- the system considers them legitimately completed runs with bad grades.
+
+This is the gap: the real-time rate limit detection (`e2e-rate-limit-detection` skill) handles per-minute rate limits. Monthly quota exhaustion uses a different error format (`api_error_status: 429` with "monthly usage limit" message) that may not trigger the same detection path, causing these runs to be treated as normal completions.
+
+## Checkpoint Structure Reference
+
+From actual test-001 checkpoint:
+
+```json
+{
+  "experiment_state": "complete",
+  "tier_states": {
+    "T0": "complete",
+    "T1": "complete",
+    "T2": "complete",
+    "T3": "complete",
+    "T4": "failed",
+    "T5": "complete",
+    "T6": "complete"
+  },
+  "run_states": {
+    "T3": {
+      "16": {
+        "1": "worktree_cleaned",
+        "2": "worktree_cleaned",
+        "3": "worktree_cleaned"
+      }
+    },
+    "T4": {
+      "01": {
+        "1": "worktree_cleaned"
+      }
+    }
+  },
+  "completed_runs": {
+    "T3": {
+      "16": {
+        "1": "failed",
+        "2": "failed",
+        "3": "failed"
+      }
+    },
+    "T4": {
+      "01": {
+        "1": "failed"
+      }
+    }
+  }
+}
+```
+
+Note: T4 `tier_states="failed"` but the runs that completed without rate limiting had 97.3% pass rate. The "failed" tier state just means at least one run failed, not that the tier design is broken.
+
+## Recovery Workflow
+
+After applying the reset script:
+
+```bash
+# 1. Verify the reset (check checkpoint)
+python -c "
+import json
+with open('results/<experiment>/checkpoint.json') as f:
+    cp = json.load(f)
+print('Experiment state:', cp['experiment_state'])
+for tier, state in cp['tier_states'].items():
+    print(f'  {tier}: {state}')
+"
+
+# 2. Re-run affected tiers
+pixi run python scripts/manage_experiment.py run \
+  --config <experiment_dir> \
+  --tiers T3 T4 T5 T6
+
+# 3. Verify results after rerun
+# Check that previously rate-limited runs now have real results
+```
+
+## Related Sessions
+
+- 2026-01-04: `e2e-rate-limit-detection` -- Fixed real-time rate limit parsing from JSON
+- 2026-03-06: `batch-retry-errors-checkpoint-reset` -- Fixed batch mode retry to check checkpoints
+- 2026-03-14: `always-retry-infra-failures` -- Made retry unconditional, fixed state semantics


### PR DESCRIPTION
## Summary

- Adds new `e2e-rate-limit-diagnosis-reset` debugging skill capturing learnings from diagnosing test-001 experiment failures
- Root cause: Anthropic API monthly usage limit (HTTP 429) hit mid-experiment, causing T3/16-41 and all T4-T6 runs to fail with zero tokens/cost
- Covers: diagnosis workflow (aggregate data -> result.json inspection), checkpoint reset script usage, key pitfalls (rate-limited runs marked as valid F-grade results), and checkpoint structure facts

## Test plan

- [x] `scripts/validate_plugins.py` passes (1009/1009 valid)
- [x] No overlap with existing skills (`e2e-rate-limit-detection` covers real-time detection; `always-retry-infra-failures` covers retry semantics; this covers post-hoc diagnosis and recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)