### PR TITLE
feat: amend batch-low-difficulty-issue-impl skill (v1.10.0)

### DIFF
--- a/skills/batch-low-difficulty-issue-impl.history
+++ b/skills/batch-low-difficulty-issue-impl.history
@@ -1,5 +1,48 @@
 # History: batch-low-difficulty-issue-impl
 
+## v1.10.0 (2026-04-26)
+
+**Changed by:** ProjectKeystone PR #451 cleanup — CI cancelled-vs-failure diagnosis
+**Verification:** verified-local
+
+### What changed
+- Added Failed Attempts row: CI `cancelled` conclusion mistaken for real failure
+- Added `### Diagnosing CI Failures` subsection with `gh run view --json jobs` triage command and rebase retrigger recipe
+- Note: v1.9.0 was authored in this session but exists only in unmerged Mnemosyne PR #1406; this v1.10.0 is based on the v1.8.0 on-disk baseline and will be rebased by maintainers when both PRs land
+
+### Why
+After a 28-PR myrmidon swarm exhausted GitHub's runner pool, PR #451 showed CI Summary / Python Tests / codeql-analysis as "fail". All three had job conclusion `cancelled`, not `failure`. Future swarm sessions need this triage pattern to avoid wasting time debugging non-existent code bugs.
+
+### Previous version (v1.8.0) snapshot
+
+---
+name: batch-low-difficulty-issue-impl
+description: 'Classify, deduplicate, and batch-implement GitHub issues in a large swarm
+  session (24+ waves, 200+ issues). Use when: (1) a large backlog of open issues needs
+  triage, (2) many issues are pure doc/text or infra-only changes, (3) duplicate issues
+  need closing before implementation. Includes worktree-safe grep pattern for ALREADY-DONE
+  verification, correct pre-filter order, ci.yml conflict avoidance, EASY queue exhaustion
+  detection, Docker inline comment parse error pattern, parallel-agent add/add rebase
+  conflict resolution when multiple agents create the same package independently,
+  pre-launch repo-capability checks (autoMergeAllowed, lockfile, pre-commit config),
+  hot-file serialization for shared scripts (apply.sh/reconcile.sh), pre-swarm
+  existing-PR audit, close-before-delegate pattern, and C++20/Conan/pixi-specific
+  guards (libssl-dev, TSan+concurrentqueue blocker, enable_shared_from_this diamond
+  inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check).'
+category: tooling
+date: 2026-04-25
+version: 1.8.0
+user-invocable: false
+verification: verified-local
+history: batch-low-difficulty-issue-impl.history
+
+Key state at v1.8.0: Added 7 C++20/Conan/pixi-specific failure modes from ProjectKeystone
+180-issue swarm. Added C++20/Conan/pixi Project-Specific Guards checklist (6 items).
+Added CMakeLists.txt single-agent anchor rule. Added asyncio_mode auto decorator check.
+Added agent PR number unreliability pattern. No CI cancelled-vs-failure diagnosis documented.
+
+---
+
 ## v1.8.0 (2026-04-25)
 
 **Changed by:** ProjectKeystone 180-issue C++20 myrmidon swarm (7 EASY waves + 9 MEDIUM waves, 2026-04-25)

--- a/skills/batch-low-difficulty-issue-impl.md
+++ b/skills/batch-low-difficulty-issue-impl.md
@@ -13,8 +13,8 @@ description: 'Classify, deduplicate, and batch-implement GitHub issues in a larg
   guards (libssl-dev, TSan+concurrentqueue blocker, enable_shared_from_this diamond
   inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check).'
 category: tooling
-date: 2026-04-25
-version: 1.8.0
+date: 2026-04-26
+version: "1.10.0"
 user-invocable: false
 verification: verified-local
 history: batch-low-difficulty-issue-impl.history
@@ -327,6 +327,31 @@ Never trust agent-reported PR numbers — agents report stale in-flight views. T
 gh pr list --author "@me" --state all --limit 50
 ```
 
+### Diagnosing CI Failures
+
+When `gh pr checks` shows failures, check the underlying job conclusion before touching code:
+
+```bash
+# Distinguish cancelled (runner exhaustion) from failure (real bug)
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, conclusion}'
+```
+
+- `conclusion: "cancelled"` → runner exhaustion; fix is retrigger, not code change
+- `conclusion: "failure"` → real failure; read the logs
+
+**Retrigger recipe** (when conclusion is cancelled):
+```bash
+git fetch origin
+git rebase origin/main          # preserves GPG signatures when no conflict
+git push --force-with-lease     # triggers fresh CI on available runners
+```
+
+**`pending` vs `queued`** in `gh pr checks` output:
+- `pending` = runner accepted the job (healthy)
+- `queued` = waiting for an available runner (pool exhausted)
+
+After a retrigger, seeing `pending` instead of `queued` confirms runners have recovered.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -360,6 +385,7 @@ gh pr list --author "@me" --state all --limit 50
 | Two agents both modifying CMakeLists.txt in the same wave (ProjectKeystone 2026-04-25) | Despite same-file grouping rules, two different agents both modified `CMakeLists.txt` for separate SPDX/spdlog fixes (PRs #392 and #395) in the same wave because the changes appeared unrelated | Second PR could not auto-merge cleanly; one became a duplicate requiring manual resolution | Treat `CMakeLists.txt` as a hard file-grouping anchor: any issue touching it must be batched into ONE agent per wave, regardless of how different the individual changes appear. Apply the same rule as ci.yml: batch all CMakeLists.txt issues into a single Sonnet agent per wave |
 | Adding @pytest.mark.asyncio when asyncio_mode='auto' set in pyproject.toml (ProjectKeystone 2026-04-25) | Agent wrote new Python test files and added `@pytest.mark.asyncio` decorators to async test functions | `pyproject.toml` already had `asyncio_mode = "auto"` in `[tool.pytest.ini_options]`. With auto mode, pytest-asyncio automatically treats all async test functions as async tests — the decorator is redundant and produces deprecation warnings or errors | Before writing Python test files, check: `grep -A5 "pytest.ini_options" pyproject.toml | grep asyncio_mode`. If `asyncio_mode = "auto"` is present, omit all `@pytest.mark.asyncio` decorators |
 | Trusting agent-reported PR numbers without verification (ProjectKeystone 2026-04-25) | In 3 out of 16 waves, accepted agent's final output ("PR #403") as the authoritative PR number for wave reconciliation | Agents report their in-flight view of PR numbers, which can be stale or incorrect when races occur or the agent mistakes a draft PR number. 3/16 waves had wrong agent-reported PR numbers | After every wave, always verify PR numbers with `gh pr list --author "@me" --state all --limit 50`. Never trust agent-reported PR numbers as ground truth |
+| CI cancelled mistaken for failure | Diagnosed PR checks showing 'fail' for Python Tests and codeql-analysis after rebase+push | Job conclusion was `cancelled` (runner exhaustion from 28-PR swarm), not `failure` — CI Summary gate treats `cancelled != "success"` and exits 1 | Run `gh run view <id> --json jobs --jq '.jobs[] | {name, conclusion}'` before assuming code is broken; if all are `cancelled`, rebase+force-push to retrigger — do not change code |
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends `batch-low-difficulty-issue-impl` from v1.8.0 to v1.10.0.

Documents the CI `cancelled`-vs-`failure` diagnosis pattern discovered during post-swarm cleanup of ProjectKeystone PR #451.

- New **Failed Attempts** row: after a 28-PR myrmidon swarm exhausted GitHub's runner pool, PR checks showed "fail" for Python Tests and codeql-analysis — but job conclusion was `cancelled`, not `failure`
- New **`### Diagnosing CI Failures`** subsection with `gh run view --json jobs` triage command, retrigger recipe (rebase + force-with-lease), and `pending` vs `queued` runner-state explanation
- Version note: v1.9.0 exists only in unmerged Mnemosyne PR #1406; this v1.10.0 is based on the v1.8.0 on-disk baseline and will be rebased by maintainers when both PRs land

## Verification Level

**verified-local**

CI cancelled diagnosis was observed directly during ProjectKeystone PR #451 cleanup; the `gh run view --json jobs` triage command was executed live and confirmed all failing jobs had `conclusion: "cancelled"`.

## Key Findings

**What Worked**:
- `gh run view <run-id> --json jobs --jq '.jobs[] | {name, conclusion}'` reliably distinguishes cancelled (runner exhaustion) from real failures
- `git rebase origin/main && git push --force-with-lease` successfully retriggers CI without code changes
- After retrigger, jobs move from `queued` to `pending` confirming runners recovered

**What Failed**:
- Trusting `gh pr checks` "fail" status at face value → wasted time investigating non-existent code bugs

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` — 1009/1009 pass
- [ ] Verify skill appears in marketplace with CI cancelled triage keywords
- [ ] Test skill discovery via `advise` with query "CI cancelled runner exhaustion"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>