### PR TITLE
feat: amend docker-to-podman-migration skill (v1.1.0)

### DIFF
--- a/skills/docker-to-podman-migration.history
+++ b/skills/docker-to-podman-migration.history
@@ -1,0 +1,88 @@
+# docker-to-podman-migration — History
+
+## v1.1.0 (2026-04-26)
+
+**Changed by:** ProjectKeystone session — PR #499 Docker→Podman migration, NATIVE=1 removal from C++/CMake Makefile/justfile
+**Verification:** verified-local
+
+### What changed
+- Extended "When to Use" with C++/CMake-specific triggers: Containerfile adoption, Makefile variable replacement pattern
+- Added Step 7 (C++/CMake Makefile migration): replacing `DOCKER_CHECK`/`DOCKER_PREFIX` with `CONTAINER_CHECK`/`CONTAINER_PREFIX`, removing `ifeq ($(NATIVE),1)` block, removing `%.native` pattern rule, renaming `docker.*` → `container.*` targets
+- Added Step 8 (justfile for C++/CMake): removing `NATIVE=1` from make calls, renaming `make docker.up` → `make container.up`
+- Added Step 9 (Containerfile): rename Dockerfile → Containerfile + .containerignore
+- Added 3 new Failed Attempts rows for C++/CMake context
+- Added "C++/CMake Makefile Variables" section to Results & Parameters
+- Added `verification` frontmatter field
+- Added `history` frontmatter field
+- Updated description to include C++/CMake/Makefile/justfile trigger
+- Added ProjectKeystone PR #499 to Verified On table
+- Bumped version 1.0.0 → 1.1.0, date 2026-03-19 → 2026-04-26
+
+### Why
+The original skill (v1.0.0) documented CI/CD migration for a Mojo/Python project (ProjectOdyssey). The 2026-04-26 session showed a distinct migration pattern for C++/CMake projects (ProjectKeystone) that uses a Makefile+justfile build system with `NATIVE=1` escape hatches rather than GitHub Actions composite actions. The Makefile variable replacement pattern (`DOCKER_CHECK`/`DOCKER_PREFIX` → `CONTAINER_CHECK`/`CONTAINER_PREFIX`) and `Containerfile` adoption are reusable across any C++ project doing this migration.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: docker-to-podman-migration
+description: 'Migrate CI/CD from Docker to Podman for container builds, test execution,
+  and GHCR publishing. Use when: replacing Docker with Podman in GitHub Actions, eliminating
+  NATIVE=1 workarounds, rewriting GHCR publish workflows.'
+category: ci-cd
+date: 2026-03-19
+version: 1.0.0
+user-invocable: false
+---
+# Docker to Podman CI/CD Migration
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-19 |
+| **Objective** | Replace Docker with Podman as the sole container engine for local dev, CI test execution, and GHCR publishing |
+| **Outcome** | Successfully migrated 17 CI jobs across 10 workflow files, eliminated all NATIVE=1 workarounds |
+| **Scope** | GitHub Actions workflows, justfile recipes, docker-compose.yml, GHCR publishing, documentation |
+
+## When to Use
+
+Invoke this skill when:
+
+1. **Migrating from Docker to Podman** in a project's CI/CD infrastructure
+2. **Eliminating `NATIVE=1` workarounds** that bypass container-based test execution
+3. **Rewriting GHCR publish workflows** from `docker/*` GitHub Actions to raw `podman` commands
+4. **Creating a `setup-container` composite action** for Podman compose in CI
+5. **Ubuntu-latest runners** already have Podman pre-installed and you want to leverage it
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# Composite action: .github/actions/setup-container/action.yml
+# 1. touch $HOME/.gitconfig (prevents bind-mount failure on CI)
+# 2. Export USER_ID/GROUP_ID to GITHUB_ENV
+# 3. actions/cache on ~/.local/share/containers
+# 4. podman compose build <service>
+# 5. podman compose up -d <service>
+# 6. Wait + verify with podman compose exec -T <service> pixi run mojo --version
+```
+
+### Step 1: Create setup-container composite action
+...
+[full content in v1.0.0 file]
+...
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #4991 | Full Docker→Podman migration, 17 CI jobs, GHCR publishing |
+```
+
+---
+
+## v1.0.0 (2026-03-19)
+
+**Initial version.** Documented Docker→Podman migration for ProjectOdyssey (Mojo/Python project), covering GitHub Actions composite action, GHCR publishing, docker-compose.yml volume mounts, and justfile `_run` helper.

--- a/skills/docker-to-podman-migration.md
+++ b/skills/docker-to-podman-migration.md
@@ -1,49 +1,68 @@
 ---
 name: docker-to-podman-migration
-description: 'Migrate CI/CD from Docker to Podman for container builds, test execution,
-  and GHCR publishing. Use when: replacing Docker with Podman in GitHub Actions, eliminating
-  NATIVE=1 workarounds, rewriting GHCR publish workflows.'
+description: 'Migrate a project from Docker to Podman, removing NATIVE=1 escape hatches.
+  Use when: (1) replacing Docker with Podman in GitHub Actions or Makefile/justfile
+  ecosystems, (2) eliminating NATIVE=1 workarounds that bypass container-based builds,
+  (3) rewriting GHCR publish workflows, (4) adopting Containerfile over Dockerfile in
+  C++/CMake or Mojo/Python projects.'
 category: ci-cd
-date: 2026-03-19
-version: 1.0.0
+date: 2026-04-26
+version: 1.1.0
 user-invocable: false
+verification: verified-local
+history: docker-to-podman-migration.history
+tags: [podman, docker, containerfile, makefile, justfile, native, migration, cmake, cpp]
 ---
-# Docker to Podman CI/CD Migration
+# Docker to Podman Migration
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-19 |
-| **Objective** | Replace Docker with Podman as the sole container engine for local dev, CI test execution, and GHCR publishing |
-| **Outcome** | Successfully migrated 17 CI jobs across 10 workflow files, eliminated all NATIVE=1 workarounds |
-| **Scope** | GitHub Actions workflows, justfile recipes, docker-compose.yml, GHCR publishing, documentation |
+| **Date** | 2026-04-26 (amended; original 2026-03-19) |
+| **Objective** | Replace Docker with Podman as the sole container engine for local dev, CI test execution, GHCR publishing, and Makefile/justfile build systems |
+| **Outcome** | Successfully migrated ProjectOdyssey (17 CI jobs, GHCR publishing) and ProjectKeystone (Makefile+justfile, NATIVE=1 removal, Containerfile adoption) |
+| **Verification** | verified-local (ProjectKeystone PR #499); verified-ci (ProjectOdyssey PR #4991) |
+| **History** | [changelog](./docker-to-podman-migration.history) |
 
 ## When to Use
 
 Invoke this skill when:
 
-1. **Migrating from Docker to Podman** in a project's CI/CD infrastructure
-2. **Eliminating `NATIVE=1` workarounds** that bypass container-based test execution
+1. **Migrating from Docker to Podman** in a project's CI/CD infrastructure (GitHub Actions or local Makefile)
+2. **Eliminating `NATIVE=1` workarounds** that bypass container-based test/build execution
 3. **Rewriting GHCR publish workflows** from `docker/*` GitHub Actions to raw `podman` commands
 4. **Creating a `setup-container` composite action** for Podman compose in CI
 5. **Ubuntu-latest runners** already have Podman pre-installed and you want to leverage it
+6. **Adopting `Containerfile`** (Podman-native name) over `Dockerfile` in a C++/CMake project
+7. **Replacing `docker-compose` CLI** with `podman compose` in a Makefile or justfile
 
 ## Verified Workflow
 
 ### Quick Reference
 
-```yaml
+```bash
+# --- GitHub Actions / Mojo / Python projects ---
 # Composite action: .github/actions/setup-container/action.yml
 # 1. touch $HOME/.gitconfig (prevents bind-mount failure on CI)
 # 2. Export USER_ID/GROUP_ID to GITHUB_ENV
 # 3. actions/cache on ~/.local/share/containers
 # 4. podman compose build <service>
 # 5. podman compose up -d <service>
-# 6. Wait + verify with podman compose exec -T <service> pixi run mojo --version
+# 6. Verify: podman compose exec -T <service> pixi run mojo --version
+
+# --- C++/CMake / Makefile / justfile projects ---
+# 1. Rename Dockerfile → Containerfile
+# 2. Copy .dockerignore → .containerignore
+# 3. Replace Makefile DOCKER_CHECK/DOCKER_PREFIX vars with CONTAINER_CHECK/CONTAINER_PREFIX
+# 4. Remove ifeq ($(NATIVE),1) block entirely
+# 5. Remove %.native pattern rule
+# 6. Rename docker.* targets → container.*
+# 7. Strip NATIVE=1 from all justfile make calls
+# 8. Update docker-compose → podman compose in justfile
 ```
 
-### Step 1: Create setup-container composite action
+### Step 1: Create setup-container composite action (GitHub Actions / Mojo projects)
 
 ```yaml
 name: Set Up Podman Container
@@ -74,7 +93,7 @@ runs:
         podman compose up -d projectodyssey-dev
 ```
 
-### Step 2: Migrate workflow jobs
+### Step 2: Migrate workflow jobs (GitHub Actions)
 
 For each job that runs Mojo commands:
 
@@ -126,7 +145,7 @@ volumes:
   - ${HOME:-.}/.gitconfig:/home/dev/.gitconfig:ro  # ${HOME:-.} fallback for CI
 ```
 
-### Step 5: Update justfile _run helper
+### Step 5: Update justfile _run helper (Mojo/Python projects)
 
 ```just
 _run cmd:
@@ -159,6 +178,85 @@ grep -r 'NATIVE=1' .github/workflows/*.yml
 # If no (Python-only, shell-only) → keep setup-pixi
 ```
 
+### Step 7: C++/CMake Makefile migration (remove NATIVE=1 escape hatch)
+
+This pattern applies to C++/CMake projects (e.g., ProjectKeystone) that use a
+Makefile+justfile build system with a Docker/Podman prefix variable pattern.
+
+```makefile
+# BEFORE: ifeq block with NATIVE=1 escape hatch
+ifeq ($(NATIVE),1)
+    DOCKER_CHECK :=
+    DOCKER_PREFIX :=
+else
+    DOCKER_CHECK := docker-compose up -d dev >/dev/null 2>&1 || true;
+    DOCKER_PREFIX := docker-compose exec -T dev
+endif
+
+# AFTER: unconditional podman compose (no escape hatch)
+CONTAINER_CHECK := podman compose up -d dev >/dev/null 2>&1 || true;
+CONTAINER_PREFIX := podman compose exec -T dev
+```
+
+Makefile target body pattern (no change needed besides variable rename):
+
+```makefile
+compile:
+	@$(CONTAINER_CHECK) $(CONTAINER_PREFIX) cmake --build --preset $(PRESET) -- -j$(NPROC)
+
+test:
+	@$(CONTAINER_CHECK) $(CONTAINER_PREFIX) ctest --preset $(PRESET) --output-on-failure
+```
+
+Also remove the `%.native` pattern rule (the escape hatch entry point):
+
+```makefile
+# DELETE this rule entirely:
+# %.native:
+#     @$(MAKE) $* NATIVE=1
+```
+
+Rename Docker management targets:
+
+```makefile
+# BEFORE                    AFTER
+docker.build:               container.build:
+docker.up:                  container.up:
+docker.down:                container.down:
+docker.shell:               container.shell:
+```
+
+### Step 8: justfile for C++/CMake projects
+
+```bash
+# Remove NATIVE=1 from all make calls:
+# BEFORE: make compile NATIVE=1
+# AFTER:  make compile
+
+# Update docker-compose references:
+sed -i 's/docker-compose/podman compose/g' justfile
+
+# Update management target names:
+# BEFORE: make docker.up
+# AFTER:  make container.up
+```
+
+### Step 9: Adopt Containerfile (C++/CMake projects)
+
+```bash
+# Rename Dockerfile → Containerfile (podman looks for this first)
+cp Dockerfile Containerfile
+git rm Dockerfile
+git add Containerfile
+
+# Copy .dockerignore → .containerignore (podman reads this preferentially)
+cp .dockerignore .containerignore
+git add .containerignore
+
+# Update CODEOWNERS: Dockerfile → Containerfile
+# docker-compose.yml files do NOT need renaming — podman compose reads them natively
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -168,6 +266,9 @@ grep -r 'NATIVE=1' .github/workflows/*.yml
 | Using `type=gha` Docker cache with Podman | Docker buildx cache strategies are Docker-specific | Podman doesn't support buildx or GHA cache type | Use `actions/cache` on `~/.local/share/containers` keyed by Dockerfile hash |
 | Keeping `:delegated` volume mount | Docker-only volume consistency option | Podman ignores `:delegated` and may warn | Use `:Z` for SELinux label (no-op without SELinux) |
 | Single grep for unwrapped `pixi run mojo` | Grepped individual lines for `pixi run mojo` not inside `podman compose exec` | False positives: heredoc templates and multi-line `podman compose exec` blocks where the `pixi run` is on a separate line | Verify in context — check surrounding lines, not just the matching line |
+| Renaming docker-compose.yml to podman-compose.yml | Considered renaming to match Podman naming conventions | Not needed — both `podman compose` and `podman-compose` read `docker-compose.yml` natively | Keep compose YAML filenames as-is; only the CLI changes, not the file format |
+| Using symlink Dockerfile → Containerfile | Considered keeping `Dockerfile` with a symlink to `Containerfile` | Unnecessary complexity | Rename directly to `Containerfile`; Podman finds it first and docker-compose/podman-compose fall back correctly |
+| Post-migration: pre-commit reverts on older branches | After merging the Podman PR, branches created before the merge had `NATIVE=1` reverted by pre-commit linter | The branch's justfile/Makefile were at the pre-migration state; checking them out caused linter to revert them | After this migration, any older branches need `git rebase origin/main` before the linter runs; rebase, not cherry-pick |
 
 ## Results & Parameters
 
@@ -195,14 +296,42 @@ podman compose exec -T <service> bash -c '<command>'
 # docker-compose.yml filename: keep as-is (podman compose reads it natively)
 ```
 
+### C++/CMake Makefile Variables
+
+```bash
+# Verify podman is available
+which podman
+podman --version        # tested with 4.9.3
+podman compose version  # uses Docker Compose v2.x engine
+
+# Build the dev image
+podman compose build dev
+
+# Start dev container
+podman compose up -d dev
+
+# Run a command inside the container
+podman compose exec -T dev cmake --preset debug
+
+# All just targets now route through container (no NATIVE=1 needed)
+just build    # → make compile → podman compose exec -T dev cmake ...
+just test     # → make test   → podman compose exec -T dev ctest ...
+just lint     # → make lint   → podman compose exec -T dev ./scripts/run_static_analysis.sh
+just format   # → make format → podman compose exec -T dev bash -c "find ... | xargs clang-format"
+```
+
 ### Files Typically Modified
 
 | File | Change |
 |------|--------|
 | `.github/actions/setup-container/action.yml` | **NEW** — Podman compose setup for CI |
 | `.github/workflows/*.yml` | `setup-pixi` → `setup-container` for Mojo jobs |
-| `justfile` | `docker-*` → `podman-*` recipes, `_run` helper |
+| `justfile` | `docker-*` → `podman-*` / `container-*` recipes, remove `NATIVE=1` |
 | `docker-compose.yml` | `:delegated` → `:Z`, gitconfig mount fix |
+| `Makefile` | `DOCKER_CHECK/PREFIX` → `CONTAINER_CHECK/PREFIX`, remove `%.native` rule |
+| `Dockerfile` → `Containerfile` | Rename (Podman prefers `Containerfile`) |
+| `.containerignore` | **NEW** — copy of `.dockerignore` for Podman |
+| `CODEOWNERS` | `Dockerfile` → `Containerfile` |
 | `scripts/run_mojo.sh` | Remove Docker fallback |
 | `CLAUDE.md` / docs | Docker → Podman references |
 
@@ -216,4 +345,5 @@ podman compose exec -T <service> bash -c '<command>'
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | PR #4991 | Full Docker→Podman migration, 17 CI jobs, GHCR publishing |
+| ProjectOdyssey | PR #4991 | Full Docker→Podman migration, 17 CI jobs, GHCR publishing; verified-ci |
+| ProjectKeystone | PR #499 (2026-04-26) | Makefile+justfile migration, NATIVE=1 removal, Containerfile adoption; verified-local |


### PR DESCRIPTION
## Summary

Amends `docker-to-podman-migration` skill from v1.0.0 → v1.1.0.

- Extends coverage from Mojo/Python (GitHub Actions) to C++/CMake (Makefile+justfile) migration pattern
- Documents NATIVE=1 escape-hatch removal via Makefile variable replacement (DOCKER_CHECK/PREFIX → CONTAINER_CHECK/PREFIX)
- Adds Containerfile adoption steps (rename Dockerfile + create .containerignore)
- Adds 3 new Failed Attempts rows from ProjectKeystone PR #499 session

## Verification Level

**verified-local** (ProjectKeystone PR #499, 2026-04-26)

The C++/CMake Makefile/justfile steps were executed locally and PR #499 was created with schema-validation and deps/version-sync CI checks passing. The original skill's workflow (ProjectOdyssey PR #4991) remains verified-ci.

## Key Findings

**What Worked**:
- Replacing `ifeq ($(NATIVE),1)` block with unconditional `CONTAINER_CHECK`/`CONTAINER_PREFIX` Makefile vars
- Renaming `Dockerfile` → `Containerfile` (Podman's preferred name); `podman compose` finds it without config changes
- Copying `.dockerignore` → `.containerignore`; `docker-compose.yml` files need no renaming
- Removing `%.native` pattern rule eliminates the `NATIVE=1` entry point entirely

**What Failed**:
- Renaming `docker-compose.yml` → `podman-compose.yml` — not needed; `podman compose` reads it natively
- Using a symlink `Dockerfile` → `Containerfile` — unnecessary; direct rename is cleaner
- Not rebasing older branches after merge — pre-commit linter reverts files if branch is at pre-migration state; `git rebase origin/main` is required

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 1009/1009 valid
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: podman, docker, NATIVE=1, Containerfile, makefile

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>