### PR TITLE
feat: add Radiance headless graph skill and amend audit triage

### DIFF
--- a/skills/radiance-headless-graph-existing-pipeline-json-validation.md
+++ b/skills/radiance-headless-graph-existing-pipeline-json-validation.md
@@ -1,0 +1,165 @@
+---
+name: radiance-headless-graph-existing-pipeline-json-validation
+description: "Build a headless Radiance graph export CLI by reusing the existing run/artifact pipeline. Use when: (1) validating model graph output without the web UI, (2) adding CLI coverage to a browser-first analysis app, (3) exporting Model Explorer graphCollections or raw source graph JSON for tests."
+category: tooling
+date: 2026-04-29
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - radiance
+  - cli
+  - headless
+  - graph-export
+  - testing
+---
+
+# Radiance Headless Graph Export CLI Using Existing Pipeline
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-29 |
+| **Objective** | Add a non-browser validation path that can download or resolve a model, run Radiance analysis, and emit graph JSON. |
+| **Outcome** | Successful local implementation: `radiance-graph` console script, reusable `radiance.headless` helper, tests for local/Hugging Face/stdout flows, and README usage. |
+| **Verification** | verified-local — focused tests, Ruff, CLI help, and `make check` passed locally; CI validation pending. |
+
+## When to Use
+
+- A browser-first analysis tool needs a CLI path for automated validation.
+- You need to test model graph generation without Model Explorer or a Flask server.
+- You want JSON outputs that can be diffed in tests, CI, or fixture generation.
+- The application already has a run service that persists graph artifacts, metrics, and run manifests.
+- A known runtime execution gap exists, so the safe CLI default should be structural analysis until runtime mode is fixed.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Add the console script
+# pyproject.toml
+[project.scripts]
+radiance-appliance = "radiance.server.app:main"
+radiance-graph = "radiance.cli:main"
+
+# Typical user commands
+radiance-graph sshleifer/tiny-gpt2 --source-kind hugging-face > graphCollections.json
+radiance-graph ./models/my-checkpoint --source-kind local --output graphCollections.json
+radiance-graph sshleifer/tiny-gpt2 --source-kind hugging-face \
+  --output-format source-graph -o graph.json
+
+# Local verification
+.venv/bin/ruff check radiance/headless.py radiance/cli.py tests/backend/test_headless_cli.py
+.venv/bin/pytest -q tests/backend/test_headless_cli.py
+make check
+```
+
+### Detailed Steps
+
+1. Start with tests for the CLI behavior, not the implementation. Cover:
+   - local path source resolution
+   - Hugging Face source setup with the snapshot downloader faked
+   - missing local path errors
+   - CLI stdout JSON shape
+
+2. Build a reusable headless module instead of putting all logic in `argparse`.
+   In Radiance this became `radiance/headless.py` with:
+   - `HeadlessGraphOptions`
+   - `HeadlessGraphResult`
+   - `HeadlessSourceKind`
+   - `GraphOutputFormat`
+   - `run_headless_graph(...)`
+
+3. Reuse the existing artifact pipeline. The key implementation was:
+   - create a `SourceRegistry` in the configured runtime cache
+   - register the model source as a normal `SourceRegistryEntry`
+   - instantiate `TheoreticalRunService(..., max_workers=1)`
+   - call `start_run(...)`
+   - poll `get_run(run_id)` until terminal state
+   - read outputs from the persisted run root or service helpers
+
+4. For local paths outside the configured models root, do not copy files. Instead, set a run-local `RuntimePaths.models_dir` to the source parent and use the basename as `mounted_subpath`. This preserves the same mounted-path contract while letting the CLI accept arbitrary local checkpoint paths.
+
+5. For Hugging Face sources, create the source through the same helper as the UI:
+   `create_huggingface_model_source(...)`. Only call full snapshot download with `allow_patterns=None` when the user passes `--download-weights`; otherwise metadata-only behavior should remain the default.
+
+6. Default the CLI to `structural_only` analysis. In Radiance, runtime mode was known to be misleading until the runtime orchestration gap was fixed, so the CLI default avoided locking tests to a broken runtime claim.
+
+7. Offer output formats that map to persisted artifacts:
+   - `graph-collections`: `service.get_graph_collections(run_id)`
+   - `source-graph`: `graphs/operators/source_graph.json`
+   - `run-summary`: the run status payload
+
+8. Register a small `argparse` entrypoint in `radiance/cli.py`. Keep JSON writing centralized so `stdout` and `--output <path>` use the same payload.
+
+9. After adding a new console script, refresh a local editable install before manually testing `.venv/bin/<script>`:
+
+   ```bash
+   .venv/bin/python -m pip install -e . --no-deps
+   .venv/bin/radiance-graph --help
+   ```
+
+10. Document the command in the README with examples for local paths, Hugging Face repos, full weight download, and raw source graph output.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Build a parallel analyzer | Considered adding a CLI that directly calls graph extraction and serializes the result | That would bypass run manifests, graphCollections translation, metrics, and persisted artifact behavior used by the UI | Reuse `TheoreticalRunService` so CLI validation exercises the same pipeline as the browser |
+| Assume raw graph JSON is camelCase | Test expected `nodes[0]["opName"]` in `source-graph` output | The raw dataclass artifact is persisted as snake_case (`op_name`); camelCase labels exist in graphCollections | Distinguish raw internal artifacts from Model Explorer graphCollections payloads |
+| Manually test new console script before reinstall | Ran `.venv/bin/radiance-graph --help` after editing `pyproject.toml` | Existing editable install did not yet expose the new console entrypoint | Run `pip install -e . --no-deps` after adding a script entry |
+| Default to runtime mode | Letting the CLI default to `runtime_with_weights` looked attractive for coverage | Radiance had an open runtime orchestration blocker, so runtime mode could imply execution that did not happen | Default to `structural_only`; expose runtime mode only as an explicit flag |
+
+## Results & Parameters
+
+### Files Added Or Changed In Radiance
+
+```text
+radiance/headless.py
+radiance/cli.py
+tests/backend/test_headless_cli.py
+pyproject.toml
+README.md
+```
+
+### Command Surface
+
+```bash
+radiance-graph [-h]
+  [--source-kind {auto,local,hugging-face}]
+  [--revision REVISION]
+  [--trust-remote-code]
+  [--download-weights]
+  [--analysis-mode {structural_only,runtime_with_weights}]
+  [--output-format {graph-collections,source-graph,run-summary}]
+  [--output OUTPUT]
+  [--hardware-id HARDWARE_ID]
+  [--timeout-seconds TIMEOUT_SECONDS]
+  [--models-dir MODELS_DIR]
+  [--runs-dir RUNS_DIR]
+  [--cache-dir CACHE_DIR]
+  [--uploads-dir UPLOADS_DIR]
+  [--access-token-env ACCESS_TOKEN_ENV]
+  source
+```
+
+### Observed Local Verification
+
+```text
+.venv/bin/pytest -q tests/backend/test_headless_cli.py
+4 passed in 0.21s
+
+.venv/bin/pytest -q tests/backend/test_headless_cli.py tests/backend/test_app_entrypoint.py tests/backend/test_theoretical_runs.py
+9 passed in 0.41s
+
+make check
+218 passed, 4 skipped in 4.74s
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Radiance | Added `radiance-graph` after strict audit identified the need to validate graph output without a browser | Verified locally with focused tests, Ruff, CLI help, editable install refresh, and full `make check` |

--- a/skills/radiance-headless-graph-existing-pipeline-json-validation.md
+++ b/skills/radiance-headless-graph-existing-pipeline-json-validation.md
@@ -19,7 +19,7 @@ tags:
 ## Overview
 
 | Field | Value |
-|-------|-------|
+| ------- | ------- |
 | **Date** | 2026-04-29 |
 | **Objective** | Add a non-browser validation path that can download or resolve a model, run Radiance analysis, and emit graph JSON. |
 | **Outcome** | Successful local implementation: `radiance-graph` console script, reusable `radiance.headless` helper, tests for local/Hugging Face/stdout flows, and README usage. |
@@ -106,7 +106,7 @@ make check
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-|---------|----------------|---------------|----------------|
+| --------- | ---------------- | --------------- | ---------------- |
 | Build a parallel analyzer | Considered adding a CLI that directly calls graph extraction and serializes the result | That would bypass run manifests, graphCollections translation, metrics, and persisted artifact behavior used by the UI | Reuse `TheoreticalRunService` so CLI validation exercises the same pipeline as the browser |
 | Assume raw graph JSON is camelCase | Test expected `nodes[0]["opName"]` in `source-graph` output | The raw dataclass artifact is persisted as snake_case (`op_name`); camelCase labels exist in graphCollections | Distinguish raw internal artifacts from Model Explorer graphCollections payloads |
 | Manually test new console script before reinstall | Ran `.venv/bin/radiance-graph --help` after editing `pyproject.toml` | Existing editable install did not yet expose the new console entrypoint | Run `pip install -e . --no-deps` after adding a script entry |
@@ -161,5 +161,5 @@ make check
 ## Verified On
 
 | Project | Context | Details |
-|---------|---------|---------|
+| --------- | --------- | --------- |
 | Radiance | Added `radiance-graph` after strict audit identified the need to validate graph output without a browser | Verified locally with focused tests, Ruff, CLI help, editable install refresh, and full `make check` |

--- a/skills/repo-audit-triage-fix-and-issue-workflow.history
+++ b/skills/repo-audit-triage-fix-and-issue-workflow.history
@@ -1,12 +1,33 @@
+# repo-audit-triage-fix-and-issue-workflow — History
+
+## v1.1.0 (2026-04-29)
+
+**Changed by:** Radiance strict audit issue-backlog reconciliation and focused issue creation
+**Verification:** verified-local
+
+### What changed
+
+- Added the backlog-search-before-create pattern for strict audit findings.
+- Added guidance for commenting on existing open issues, commenting on closed regression issues, and opening only focused gap issues.
+- Added label normalization and readback checks after issue updates.
+- Added failed-attempt rows for duplicate issue creation and broad closed-issue reopening.
+- Added Radiance issue mapping results for #167, #168, #171, #172, #173, #175, #181, #182, #183, and #184.
+- Added `verification` and `history` frontmatter fields.
+
+### Why
+
+The original workflow handled audit triage into direct fixes versus newly filed issues, but did not stress deduplicating against an existing issue backlog. In the Radiance audit follow-up, most audit findings were already represented by open issues. The reliable pattern was to inspect open/all issues first, add evidence comments and labels where coverage already existed, and create only narrow new issues for uncovered gaps or regressions.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: repo-audit-triage-fix-and-issue-workflow
 description: "Full workflow for strict repo audit triage: run audit, classify findings by complexity, batch-fix simple items in one PR, file GitHub issues for complex work. Use when: (1) running a comprehensive repository quality audit and acting on all findings, (2) needing to triage audit results into immediate fixes vs tracked issues, (3) remediating dead code, stale docs, broken CI, or missing requirements files."
 category: tooling
-date: 2026-04-29
-version: "1.1.0"
+date: 2026-03-28
+version: "1.0.0"
 user-invocable: false
-verification: verified-local
-history: repo-audit-triage-fix-and-issue-workflow.history
 tags: [audit, triage, remediation, github-issues, dead-code, ci, requirements, parallel-execution]
 ---
 
@@ -15,19 +36,15 @@ tags: [audit, triage, remediation, github-issues, dead-code, ci, requirements, p
 ## Overview
 
 | Field | Value |
-| ------- | ------- |
-| **Date** | 2026-04-29 |
-| **Objective** | Run a strict repo audit, triage findings by complexity, batch-fix scoped items, and reconcile complex work against the existing GitHub issue backlog before creating focused gaps. |
-| **Outcome** | Successful across ProjectMnemosyne and Radiance: one audit cleanup PR pattern, existing issues updated/commented/labeled first, and only missing focused gaps filed as new issues. |
-| **Verification** | verified-local |
-| **History** | [changelog](./repo-audit-triage-fix-and-issue-workflow.history) |
+|-------|-------|
+| **Date** | 2026-03-28 |
+| **Objective** | Run a strict repo audit on ProjectMnemosyne, triage all findings by complexity, fix simple/medium items directly, and file GitHub issues for complex work |
+| **Outcome** | Successful. Audit scored C+ (77%). 10 simple fixes applied in one PR (14 files changed, -1,280 net lines). 6 GitHub issues filed (#1105–#1110). 9/9 tests passing after fixes. |
 
 ## When to Use
 
 - You have just run `/repo-analyze-strict` and have a list of graded findings
 - You want to separate work that fits in one PR from work that needs its own branch/epic
-- You need to map audit findings onto an existing GitHub backlog without creating duplicates
-- You want to update/comment/label existing issues before filing only the missing gaps
 - You need to clear dead migration scripts, duplicate files, or stale changelog entries
 - CI tests are partially broken and you need to scope the test runner to the working subset
 - You suspect some test failures are pre-existing (not caused by your changes) and need to verify
@@ -51,24 +68,16 @@ git stash
 python3 -m pytest tests/ -v 2>&1 | grep -E "PASSED|FAILED|ERROR"
 git stash pop
 
-# Step 5: Search/update existing issues before filing gaps
-gh issue list --state open --limit 200 --json number,title,labels,url,updatedAt
-gh issue list --state all --limit 200 \
-  --search "runtime OR healthcheck OR auth OR security OR upload OR dependencies" \
-  --json number,title,state,labels,url,updatedAt
-gh issue comment 167 --body "Audit update (...): ..."
-gh issue edit 167 --add-label bug --add-label priority:P0 --add-label phase:release
-
-# Step 6: Scope CI to working test files only (if needed)
+# Step 5: Scope CI to working test files only (if needed)
 # In workflow YAML, change:
 #   run: pytest tests/
 # to:
 #   run: pytest tests/test_generate_marketplace.py -v
 
-# Step 7: Validate skill files
+# Step 6: Validate skill files
 python3 scripts/validate_plugins.py
 
-# Step 8: Commit, push, open PR with auto-merge
+# Step 7: Commit, push, open PR with auto-merge
 ```
 
 ### Detailed Steps
@@ -85,7 +94,7 @@ Run `/repo-analyze-strict`. This produces a graded report across 15 dimensions. 
 Use these criteria to decide between **fix-now** and **file-as-issue**:
 
 | Criteria | Fix Now | File as Issue |
-| ---------- | --------- | --------------- |
+|----------|---------|---------------|
 | Time estimate | < 1 hour | > 1 hour |
 | Design decisions required | None | Yes |
 | Cross-repo or multi-file refactor | No | Yes |
@@ -161,30 +170,7 @@ File a GitHub issue for the broken test files rather than deleting them (they ma
 
 #### Phase 5: File GitHub Issues for Complex Items
 
-Before creating issues, search the backlog. Strict audits often rediscover known work.
-Use both title lists and broader full-text searches:
-
-```bash
-gh issue list --state open --limit 200 \
-  --json number,title,labels,url,updatedAt \
-  --jq '.[] | "#\(.number)\t\(.title)\t[\([.labels[].name] | join(","))]"'
-
-gh issue list --state all --limit 200 \
-  --search "runtime OR healthcheck OR auth OR security OR upload OR dependencies" \
-  --json number,title,state,labels,url,updatedAt \
-  --jq '.[] | "#\(.number)\t\(.state)\t\(.title)"'
-```
-
-Classify each audit finding:
-
-| Audit finding state | Action |
-| --------------------- | -------- |
-| Existing open issue covers it | Add an audit comment with concrete evidence and any new acceptance detail |
-| Existing closed issue regressed | Comment on the closed issue with regression evidence, then open a narrow follow-up |
-| Existing issue covers adjacent but not exact scope | Comment to clarify boundary, then open a focused gap issue |
-| No issue found | Create a new issue with orchestrator kickoff, evidence, and acceptance criteria |
-
-For each new file-as-issue item, create a GitHub issue with:
+For each file-as-issue item, create a GitHub issue with:
 - Clear title stating the problem
 - Background: what the audit found
 - Acceptance criteria: what "done" looks like
@@ -210,24 +196,6 @@ EOF
   --label "technical-debt,testing"
 ```
 
-After creating or updating issues, normalize labels so the backlog is filterable:
-
-```bash
-gh issue edit 181 \
-  --add-label bug \
-  --add-label type:validation \
-  --add-label area:runtime \
-  --add-label priority:P0 \
-  --add-label phase:core
-```
-
-Read back the final issue list and comment counts:
-
-```bash
-gh issue list --state open --limit 50 --json number,title,labels,url \
-  --jq '.[] | "#\(.number)\t\(.title)\t[\([.labels[].name] | join(","))]\t\(.url)"'
-```
-
 #### Phase 6: Validate and Commit
 
 ```bash
@@ -248,19 +216,17 @@ git commit -m "fix: apply audit remediation (dead code, CI, docs, requirements)"
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
+|---------|----------------|---------------|----------------|
 | Run `pytest tests/` in CI | Pointed the CI workflow test step at the full `tests/` directory | Two test files import a non-existent module (`fix_remaining_warnings`), causing `ImportError` collection failure | Always verify full test suite runs clean before setting CI to `tests/`; scope to working subset and file issues for broken files |
 | Attribute test failures to own changes | Assumed `ImportError` failures in `test_fix_remaining_warnings.py` were caused by the deletion of migration scripts | Git stash + re-run proved the failures pre-existed | Always stash and re-run before concluding test failures are your fault |
 | Fix broken test files in same PR | Tried to fix the broken test imports as part of the cleanup PR | The missing module `fix_remaining_warnings` doesn't exist and creating it is a design decision requiring its own scope | Keep the cleanup PR focused; file a dedicated issue for the broken tests |
-| Create a new issue for every audit finding | Treating each strict audit finding as new work without checking the backlog first | Existing issues may already cover the work, and duplicate issues fragment implementation context | Search open and closed issues first; update existing issues and create only focused gap issues |
-| Reopen broad closed work for a narrow regression | A closed implementation issue may be related to a new failing behavior | Reopening the broad issue can obscure the exact regression and old acceptance criteria | Comment on the closed issue for traceability, then open a narrow regression follow-up |
 
 ## Results & Parameters
 
 ### Audit Score Baseline (ProjectMnemosyne, 2026-03-28)
 
 | Section | Grade | Key Findings |
-| --------- | ------- | -------------- |
+|---------|-------|--------------|
 | Documentation | B+ | Good README/CHANGELOG, missing ADRs |
 | AI Agent Tooling | B+ | Skills marketplace functional |
 | Planning/Compliance | B | Issues filed but no roadmap doc |
@@ -271,7 +237,7 @@ git commit -m "fix: apply audit remediation (dead code, CI, docs, requirements)"
 ### Changes Applied (10 fix-now items)
 
 | Change | Type | Net Lines |
-| -------- | ------ | ----------- |
+|--------|------|-----------|
 | Fix `.claude-plugin/plugin.json` metadata | Edit | +10 / -10 |
 | Create `requirements.txt` | New file | +2 |
 | Create `requirements-dev.txt` | New file | +3 |
@@ -289,7 +255,7 @@ git commit -m "fix: apply audit remediation (dead code, CI, docs, requirements)"
 ### GitHub Issues Filed (Complex Work)
 
 | Issue | Title | Label |
-| ------- | ------- | ------- |
+|-------|-------|-------|
 | #1105 | Fix broken test files (`fix_remaining_warnings`) | testing, technical-debt |
 | #1106 | Add type annotations throughout codebase | code-quality |
 | #1107 | Security hardening: input validation + sandboxing | security |
@@ -297,31 +263,11 @@ git commit -m "fix: apply audit remediation (dead code, CI, docs, requirements)"
 | #1109 | Add ADR directory and document key decisions | documentation |
 | #1110 | Enforce test coverage threshold in CI | testing, ci-cd |
 
-### Existing Backlog Mapping Example (Radiance, 2026-04-28)
-
-After a strict Radiance audit, most findings already had issue coverage:
-
-| Audit finding | Existing or New Issue | Action |
-| --------------- | ----------------------- | -------- |
-| Mutating API endpoints exposed before non-local deployment | #167 | Commented with updated evidence and labels |
-| Archive extraction hardening | #168 | Commented to keep archive scope separate from upload boundary |
-| Oversized run orchestration module | #171 | Commented that runtime execution wiring should be sequenced with the refactor |
-| Dependency lock/constraints strategy | #172 | Commented with container build dependency-resolution evidence |
-| Browser/container smoke usability | #173 | Commented with stale container/port diagnostic evidence |
-| Coverage gaps | #175 | Commented with new high-value regression targets |
-| Healthcheck regression in previously closed hardening issue | #114 and #182 | Commented on closed #114, opened focused #182 |
-| Runtime execution not wired into runtime mode | #181 | Opened new focused P0 blocker |
-| Upload size enforcement independent of `Content-Length` | #183 | Opened new focused issue |
-| User-provided model code execution policy | #184 | Opened new focused issue |
-
-This produced four new focused issues instead of duplicating the entire audit as new tickets.
-
 ## Verified On
 
 | Project | Context | Details |
-| --------- | --------- | --------- |
+|---------|---------|---------|
 | ProjectMnemosyne | Strict audit + triage + 10-item cleanup PR (March 2026) | 9/9 tests passing, 6 issues filed (#1105–#1110) |
-| Radiance | Strict audit issue-backlog reconciliation (April 2026) | Existing open issues were updated/commented/labeled first; only four missing focused issues were created (#181–#184) |
 
 ## References
 
@@ -329,3 +275,10 @@ This produced four new focused issues instead of duplicating the entire audit as
 - Related skill: [issue-triage-wave-parallel-execution](./issue-triage-wave-parallel-execution.md) — parallel batching of independent fixes
 - Related skill: [pre-existing-ci-failure-triage](./pre-existing-ci-failure-triage.md) — diagnosing failures that existed before your changes
 - Related skill: [preexisting-ci-failure-triage](./preexisting-ci-failure-triage.md) — alternate entry for same pattern
+```
+
+---
+
+## v1.0.0 (2026-03-28)
+
+**Initial version.**


### PR DESCRIPTION
## Summary

Adds one new Radiance skill and amends one existing audit workflow skill.

- New skill: `radiance-headless-graph-existing-pipeline-json-validation`
- Amends `repo-audit-triage-fix-and-issue-workflow` from v1.0.0 to v1.1.0
- Captures the pattern for using existing run/artifact pipelines for headless graph JSON validation
- Extends strict audit triage with search/update/comment/label-before-create GitHub issue reconciliation

## Verification Level

**verified-local**

CI validation pending.

## Key Findings

**What Worked**:
- Reuse Radiance's existing run service for headless graph JSON exports.
- Default headless validation to `structural_only` while runtime execution is blocked.
- Search and update existing GitHub issues before opening focused audit gaps.

**What Failed**:
- Building a parallel analyzer would bypass the UI artifact pipeline.
- Creating one new issue per audit finding duplicates existing backlog context.

## Test Plan

- [x] `.venv/bin/python scripts/validate_plugins.py` — 1039/1039 valid
- [x] pre-push `pytest -q` — 171 passed
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Codex <noreply@openai.com>