### PR TITLE
feat: add python-mypy-explicit-reexport-pattern skill

### DIFF
--- a/skills/architecture-radiance-per-layer-metrics-selected-profile-only.history
+++ b/skills/architecture-radiance-per-layer-metrics-selected-profile-only.history
@@ -1,0 +1,188 @@
+# architecture-radiance-per-layer-metrics-selected-profile-only - History
+
+## v1.1.0 (2026-04-27)
+
+**Changed by:** Radiance session adding dtype-aware complete SoL coverage, serving estimates, and a Model Explorer performance recompute panel.
+**Verification:** verified-local
+
+### What changed
+- Added complete SoL coverage guidance: every operator/graph node should receive either a modeled row or an explicit unmodeled row with nullable latency/SoL percent and diagnostics.
+- Added dtype-aware modeling guidance for hardware supported dtypes, dtype-specific peak TFLOPs, dtype-dependent storage bytes, and unsupported dtype/operator diagnostics.
+- Added backend serving estimate guidance for TTFT, TPOT/ITL, end-to-end latency, output tokens/sec, KV cache footprint, and decode roofline from `performanceInputs`.
+- Added frontend guidance for the left-side Radiance Perf panel and Update button that launches a recomputed backend run.
+- Added operator-formula corrections for `addmm`, `matmul`, and `embedding`.
+- Added the local verification results from the Radiance implementation session.
+
+### Why
+The v1.0.0 skill covered per-layer analytical metrics and selected hardware projection, but the implementation session exposed gaps that were directly within the same search surface: missing SoL rows for unmodeled nodes, dtype-insensitive projection, missing serving estimates, and no viewer recompute controls. These are incremental architecture findings for the existing Radiance metrics skill, so the existing skill was amended instead of creating a duplicate.
+
+### Previous version (v1.0.0) snapshot
+
+~~~markdown
+---
+name: architecture-radiance-per-layer-metrics-selected-profile-only
+description: "Use when adding analytical model metrics to a tracing pipeline: (1) exact operator kernels should roll up into per-layer outputs, (2) hardware projection must use a user-selected inline profile rather than a fixed built-in set."
+category: architecture
+date: 2026-04-15
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [radiance, metrics, hardware-profile, operator-kernels, layer-aggregation, sol, roofline]
+---
+
+# Radiance Per-Layer Metrics With Selected-Profile Projection
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-15 |
+| **Objective** | Add an extensible analytical metrics system to Radiance that computes per-layer compute, memory, bandwidth, and SoL from exact operator kernels. |
+| **Outcome** | Successful local implementation: new `radiance.metrics` package, one-op-per-file kernels, operator-to-layer aggregation, selected-profile-only hardware projection, docs updated, and backend tests passing. |
+| **Verification** | verified-local — `pytest tests/backend -q` passed locally; CI validation pending. |
+| **Scope** | Route contract, run-service persistence, analytical kernel registry, hardware projector, and contract/docs fixtures. |
+
+## When to Use
+
+- You need per-layer analytical outputs but the only trustworthy formulas live at the operator level.
+- The system already has a user-facing layer graph and you want to preserve it instead of exposing raw operator rows as the primary UI artifact.
+- Hardware modeling must be configurable per run and must not fan out across hardcoded accelerator profiles.
+- You want a plugin-like Python layout where one op lives in one file and unsupported ops stay explicit.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Add tests first for the selected hardwareProfile request contract and layer metrics artifacts
+pytest tests/backend/test_run_routes.py tests/backend/test_theoretical_runs.py tests/backend/test_metrics_engine.py tests/backend/test_hardware_sol_contract.py -q
+
+# 2. Implement an exact-op metrics package
+# radiance/metrics/{models,interfaces,registry,engine,hardware}.py
+# radiance/metrics/ops/<one-op-per-file>.py
+
+# 3. Extract both graphs, not just the layer graph
+# operator_graph: torch_export_adapter / torch_fx_adapter
+# layer_graph: torch_export_layer_adapter / torch_fx_layer_adapter
+
+# 4. Project only the selected inline hardware profile
+pytest tests/backend -q
+```
+
+### Detailed Steps
+
+1. Start from the route and run-service contract, not from the math. Require `hardwareProfile` alongside `sourceId` on `POST /api/v1/radiance/runs`, parse it into a first-class `HardwareProfile`, and thread that object through the run lifecycle.
+2. Keep two structural views during analysis. Extract an operator graph for exact formulas and a layer graph for the persisted/UI-facing scope. Do not try to estimate layer costs directly from layer type.
+3. Create a small `radiance.metrics` package with stable seams:
+   `models.py` for estimate dataclasses, `interfaces.py` for the kernel protocol, `registry.py` for exact-op lookup, `engine.py` for operator analysis plus layer aggregation, `hardware.py` for selected-profile projection, and `ops/` for one kernel file per supported op.
+4. Register kernels explicitly by exact operator name. Support the initial transformer-core slice (`mm`, `matmul`, `bmm`, `addmm`, `linear`, `embedding`, `softmax`, `log_softmax`, `layer_norm`, `rms_norm`, and movement/view ops). Unknown ops should produce uncovered coverage, not guessed values.
+5. Map operator rows back to leaf layers using `module_path` and `module_stack`. Aggregate compute, memory, parameter bytes, input bytes, output bytes, and covered/uncovered counts into `LayerEstimate`.
+6. Compute SoL only for the selected hardware profile. Use peak FLOPs and peak bandwidth from the provided profile object, classify compute-bound vs memory-bound, and persist only that single profile’s projection artifacts for the run.
+7. Persist layer-facing results in the existing run layout:
+   `metrics/metrics.jsonl`, `metrics/coverage.jsonl`, `hardware/profiles.json`, and `hardware/sol.jsonl`.
+   Keep operator-level artifacts as helper/debug outputs rather than the primary public contract.
+8. Update contract fixtures and docs after the code lands so they stop describing a fixed built-in profile set. The architecture should say "user-supplied or persisted hardware profile" and "single selected profile per run."
+9. Verify locally with focused backend tests first, then run the full backend suite to catch contract drift and fixture mismatches.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Start from layer-only graph extraction | Reuse the existing layer graph as the sole source of analytical truth | Layer nodes are the right user-facing scope, but they do not preserve the exact operator semantics needed for FLOPs and memory formulas | Keep operator truth internally and aggregate onto layers afterward |
+| Treat hardware as a fixed built-in catalog | Initial plan referenced preselected accelerator profiles for every run | Product direction changed: hardware must be configurable per request, and computing all profiles adds noise and cost | Make `hardwareProfile` required on run start and project only the selected profile |
+| Hide unsupported operations behind heuristic fallbacks | Could have estimated unknown ops from adjacent layer shape or layer type | That would silently inflate modeled coverage and weaken trust in analytical output | Unsupported ops must stay explicit in coverage and produce no fabricated metric values |
+
+## Results & Parameters
+
+### Files and Structure
+
+```text
+radiance/metrics/
+  models.py
+  interfaces.py
+  registry.py
+  engine.py
+  hardware.py
+  ops/
+    addmm.py
+    bmm.py
+    contiguous.py
+    embedding.py
+    flatten.py
+    layer_norm.py
+    linear.py
+    log_softmax.py
+    matmul.py
+    mm.py
+    permute.py
+    reshape.py
+    rms_norm.py
+    softmax.py
+    transpose.py
+    view.py
+```
+
+### Route Contract
+
+```json
+{
+  "sourceId": "source-mounted-001",
+  "hardwareProfile": {
+    "hardware_id": "nvidia-h200",
+    "display_name": "NVIDIA H200",
+    "vendor": "nvidia",
+    "memory_gib": 141,
+    "peak_fp16_tflops": 989.0,
+    "peak_hbm_gbps": 4800.0
+  }
+}
+```
+
+### Persistence Contract
+
+```text
+metrics/metrics.jsonl
+metrics/coverage.jsonl
+hardware/profiles.json
+hardware/sol.jsonl
+graphs/operators/source_graph.json   # helper/debug artifact
+metrics/layer_summary.json           # helper/debug artifact
+```
+
+### Projection Formula
+
+```python
+compute_latency_ms = (layer.compute_flops / (profile.peak_fp16_tflops * 1e12)) * 1e3
+memory_latency_ms = (layer.memory_bytes / (profile.peak_hbm_gbps * 1e9)) * 1e3
+theoretical_latency_ms = max(compute_latency_ms, memory_latency_ms)
+```
+
+### Verification Commands
+
+```bash
+pytest tests/backend/test_metrics_engine.py \
+  tests/backend/test_run_routes.py \
+  tests/backend/test_theoretical_runs.py \
+  tests/backend/test_hardware_sol_contract.py -q
+
+pytest tests/backend -q
+```
+
+### Observed Result
+
+```text
+113 passed in 4.96s
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Radiance | Implementing configurable single-profile per-layer analytical metrics and selected-profile SoL persistence | Verified locally with targeted backend tests and full `tests/backend` suite after updating routes, run persistence, docs, and fixtures |
+~~~
+
+---
+
+## v1.0.0 (2026-04-15)
+
+**Initial version.**

--- a/skills/architecture-radiance-per-layer-metrics-selected-profile-only.md
+++ b/skills/architecture-radiance-per-layer-metrics-selected-profile-only.md
@@ -1,67 +1,86 @@
 ---
 name: architecture-radiance-per-layer-metrics-selected-profile-only
-description: "Use when adding analytical model metrics to a tracing pipeline: (1) exact operator kernels should roll up into per-layer outputs, (2) hardware projection must use a user-selected inline profile rather than a fixed built-in set."
+description: "Use when adding analytical model metrics to Radiance: (1) every operator/graph node needs explicit SoL coverage, (2) dtype-aware hardware projection and serving estimates must recompute from user-provided inference inputs."
 category: architecture
-date: 2026-04-15
-version: "1.0.0"
+date: 2026-04-27
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
-tags: [radiance, metrics, hardware-profile, operator-kernels, layer-aggregation, sol, roofline]
+history: architecture-radiance-per-layer-metrics-selected-profile-only.history
+tags: [radiance, metrics, hardware-profile, operator-kernels, layer-aggregation, sol, roofline, dtype, serving-estimates]
 ---
 
-# Radiance Per-Layer Metrics With Selected-Profile Projection
+# Radiance Dtype-Aware SoL Coverage And Serving Estimates
 
 ## Overview
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-04-15 |
-| **Objective** | Add an extensible analytical metrics system to Radiance that computes per-layer compute, memory, bandwidth, and SoL from exact operator kernels. |
-| **Outcome** | Successful local implementation: new `radiance.metrics` package, one-op-per-file kernels, operator-to-layer aggregation, selected-profile-only hardware projection, docs updated, and backend tests passing. |
-| **Verification** | verified-local — `pytest tests/backend -q` passed locally; CI validation pending. |
-| **Scope** | Route contract, run-service persistence, analytical kernel registry, hardware projector, and contract/docs fixtures. |
+| **Date** | 2026-04-27 |
+| **Objective** | Extend Radiance's analytical metrics so every graph/operator node receives an explicit Speed-of-Light (SoL) row, unsupported coverage is visible, hardware projection is dtype-aware, and serving estimates are recomputed from user-provided inference inputs. |
+| **Outcome** | Successful local implementation: complete modeled/unmodeled SoL coverage, dtype-dependent peak compute and storage bytes, nullable SoL rows with diagnostics, backend TTFT/TPOT/ITL estimates, frontend Radiance Perf recompute panel, and unit scale helpers. |
+| **Verification** | verified-local - backend tests, targeted frontend tests, frontend build, diff check, and targeted Ruff passed locally; CI validation pending. |
+| **History** | [changelog](./architecture-radiance-per-layer-metrics-selected-profile-only.history) |
 
 ## When to Use
 
-- You need per-layer analytical outputs but the only trustworthy formulas live at the operator level.
-- The system already has a user-facing layer graph and you want to preserve it instead of exposing raw operator rows as the primary UI artifact.
-- Hardware modeling must be configurable per run and must not fan out across hardcoded accelerator profiles.
-- You want a plugin-like Python layout where one op lives in one file and unsupported ops stay explicit.
+- You need Radiance graph/operator nodes to have complete SoL coverage instead of silently omitting unsupported or unmodeled nodes.
+- Hardware projection must account for dtype support, dtype-specific peak TFLOPs, and dtype-dependent memory/storage bytes.
+- Serving performance estimates such as TTFT, TPOT, ITL, output tokens/sec, and KV cache footprint need to be derived from inference scenario inputs.
+- The Model Explorer viewer needs a left-side performance panel that can start a recomputation run with updated `performanceInputs`.
+- You are touching Radiance metric formulas and need to avoid repeated magic constants such as `1_000_000_000_000`.
 
 ## Verified Workflow
+
+Verified locally only - CI validation pending.
 
 ### Quick Reference
 
 ```bash
-# 1. Add tests first for the selected hardwareProfile request contract and layer metrics artifacts
-pytest tests/backend/test_run_routes.py tests/backend/test_theoretical_runs.py tests/backend/test_metrics_engine.py tests/backend/test_hardware_sol_contract.py -q
+# Backend contract, SoL coverage, serving estimate, and fixture checks
+python -m pytest tests/backend -q
 
-# 2. Implement an exact-op metrics package
-# radiance/metrics/{models,interfaces,registry,engine,hardware}.py
-# radiance/metrics/ops/<one-op-per-file>.py
+# Frontend build and targeted Radiance UI/service tests
+cd vendor/model_explorer/src/ui
+npm run build
+npm test -- --watch=false --browsers=ChromeHeadless \
+  --include=src/services/radiance_run_service.spec.ts \
+  --include=src/components/radiance_source_input/radiance_source_input.spec.ts
 
-# 3. Extract both graphs, not just the layer graph
-# operator_graph: torch_export_adapter / torch_fx_adapter
-# layer_graph: torch_export_layer_adapter / torch_fx_layer_adapter
-
-# 4. Project only the selected inline hardware profile
-pytest tests/backend -q
+# Mechanical checks used for this change
+git diff --check
+python -m ruff check \
+  radiance/units.py \
+  radiance/metrics/hardware.py \
+  radiance/metrics/models.py \
+  radiance/metrics/engine.py \
+  radiance/metrics/ops/addmm.py \
+  radiance/metrics/ops/matmul.py \
+  radiance/metrics/ops/embedding.py \
+  radiance/server/routes.py \
+  radiance/server/runs.py \
+  tests/backend/test_units.py \
+  tests/backend/test_metrics_engine.py \
+  tests/backend/test_run_routes.py \
+  tests/backend/test_theoretical_runs.py \
+  tests/backend/test_release_fixture_suite.py \
+  --select E,F,B,I --ignore E402
 ```
 
 ### Detailed Steps
 
-1. Start from the route and run-service contract, not from the math. Require `hardwareProfile` alongside `sourceId` on `POST /api/v1/radiance/runs`, parse it into a first-class `HardwareProfile`, and thread that object through the run lifecycle.
-2. Keep two structural views during analysis. Extract an operator graph for exact formulas and a layer graph for the persisted/UI-facing scope. Do not try to estimate layer costs directly from layer type.
-3. Create a small `radiance.metrics` package with stable seams:
-   `models.py` for estimate dataclasses, `interfaces.py` for the kernel protocol, `registry.py` for exact-op lookup, `engine.py` for operator analysis plus layer aggregation, `hardware.py` for selected-profile projection, and `ops/` for one kernel file per supported op.
-4. Register kernels explicitly by exact operator name. Support the initial transformer-core slice (`mm`, `matmul`, `bmm`, `addmm`, `linear`, `embedding`, `softmax`, `log_softmax`, `layer_norm`, `rms_norm`, and movement/view ops). Unknown ops should produce uncovered coverage, not guessed values.
-5. Map operator rows back to leaf layers using `module_path` and `module_stack`. Aggregate compute, memory, parameter bytes, input bytes, output bytes, and covered/uncovered counts into `LayerEstimate`.
-6. Compute SoL only for the selected hardware profile. Use peak FLOPs and peak bandwidth from the provided profile object, classify compute-bound vs memory-bound, and persist only that single profile’s projection artifacts for the run.
-7. Persist layer-facing results in the existing run layout:
-   `metrics/metrics.jsonl`, `metrics/coverage.jsonl`, `hardware/profiles.json`, and `hardware/sol.jsonl`.
-   Keep operator-level artifacts as helper/debug outputs rather than the primary public contract.
-8. Update contract fixtures and docs after the code lands so they stop describing a fixed built-in profile set. The architecture should say "user-supplied or persisted hardware profile" and "single selected profile per run."
-9. Verify locally with focused backend tests first, then run the full backend suite to catch contract drift and fixture mismatches.
+1. Preserve the operator graph as the metric source of truth and the layer graph as the user-facing aggregation target. Do not try to infer exact FLOPs or memory traffic from layer type alone.
+2. Require complete SoL artifact coverage. For every operator/graph node, write either a modeled SoL row or an explicit unmodeled row. Unmodeled rows should use nullable `theoretical_latency_ms` and `speed_of_light_pct`, set `coverage_kind`, and include a diagnostic.
+3. Add dtype fields at each metric boundary. `OpEstimate` and `LayerEstimate` should carry compute, activation, weight, and memory dtype information so formulas and projections do not collapse everything into fp16.
+4. Make hardware profiles dtype-aware. Keep `supported_dtypes` and `peak_tflops_by_dtype` on `HardwareProfile`, and have projection choose the effective compute dtype peak rather than a single fixed `peak_fp16_tflops` value.
+5. Treat unsupported dtype/operator combinations as uncovered diagnostics, not estimates. If the hardware or kernel cannot support the requested dtype, produce an explicit unmodeled reason and avoid guessed latency.
+6. Use dtype-dependent byte accounting. Normalize dtype aliases and compute storage bytes from dtype for weights, activations, KV cache, and operator memory traffic.
+7. Fix shape-sensitive kernels while adding coverage. In this session `addmm` needed robust operand inference for both PyTorch argument order and the local trace order, `matmul` needed broadcasted output batch handling, and `embedding` needed zero FLOPs plus traffic based on accessed rows/output/index rather than full table reads.
+8. Add serving estimates to the run pipeline. Persist `performance/serving_estimates.json` and include TTFT, TPOT/ITL, end-to-end latency, output tokens/sec, decode roofline, KV bytes per token, and KV cache footprint.
+9. Accept `performanceInputs` on run creation and map them into an inference scenario. Include batch size, context/sequence length, max output tokens, max sequence length, max num sequences, max batched tokens, KV cache budget GiB, compute/activation/weight/KV dtypes, tensor parallel size, and pipeline parallel size.
+10. Add a viewer-side Radiance Perf panel on the left side, opposite graph/node details. Show roofline and serving metrics, expose the inference inputs, and wire the Update button to start a new backend run with `performanceInputs` and navigate to the recomputed run.
+11. Replace repeated scale constants with helpers. Add `radiance/units.py` with decimal helpers (`hundred`, `thousand`, `million`, `billion`, `trillion`) and binary helpers (`kilo`, `mega`, `giga`, `tera`, `peta`) so formulas express units directly.
+12. Update fixtures and release tests so missing SoL rows fail. A release fixture check should assert that operator SoL coverage includes all graph node IDs, including unmodeled nodes.
 
 ## Failed Attempts
 
@@ -70,91 +89,134 @@ pytest tests/backend -q
 | Start from layer-only graph extraction | Reuse the existing layer graph as the sole source of analytical truth | Layer nodes are the right user-facing scope, but they do not preserve the exact operator semantics needed for FLOPs and memory formulas | Keep operator truth internally and aggregate onto layers afterward |
 | Treat hardware as a fixed built-in catalog | Initial plan referenced preselected accelerator profiles for every run | Product direction changed: hardware must be configurable per request, and computing all profiles adds noise and cost | Make `hardwareProfile` required on run start and project only the selected profile |
 | Hide unsupported operations behind heuristic fallbacks | Could have estimated unknown ops from adjacent layer shape or layer type | That would silently inflate modeled coverage and weaken trust in analytical output | Unsupported ops must stay explicit in coverage and produce no fabricated metric values |
+| Omit unmodeled nodes from SoL artifacts | Only write SoL rows when a kernel produced a theoretical latency | Many graph nodes appeared to have no calculation at all, making coverage impossible to audit | Write explicit unmodeled SoL rows with `coverage_kind`, null latency/SoL percent, and diagnostics |
+| Use one fp16 peak for all projections | Project all modeled ops through `peak_fp16_tflops` | bf16/fp8/int8/fp32 support and throughput differ by hardware, so a single peak makes roofline output misleading | Store `peak_tflops_by_dtype` and select projection peak from the effective compute dtype |
+| Count embedding as full table traffic | Treat embedding memory as if the entire table were read and assign compute work | Inference only accesses indexed rows; full table size is capacity, not per-request traffic | Use accessed row/output/index bytes for traffic and zero compute FLOPs |
+| Keep repeated numeric scale literals | Inline constants such as `1_000_000_000_000` in projection formulas | Repetition made units harder to audit and encouraged inconsistent decimal/binary scaling | Centralize decimal and binary scale helpers in `radiance/units.py` |
 
 ## Results & Parameters
 
-### Files and Structure
+### Core Contract Changes
 
 ```text
-radiance/metrics/
-  models.py
-  interfaces.py
-  registry.py
-  engine.py
-  hardware.py
-  ops/
-    addmm.py
-    bmm.py
-    contiguous.py
-    embedding.py
-    flatten.py
-    layer_norm.py
-    linear.py
-    log_softmax.py
-    matmul.py
-    mm.py
-    permute.py
-    reshape.py
-    rms_norm.py
-    softmax.py
-    transpose.py
-    view.py
+radiance/contracts/models.py
+  InferenceScenario:
+    batch_size
+    context_length
+    sequence_length
+    max_output_tokens
+    max_sequence_length
+    max_num_sequences
+    max_num_batched_tokens
+    kv_cache_budget_gib
+    compute_dtype
+    activation_dtype
+    weight_dtype
+    kv_cache_dtype
+    tensor_parallel_size
+    pipeline_parallel_size
+
+  HardwareProfile:
+    supported_dtypes
+    peak_tflops_by_dtype
+    peak_tflops_for_dtype(dtype)
+    supports_dtype(dtype)
+
+  SolRecord:
+    theoretical_latency_ms: nullable
+    speed_of_light_pct: nullable
+    coverage_kind
+    diagnostic
+    compute_dtype
+    memory_dtype
 ```
 
-### Route Contract
+### Metric Model Changes
+
+```text
+radiance/metrics/models.py
+  dtype_storage_nbytes(dtype)
+  normalize_dtype_name(dtype)
+  promoted_compute_dtype(...)
+  OpEstimate dtype fields
+  LayerEstimate dtype fields
+
+radiance/metrics/engine.py
+  MetricsAnalysisResult.unmodeled_operator_reasons
+  explicit uncovered diagnostics for unknown ops and unsupported dtype/operator cases
+```
+
+### Serving Estimate Inputs
 
 ```json
 {
-  "sourceId": "source-mounted-001",
-  "hardwareProfile": {
-    "hardware_id": "nvidia-h200",
-    "display_name": "NVIDIA H200",
-    "vendor": "nvidia",
-    "memory_gib": 141,
-    "peak_fp16_tflops": 989.0,
-    "peak_hbm_gbps": 4800.0
+  "performanceInputs": {
+    "batchSize": 1,
+    "contextLength": 2048,
+    "sequenceLength": 2048,
+    "maxOutputTokens": 128,
+    "maxSequenceLength": 4096,
+    "maxNumSequences": 1,
+    "maxNumBatchedTokens": 2048,
+    "kvCacheBudgetGib": 16,
+    "computeDtype": "float16",
+    "activationDtype": "float16",
+    "weightDtype": "float16",
+    "kvCacheDtype": "float16",
+    "tensorParallelSize": 1,
+    "pipelineParallelSize": 1
   }
 }
 ```
 
-### Persistence Contract
+### Serving Estimate Artifact
 
 ```text
-metrics/metrics.jsonl
-metrics/coverage.jsonl
-hardware/profiles.json
-hardware/sol.jsonl
-graphs/operators/source_graph.json   # helper/debug artifact
-metrics/layer_summary.json           # helper/debug artifact
+performance/serving_estimates.json
+  formula_version: serving-roofline-v1
+  ttft_ms
+  tpot_ms
+  inter_token_latency_ms
+  end_to_end_latency_ms
+  output_tokens_per_second
+  kv_cache_bytes_per_token
+  kv_cache_footprint_bytes
+  decode_roofline
 ```
 
-### Projection Formula
+### Unit Helpers
 
 ```python
-compute_latency_ms = (layer.compute_flops / (profile.peak_fp16_tflops * 1e12)) * 1e3
-memory_latency_ms = (layer.memory_bytes / (profile.peak_hbm_gbps * 1e9)) * 1e3
-theoretical_latency_ms = max(compute_latency_ms, memory_latency_ms)
+from radiance.units import billion, giga, trillion
+
+compute_latency_ms = (flops / trillion(peak_tflops)) * thousand(1)
+memory_latency_ms = (bytes_moved / billion(peak_hbm_gbps)) * thousand(1)
+memory_capacity_bytes = giga(memory_gib)
 ```
 
-### Verification Commands
-
-```bash
-pytest tests/backend/test_metrics_engine.py \
-  tests/backend/test_run_routes.py \
-  tests/backend/test_theoretical_runs.py \
-  tests/backend/test_hardware_sol_contract.py -q
-
-pytest tests/backend -q
-```
-
-### Observed Result
+### Verification Commands And Results
 
 ```text
-113 passed in 4.96s
+python -m pytest tests/backend -q
+202 passed, 2 skipped
+
+npm run build
+passed
+
+npm test -- --watch=false --browsers=ChromeHeadless --include=src/services/radiance_run_service.spec.ts --include=src/components/radiance_source_input/radiance_source_input.spec.ts
+14 SUCCESS
+
+git diff --check
+passed
+
+targeted python -m ruff check on touched backend core files
+passed
 ```
+
+Full Ruff was not used as a gate for this session because the repository had many pre-existing unrelated Ruff findings outside the touched scope.
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| Radiance | Implementing configurable single-profile per-layer analytical metrics and selected-profile SoL persistence | Verified locally with targeted backend tests and full `tests/backend` suite after updating routes, run persistence, docs, and fixtures |
+| Radiance | Dtype-aware complete SoL coverage, serving performance estimates, and Model Explorer recompute panel | Verified locally with backend suite, targeted frontend tests, frontend build, diff check, and targeted Ruff on touched backend files |

--- a/skills/architecture-radiance-per-layer-metrics-selected-profile-only.md
+++ b/skills/architecture-radiance-per-layer-metrics-selected-profile-only.md
@@ -15,7 +15,7 @@ tags: [radiance, metrics, hardware-profile, operator-kernels, layer-aggregation,
 ## Overview
 
 | Field | Value |
-| ------- | ------- |
+| :--- | :--- |
 | **Date** | 2026-04-27 |
 | **Objective** | Extend Radiance's analytical metrics so every graph/operator node receives an explicit Speed-of-Light (SoL) row, unsupported coverage is visible, hardware projection is dtype-aware, and serving estimates are recomputed from user-provided inference inputs. |
 | **Outcome** | Successful local implementation: complete modeled/unmodeled SoL coverage, dtype-dependent peak compute and storage bytes, nullable SoL rows with diagnostics, backend TTFT/TPOT/ITL estimates, frontend Radiance Perf recompute panel, and unit scale helpers. |
@@ -85,7 +85,7 @@ python -m ruff check \
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
+| :--- | :--- | :--- | :--- |
 | Start from layer-only graph extraction | Reuse the existing layer graph as the sole source of analytical truth | Layer nodes are the right user-facing scope, but they do not preserve the exact operator semantics needed for FLOPs and memory formulas | Keep operator truth internally and aggregate onto layers afterward |
 | Treat hardware as a fixed built-in catalog | Initial plan referenced preselected accelerator profiles for every run | Product direction changed: hardware must be configurable per request, and computing all profiles adds noise and cost | Make `hardwareProfile` required on run start and project only the selected profile |
 | Hide unsupported operations behind heuristic fallbacks | Could have estimated unknown ops from adjacent layer shape or layer type | That would silently inflate modeled coverage and weaken trust in analytical output | Unsupported ops must stay explicit in coverage and produce no fabricated metric values |
@@ -218,5 +218,5 @@ Full Ruff was not used as a gate for this session because the repository had man
 ## Verified On
 
 | Project | Context | Details |
-| --------- | --------- | --------- |
+| :--- | :--- | :--- |
 | Radiance | Dtype-aware complete SoL coverage, serving performance estimates, and Model Explorer recompute panel | Verified locally with backend suite, targeted frontend tests, frontend build, diff check, and targeted Ruff on touched backend files |


### PR DESCRIPTION
## Summary

New skill documenting the Python/mypy explicit re-export pattern required when `implicit_reexport = false` is configured.

- When moving a symbol to a leaf module and re-exporting for backward compatibility, plain `from X import Y` is insufficient — mypy requires `from X import Y as Y`
- `mock.patch` continues working correctly with the explicit form because it patches the runtime namespace binding
- The `__all__` mechanism is independent and may be needed separately

## Verification Level

**verified-local** — mypy passed and all tests passed locally (ProjectHephaestus PR #308). CI validation pending.

## Key Findings

**What Worked**:
- `from hephaestus.github.gh_subprocess import _gh_call as _gh_call` — explicit re-export satisfies mypy and preserves mock.patch compatibility
- The `as Y` form (same name) is the PEP 484-blessed signal for intentional public re-export under `implicit_reexport = false`

**What Failed**:
- Plain `from X import Y` → mypy raises "Module does not explicitly export attribute 'Y'" when `implicit_reexport = false`
- Adding symbol to `__all__` only → does not satisfy mypy's per-import-statement requirement for explicit re-export

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — passes (✓ python-mypy-explicit-reexport-pattern.md)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: mypy, reexport, implicit_reexport, mock.patch, backward-compatibility

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>