### PR TITLE
feat(skills): add ci-cd-skill-validation-failed-attempts-inline-html skill (v1.0.0)

### DIFF
--- a/skills/ci-cd-skill-validation-failed-attempts-inline-html.md
+++ b/skills/ci-cd-skill-validation-failed-attempts-inline-html.md
@@ -1,0 +1,169 @@
+---
+name: ci-cd-skill-validation-failed-attempts-inline-html
+description: "Fix CI failures in skill PRs caused by wrong Failed Attempts table column
+  names or inline HTML from angle-bracket placeholders. Use when: (1) a skill PR fails
+  validate/unit-tests with 'Failed Attempts table missing required columns', (2) a skill
+  PR fails markdownlint MD033 no-inline-html on a <placeholder> pattern in prose, (3)
+  writing a new skill and wanting to avoid these common validation failures."
+category: ci-cd
+date: 2026-05-02
+version: "1.0.0"
+user-invocable: false
+tags: [markdownlint, md033, inline-html, failed-attempts, skill-format, validate, unit-tests]
+---
+
+# Fix Skill PR CI Failures — Failed Attempts Table + Inline HTML
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-02 |
+| **Objective** | Fix CI failures in PRs #1498 and #1516 in ProjectMnemosyne caused by wrong Failed Attempts column names and an MD033 inline-HTML false positive |
+| **Outcome** | Both issues resolved; pre-commit hooks passed after fixes |
+
+## When to Use
+
+- A skill PR fails `validate` or `unit-tests` with message "Failed Attempts table missing required columns"
+- A skill PR fails `markdownlint` with `MD033/no-inline-html` on a `<word>` placeholder in prose
+- You are writing a new skill file and want to avoid these two common authoring mistakes
+- The same skill file exists on multiple PR branches and both need the same fix applied independently
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Validate a skill file locally before pushing
+python3 scripts/validate_plugins.py
+
+# Check markdownlint for MD033 issues
+pixi run npx markdownlint-cli2 skills/<skill-name>.md
+```
+
+**Failed Attempts table — exact required column names:**
+
+```markdown
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Attempt 1 | Description | Reason | Takeaway |
+```
+
+**Inline HTML fix — wrap angle-bracket placeholders in backticks:**
+
+```markdown
+<!-- WRONG — triggers MD033 -->
+here's the actual CI config, addresses #<existing-issue-number>.
+
+<!-- CORRECT — backticks escape the angle brackets -->
+here's the actual CI config, addresses `#<existing-issue-number>`.
+```
+
+### Detailed Steps
+
+#### Fix 1: Failed Attempts Table Column Names
+
+The `scripts/validate_plugins.py` validator enforces exact column header names. The
+check (`validate_failed_attempts_table`) requires all four of these strings to appear
+in the header row:
+
+- `Attempt`
+- `What Was Tried`
+- `Why It Failed`
+- `Lesson Learned`
+
+**Any other column naming will fail validation.** Common wrong variants:
+
+| Wrong column name | Correct column name |
+|---|---|
+| `Approach` | `Attempt` |
+| `Description` | `What Was Tried` |
+| `Correct Approach` | `Lesson Learned` |
+| 3-column table (any names) | Must be 4 columns with exact names |
+
+**Fix procedure:**
+
+1. Open the skill `.md` file
+2. Locate the `## Failed Attempts` section
+3. Replace the header row with the exact required header:
+   `| Attempt | What Was Tried | Why It Failed | Lesson Learned |`
+4. Adjust the separator row column count to match (4 columns)
+5. Reformat data rows to fit 4 columns
+6. Run `python3 scripts/validate_plugins.py` — must report zero errors for the file
+
+#### Fix 2: MD033 Inline HTML from Angle-bracket Placeholders
+
+Markdownlint rule MD033 (`no-inline-html`) treats any `<word>` pattern as an HTML
+element tag — including documentation placeholders like `<existing-issue-number>`,
+`<branch-name>`, or `<run-id>`.
+
+**Fix**: wrap every angle-bracket placeholder in backticks so markdownlint sees it as
+inline code, not HTML:
+
+```markdown
+<!-- Before (triggers MD033) -->
+Addresses #<existing-issue-number>.
+
+<!-- After (clean) -->
+Addresses `#<existing-issue-number>`.
+```
+
+This applies anywhere in prose, including list items, table cells, and inline text.
+The fix does not affect readability — readers still understand the placeholder meaning.
+
+#### Fix 3: Same File on Multiple Branches
+
+When the same skill file exists on multiple PR branches (e.g., two concurrent PRs both
+touched `skills/oss-contribution-issue-filing-pattern.md`), each branch must be fixed
+independently:
+
+1. Check out branch A, apply both fixes, commit, push
+2. Check out branch B, apply both fixes, commit, push
+3. Verify CI on each PR separately
+
+There is no shortcut — a fix committed to branch A does not appear on branch B unless
+cherry-picked or rebased.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 3-column Failed Attempts table | Used `\| Approach \| Why It Failed \| Correct Approach \|` (3 columns, non-standard names) | `validate_plugins.py` checks for all 4 exact header strings; missing `Attempt`, `What Was Tried`, `Lesson Learned` caused rejection | Always use the exact 4-column header: `Attempt \| What Was Tried \| Why It Failed \| Lesson Learned` |
+| Bare angle-bracket placeholder in prose | Left `#<existing-issue-number>` as unescaped text in a sentence | Markdownlint MD033 parses `<existing-issue-number>` as an HTML element tag and flags it | Wrap every `<placeholder>` in backticks when it appears in prose |
+
+## Results & Parameters
+
+### Validator Column Check (from `scripts/validate_plugins.py`)
+
+```python
+# The exact check — all four must be present in the header row
+if not all(col in header for col in ["Attempt", "What Was Tried", "Why It Failed", "Lesson Learned"]):
+    errors.append("Failed Attempts table missing required columns")
+```
+
+### Expected Output After Fix
+
+```text
+$ python3 scripts/validate_plugins.py
+Validating skills...
+✓ skills/your-skill.md
+All skills valid.
+```
+
+```text
+$ pixi run npx markdownlint-cli2 skills/your-skill.md
+skills/your-skill.md: 0 error(s), 0 warning(s)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectMnemosyne | PR #1498 and PR #1516 — `oss-contribution-issue-filing-pattern.md` | Two branches, same file, both fixes applied independently |
+
+## References
+
+- [markdownlint MD033 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md)
+- [Skill template](../templates/skill-template.md)
+- [ci-cd-pre-commit-ci-hook-failures](ci-cd-pre-commit-ci-hook-failures.md)
+- [markdownlint-troubleshooting](markdownlint-troubleshooting.md)

--- a/skills/oss-contribution-issue-filing-pattern.md
+++ b/skills/oss-contribution-issue-filing-pattern.md
@@ -161,7 +161,7 @@ EOF
 
 If the maintainer already has an open "should we add CI?" issue, don't file a new one
 asking the same question. File a **concrete implementation issue** that says
-"here's the actual CI config, addresses #<existing-issue-number>."
+"here's the actual CI config, addresses `#<existing-issue-number>`."
 
 ```bash
 --body "...
@@ -306,12 +306,12 @@ Group by area, then within each group order by effort (ascending). Suggested are
 
 ## Failed Attempts
 
-| Approach | Why It Failed | Correct Approach |
-| ---------- | --------------- | ----------------- |
-| Filing a new CI issue without referencing the maintainer's existing #28 | Looks like you didn't read the issue tracker; duplicate question | File a concrete implementation issue that says "addresses #28" |
-| Filing 12 separate quality-improvement issues | Floods the issue tracker; maintainer has to triage 12 issues, most of which they may not want | Bundle into one omnibus issue and ask which ones they want |
-| Filing the audit results before checking existing issues | Discovered issues #64/#65/#66 already existed from the same session; would have created duplicates | Always run `gh issue list --state all` first |
-| Assigning labels without checking what labels exist | `gh issue create --label xyz` fails silently or errors if label doesn't exist | Run `gh label list --repo <owner>/<repo>` first |
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| File a new CI issue without referencing existing | Filed new "should we add CI?" issue without checking tracker | Looks like you didn't read the issue tracker; duplicate question | Reference the maintainer's existing issue; file a concrete implementation that says "addresses #28" |
+| File 12 separate quality-improvement issues | One issue per audit finding | Floods the issue tracker; maintainer has to triage 12 issues, most of which they may not want | Bundle into one omnibus issue and ask which ones they want |
+| File audit results before checking existing issues | Ran audit, immediately filed issues | Discovered issues #64/#65/#66 already existed from the same session; would have created duplicates | Always run `gh issue list --state all` first |
+| Assign labels without checking what labels exist | `gh issue create --label xyz` | Fails silently or errors if label doesn't exist | Run `gh label list --repo <owner>/<repo>` first |
 
 ## Related Skills
 

--- a/skills/oss-contribution-issue-filing-pattern.md
+++ b/skills/oss-contribution-issue-filing-pattern.md
@@ -161,7 +161,7 @@ EOF
 
 If the maintainer already has an open "should we add CI?" issue, don't file a new one
 asking the same question. File a **concrete implementation issue** that says
-"here's the actual CI config, addresses `#<existing-issue-number>`."
+"here's the actual CI config, addresses #<existing-issue-number>."
 
 ```bash
 --body "...
@@ -306,12 +306,12 @@ Group by area, then within each group order by effort (ascending). Suggested are
 
 ## Failed Attempts
 
-| Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| File a new CI issue without referencing existing | Filed new "should we add CI?" issue without checking tracker | Looks like you didn't read the issue tracker; duplicate question | Reference the maintainer's existing issue; file a concrete implementation that says "addresses #28" |
-| File 12 separate quality-improvement issues | One issue per audit finding | Floods the issue tracker; maintainer has to triage 12 issues, most of which they may not want | Bundle into one omnibus issue and ask which ones they want |
-| File audit results before checking existing issues | Ran audit, immediately filed issues | Discovered issues #64/#65/#66 already existed from the same session; would have created duplicates | Always run `gh issue list --state all` first |
-| Assign labels without checking what labels exist | `gh issue create --label xyz` | Fails silently or errors if label doesn't exist | Run `gh label list --repo <owner>/<repo>` first |
+| Approach | Why It Failed | Correct Approach |
+| ---------- | --------------- | ----------------- |
+| Filing a new CI issue without referencing the maintainer's existing #28 | Looks like you didn't read the issue tracker; duplicate question | File a concrete implementation issue that says "addresses #28" |
+| Filing 12 separate quality-improvement issues | Floods the issue tracker; maintainer has to triage 12 issues, most of which they may not want | Bundle into one omnibus issue and ask which ones they want |
+| Filing the audit results before checking existing issues | Discovered issues #64/#65/#66 already existed from the same session; would have created duplicates | Always run `gh issue list --state all` first |
+| Assigning labels without checking what labels exist | `gh issue create --label xyz` fails silently or errors if label doesn't exist | Run `gh label list --repo <owner>/<repo>` first |
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

- Documents two common CI failures in skill PRs found during fixes for PR #1498 and PR #1516
- Failed Attempts table must use exact 4-column header: `Attempt | What Was Tried | Why It Failed | Lesson Learned` — `validate_plugins.py` enforces this with a string-match check
- Angle-bracket placeholders like `<existing-issue-number>` in prose trigger markdownlint MD033 (no-inline-html) and must be wrapped in backticks
- Covers the pattern of the same file existing on multiple PR branches requiring independent fixes on each

## Test plan

- [x] `python3 scripts/validate_plugins.py` — 1041/1041 valid (including new skill)
- [x] Pre-commit hooks passed on commit (trim whitespace, end of files, large files checks)
- [ ] CI validate/unit-tests job passes
- [ ] CI markdownlint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)