### PR TITLE
feat: amend multi-branch-rebase-workflow skill (v2.1.0)

### DIFF
--- a/skills/multi-branch-rebase-workflow.history
+++ b/skills/multi-branch-rebase-workflow.history
@@ -1,0 +1,47 @@
+# multi-branch-rebase-workflow — History
+
+## v2.1.0 (2026-05-02)
+
+**Changed by:** Session — rebase 3 ProjectMnemosyne branches onto origin/main
+**Verification:** verified-local
+
+### What changed
+
+- Added markdown table separator conflict pattern to When to Use and Step 3
+- Added new Step 3 subsection: "Markdown table separator conflicts (`:---` vs `-------`)"
+- Added clarifying note to Step 6 (cleanup) about `git worktree prune` being a no-op when no stale worktrees exist
+- Added 2 new Failed Attempts rows: keeping `-------` separator style, and creating PR for 0-commits-ahead branch
+- Added "Markdown Separator Conflict Pattern" config block to Results & Parameters
+- Added Verified On section documenting both sessions (ProjectOdyssey 2026-04-03, ProjectMnemosyne 2026-05-02)
+- Added `verification` and `history` frontmatter fields
+
+### Why
+
+Previous v2.0.0 already covered the core pitfalls (--force-with-lease, GIT_EDITOR=true,
+worktrees for non-current branches) but did not document the markdown table separator
+conflict pattern. In a repo like ProjectMnemosyne where markdownlint compliance was
+enforced on main, all conflicts across 3 branches were this same formatting issue.
+The resolution rule (always keep main's `:---`) is non-obvious and worth documenting.
+
+### Previous version (v2.0.0) snapshot
+
+```
+---
+name: multi-branch-rebase-workflow
+description: 'Parallel multi-branch rebase with semantic conflict resolution and batch
+  PR creation. Includes prevention: ALWAYS branch from origin/main to avoid stale
+  bases. Use when: (1) creating feature branches (always from origin/main), (2) multiple
+  branches need rebasing, (3) semantic conflict resolution needed, (4) batch PR creation
+  after rebase.'
+category: tooling
+date: 2026-04-03
+version: 2.0.0
+user-invocable: false
+---
+```
+
+---
+
+## v2.0.0 (2026-04-03)
+
+**Initial version of this file** (prior history not recorded — skill was created/amended before history tracking was introduced).

--- a/skills/multi-branch-rebase-workflow.md
+++ b/skills/multi-branch-rebase-workflow.md
@@ -1,14 +1,17 @@
 ---
 name: multi-branch-rebase-workflow
-description: 'Parallel multi-branch rebase with semantic conflict resolution and batch
-  PR creation. Includes prevention: ALWAYS branch from origin/main to avoid stale
-  bases. Use when: (1) creating feature branches (always from origin/main), (2) multiple
-  branches need rebasing, (3) semantic conflict resolution needed, (4) batch PR creation
-  after rebase.'
+description: >-
+  Parallel multi-branch rebase with semantic conflict resolution and batch PR creation.
+  Includes prevention: ALWAYS branch from origin/main to avoid stale bases. Use when:
+  (1) creating feature branches (always from origin/main), (2) multiple branches need
+  rebasing, (3) semantic conflict resolution needed, (4) batch PR creation after rebase,
+  (5) rebase conflicts are purely markdown table separator style differences.
 category: tooling
-date: 2026-04-03
-version: 2.0.0
+date: 2026-05-02
+version: 2.1.0
 user-invocable: false
+verification: verified-local
+history: multi-branch-rebase-workflow.history
 ---
 # Multi-Branch Rebase Workflow
 
@@ -29,6 +32,7 @@ user-invocable: false
 - Some branches have conflicts that require semantic understanding (not just accept-theirs/ours)
 - Batch PR creation is needed after rebase
 - Branches have varying complexity: some empty (already on main), some trivial, some with 20+ conflicts
+- Rebase conflicts are purely markdown table separator style — `main` uses `:---` (markdownlint-compliant) and branches use `-------` (plain dashes)
 
 ## Verified Workflow
 
@@ -129,6 +133,23 @@ git rebase --skip  # commit becomes empty, skip it
 
 **Trivial conflicts**: Use Edit tool to resolve conflict markers directly.
 
+**Markdown table separator conflicts** (`:---` vs `-------`): When main enforces markdownlint-compliant `:---` separators and branches use plain `-------` dashes, the conflict is purely formatting. Resolution rule:
+- **Always keep main's `:---` style** (it is markdownlint-compliant; `-------` fails CI)
+- This can appear multiple times across separate rebase commits — resolve identically each time
+- For **content+formatting conflicts** (branch changed real content AND separator style): keep the branch's content data, but use main's `:---` separator style
+
+```bash
+# Example conflict block — always resolve by keeping HEAD (main) version for separators:
+# <<<<<<< HEAD
+# | Col A | Col B |
+# | :--- | :--- |
+# =======
+# | Col A | Col B |
+# | ------- | ------- |
+# >>>>>>> branch-commit
+# Resolution: use the :--- version from HEAD
+```
+
 **Complex semantic merges (20+ conflicts)**: Delegate to a general-purpose sub-agent with explicit resolution rules per conflict group. Provide:
 - The file path and conflict count
 - Category of each conflict group (e.g., "arithmetic operators", "save/load methods")
@@ -156,9 +177,14 @@ Skip PRs for empty branches (0 commits ahead of main).
 ### Step 6: Cleanup
 
 ```bash
+# Remove the temp worktree for this branch
 git worktree remove /tmp/rebase-NAME
+
+# Prune stale worktree refs (no-op if only main worktree remains)
 git worktree prune
 ```
+
+Note: `git worktree prune` is always safe to run. If no stale worktrees exist it exits silently. It does NOT remove existing worktrees or delete branches.
 
 ## Failed Attempts
 
@@ -171,6 +197,8 @@ git worktree prune
 | Branched from detached HEAD in submodule | `git checkout -b chore/fix` from detached HEAD at old pin | Branch was based on stale commit, main had 3-10 new commits with governance files and CI fixes | Always `git fetch origin main` then branch from `origin/main` explicitly |
 | Branched from current branch without fetch | `git checkout -b feat/x` on submodule's current branch | Current branch was behind main | Specify `origin/main` as the start point |
 | Assumed main hadn't moved | Didn't fetch before branching | Main had governance files, CI fixes, coverage improvements merged since submodule pin | Always `git fetch origin main` first, even if you think main is up to date |
+| Kept `-------` separator in markdown conflict | Resolved markdown table separator conflict by keeping branch's `-------` style | Fails markdownlint MD055/table rules in CI | Always use main's `:---` separator style — it is the markdownlint-compliant form |
+| Treated 0-commits-ahead branch as needing PR | Rebased branch that turned out to be identical to main | Branch's content was already merged; rebase left 0 commits ahead | Check `git log --oneline origin/main..BRANCH` before creating a PR — skip if empty |
 
 ## Results & Parameters
 
@@ -216,3 +244,23 @@ split_docstring:  # 1 conflict
 final_block:  # 1 large conflict
   resolution: keep_both  # main's split/split_with_indices + branch's helpers
 ```
+
+### Markdown Separator Conflict Pattern (2026-05-02 Session)
+
+```yaml
+# ProjectMnemosyne — 3 branches, all conflicts were markdown table separator style
+branches_total: 3
+conflict_type: markdown_table_separators  # :--- (main) vs ------- (branch)
+branches_with_formatting_only_conflicts: 2
+branches_already_on_main: 1  # skill/radiance-sol-dtype-serving-estimates-v1-1 (0 commits ahead)
+resolution_rule: always_keep_main_style  # :--- is markdownlint-compliant
+worktree_pattern: /tmp/rebase-<slug>  # one per branch, removed after push
+push_strategy: --force-with-lease
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | 8 branches, 26-conflict semantic merge, 2026-04-03 | Full semantic rebase including submodule detached HEAD fix |
+| ProjectMnemosyne | 3 branches, markdown separator conflicts only, 2026-05-02 | All conflicts were `:---` vs `-------` table separator style |


### PR DESCRIPTION
## Summary

Amends `multi-branch-rebase-workflow` from v2.0.0 to v2.1.0.

Documents the markdown table separator conflict pattern encountered when rebasing 3 ProjectMnemosyne branches — all conflicts were purely `:---` (markdownlint-compliant, on main) vs `-------` (plain dashes, on branch).

- New Step 3 subsection with resolution rules for separator-only conflicts
- Always keep main's `:---` style — `-------` fails markdownlint in CI
- 2 new Failed Attempts: keeping `-------` style, and treating 0-commits-ahead branch as needing a PR
- Added Verified On section covering both session contexts
- Added `verification` and `history` frontmatter fields; history file created

## Verification Level

**verified-local** — rebases succeeded, branches pushed. CI on the rebased branches not yet confirmed.

## Key Findings

**What Worked**:
- Sequential rebase via temp worktrees (`/tmp/rebase-<slug>`), one per branch, removed after push
- `GIT_EDITOR=true git rebase --continue` to avoid editor prompt on conflict continuation
- For formatting-only conflicts: always keep main's `:---` separator style
- For content+formatting conflicts: keep branch content data, use main's separator style

**What Failed**:
- Keeping `-------` separator → fails markdownlint in CI; always use `:---`
- Treating 0-commits-ahead branch as needing a PR → check `git log origin/main..BRANCH` first

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 1040/1040 valid
- [ ] Verify skill appears in marketplace after merge
- [ ] Test skill discovery with keywords: rebase, worktree, markdown, separator

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>