### PR TITLE
feat: amend markdown-linting-bulk-table-format-fix skill (v1.1.0)

### DIFF
--- a/skills/markdown-linting-bulk-table-format-fix.history
+++ b/skills/markdown-linting-bulk-table-format-fix.history
@@ -1,0 +1,59 @@
+# markdown-linting-bulk-table-format-fix — History
+
+## v1.1.0 (2026-05-03)
+
+**Changed by:** CI-fixing session on ProjectOdyssey PR #5347/#5348
+**Verification:** verified-ci — markdownlint CI job passed with 0 violations on ProjectOdyssey
+
+### What changed
+
+- Added new `When to Use` trigger: markdownlint v0.40.0 upgrade introduces MD060 and
+  `markdownlint-cli2 --fix` does NOT fix MD060 violations
+- Added new variant workflow: "Scenario B — markdownlint v0.40.0 upgrade adds MD060 with no
+  auto-fix" with two-pass Python script strategy
+- Added `MD060: { style: compact }` config option as alternative to `style: consistent` when
+  all tables must be normalized to compact style
+- Added 2 new `Failed Attempts` rows: `--fix` flag silent no-op on MD060, and single-pass
+  script leaving wide-padded header cells
+- Added ProjectOdyssey to `Verified On` table
+- Updated `description` frontmatter to mention v0.40.0 upgrade scenario
+- Bumped version from `1.0.0` to `1.1.0`
+- Updated date from `2026-05-01` to `2026-05-03`
+- Added `verification` frontmatter field
+
+### Why
+
+v1.0.0 covered the case where `.markdownlint.yaml` was missing (mass failures). A new scenario
+emerged: markdownlint-cli2 v0.40.0 added the MD060 rule. Running `--fix` on ~1079 violations
+across 165 files silently produced 0 modifications — the auto-fixer does not implement MD060.
+The fix requires a two-pass Python script and explicitly setting `MD060: { style: compact }`.
+
+### Previous version (v1.0.0) snapshot
+
+```
+---
+name: markdown-linting-bulk-table-format-fix
+description: "Use when: (1) markdownlint CI fails with 20,000+ errors across hundreds of
+  files due to missing .markdownlint.yaml config, (2) MD060 table style errors flood CI
+  output after a linter config is added or upgraded, (3) you need to bulk-normalize markdown
+  table formatting to compact style across an entire repository"
+category: ci-cd
+date: 2026-05-01
+version: 1.0.0
+user-invocable: false
+tags:
+  - markdownlint
+  - MD060
+  - tables
+  - pre-commit
+  - bulk-fix
+  - ci-unblocking
+---
+[... full v1.0.0 content preserved in git history ...]
+```
+
+---
+
+## v1.0.0 (2026-05-01)
+
+**Initial version.**

--- a/skills/markdown-linting-bulk-table-format-fix.md
+++ b/skills/markdown-linting-bulk-table-format-fix.md
@@ -1,10 +1,17 @@
 ---
 name: markdown-linting-bulk-table-format-fix
-description: "Use when: (1) markdownlint CI fails with 20,000+ errors across hundreds of files due to missing .markdownlint.yaml config, (2) MD060 table style errors flood CI output after a linter config is added or upgraded, (3) you need to bulk-normalize markdown table formatting to compact style across an entire repository"
+description: "Use when: (1) markdownlint CI fails with 20,000+ errors across hundreds of files due
+  to missing .markdownlint.yaml config, (2) MD060 table style errors flood CI output after a linter
+  config is added or upgraded, (3) markdownlint-cli2 is upgraded to v0.40.0+ and adds MD060 with
+  ~1000 violations that --fix silently ignores (requires two-pass Python script + style: compact),
+  (4) you need to bulk-normalize markdown table formatting to compact style across an entire
+  repository"
 category: ci-cd
-date: 2026-05-01
-version: 1.0.0
+date: 2026-05-03
+version: "1.1.0"
 user-invocable: false
+verification: verified-ci
+history: markdown-linting-bulk-table-format-fix.history
 tags:
   - markdownlint
   - MD060
@@ -20,10 +27,11 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-01 |
-| **Objective** | Fix 20,131 markdownlint errors across 1,189 files in ProjectMnemosyne after CI began enforcing a missing `.markdownlint.yaml` config |
+| **Date** | 2026-05-03 |
+| **Objective** | Fix markdownlint CI failures — either mass failures from missing config, or MD060 violations from v0.40.0 upgrade that `--fix` silently ignores |
 | **Outcome** | Fixed: markdownlint CI passes with 0 errors after adding config + running bulk table normalizer script |
-| **Status** | Completed — CI verified passing |
+| **Verification** | verified-ci |
+| **History** | [changelog](./markdown-linting-bulk-table-format-fix.history) |
 
 ## When to Use
 
@@ -31,9 +39,13 @@ Apply this pattern when:
 
 1. **CI references `.markdownlint.yaml` but the file is missing** from the repo — causes sudden mass failures on all files
 2. **MD060 table style errors** flood across hundreds of files (tables using non-compact `| cell |` vs. compact `|cell|` style inconsistently)
-3. **MD024 "duplicate heading" errors** in changelogs or version files where repeated headings (Added/Fixed/Changed) are legitimate under different version headers
-4. **MD003 setext heading style errors** caused by orphaned YAML-like `---...---` blocks embedded in markdown content (not real frontmatter)
-5. **MD056 column count mismatch** in tables containing literal pipe characters in cell content
+3. **markdownlint-cli2 upgraded to v0.40.0+** — MD060 is a new rule in this version; running
+   `markdownlint-cli2 --fix "**/*.md"` silently produces **0 file modifications** for MD060
+   violations. The auto-fixer does not implement MD060. ~1079 violations across 165 files remain
+   after `--fix`.
+4. **MD024 "duplicate heading" errors** in changelogs or version files where repeated headings (Added/Fixed/Changed) are legitimate under different version headers
+5. **MD003 setext heading style errors** caused by orphaned YAML-like `---...---` blocks embedded in markdown content (not real frontmatter)
+6. **MD056 column count mismatch** in tables containing literal pipe characters in cell content
 
 **Do NOT use** when:
 
@@ -45,25 +57,31 @@ Apply this pattern when:
 ### Quick Reference
 
 ```bash
-# 1. Add .markdownlint.yaml with correct options
-cat .markdownlint.yaml
-
+# Scenario A: Missing .markdownlint.yaml (mass failures)
+# 1. Add .markdownlint.yaml with MD060: { style: consistent }
 # 2. Run bulk table normalizer
 python3 scripts/fix_md_tables.py --all
-
-# 3. Fix ruff import sorting in the new script
+# 3. Fix ruff import sorting
 ruff check --fix scripts/fix_md_tables.py
-
-# 4. Fix trailing whitespace + missing EOF newlines (pre-commit catches these)
+# 4. Fix trailing whitespace + missing EOF newlines
 pre-commit run --all-files
+# 5. Verify
+pre-commit run markdownlint --all-files
 
-# 5. Stage and verify
+# Scenario B: markdownlint v0.40.0 upgrade — MD060 added, --fix is silent no-op
+# 1. Add MD060: { style: compact } to .markdownlint.yaml
+# 2. Run two-pass Python script (separator rows first, then cell padding)
+python3 scripts/fix_md_tables.py --all   # Pass 1: normalize separator rows
+# Pass 2 (if needed): strip wide padding from header/data cells
+# 3. Verify
 pre-commit run markdownlint --all-files
 ```
 
 ### Detailed Steps
 
-#### Step 1 — Create `.markdownlint.yaml`
+#### Scenario A — Missing `.markdownlint.yaml` (20k+ errors)
+
+##### Step A1 — Create `.markdownlint.yaml`
 
 The root cause is almost always a missing or incomplete `.markdownlint.yaml`. CI references it, but it was never committed.
 
@@ -86,7 +104,7 @@ Key config decisions:
 - `MD060: style: consistent` — tells markdownlint to accept whatever style a table already uses, rather than enforcing a single global style. This resolves the bulk of errors without changing table content.
 - `MD024: siblings_only: true` — changelogs legitimately repeat "Added"/"Fixed" headings under different version headers; `siblings_only` allows this.
 
-#### Step 2 — Write and Run the Bulk Table Normalizer
+##### Step A2 — Write and Run the Bulk Table Normalizer
 
 For repos with thousands of tables in non-compact format, write a Python normalizer script. The key correctness requirements:
 
@@ -107,7 +125,7 @@ python3 scripts/fix_md_tables.py --all
 # Expected: "Fixed 1,176 files" (or similar count)
 ```
 
-#### Step 3 — Fix MD056 (column count mismatch)
+##### Step A3 — Fix MD056 (column count mismatch)
 
 MD056 fires when a table cell contains a literal `|`. Escape it:
 
@@ -123,7 +141,7 @@ MD056 fires when a table cell contains a literal `|`. Escape it:
 
 Alternatively use the HTML entity `&#124;` instead of `\|`.
 
-#### Step 4 — Fix MD003 (setext heading style)
+##### Step A4 — Fix MD003 (setext heading style)
 
 Some markdown files embed YAML-like blocks after the real frontmatter, which markdownlint misdetects as headings with setext style (underline `---`). Remove orphaned `---...---` blocks from content sections — they are not valid frontmatter.
 
@@ -133,7 +151,7 @@ pre-commit run markdownlint --all-files 2>&1 | grep MD003
 # Inspect each: look for stray --- blocks in content (not at file top)
 ```
 
-#### Step 5 — Run Pre-commit to Catch Remaining Issues
+##### Step A5 — Run Pre-commit to Catch Remaining Issues
 
 After the bulk table fix, pre-commit will catch trailing whitespace and missing end-of-file newlines on 600+ files. Let it auto-fix:
 
@@ -144,7 +162,7 @@ pre-commit run --all-files
 pre-commit run --all-files
 ```
 
-#### Step 6 — Fix Ruff Import Sorting in New Scripts
+##### Step A6 — Fix Ruff Import Sorting in New Scripts
 
 If you wrote a new Python script, `ruff` will flag unsorted imports (I001):
 
@@ -152,7 +170,7 @@ If you wrote a new Python script, `ruff` will flag unsorted imports (I001):
 ruff check --fix scripts/fix_md_tables.py
 ```
 
-#### Step 7 — Verify and Commit
+##### Step A7 — Verify and Commit
 
 ```bash
 # Confirm markdownlint passes
@@ -165,6 +183,71 @@ git add $(git diff --name-only)   # all modified skills/docs files
 git commit -m "fix(lint): fix 20k markdownlint errors — add config + bulk table normalizer"
 ```
 
+#### Scenario B — markdownlint v0.40.0 Upgrade Adds MD060 (--fix is silent no-op)
+
+This is the case where the config file exists and CI was passing, then markdownlint-cli2 is
+upgraded to v0.40.0 which introduced MD060. Running `--fix` produces **zero file changes**
+despite ~1000+ violations — MD060 is not implemented in the auto-fixer.
+
+##### Step B1 — Add `MD060: { style: compact }` to `.markdownlint.yaml`
+
+```yaml
+# Add to .markdownlint.yaml:
+MD060:
+  style: compact    # All table columns must use compact separator: | --- |
+```
+
+Use `style: compact` (not `style: consistent`) when you want to enforce a single canonical
+style across all tables. After adding this, markdownlint will report all violations against
+a single standard, which the two-pass script can reliably fix.
+
+##### Step B2 — Run the Two-Pass Fix Script
+
+MD060 violations fall into two categories that require separate passes:
+
+**Pass 1: Normalize separator rows**
+
+Find lines matching `^\|[-: |]+\|$` and replace with compact separators:
+`| --- | --- | ...` (one `---` per column, based on column count of the header row).
+
+```python
+import re
+
+def fix_separator_row(line: str, col_count: int) -> str:
+    """Replace any separator row with compact | --- | --- | ... form."""
+    if re.match(r'^\|[-: |]+\|$', line.strip()):
+        return '| ' + ' | '.join(['---'] * col_count) + ' |'
+    return line
+```
+
+**Pass 2: Strip wide padding from header and data cells**
+
+After Pass 1, tables that used "aligned" style (padded to column width) still fail because
+the header/data cells have wide padding that doesn't match the new compact separators.
+Strip extra spaces from inside cells:
+
+```python
+def compact_table_row(line: str) -> str:
+    """Convert | wide cell | to | compact cell | (single space padding)."""
+    if not line.strip().startswith('|'):
+        return line
+    cells = line.split('|')
+    cells = [''] + [c.strip() for c in cells[1:-1]] + ['']
+    return '| ' + ' | '.join(c for c in cells[1:-1]) + ' |'
+```
+
+**Why two passes**: After Pass 1, separator rows are compact but header/data cells retain
+their wide padding (e.g., `|  Command  |  Description  |`). MD060 considers the full table
+style — mismatched padding between separator and content rows still triggers violations.
+
+##### Step B3 — Verify
+
+```bash
+# Run markdownlint on all files
+pre-commit run markdownlint --all-files
+# Expected: Passed (0 violations)
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -173,10 +256,12 @@ git commit -m "fix(lint): fix 20k markdownlint errors — add config + bulk tabl
 | Suppress MD060 entirely | Set `MD060: false` to disable the rule | CI still required real fixes; disabling hid the errors but did not normalize the files | Use `style: consistent` to accept existing style rather than disabling the rule |
 | Ruff clean script | Added `fix_md_tables.py` without running ruff | I001 import order violation caused pre-commit to fail on the new script | Always run `ruff check --fix` on any new Python file before committing |
 | Manual table edits | Attempted to fix a sample of tables by hand | 1,189 files × multiple tables each = impractical; introduced inconsistencies | Automate bulk fixes with a script that handles edge cases (frontmatter, code blocks) |
+| `markdownlint-cli2 --fix "**/*.md"` for MD060 | Ran auto-fixer expecting it to fix MD060 violations after v0.40.0 upgrade | Silent no-op — produced 0 file modifications despite ~1079 violations across 165 files. MD060 is not implemented in the markdownlint-cli2 auto-fixer. | When `--fix` produces no changes but violations remain, the rule lacks an auto-fix implementation. Write a custom Python script instead. |
+| Single-pass separator normalization | Ran only Pass 1 (normalize separator rows) expecting all MD060 violations to be fixed | ~1079 violations remained — header and data cells with wide padding (`|  wide content  |`) still violated MD060 compact style after separator rows were normalized | Two passes required: Pass 1 normalizes separators, Pass 2 strips wide cell padding |
 
 ## Results & Parameters
 
-### `.markdownlint.yaml` Configuration
+### `.markdownlint.yaml` Configuration — Scenario A (missing config)
 
 ```yaml
 default: true
@@ -191,10 +276,25 @@ MD060:
   style: consistent
 ```
 
+### `.markdownlint.yaml` Configuration — Scenario B (v0.40.0 upgrade, enforce compact)
+
+```yaml
+default: true
+
+MD024:
+  siblings_only: true
+
+MD046:
+  style: fenced
+
+MD060:
+  style: compact    # Enforce compact separators; requires two-pass script to fix existing tables
+```
+
 ### Script Invocation
 
 ```bash
-# Fix all markdown files in the repo
+# Fix all markdown files in the repo (Scenario A)
 python3 scripts/fix_md_tables.py --all
 
 # Fix a single file
@@ -205,23 +305,22 @@ python3 scripts/fix_md_tables.py skills/some-skill.md
 
 - Bulk normalizer: `Fixed N files` (ProjectMnemosyne: 1,176 files)
 - Pre-commit markdownlint: `Passed` with no file modifications
-- Total errors eliminated: 20,131 across 1,189 files
+- Total errors eliminated: 20,131 across 1,189 files (Scenario A)
+- Total errors eliminated: ~1,079 across 165 files (Scenario B — ProjectOdyssey v0.40.0 upgrade)
 
-### Scale Metrics (ProjectMnemosyne)
+### Scale Metrics
 
-| Metric | Value |
-| ------- | ------- |
-| Total markdownlint errors before | 20,131 |
-| Files affected | 1,189 |
-| Files fixed by script | 1,176 |
-| Files fixed manually (MD003/MD056) | ~13 |
-| Pre-commit trailing-whitespace/EOF fixes | 600+ |
+| Project | Scenario | Errors Before | Files Affected | Fix Method |
+| ------- | -------- | ------------- | -------------- | ---------- |
+| ProjectMnemosyne | A (missing config) | 20,131 | 1,189 | `fix_md_tables.py --all` + `style: consistent` |
+| ProjectOdyssey | B (v0.40.0 upgrade) | ~1,079 | ~165 | Two-pass Python script + `style: compact` |
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
 | ProjectMnemosyne | 2026-05-01 — mass fix of missing .markdownlint.yaml | CI markdownlint job passes with 0 errors after fix |
+| ProjectOdyssey | 2026-05-03 — PR #5347/#5348, markdownlint-cli2 v0.40.0 upgrade added MD060 | Two-pass Python script + `style: compact`; CI markdownlint job passed with 0 violations |
 
 ## References
 


### PR DESCRIPTION
## Summary

Amends `markdown-linting-bulk-table-format-fix` from v1.0.0 to v1.1.0.

Adds Scenario B: markdownlint-cli2 upgraded to v0.40.0 which introduces MD060 as a new rule.
Running `markdownlint-cli2 --fix "**/*.md"` is a **silent no-op** for MD060 — it produces 0
file modifications despite ~1079 violations across 165 files. Fix requires:

- Add `MD060: { style: compact }` to `.markdownlint.yaml`
- Two-pass Python script: Pass 1 normalizes separator rows, Pass 2 strips wide cell padding

v1.0.0 covered the missing-config scenario (20k+ errors). v1.1.0 adds the upgrade scenario.

## Verification Level

**verified-ci** — markdownlint CI job passed with 0 violations on ProjectOdyssey PR #5347/#5348
after the two-pass script + `style: compact` config.

## Key Findings

**What Worked**:
- Two-pass approach: normalize separator rows first, then strip wide padding from cells
- `MD060: { style: compact }` in config provides a consistent target for the script

**What Failed**:
- `markdownlint-cli2 --fix` → Silent no-op for MD060; 0 file changes despite 1079 violations
- Single-pass separator normalization → Remaining violations from wide-padded header cells

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` (1045/1045 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: `markdownlint`, `MD060`, `md060`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>