### PR TITLE
feat: amend investigate-mojo-heap-corruption skill (v1.0.0 -> v1.1.0)

### DIFF
--- a/skills/investigate-mojo-heap-corruption.history
+++ b/skills/investigate-mojo-heap-corruption.history
@@ -1,0 +1,52 @@
+# investigate-mojo-heap-corruption -- History
+
+## v1.1.0 (2026-05-03)
+
+**Changed by:** ProjectOdyssey and ProjectScylla fix session (2026-05-03)
+**Verification:** verified-ci -- `def main()` fix confirmed by CI passing; ADR-009 split pattern confirmed
+
+### What changed
+- Added ADR-009 test file splitting workflow (Phase 5): split oversized files to <=10 functions each
+- Added critical `fn main` -> `def main` deprecation fix (Phase 6): Mojo 0.26.3 deprecated `fn main()`, causing parse errors in all new split files
+- Added CI glob update step (Phase 7): after splitting, update CI glob to `test_*_part*.mojo`
+- Updated description to cover test splitting and fn main deprecation triggers
+- Updated When to Use with 3 new trigger conditions (ADR-009 splitting, parse errors after splitting)
+- Added Quick Reference section showing full split workflow
+- Added 4 new Failed Attempts rows: `fn main()` in split files, missing CI glob update, partial import block, blocking on pre-existing flakes
+- Added ADR-009 Splitting Rules table in Results & Parameters
+- Added Mojo Version Compatibility table
+- Bumped version to 1.1.0
+- Upgraded verification from unverified (v1.0) to verified-ci
+- Added history frontmatter field
+
+### Why
+During ProjectOdyssey issue fixes (2026-05-03), ADR-009 required splitting test files with >15
+functions into part files. All 11 new part files were initially written with `fn main() raises:`
+(copied from the original file template). CI failed immediately with parse errors on every new file:
+`error: 'fn' keyword not valid for 'main'; use 'def' instead`. Mojo 0.26.3 deprecated `fn main()`.
+The fix was a global replace across all 11 files. This is a recurring trap for anyone splitting
+Mojo test files: the original file may use `fn main()` (valid in older Mojo), and that gets
+copied into the new part files, causing CI to fail.
+
+### Previous version (v1.0.0) snapshot
+
+---
+name: investigate-mojo-heap-corruption
+description: Systematic workflow for investigating and fixing Mojo 0.26.1 heap corruption
+  crashes that occur in CI but not locally
+category: debugging
+date: 2026-01-08
+version: 1.0.0
+user-invocable: false
+
+Documented: CI-only heap corruption crashes in libKGENCompilerRTShared.so. Root cause:
+unnecessary Float32->Float64 type conversion in test_fp16_vs_fp32_accuracy() function
+(lines 337-338, test_multi_precision_training.mojo). Fix: replace ._get_float64() with
+._get_float32() for Float32 data. Crash triggers after ~15 cumulative test executions.
+Fixed via PR #3103. Verification: unverified (CI validation was pending at time of capture).
+
+---
+
+## v1.0.0 (2026-01-08)
+
+**Initial version.**

--- a/skills/investigate-mojo-heap-corruption.md
+++ b/skills/investigate-mojo-heap-corruption.md
@@ -1,24 +1,34 @@
 ---
 name: investigate-mojo-heap-corruption
-description: Systematic workflow for investigating and fixing Mojo 0.26.1 heap corruption
-  crashes that occur in CI but not locally
+description: "Systematic workflow for investigating and fixing Mojo heap corruption crashes, test file splitting (ADR-009), and Mojo version deprecation pitfalls. Use when: (1) CI-only heap corruption crashes in libKGENCompilerRTShared.so, (2) splitting oversized Mojo test files to <=10 functions (ADR-009), (3) Mojo 0.26.3+ parse errors in test files after splitting."
 category: debugging
-date: 2026-01-08
-version: 1.0.0
+date: 2026-05-03
+version: "1.1.0"
 user-invocable: false
+verification: verified-ci
+history: investigate-mojo-heap-corruption.history
+tags:
+  - mojo
+  - heap-corruption
+  - adr-009
+  - test-splitting
+  - fn-main
+  - def-main
+  - deprecation
+  - ci
 ---
+
 # Investigate Mojo Heap Corruption Crashes
 
 ## Overview
 
 | Attribute | Value |
 | ----------- | ------- |
-| **Date** | 2026-01-08 |
-| **Objective** | Investigate and fix Mojo 0.26.1 heap corruption crash in `test_multi_precision_training.mojo` Test 9 |
-| **Outcome** | ✅ Success - Crash identified and fixed |
-| **CI Run** | [#20826482385](https://github.com/mvillmow/ProjectOdyssey/actions/runs/20826482385) |
-| **Failing Commit** | `ba12f57ca6c2c624341f2a8046f3c2a701bed69c` |
-| **Fix PR** | [#3103](https://github.com/mvillmow/ProjectOdyssey/pull/3103) |
+| **Date** | 2026-05-03 |
+| **Objective** | Investigate and fix Mojo heap corruption crashes; split oversized test files per ADR-009; avoid Mojo 0.26.3 `fn main` deprecation parse errors |
+| **Outcome** | Crash identified and fixed (v1.0); ADR-009 test splits confirmed (v1.1); `fn main` deprecation CI fix confirmed (v1.1) |
+| **Verification** | verified-ci -- `def main()` fix confirmed by CI passing after global replace |
+| **History** | [changelog](./investigate-mojo-heap-corruption.history) |
 
 ## When to Use This Skill
 
@@ -26,9 +36,11 @@ Invoke this workflow when you encounter:
 
 1. **CI-only crashes** that don't reproduce locally
 2. **Heap corruption** errors in `libKGENCompilerRTShared.so`
-3. **Crashes after ~15 cumulative tests** (heap corruption threshold in Mojo 0.26.1)
+3. **Crashes after ~15 cumulative tests** (heap corruption threshold in Mojo 0.26.x)
 4. **Runtime crashes** with stack traces but no symbols
 5. **Intermittent failures** in integration test suites
+6. **ADR-009 file splitting** -- oversized Mojo test files need splitting to <=10 functions each
+7. **Parse errors in new Mojo test files** after splitting (Mojo 0.26.3+: `fn main` deprecated)
 
 ### Trigger Patterns
 
@@ -38,9 +50,46 @@ error: execution crashed
 #1 0x00007fe7ca5c3ce6 (/path/to/libKGENCompilerRTShared.so+0x3c3ce6)
 ```
 
+```text
+# Mojo 0.26.3 parse error in new split files:
+error: 'fn' keyword not valid for 'main'; use 'def' instead
+```
+
 ## Verified Workflow
 
-### Phase 1: Identify Failing CI Run
+### Quick Reference
+
+```bash
+# Phase 1: Reproduce or localize crash
+gh run view <run-id> --log 2>&1 | grep -A 10 -B 10 "<test-file-name>"
+git checkout <headSha>
+pixi run mojo -I . tests/path/to/test.mojo
+
+# Phase 2: Fix root cause (type conversion or oversized file)
+# For type conversion: replace ._get_float64() with ._get_float32()
+
+# Phase 3: Split oversized test files (ADR-009 -- <=10 functions per file)
+# Copy full import block verbatim to each part file
+# Keep <=10 test functions per file
+# Name parts: test_<base>_part1.mojo, test_<base>_part2.mojo, ...
+
+# CRITICAL: After splitting, fix fn main deprecation (Mojo 0.26.3+)
+# ALL new part files must use def main() not fn main()
+find . -name "test_*_part*.mojo" -exec grep -l "fn main" {} \;
+# Global replace in each file found:
+sed -i 's/fn main() raises:/def main() raises:/g' test_*_part*.mojo
+
+# Phase 4: Update CI glob patterns
+# Old:  test_<base>.mojo
+# New:  test_<base>_part*.mojo
+
+# Phase 5: Validate
+pixi run bash -c "for f in tests/**/test_*_part*.mojo; do mojo -I . \$f && echo OK: \$f; done"
+```
+
+### Detailed Steps
+
+#### Phase 1: Identify Failing CI Run
 
 1. **Locate the exact failing CI run** (don't rely on general reports)
 
@@ -59,19 +108,14 @@ error: execution crashed
    - Look for: Test number, last output before crash
    - Example: "Test 9: FP16 vs FP32 accuracy..." followed by crash
 
-### Phase 2: Checkout Exact Failing Commit
+#### Phase 2: Checkout Exact Failing Commit
 
 ```bash
-# Use headSha from CI metadata
-git checkout <commit-sha>
-
-# Verify it's the exact commit
+git checkout <headSha>
 git log -1 --oneline
 ```
 
-### Phase 3: Attempt Local Reproduction
-
-**Important**: Crashes may NOT reproduce locally due to environment differences.
+#### Phase 3: Attempt Local Reproduction
 
 1. **Run test file individually** (usually passes):
 
@@ -94,76 +138,126 @@ git log -1 --oneline
    done
    ```
 
-### Phase 4: Analyze Crashing Code
+#### Phase 4: Analyze Crashing Code
 
-1. **Read the specific test function** identified in crash logs
-2. **Look for suspicious patterns**:
-   - Unnecessary type conversions (e.g., `._get_float64()` on Float32 data)
-   - Multiple ExTensor allocations in sequence
-   - Complex dtype casting operations
-   - Raw pointer access via `._data.bitcast[T]()`
+Look for suspicious patterns:
+- Unnecessary type conversions (e.g., `._get_float64()` on Float32 data)
+- Multiple ExTensor allocations in sequence
+- Complex dtype casting operations
 
-3. **Check cumulative test count patterns**:
-   - Cumulative test count (>10-15 tests triggers heap corruption in Mojo 0.26.1)
-   - Operations that worked in isolation but fail in CI
-
-### Phase 5: Apply Fix
-
-**Pattern**: Replace unnecessary type conversions with native type operations.
-
-**Before** (causes heap corruption):
+**Fix pattern**: Replace unnecessary type conversions with native type operations.
 
 ```mojo
+# Before (causes heap corruption):
 var original_val = test_data._get_float64(0)      # Float32 -> Float64
-var roundtrip_val = back_to_fp32._get_float64(0)  # Float32 -> Float64
-```
 
-**After** (uses native type):
-
-```mojo
+# After (uses native type):
 var original_val = test_data._get_float32(0)      # Native Float32
-var roundtrip_val = back_to_fp32._get_float32(0)  # Native Float32
 ```
 
-### Phase 6: Verify Fix
+#### Phase 5: ADR-009 Test File Splitting (>10 functions per file)
 
-1. **Local testing**:
+When a test file has >10 functions, split it into part files:
 
-   ```bash
-   for i in $(seq 1 10); do
-     pixi run mojo -I . tests/path/to/test.mojo
-   done
-   ```
+```bash
+# Count functions in a test file
+grep -c "^fn test_\|^def test_" tests/path/to/test_<base>.mojo
 
-2. **Create PR and wait for CI validation**
+# If >10, split into parts:
+# - test_<base>_part1.mojo  (functions 1-10)
+# - test_<base>_part2.mojo  (functions 11-20)
+# etc.
+
+# RULES:
+# 1. Copy the FULL import block verbatim to EVERY part file
+# 2. Keep <= 10 test functions per file
+# 3. Keep the original test_<base>.mojo if it still has <= 10 functions
+#    (or delete it and replace with parts)
+```
+
+#### Phase 6: Fix fn main Deprecation (Mojo 0.26.3+) -- CRITICAL
+
+**After splitting**, every new part file must have `def main() raises:` not `fn main() raises:`.
+Mojo 0.26.3 deprecated `fn main()` and will produce a parse error in CI.
+
+```bash
+# Find all new part files using fn main
+find . -name "test_*_part*.mojo" -exec grep -l "fn main" {} \;
+
+# Fix: global replace in each file
+# If using sed:
+for f in $(find . -name "test_*_part*.mojo"); do
+  sed -i 's/fn main() raises:/def main() raises:/g' "$f"
+done
+
+# Verify all fixed:
+grep -r "fn main" tests/ --include="*.mojo" | grep "part"
+# Should produce no output
+```
+
+#### Phase 7: Update CI Glob Patterns
+
+Update CI workflow to include new part files:
+
+```yaml
+# Old pattern (misses part files):
+- "tests/**/test_<base>.mojo"
+
+# New pattern (catches all parts):
+- "tests/**/test_<base>_part*.mojo"
+```
+
+Or use a broader glob if splitting many files:
+
+```yaml
+- "tests/**/test_*_part*.mojo"
+```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| Running test file individually to reproduce crash | Used `pixi run mojo -I . tests/.../test.mojo` | Crash requires 15+ cumulative test executions (heap corruption threshold) | CI-only crashes may need cumulative reproduction -- run all integration tests sequentially |
+| `fn main() raises:` in new split files | All 11 split files were written with `fn main()` | Mojo 0.26.3 deprecates `fn main()`; CI failed with parse error on every new file | After any file split in Mojo 0.26.3+, globally replace `fn main() raises:` with `def main() raises:` |
+| Not updating CI glob after splitting | Left CI glob as `test_<base>.mojo` | Split files named `test_<base>_part*.mojo` were not discovered by CI | Always update CI glob patterns to `test_*_part*.mojo` when splitting |
+| Partial import block in part files | Only copied some imports to part files | Missing imports cause compile errors in all functions that depend on them | Copy the FULL import block verbatim to every part file when splitting |
+| Blocking PR on pre-existing ADR-009 flakes | Treated pre-existing test failures on main as regressions | Several test suites had ADR-009 flakes on main before the split | Pre-existing CI failures on main should not block a PR introducing the split fix |
+
 ## Results & Parameters
 
-### Root Cause
+### Root Cause (v1.0 -- Type Conversion)
 
-**Unnecessary Float32 → Float64 conversion** in `test_fp16_vs_fp32_accuracy()`:
+**Unnecessary Float32 -> Float64 conversion** in `test_fp16_vs_fp32_accuracy()`:
 
 ```mojo
-# Lines 337-338 (before fix)
+# Before fix (lines 337-338):
 var original_val = test_data._get_float64(0)
 var roundtrip_val = back_to_fp32._get_float64(0)
-```
 
-This triggered Mojo 0.26.1's heap corruption bug when combined with cumulative test executions
-(13 tests total across all integration tests run before this one).
-
-### Fix Applied
-
-```mojo
-# Lines 339-340 (after fix)
+# After fix (lines 339-340):
 var original_val = test_data._get_float32(0)
 var roundtrip_val = back_to_fp32._get_float32(0)
 ```
+
+Triggered Mojo 0.26.1's heap corruption bug when combined with cumulative test executions
+(13 tests total across all integration tests run before this one).
+
+### ADR-009 Splitting Rules (v1.1)
+
+| Rule | Detail |
+| ---- | ------ |
+| Max functions per file | 10 |
+| Part file naming | `test_<base>_part1.mojo`, `test_<base>_part2.mojo`, ... |
+| Import block | Copy FULL import block verbatim to every part file |
+| main entrypoint | MUST use `def main() raises:` (not `fn main()`) for Mojo 0.26.3+ |
+| CI glob | Update to `test_*_part*.mojo` |
+
+### Mojo Version Compatibility
+
+| Version | `fn main()` | `def main()` |
+| ------- | ----------- | ------------ |
+| 0.26.1 | OK | OK |
+| 0.26.3 | DEPRECATED (parse error in CI) | Required |
 
 ### Verification Commands
 
@@ -174,35 +268,24 @@ pixi run pre-commit run --all-files
 # Verify test still passes
 pixi run mojo -I . tests/shared/integration/test_multi_precision_training.mojo
 
+# Verify no fn main in split files
+grep -r "fn main" tests/ --include="test_*_part*.mojo"
+
 # Check CI status
 gh pr checks <pr-number>
 ```
 
 ### Configuration
 
-- **Mojo Version**: 0.26.1
+- **Mojo Version**: 0.26.1 (v1.0 crash) / 0.26.3 (v1.1 deprecation)
 - **Platform**: Linux x86_64 (GitHub Actions)
 - **CI Environment**: Ubuntu 22.04
 - **Test Framework**: Custom Mojo tests (not pytest)
+- **ADR**: ADR-009 (heap corruption mitigation via file splitting)
 
-## Key Learnings
+## Verified On
 
-1. **CI logs are authoritative** - Use `gh run view <id> --log` to get exact crash location
-2. **Commit precision matters** - Use `headSha` from CI metadata, not approximate commits
-3. **CI-only crashes are real** - Don't dismiss failures that don't reproduce locally
-4. **Type conversions are risky** - Unnecessary conversions can trigger heap corruption in Mojo 0.26.1
-5. **Native types are safer** - Use `._get_float32()` for Float32 data, not `._get_float64()`
-
-## Related Documentation
-
-- [PR #3103: Fix Test 9 Crash](https://github.com/mvillmow/ProjectOdyssey/pull/3103)
-- [Failing CI Run](https://github.com/mvillmow/ProjectOdyssey/actions/runs/20826482385)
-
-## Success Criteria
-
-- [x] Crash location identified (Test 9, lines 337-338)
-- [x] Root cause identified (Float32→Float64 conversion)
-- [x] Fix applied (native Float32 comparison)
-- [x] Pre-commit hooks pass
-- [x] PR created and auto-merge enabled
-- [ ] CI validation passes (pending)
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| HomericIntelligence/ProjectOdyssey | Test file splitting + fn main deprecation fix 2026-05-03 | 11 split files fixed; CI confirmed passing after def main replace; verified-ci |
+| HomericIntelligence/ProjectOdyssey | Heap corruption crash fix 2026-01-08 (v1.0) | PR #3103 -- Float32->Float64 conversion removed; CI run #20826482385 |


### PR DESCRIPTION
## Summary

Amends `investigate-mojo-heap-corruption` from v1.0.0 (heap corruption root cause fix) to v1.1.0, adding ADR-009 test file splitting workflow and the critical Mojo 0.26.3 `fn main` deprecation fix.

- Adds Phase 5: ADR-009 file splitting (<=10 functions, copy full import block)
- Adds Phase 6: `fn main() raises:` -> `def main() raises:` global replace (Mojo 0.26.3 deprecated `fn main`)
- Adds Phase 7: CI glob update to `test_*_part*.mojo`
- Adds 4 new Failed Attempts rows covering splitting pitfalls
- Adds Mojo Version Compatibility table (0.26.1 vs 0.26.3)

## Verification Level

**verified-ci** — `def main()` fix confirmed by CI passing after global replace across 11 split files

## Key Findings

**What Worked**:
- Global `sed -i 's/fn main() raises:/def main() raises:/g'` across all part files fixes CI parse errors
- Copy full import block verbatim to every part file (not partial)
- Update CI glob to `test_*_part*.mojo` after splitting

**What Failed**:
- All 11 new split files used `fn main() raises:` (copied from original) -> Mojo 0.26.3 parse error on every file
- Not updating CI glob after splitting -> part files not discovered

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1020/1020 valid)
- [ ] Verify skill appears in marketplace after merge
- [ ] Test skill discovery with keywords: mojo test split, fn main deprecation, ADR-009, def main

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>