### PR TITLE
feat: amend worktree-cleanup-user-constraints skill (v1.6.0)

### DIFF
--- a/skills/worktree-cleanup-user-constraints.history
+++ b/skills/worktree-cleanup-user-constraints.history
@@ -1,5 +1,40 @@
 # worktree-cleanup-user-constraints — Change History
 
+## v1.6.0 — 2026-05-04
+
+**Amendment**: ProjectMnemosyne session — locked worktrees from dead myrmidon swarm sessions; unlock+remove without --force when clean.
+**Verification**: verified-local (executed on 13 worktrees, all `dirty=0`, 2026-05-04)
+
+### What changed
+- Updated `description` frontmatter to mention locked-but-clean worktrees pattern
+- Added `locked-worktree` and `dead-agent` tags
+- Added "When to Use" trigger: locked worktrees with dead agent PIDs from myrmidon swarm sessions
+- Added Phase 0.7 "Handle Locked Worktrees" — split on cleanliness: locked+clean → unlock+remove directly (no --force); locked+dirty → classify files first
+- Updated Quick Reference with locked worktree detection and unlock steps
+- Added new Failed Attempts row: classifying all locked worktrees as KEEP regardless of cleanliness
+- Updated Scale reference table with 13-locked-clean pattern
+- Added ProjectMnemosyne row to Verified On table (13 locked agent worktrees, all dirty=0)
+- Also synced version from 1.4.0 to 1.6.0 in frontmatter (v1.5.0 entry existed in history but frontmatter was not updated)
+
+### Why
+During ProjectMnemosyne cleanup session (2026-05-04), 13 `worktree-agent-<hash>` worktrees
+from dead myrmidon swarm sessions were found in `locked` state (PIDs dead). The previous skill
+recommended classifying locked worktrees as KEEP and printing manual unlock+`--force` commands.
+This was wrong on two counts: (1) clean locked worktrees need no `--force` after unlock;
+(2) `--force` is blocked by the Safety Net hook. Correct pattern: check `git status --short`
+first; if empty → unlock+remove with no flags; if dirty → classify files before unlocking.
+
+### Snapshot of v1.5.0 key state
+
+```yaml
+version: "1.4.0"   # note: frontmatter was not updated from 1.4.0 despite v1.5.0 history entry
+date: 2026-04-25
+```
+
+Key additions in v1.5.0: `[gone]` branch re-push safety check; verify work on main before any re-push.
+
+---
+
 ## v1.5.0 — 2026-04-25
 
 **Amendment**: ProjectTelemachy git hygiene session — `[gone]` branch re-push without checking if work already on main.

--- a/skills/worktree-cleanup-user-constraints.md
+++ b/skills/worktree-cleanup-user-constraints.md
@@ -6,14 +6,16 @@ description: "Use when cleaning up worktrees under user-specified constraints: (
   of dirty worktrees (artifact noise vs real work), generating a section-annotated cleanup script,
   handling files left orphaned in merged-branch working trees, the staged-file two-step
   (reset HEAD then checkout --) required when worktrees contain staged-only new files (status A),
-  all-clean direct execution, cherry=1 rebase-merge artifact handling, and the remove-worktree-keep-branch
-  pattern for closed-not-merged PRs."
+  all-clean direct execution, cherry=1 rebase-merge artifact handling, the remove-worktree-keep-branch
+  pattern for closed-not-merged PRs, and locked-but-clean worktrees from dead myrmidon agent sessions
+  (unlock+remove without --force)."
 category: tooling
-date: 2026-04-25
-version: "1.4.0"
+date: 2026-05-04
+version: "1.6.0"
 user-invocable: false
 verification: verified-ci
-tags: [worktree, cleanup, script, branches, artifacts, safety, merged-branch, circuit-breaker, staged-files, rebase-merge, closed-pr, gitignore]
+history: worktree-cleanup-user-constraints.history
+tags: [worktree, cleanup, script, branches, artifacts, safety, merged-branch, circuit-breaker, staged-files, rebase-merge, closed-pr, gitignore, locked-worktree, dead-agent]
 ---
 
 # Worktree Cleanup Under User Constraints
@@ -36,6 +38,7 @@ tags: [worktree, cleanup, script, branches, artifacts, safety, merged-branch, ci
 - 20+ worktrees need cleanup and some have dirty working trees
 - Agent-generated worktrees (`.claude/worktrees/agent-*`) accumulated from parallel runs
 - Worktree directories (`.worktrees/`, `.claude/worktrees/`) appear as untracked directories in `git status --short` of the main workspace
+- Locked worktrees (`git worktree list` shows `locked`) with dead agent PIDs from myrmidon swarm sessions — check cleanliness before deciding approach
 
 **All-clean worktrees allow direct execution (no script required):**
 
@@ -63,6 +66,15 @@ done
 ### Quick Reference
 
 ```bash
+# 0a. Detect locked worktrees (handle these first — Phase 0.7)
+git worktree list --porcelain | awk '/^worktree /{wt=$2} /^locked/{print wt " LOCKED"}'
+
+# 0b. For each locked worktree: check cleanliness
+git -C <locked-path> status --short   # empty = clean → unlock+remove directly
+
+# 0c. Locked+clean: no --force needed
+git worktree unlock <path> && git worktree remove <path>
+
 # 1. Classify every dirty worktree
 for wt in <dirty-worktrees>; do
   echo "=== $wt ===" && git -C "$wt" status --short
@@ -145,6 +157,62 @@ git commit -m "chore: gitignore worktree dirs and agent session artifacts"
 
 **Verification**: after the commit, `git status --short` in the main worktree should show
 no untracked lines for these paths.
+
+### Phase 0.7 — Handle Locked Worktrees
+
+**Locked worktrees from dead agent sessions can be unlocked and removed directly when clean.**
+
+The previous approach classified all locked worktrees as KEEP and printed manual unlock+force-remove
+commands for the user. This was wrong:
+- When the worktree is **clean** (empty `git status --short`), `git worktree remove` succeeds
+  without `--force` after unlock — no force needed, no user intervention required
+- When the worktree is **dirty**, the correct flow is: classify files → auto-commit real work →
+  push → PR → ask user about ambiguous files → then unlock+remove
+
+**Detection** — identify locked worktrees:
+
+```bash
+git worktree list --porcelain | awk '/^worktree /{wt=$2} /^locked/{print wt " LOCKED"}'
+```
+
+**Cleanliness check for locked worktrees**:
+
+```bash
+# For each locked worktree:
+git -C <locked-path> status --short   # empty output = clean
+```
+
+**Locked + clean → unlock and remove directly (no --force)**:
+
+```bash
+# For each locked worktree where git status --short is empty:
+git worktree unlock <path>
+git worktree remove <path>     # succeeds without --force on a clean worktree
+```
+
+**Locked + dirty → classify files first**:
+
+Follow Phase 1 classification before unlocking. After real work is committed/pushed:
+
+```bash
+git worktree unlock <path>
+# Clean artifacts (reset/checkout/clean as needed)
+git worktree remove <path>
+```
+
+**Artifact patterns to always ignore (never commit)**:
+
+```
+__pycache__/  *.pyc  *.pyo  *.pyd  .pytest_cache/  .mypy_cache/  .ruff_cache/
+build/  dist/  *.egg-info/  htmlcov/  .coverage  .coverage.*
+.claude-prompt-*.md  .issue_implementer
+```
+
+**After all locked worktrees are handled**:
+
+```bash
+git worktree prune
+```
 
 ### Phase 1 — Classify Dirty Worktrees
 
@@ -348,6 +416,7 @@ bash -n /tmp/<repo>-worktree-cleanup.sh && echo "Syntax OK"
 | `git checkout -- .` alone on staged-addition worktree | Ran `checkout -- .` then `git worktree remove` | `fatal: '<path>' contains modified or untracked files` — staged new files (status `A`) survived `checkout --` unchanged | Must run `reset HEAD -- .` first to unstage, then `checkout -- .`, then `clean -fd` |
 | Assuming cherry=1 means unreleased work | Three branches showed cherry=1 despite MERGED PRs | Rebase-merge rewrites commit hashes, so cherry count is 1 even though work is in main | Always check PR state first; cherry count is only meaningful when combined with PR=NONE or PR=CLOSED |
 | Skipping .gitignore hygiene | Cleaned up all worktrees but did not add worktree dirs to `.gitignore` | `.worktrees/` directory still appeared as untracked in `git status` after the next agent session because the directory itself was never gitignored | Run Phase 0.5 gitignore hygiene before cleanup — the cleanup removes the content but the directory must be gitignored to prevent re-accumulation |
+| Classify all locked worktrees as KEEP | Treated locked worktree status as ambiguous regardless of cleanliness; printed manual unlock+--force-remove command for user | Unnecessary — locked+clean worktrees (empty `git status --short`) can be unlocked and removed directly with no `--force`; Safety Net blocks `--force` anyway | Split on cleanliness first: locked+clean → `git worktree unlock` + `git worktree remove` (no flags); locked+dirty → classify files, commit real work, ask user about ambiguous files, then unlock+remove |
 
 ## Results & Parameters
 
@@ -372,6 +441,7 @@ def is_artifact(path: str) -> bool:
 | 17 | 0 dirty (all clean) | Direct execution | No script needed | ~1 min |
 | 36 | 6 dirty | Sequential script | 7 sections, ~120 lines | ~5 min |
 | 20-35 | Mixed | Same pattern | Adjust WORKTREES array | varies |
+| 13 | 0 dirty (locked, dead PIDs) | Direct unlock+remove (no script, no --force) | None needed | ~1 min |
 
 ### Real work found in merged-branch worktrees (this session)
 
@@ -386,3 +456,4 @@ def is_artifact(path: str) -> bool:
 | ProjectScylla | 11 stale myrmidon swarm worktrees, staged-addition failures caught on cleanup, all 11 removed cleanly | 2026-04-13; `reset HEAD -- .` + `checkout -- .` + `clean -fd` sequence verified effective |
 | ProjectOdyssey | 17 worktrees (1 main + 16 feature), all clean (0 dirty), 15 agent-* in `.claude/worktrees/`, cherry=1 on MERGED PRs = rebase artifacts | 2026-04-21; direct execution (no script); 1 CLOSED PR branch kept; all 17 worktrees removed, 0 `--force` needed |
 | AchaeanFleet | 13 worktrees accumulated, `.worktrees/`, `.claude/worktrees/`, `.coverage`, `.claude/scheduled_tasks.lock` untracked in main | 2026-04-25; Phase 0.5 gitignore hygiene added first (commit dcf3d43); `git status --short` clean after cleanup; verified-ci |
+| ProjectMnemosyne | 13 locked `worktree-agent-<hash>` worktrees from dead myrmidon swarm sessions, all `dirty=0` | 2026-05-04; all 13 unlocked and removed without `--force`; `git worktree prune` cleaned up; verified-local |


### PR DESCRIPTION
## Summary

Amends `worktree-cleanup-user-constraints` from v1.4.0 (effective v1.5.0) to v1.6.0.

- Adds Phase 0.7: handle locked worktrees from dead myrmidon swarm sessions — split on cleanliness before deciding approach
- Locked + clean (`git status --short` empty): `git worktree unlock` + `git worktree remove` with no `--force` needed
- Locked + dirty: classify files → commit real work → push → PR → ask user → then unlock+remove
- Documents artifact patterns to never commit from agent worktrees
- Adds new Failed Attempts row: classifying all locked worktrees as KEEP regardless of cleanliness
- Syncs frontmatter version to 1.6.0 (was stuck at 1.4.0 despite v1.5.0 history entry)

## Verification Level

**verified-local** — executed on 13 locked `worktree-agent-<hash>` worktrees in ProjectMnemosyne (2026-05-04); all dirty=0; all removed cleanly without `--force`.

CI validation pending.

## Key Findings

**What Worked**:
- `git worktree unlock <path>` followed by `git worktree remove <path>` (no `--force`) succeeds when `git status --short` is empty
- Checking cleanliness before choosing the approach avoids unnecessary user interruption
- Artifact patterns list (`__pycache__/`, `*.pyc`, `.pytest_cache/`, etc.) covers all agent session noise

**What Failed**:
- Classifying all locked worktrees as KEEP regardless of cleanliness → unnecessary manual work for user
- Using `--force` → blocked by Safety Net hook

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: locked, worktree, dead, agent, myrmidon, unlock

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>