### PR TITLE
fix(skills): remove orphaned conflict markers from fix-stale-agent-crossrefs and mojo-bitcast

### DIFF
--- a/skills/fix-stale-agent-crossrefs.md
+++ b/skills/fix-stale-agent-crossrefs.md
@@ -170,9 +170,6 @@ With the consolidated 4-agent section:
 | Running `just pre-commit-all` | `just: command not found` | `just` not installed on this host | Fall back to `pre-commit run --all-files` directly |
 | Running `npx markdownlint-cli2` directly | `npx: command not found` | Node.js not in PATH outside pixi env | Use `pixi run npx markdownlint-cli2` or rely on pre-commit hook |
 | `pixi run markdownlint-cli2` | `markdownlint-cli2: command not found` | pixi task not registered under that name | Rely on pre-commit hook for linting instead |
-<<<<<<< HEAD
-=======
 | Searching only `.claude/agents/` | Ran grep scoped to `.claude/agents/*.md` | Tracking docs in `docs/dev/` were missed | Always search the full repo, not just the agents directory |
 | Assuming hierarchy.md is the only doc to update | Only checked `agents/hierarchy.md` | Status/tracking docs like `agent-claude4-update-status.md` also list agents by name | Search recursively across all `*.md` files |
 | Replacing agent names without reading context | Applied sed-style bulk replace | Counting labels ("Review Specialists (10)") also need updating | Read surrounding context before editing; update counts too |
->>>>>>> 5783bcc7 (chore(skills): consolidate clusters B+G — absorb stale-agent-refs + multi-repo skills (sub-wave 1 remainder))

--- a/skills/mojo-bitcast-always-inline-crash-fix.md
+++ b/skills/mojo-bitcast-always-inline-crash-fix.md
@@ -218,19 +218,14 @@ The variant `tensor._data.bitcast[T]()[] = val` (no index, dereference at offset
 
 #### Why `AnyTensor.store()` / `AnyTensor.set()` Is Safe
 
-The internal `store()` method in `any_tensor.mojo`:
+The internal `store()`/`set()` method in `any_tensor.mojo`:
 
 ```mojo
 fn store[dtype: DType](self, index: Int, value: Scalar[dtype])
-```
-
-Uses `read` convention for `self` — the tensor stays alive through the entire call under Mojo's borrow semantics. The `bitcast` inside `store()` is safe because it operates on a live reference, not a temporary derived from ASAP-eligible value.
-
-The safe replacement `set()` signature:
-
-```mojo
 fn set[dtype: DType](mut self, index: Int, value: Scalar[dtype]) raises
 ```
+
+Uses `read` convention for `self` — the tensor stays alive through the entire call under Mojo's borrow semantics. The `bitcast` inside `store()`/`set()` is safe because it operates on a live reference, not a temporary derived from ASAP-eligible value.
 
 #### Discovery: Finding All Instances
 
@@ -494,8 +489,6 @@ grep -rc "\.set(" . --include="*.mojo" | grep -v ":0" | wc -l
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
->>>>>>> 46e270b6 (fix(skills): restore missing code blocks in clusters E, H, L1 — fixer pass)
-=======
 | ProjectOdyssey | shared/tensor/any_tensor.mojo — @always_inline fix, blog PR #4900, fix PR #4897, swarm PRs #5200–#5204 | [notes](./mojo-bitcast-always-inline-crash-fix.notes.md) |
 
 ## Related Skills


### PR DESCRIPTION
## Summary

Removes orphaned conflict markers left by prior consolidation PRs:

- `fix-stale-agent-crossrefs.md`: 3 Failed Attempts rows were stranded in the discarded conflict half — searching only `.claude/agents/`, assuming `hierarchy.md` is the only doc to update, and bulk-replacing without reading context
- `mojo-bitcast-always-inline-crash-fix.md`: consolidated `store()`/`set()` documentation and restored the Verified On table row that was cut off mid-conflict

## Verification

- [x] Both files now render cleanly with no conflict markers
- [x] Content is real improvements, not artifacts

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>