### PR TITLE
feat: amend podman-scratch-image-healthcheck-workaround skill (v1.1.0)

### DIFF
--- a/skills/podman-scratch-image-healthcheck-workaround.history
+++ b/skills/podman-scratch-image-healthcheck-workaround.history
@@ -1,0 +1,49 @@
+# podman-scratch-image-healthcheck-workaround — History
+
+## v1.1.0 (2026-05-05)
+
+**Changed by:** Atlas v0.2.0 distroless image rollout (`ghcr.io/homericintelligence/atlas:v0.2.0`, ~14.9 MB, `gcr.io/distroless/static-debian12:nonroot`)
+**Verification:** verified-local
+
+### What changed
+
+- Renamed scope: applies equally to **podman compose** and **docker compose** — `docker compose` was a separate confirmed reproduction, not just a theoretical extension.
+- Added the four-way audit checklist (Dockerfile `HEALTHCHECK`, compose `healthcheck:`, k8s `livenessProbe`/`readinessProbe` with `exec`, operator runbooks that say "exec into the container") as the Quick Reference. Whenever you switch a service to distroless / scratch / minimal, all four must be audited or they break silently.
+- Added the explicit alternatives table: drop healthcheck (recommended), switch to `distroless/static:debug-nonroot` (~5 MB busybox surface), build a `-healthcheck` flag into the binary (cleanest long-term), sidecar with curl (rejected — defeats single-container simplicity).
+- Added external-probe pattern: rely on Docker's process-up signal + external HTTP probes against `:PORT/livez` (liveness) and `:PORT/readyz` (readiness). The probes live outside the container, where wget/curl exist.
+- Added 1 new Failed Attempts row: `gcr.io/distroless/static-debian12:nonroot` + `wget` healthcheck → `OCI runtime exec failed: ... exec: "wget": executable file not found in $PATH`.
+- Added Atlas v0.2.0 to the Verified On table.
+- Bumped to v1.1.0 (minor — extends scope, adds checklist, adds findings; recommendation unchanged).
+
+### Why
+
+Original v1.0.0 was framed around podman + NATS scratch images. The Atlas v0.2.0 rollout produced an independent confirmation under docker compose with `gcr.io/distroless/static-debian12:nonroot` — same root cause (no shell, no wget, no curl in distroless), same fix (remove the in-container healthcheck and rely on external probes). Generalizing the skill keeps it findable for both podman and docker users, and the four-way audit closes the gap where operators forget to check k8s probes and runbooks even after fixing the compose file.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+---
+name: podman-scratch-image-healthcheck-workaround
+description: "Work around healthcheck failures for scratch/distroless container images in podman compose. Use when: (1) NATS or other scratch images fail CMD-SHELL healthchecks, (2) depends_on service_healthy blocks container startup, (3) minimal images have no shell or utilities."
+category: debugging
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - podman
+  - healthcheck
+  - scratch
+  - distroless
+  - nats
+  - compose
+---
+```
+
+Body covered: podman compose hangs because NATS scratch healthcheck `wget` fails; remove the healthcheck; change `depends_on: condition: service_healthy` to plain `depends_on: - name`; add connection retry loop in the dependent service. Failed attempts table covered `CMD-SHELL "wget ..."`, `CMD-SHELL "true"`, `CMD ["nats-server", "--help"]`, and `CMD-SHELL "nats-server --help > /dev/null 2>&1"`. Verified on Odysseus E2E compose with `nats:latest`.
+
+---
+
+## v1.0.0 (2026-03-30)
+
+**Initial version.** Documented the podman compose hang caused by NATS scratch images failing wget/sh-based healthchecks. Recommended removing the healthcheck and using start-order-only `depends_on` plus client-side retry loops.

--- a/skills/podman-scratch-image-healthcheck-workaround.md
+++ b/skills/podman-scratch-image-healthcheck-workaround.md
@@ -1,108 +1,169 @@
 ---
 name: podman-scratch-image-healthcheck-workaround
-description: "Work around healthcheck failures for scratch/distroless container images in podman compose. Use when: (1) NATS or other scratch images fail CMD-SHELL healthchecks, (2) depends_on service_healthy blocks container startup, (3) minimal images have no shell or utilities."
-category: debugging
-date: 2026-03-30
-version: "1.0.0"
+description: "Distroless / scratch / minimal-base container images cannot run shell-based HEALTHCHECK directives — no shell, no wget, no curl, no busybox. Use when: (1) switching a service to distroless / scratch / minimal base, (2) adding a HEALTHCHECK to a Dockerfile, (3) writing a docker-compose or podman-compose healthcheck: block, (4) a container reports unhealthy forever but the process is clearly running, (5) `docker exec <c> sh` returns 'exec format error' or 'no such file', (6) k8s exec-style livenessProbe/readinessProbe silently fails."
+category: tooling
+date: 2026-05-05
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: podman-scratch-image-healthcheck-workaround.history
 tags:
-  - podman
-  - healthcheck
-  - scratch
   - distroless
+  - scratch
+  - healthcheck
+  - dockerfile
+  - docker-compose
+  - podman
+  - kubernetes
+  - liveness
+  - readiness
   - nats
-  - compose
 ---
 
-# Podman Scratch Image Healthcheck Workaround
+# Distroless / Scratch Image Healthcheck — Shell Required But Absent
 
 ## Overview
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-03-30 |
-| **Objective** | Fix compose startup blocked by healthcheck failures on scratch/distroless images |
-| **Outcome** | Successful — remove healthchecks for scratch images, use simple depends_on |
-| **Verification** | verified-local |
+| **Date** | 2026-05-05 |
+| **Objective** | Stop shipping in-container healthchecks that silently fail forever on distroless / scratch / minimal-base images, and audit every place a shell-based probe might still be lurking when a service migrates to a minimal base. |
+| **Outcome** | Successful — drop the in-container healthcheck, rely on external HTTP probes (`/livez`, `/readyz`), or build a `-healthcheck` flag into the binary. |
+| **Verification** | verified-local — confirmed under both podman compose (NATS scratch) and docker compose (Atlas v0.2.0, `gcr.io/distroless/static-debian12:nonroot`). |
+| **History** | [changelog](./podman-scratch-image-healthcheck-workaround.history) |
 
 ## When to Use
 
-- `podman compose up` hangs because a dependency's healthcheck keeps failing
-- Container logs show: `exec: "sh": executable file not found` or `exec: "wget": executable file not found`
-- The failing container is a minimal/scratch/distroless image (NATS, etcd, CoreDNS, etc.)
-- Services that `depends_on: condition: service_healthy` never start
+- You are switching any service to `gcr.io/distroless/*`, `cgr.dev/chainguard/*`, `scratch`, or any `FROM scratch`-style minimal base.
+- You are adding a `HEALTHCHECK` instruction to a Dockerfile.
+- You are writing a `healthcheck:` block in `docker-compose.yml` or `podman-compose.yml`.
+- A container shows `up (unhealthy)` in `docker compose ps` / `podman ps` but the process is clearly running and external probes against the port return 200.
+- `docker exec <container> sh` returns `OCI runtime exec failed: ... executable file not found in $PATH` or "no such file or directory".
+- Kubernetes pods stay `NotReady` forever even though the app is healthy — and the probe is `exec:`-style.
+- `podman compose up` hangs because a dependency's healthcheck never goes healthy.
+- Service binaries log `exec: "wget": executable file not found` or `exec: "sh": executable file not found`.
 
 ## Verified Workflow
 
-### Quick Reference
+### Quick Reference — the four-way audit
+
+Whenever you switch a service to distroless / scratch / minimal (or any base without busybox), audit **all four** places a shell-based probe could be hiding. Every one of them breaks silently if you miss it.
+
+```text
+[ ] 1. Dockerfile          — `HEALTHCHECK CMD wget|curl|sh ...`     → remove or replace with binary-built probe
+[ ] 2. docker-compose.yml  — `healthcheck: test: ["CMD", "wget"...]` → remove the healthcheck: block
+[ ] 3. k8s manifests       — `livenessProbe:` / `readinessProbe:`    → switch `exec:` to `httpGet:` /
+                              with `exec: command: [sh|wget|curl]`     `tcpSocket:` / `grpc:`, OR build a
+                                                                        `-healthcheck` flag into the binary
+[ ] 4. operator runbooks   — "exec into the container and run X"      → rewrite to use external HTTP probe or
+                                                                         `kubectl debug` ephemeral container
+```
+
+### Recommended fix (taken on Atlas v0.2.0)
 
 ```yaml
-# WRONG — fails for scratch images:
+# WRONG — silently fails forever on distroless:
 services:
-  nats:
-    image: nats:latest
+  atlas:
+    image: ghcr.io/homericintelligence/atlas:v0.2.0  # gcr.io/distroless/static-debian12:nonroot
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8222/healthz"]
-  app:
-    depends_on:
-      nats:
-        condition: service_healthy  # blocks forever
+      test: ["CMD", "wget", "-qO-", "http://localhost:3002/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
-# CORRECT — simple ordering for scratch images:
+# CORRECT — no in-container probe; rely on external HTTP probes:
 services:
-  nats:
-    image: nats:latest
-    # No healthcheck — scratch image has no shell/tools
-  app:
-    depends_on:
-      - nats  # start-order only, no health condition
+  atlas:
+    image: ghcr.io/homericintelligence/atlas:v0.2.0
+    # No healthcheck: block. The binary is the only thing in the image.
+    # Liveness / readiness are checked from outside via:
+    #   curl http://localhost:3002/livez   → 200 if process is up
+    #   curl http://localhost:3002/readyz  → 200 only when every component is loaded,
+    #                                        enabled, and reporting valid results
 ```
 
 ### Detailed Steps
 
-1. Identify if the image is scratch/distroless: `podman exec <container> sh -c "true"` → `executable file not found`
-2. Remove the `healthcheck:` block entirely from that service
-3. Change all `depends_on: condition: service_healthy` to simple `depends_on: - name`
-4. Add retry logic in the dependent service (connection retry loop) instead of relying on compose health
+1. **Confirm the image is shell-less.** Run `docker exec <container> sh -c "true"` or `podman exec <c> sh -c "true"`. If you see `exec: "sh": executable file not found in $PATH`, the image has no shell and every CMD-SHELL / wget / curl probe is broken.
+2. **Remove the in-container probe at the source.** Delete `HEALTHCHECK` from the Dockerfile and `healthcheck:` from compose. Do not try to "fix" the probe with a different shell command — none of them work without a shell.
+3. **Replace `depends_on: condition: service_healthy` with plain `depends_on: - name`.** Health-conditional ordering deadlocks because the dependency never becomes healthy. Use start-order only and add a connection-retry loop in the dependent service.
+4. **Move probes outside the container.** Have the orchestrator (k8s, Nomad, an external monitor) hit `http://<host>:<port>/livez` and `/readyz` from outside. The probe runs in the orchestrator's environment, where `wget`/`curl`/HTTP libraries exist.
+5. **For k8s, switch `exec:` probes to `httpGet:` / `tcpSocket:` / `grpc:`.** These are evaluated by the kubelet, not inside the container — they don't need a shell.
+6. **(Optional, cleanest long-term)** Build a `-healthcheck` flag into the binary itself: `myapp -healthcheck` calls the same handler in-process and exits 0/1. The image stays minimal and `HEALTHCHECK CMD ["/myapp", "-healthcheck"]` works on distroless because it invokes the binary directly, not a shell.
+7. **Update operator runbooks.** Any step that says "exec into the container and run X" must be rewritten to use external HTTP probes or `kubectl debug` ephemeral containers (which inject a debug image alongside the target).
 
-### What scratch images lack
+### Alternatives considered
 
-| Tool | Available? | Used by |
-| ------ | ----------- | --------- |
-| `/bin/sh` | No | CMD-SHELL healthchecks |
-| `wget` | No | HTTP healthchecks |
-| `curl` | No | HTTP healthchecks |
-| `true` | No | Trivial healthchecks |
-| `which` | No | Tool detection |
-| The service binary | Yes | Only thing present |
+| Option | Image cost | Trade-off | Recommendation |
+| -------- | ----------- | --------- | --------------- |
+| Drop in-container healthcheck (taken) | 0 | Honest about distroless constraints; relies on external probes; orchestrator must do liveness/readiness checks. | **Default.** Pair with `/livez` + `/readyz` HTTP endpoints. |
+| Switch to `gcr.io/distroless/static:debug-nonroot` | +~5 MB | Restores busybox shell + wget; expands attack surface; defeats some of the distroless rationale. | Use for debugging only — not production. |
+| Build `-healthcheck` flag into the binary | 0 | Needs source code change; cleanest long-term solution; image stays minimal; works for HEALTHCHECK + k8s exec probes alike. | **Best long-term** when you own the binary. |
+| Sidecar container with curl | +sidecar | Adds infra complexity; defeats single-container-per-pod simplicity; multiplies pods. | Reject unless already running a sidecar mesh. |
+
+### What scratch / distroless images lack
+
+| Tool | `scratch` | `distroless/static:nonroot` | `distroless/static:debug-nonroot` | Used by |
+| ------ | ---------- | ----------------------------- | ----------------------------------- | --------- |
+| `/bin/sh` | No | No | Yes (busybox) | CMD-SHELL healthchecks, k8s `exec:` probes |
+| `wget` | No | No | Yes (busybox) | HTTP healthchecks |
+| `curl` | No | No | No | HTTP healthchecks |
+| `true` | No | No | Yes (builtin) | Trivial healthchecks |
+| `which` | No | No | Yes | Tool detection in scripts |
+| The service binary | Yes | Yes | Yes | Only thing reliably present |
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
-| `CMD-SHELL "wget ..."` | Shell-based HTTP healthcheck | No shell in scratch image | Scratch = no shell at all |
-| `CMD-SHELL "true"` | Simplest possible shell command | Still requires a shell to interpret "true" | Even `true` needs `/bin/sh` |
-| `CMD ["nats-server", "--help"]` | Use existing binary as health proxy | `nats-server --help` exits with code 1 (not 0) when already running | Binary help commands often return non-zero |
+| `CMD-SHELL "wget ..."` on `nats:latest` (podman compose) | Shell-based HTTP healthcheck | No shell in scratch image | Scratch = no shell at all |
+| `CMD-SHELL "true"` | Simplest possible shell command | Still requires `/bin/sh` to interpret `true` | Even `true` needs a shell |
+| `CMD ["nats-server", "--help"]` | Use existing binary as health proxy | `nats-server --help` exits with code 1 (not 0) when already running | Binary `--help` commands often return non-zero |
 | `CMD-SHELL "nats-server --help > /dev/null 2>&1"` | Redirect stderr/stdout | No shell to do the redirection | Same shell issue |
+| `CMD ["wget", "-qO-", "http://localhost:3002/healthz"]` against `gcr.io/distroless/static-debian12:nonroot` (Atlas v0.2.0, docker compose) | HTTP healthcheck via wget on distroless | `OCI runtime exec failed: exec failed: unable to start container process: exec: "wget": executable file not found in $PATH`. Container reported `unhealthy` forever; orchestrator never sent traffic. | distroless/static has no busybox — there is **no** wget, no curl, no shell. Either drop the healthcheck or switch to `:debug-nonroot` (busybox) or build a `-healthcheck` flag into the binary. |
 
 ## Results & Parameters
 
 ```yaml
-# Known scratch/distroless images affected:
-scratch_images:
-  - nats:latest (NATS server)
-  - nats:2.10 (NATS server)
-  - gcr.io/distroless/* (Google distroless)
-  - cgr.dev/chainguard/* (Chainguard images)
+# Known shell-less images affected:
+shell_less_images:
+  - nats:latest                                # NATS server (scratch base)
+  - nats:2.10                                  # NATS server (scratch base)
+  - gcr.io/distroless/static-debian12:nonroot  # Atlas v0.2.0
+  - gcr.io/distroless/base-debian12:nonroot
+  - gcr.io/distroless/cc-debian12:nonroot
+  - cgr.dev/chainguard/static                  # Chainguard static
+  - scratch                                    # FROM scratch
 
-# Workaround pattern for compose:
-pattern: |
-  Remove healthcheck from scratch image service.
-  Use simple depends_on (start-order only).
-  Add connection retry loop in dependent services.
+# Verified-local fix (Atlas v0.2.0):
+broken_state: |
+  $ docker compose up -d atlas
+  $ docker compose ps
+  NAME    STATE          STATUS
+  atlas   running        Up 12 seconds (unhealthy)
+  $ docker logs atlas | grep -i exec
+  OCI runtime exec failed: exec failed: unable to start container process:
+  exec: "wget": executable file not found in $PATH
 
-# Example retry in C++ (nats.c):
+fixed_state: |
+  # docker-compose.yml: removed healthcheck: block entirely
+  $ docker compose up -d atlas
+  $ docker compose ps
+  NAME    STATE          STATUS
+  atlas   running        Up 8 seconds
+  $ curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:3002/livez
+  200
+  $ curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:3002/readyz
+  200
+
+# External probe pattern (recommended):
+liveness:  GET http://<host>:<port>/livez   → 200 iff the process is up
+readiness: GET http://<host>:<port>/readyz  → 200 iff every component is loaded,
+                                              enabled, and reporting valid results
+
+# Example connection retry in C++ (nats.c):
 cpp_retry: |
   for (int i = 0; i < 30 && !connected; ++i) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
@@ -114,4 +175,5 @@ cpp_retry: |
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| Odysseus | E2E compose with NATS | nats:latest scratch image caused compose deadlock |
+| Odysseus | E2E compose with NATS (podman compose) | `nats:latest` scratch image caused compose deadlock under `service_healthy` |
+| Atlas v0.2.0 | `ghcr.io/homericintelligence/atlas:v0.2.0` (~14.9 MB, `gcr.io/distroless/static-debian12:nonroot`), docker compose | Pre-existing `wget`-based healthcheck failed with `exec: "wget": executable file not found`; fix was to drop the in-container healthcheck and rely on external `/livez` + `/readyz` probes |


### PR DESCRIPTION
## Summary

Amends `podman-scratch-image-healthcheck-workaround` from v1.0.0 to v1.1.0.

Generalizes the skill from "podman compose + NATS scratch" to all distroless / scratch / minimal-base container images, with an independent docker-compose reproduction from the Atlas v0.2.0 image rollout (`ghcr.io/homericintelligence/atlas:v0.2.0`, ~14.9 MB, `gcr.io/distroless/static-debian12:nonroot`).

- Same root cause across podman and docker compose: distroless / scratch images have no shell, no wget, no curl, no busybox — every CMD-SHELL / CMD ["wget"...] healthcheck silently fails forever.
- Same fix: drop the in-container healthcheck and rely on external HTTP probes (`/livez`, `/readyz`), or build a `-healthcheck` flag into the binary.
- Adds the four-way audit checklist (Dockerfile, docker-compose, k8s exec probes, operator runbooks) so operators don't fix the compose file and forget the k8s manifests or the runbook step that says "exec into the container."

## Verification Level

**verified-local** — confirmed against the Atlas v0.2.0 production image in both broken and fixed states.

- Broken state reproduced: `docker compose up` reports `up (unhealthy)`, `docker logs` shows `OCI runtime exec failed: ... exec: "wget": executable file not found in $PATH`.
- Fixed state confirmed: removing the healthcheck block lets the container come up cleanly; `curl http://localhost:3002/livez` returns 200 from outside the container.

CI validation pending — this is a knowledge artifact, not application code; behavior is verified against the production image at `ghcr.io/homericintelligence/atlas:v0.2.0`.

## Key Findings

**What Worked**:
- Removing the in-container `healthcheck:` block entirely (the default recommendation).
- Replacing in-container probes with external HTTP probes against `/livez` (process up) and `/readyz` (every component loaded, enabled, and reporting valid results).
- For k8s, switching `exec:` probes to `httpGet:` / `tcpSocket:` / `grpc:` (kubelet-evaluated, no in-container shell needed).
- Building a `-healthcheck` flag into the binary itself — image stays minimal, works for HEALTHCHECK + k8s exec probes alike.

**What Failed**:
- `CMD ["wget", "-qO-", "http://localhost:3002/healthz"]` against `gcr.io/distroless/static-debian12:nonroot` → `exec: "wget": executable file not found in $PATH`. distroless/static has no busybox at all.
- All shell-based fallbacks (`CMD-SHELL "true"`, `CMD-SHELL "binary --help"`) — they all need `/bin/sh`, which distroless does not have.
- Sidecar container with curl — rejected: defeats single-container-per-pod simplicity.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (988/988 valid)
- [x] History file `podman-scratch-image-healthcheck-workaround.history` created with v1.0.0 snapshot
- [x] Frontmatter `version` bumped to `1.1.0`, `date` updated to 2026-05-05, `history` field added
- [x] Skill `category` updated from `debugging` to `tooling` (matches the four-way audit nature of the skill)
- [ ] Verify skill appears in marketplace after merge
- [ ] Test discovery with keywords: distroless, scratch, healthcheck, "wget executable file not found", unhealthy, /livez

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>