### PR TITLE
[NITPICK] §5: remove --cov-report=html from default addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=scripts --cov-report=term-missing --cov-report=html"
+addopts = "--cov=scripts --cov-report=term-missing"
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
## Summary
- Remove `--cov-report=html` from `[tool.pytest.ini_options] addopts` in `pyproject.toml`
- This prevents `htmlcov/` from being generated on every test run including quick unit tests
- `--cov-report=term-missing` is retained for useful terminal output

## Test plan
- [ ] Run `pytest` and verify no `htmlcov/` directory is created
- [ ] Confirm coverage output still appears in terminal via term-missing

Closes #1491

🤖 Generated with [Claude Code](https://claude.com/claude-code)