### PR TITLE
[NITPICK] §7: add pytest-cov to pyproject.toml dev extras; confirm requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=9.0",
+    "pytest-cov>=7.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- `requires-python = ">=3.9"` was already present in `pyproject.toml`, confirming Python version compatibility is explicit
- `pytest-cov` was listed in `requirements-dev.txt` but missing from `[project.optional-dependencies]`, making `pip install -e .[dev]` incomplete — add `pytest-cov>=7.0` to sync both sources

## Test plan
- [ ] Verify `pip install -e .[dev]` installs `pytest-cov`
- [ ] Confirm `requires-python = ">=3.9"` is present in `pyproject.toml`

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)