### PR TITLE
[NITPICK] §13: add --help usage examples to validate_plugins.py

### DIFF
--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -11,8 +11,10 @@ Checks:
 - Quick Reference demotion check (should be ### not ##)
 """
 
+import argparse
 import re
 import sys
+import textwrap
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -242,8 +244,36 @@ def validate_plugin(filename: str) -> List[str]:
     return errors
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="validate_plugins.py",
+        description="Validate flat-format skill files (skills/*.md).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            examples:
+              # Validate all skill files in skills/
+              python3 scripts/validate_plugins.py
+
+              # Run from any directory (skills/ resolved relative to cwd)
+              cd /path/to/ProjectMnemosyne && python3 scripts/validate_plugins.py
+
+              # Pipe through grep to show only failing files
+              python3 scripts/validate_plugins.py 2>&1 | grep '^✗'
+
+              # Use in CI — exits 1 if any errors are found
+              python3 scripts/validate_plugins.py || exit 1
+            """
+        ),
+    )
+    return parser
+
+
 def main():
     """Main validation entry point."""
+    build_parser().parse_args()
+
     plugins = find_plugins()
 
     if not plugins:


### PR DESCRIPTION
## Summary
- Add `argparse` with `RawDescriptionHelpFormatter` and an `epilog` containing four usage examples to `scripts/validate_plugins.py`
- `python3 scripts/validate_plugins.py --help` now shows: basic invocation, directory-agnostic invocation, grep-filter pattern, and CI usage
- No behavioral change to the script's normal execution — existing callers are unaffected

## Test plan
- [ ] `python3 scripts/validate_plugins.py --help` shows usage examples
- [ ] `python3 scripts/validate_plugins.py` still validates all skill files normally
- [ ] All existing `test_validate_plugins.py` tests pass

Closes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)