### PR TITLE
chore: easy-issue sweep — refs #1481 (#1483/#1485/#1488/#1489 already-done)

### DIFF
--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Easy-sweep PR addressing 5 minor audit findings. Only **#1481** required code changes; the other four were already implemented on `main`.

## Per-issue status

- **#1481** §6 — floating runner: FIXED. `.github/workflows/update-marketplace.yml` now pins `ubuntu-24.04` instead of `ubuntu-latest`.
- **#1483** §8 — security policy: ALREADY-DONE. `SECURITY.md` exists at repo root.
- **#1485** §10 — issue/PR templates: ALREADY-DONE. `.github/ISSUE_TEMPLATE/{bug-report.md,skill-request.md}` and `.github/PULL_REQUEST_TEMPLATE.md` all exist.
- **#1488** §13 — coverage HTML pollution: ALREADY-DONE. `pyproject.toml` `addopts` is `--cov=scripts --cov-report=term-missing`; no `--cov-report=html`.
- **#1489** §15 — code of conduct: ALREADY-DONE. `CODE_OF_CONDUCT.md` exists at repo root.

The four already-done issues will be closed with the evidence above as comments.

Refs #1481, #1483, #1485, #1488, #1489

## Test plan

- [x] `git diff --stat` shows 1 file / 1 insertion / 1 deletion
- [ ] CI green on the pinned runner