### PR TITLE
feat: amend multi-repo-pr-orchestration-swarm-pattern skill (v2.1.0)

### DIFF
--- a/skills/multi-repo-pr-orchestration-swarm-pattern.history
+++ b/skills/multi-repo-pr-orchestration-swarm-pattern.history
@@ -3,8 +3,43 @@
 # Each entry records what changed and why; full snapshots for major versions only.
 ---
 
-<<<<<<< HEAD
-=======
+## v2.1.0 — 2026-05-10
+
+**Changed by**: Multi-repo CI sweep + easy-issue dispatch session 2026-05-10 (12 repos / 18 PRs / 17 merged auto-squash)
+**Session context**: HomericIntelligence ecosystem-wide sweep (Wave 1 CI fixes + Wave 2 easy-issue dispatch + Wave 3 Odysseus pin bump), 2026-05-10
+
+**Verification**: verified-ci
+
+### What Changed
+
+- Bumped version 2.0.0 → 2.1.0; date updated to 2026-05-10
+- Verified On: appended new entry for 2026-05-10 12-repo / 18-PR sweep
+- Failed Attempts: appended new row for Mnemosyne `Update Marketplace` direct-commit pattern + branch-protection bypass-actor caveat
+- Phase 2 (Wave 1) "Auto-merge disabled detection": corrected stale claim that AchaeanFleet has auto-merge disabled — `allow_auto_merge` is now `true`; only Myrmidons remains disabled in the in-scope set
+- Phase 0 (Supplemental): added empirical ALREADY-DONE closure rate at scale (16/49 = ~33%) from the 2026-05-10 session
+
+### Why
+
+- AchaeanFleet auto-merge status data point in v2.0.0 was stale and contradicted by 2026-05-10 evidence — corrected
+- Direct-commit workflow pattern (Mnemosyne marketplace) needs a branch-protection bypass-actor entry to actually land; v2.0.0 omitted that caveat
+- Phase 0 mentioned the ALREADY-DONE preflight automation but did not quantify its return — 33% session closure rate is verified-effective ROI worth documenting
+
+### v2.0.0 frontmatter snapshot
+
+```yaml
+name: multi-repo-pr-orchestration-swarm-pattern
+version: "2.0.0"
+date: 2026-04-23
+category: ci-cd
+user-invocable: false
+verification: verified-ci
+history: multi-repo-pr-orchestration-swarm-pattern.history
+```
+
+Unchanged sections (Quick Reference, Phase 1, Phase 3 Wave 1b, Phase 4 Wave 1c, Phase 5 Wave 2, Phase 4b CI triage, Phase 6 Verification, Results & Parameters, References) carried forward as-is — see git history at the v2.0.0 tip for the full text. Only the AchaeanFleet sentence in Phase 2, the Phase 0 quantification paragraph, and the Verified On + Failed Attempts tables were modified between v2.0.0 and v2.1.0.
+
+---
+
 ## v2.0.0 (2026-05-03)
 
 Absorbed: multi-repo-automation-loop-shell-script (v1.0.0), multi-repo-pr-triage (v1.0.0)
@@ -25,7 +60,6 @@ Code blocks added: 10 new blocks (2 from automation-loop + 8 from pr-triage); po
 
 ---
 
->>>>>>> 5783bcc7 (chore(skills): consolidate clusters B+G — absorb stale-agent-refs + multi-repo skills (sub-wave 1 remainder))
 ## v1.2.0 — 2026-04-23
 
 **Changed by**: Odysseus issue closeout session (Issues #102, #76, #136)

--- a/skills/multi-repo-pr-orchestration-swarm-pattern.md
+++ b/skills/multi-repo-pr-orchestration-swarm-pattern.md
@@ -2,8 +2,8 @@
 name: multi-repo-pr-orchestration-swarm-pattern
 description: "Orchestrate PR management across all HomericIntelligence repos using myrmidon swarm. Use when: (1) multiple repos have open PRs that need merging, conflict resolution, or CI fixes, (2) Odysseus submodule pins need updating after cross-repo PR merges, (3) coordinating parallel waves of agents across 5+ repos with sequential-within-repo merge ordering, (4) a PR branch has a duplicate commit that's already on main and needs rebase, (5) mergeStateStatus is BLOCKED but statusCheckRollup is empty — CI may not have started yet, (6) running hephaestus-plan-issues and hephaestus-implement-issues across 10+ repos in a cron-style automation loop, (7) multiple repos have failing PRs that need CI diagnosis and fixing via parallel sub-agents, (8) CI failures share common root causes across repos (org policy, missing images, deprecated syntax, formatting)."
 category: ci-cd
-date: 2026-04-23
-version: "2.0.0"
+date: 2026-05-10
+version: "2.1.0"
 user-invocable: false
 verification: verified-ci
 tags: [multi-repo, PR, merge, submodule, myrmidon-swarm, cross-repo, orchestration, odysseus, duplicate-commit, pin-audit, automation-loop, pixi, pythonpath, gh-cli, rate-limit, ci-triage, org-policy, container-image]
@@ -120,7 +120,7 @@ gh api repos/HomericIntelligence/$REPO --jq '.allow_auto_merge'
 # Also check branch protection:
 gh api repos/HomericIntelligence/$REPO/branches/main --jq '.protection.required_status_checks'
 ```
-Repos with auto-merge disabled (e.g., AchaeanFleet, Myrmidons) require direct `gh pr merge --rebase` once CI is green. Do **not** use `gh pr merge --auto --rebase` on these repos — it produces a GraphQL error.
+As of 2026-05-10: AchaeanFleet's `allow_auto_merge` is now `true`; only Myrmidons remains with auto-merge disabled in the in-scope set. Always re-verify per-session — these settings change. Cmd: `gh api repos/HomericIntelligence/<repo> --jq '.allow_auto_merge'`. Repos with auto-merge disabled require direct `gh pr merge --rebase` once CI is green. Do **not** use `gh pr merge --auto --rebase` on those repos — it produces a GraphQL error.
 
 **Model tier selection**:
 - **Haiku**: sufficient for clean merges (mechanical: check status, run `gh pr merge`)
@@ -364,6 +364,13 @@ if plan_script.exists():
 - GraphQL quota: 5000 requests/hour; 14 repos × prefetch calls exhausts quota in ~1 full run
 - RuntimeWarning on `-m` invocations: `<frozen runpy>:128: RuntimeWarning: 'hephaestus.automation.planner' found in sys.modules after import of package 'hephaestus.automation'` — safe to ignore, suppress with `PYTHONWARNINGS=ignore::RuntimeWarning`
 
+**Empirical ALREADY-DONE rate at scale (2026-05-10 session):** Across 49 candidate
+"easy" issues (severity:minor + [Audit] Minor titles) curated for 10 sub-agents,
+16 (33%) were closed as ALREADY-DONE during per-agent verification gates BEFORE
+any code was written. Audit issues filed >2 weeks ago go stale particularly fast
+in this ecosystem; running the `already-done-issue-detection` Quick-Reference checks
+in every dispatch prompt is verified-effective and saves ~33% of agent-budget at scale.
+
 ### Phase 4b (Supplemental): CI Triage — Root Cause Categorization
 
 When diagnosing CI failures across multiple repos, categorize before spawning fix agents:
@@ -500,6 +507,7 @@ git status
 | Assume alias→comptime is the only Mojo blocker | Only searched for `alias` keyword | Other blockers existed: unused var (--Werror), type mismatch (Float64 vs Int) | After fixing the stated issue, run the compiler to discover additional blockers |
 | Add pull-requests: write to workflow YAML | Added permission to "Update Marketplace" workflow | GitHub org policy overrides YAML permissions — `default_workflow_permissions: read` takes precedence | Org-level default_workflow_permissions takes precedence over workflow YAML; switch to direct-commit pattern instead |
 | Reference custom CI container before it's built | Used ghcr.io image in workflows on PR branches | Image only gets built on merge to main, not during PR runs | Don't reference custom CI images in workflows until the image build pipeline is proven to work; check `docker manifest inspect <image>` first |
+| Mnemosyne `Update Marketplace` workflow direct-commit pattern shipped, declared a fix | Workflow now uses `git commit && git push origin main` from `github-actions[bot]` instead of the PR-creation step. Lands cleanly in workflow file but UNTESTED until next `skills/**` or `plugins/**` push triggers it. Branch protection ruleset 15556493 may still reject the direct push because the bot is not in the bypass-actors list | The web-UI bypass-actors list (Settings > Rules > Rulesets > 15556493 > Bypass list) is the authoritative source; YAML `permissions:` and direct-commit pattern do NOT bypass branch-protection rulesets. Cannot be configured via API (HTTP 403) | Whenever you ship the direct-commit pattern as a fix for the org-Actions-PR-creation policy, ALSO open a follow-up to add `github-actions[bot]` to the relevant ruleset's bypass actors via the web UI. Flag to user; do not assume the workflow file change alone is sufficient |
 
 ## Results & Parameters
 
@@ -592,6 +600,7 @@ gh pr checks $PR_NUM --repo HomericIntelligence/$REPO
 | ProjectMnemosyne | Marketplace workflow broken by org policy, CI triage session 2026-03-15 | org-level `can_approve_pull_request_reviews: false` → switched to direct-commit pattern |
 | ProjectScylla | Missing CI container image, CI triage session 2026-03-15 | Removed container blocks from workflows; added README.md to Containerfile COPY |
 | ProjectKeystone | clang-format violations + Dockerfile issues on Dependabot PR, CI triage session 2026-03-15 | Docker clang-format-18 run to format 30 files; removed 3 stale COPY lines; supply-chain-scanning flagged as manual action |
+| HomericIntelligence ecosystem | 12 repos (excl. ProjectOdyssey + ProjectHephaestus), 18 sweep PRs (8 CI fix + 10 easy-issue), Wave 1 + Wave 2 + Wave 3 (Odysseus pin bump), 2026-05-10 | 17/18 PRs auto-squash-merged within ~30min; ProjectCharybdis #219 escalated (Conan/gcc-14 chain) and manually merged by user. ALREADY-DONE preflight closed 16 of 49 candidate issues (~33%) before agents started writing code. AchaeanFleet auto-merge confirmed ENABLED (skill v2.0.0 said disabled — now corrected). Mnemosyne marketplace direct-commit pattern landed but UNTESTED in CI as of session end (no `skills/**` push triggered yet) |
 
 ## References
 


### PR DESCRIPTION
## Summary

Amends `skills/multi-repo-pr-orchestration-swarm-pattern` (v2.0.0 -> v2.1.0) with findings from the 2026-05-10 multi-repo CI sweep + easy-issue dispatch session (12 repos, 18 PRs, 17 auto-squash-merged, 1 manually escalated).

- Corrected stale data point: AchaeanFleet `allow_auto_merge` is now `true` (was disabled in v2.0.0); only Myrmidons remains disabled in the in-scope set.
- Added new Failed Attempts row covering the Mnemosyne `Update Marketplace` direct-commit pattern caveat: workflow YAML changes do NOT bypass branch-protection rulesets; `github-actions[bot]` must be added to the ruleset's bypass actors via the web UI (HTTP 403 on API).
- Quantified Phase 0 ALREADY-DONE preflight ROI: 16/49 candidate issues (~33%) closed before any code was written.
- Appended new "Verified On" row for the 2026-05-10 sweep.
- Cleaned leftover merge-conflict markers in the `.history` file.

History file: appended v2.1.0 entry on top with a v2.0.0 frontmatter snapshot and a note pointing to git for unchanged sections (skill is large).

## Test plan

- [x] `python3 scripts/validate_plugins.py` -> 1024/1024 valid
- [ ] Skill renders correctly in next consumer (downstream agents reading from main)
- [ ] AchaeanFleet auto-merge correction is reflected in next multi-repo sweep dispatch prompt

Generated with Claude Code