### PR TITLE
feat: add debugging-argparse-ambiguous-flag-silent-mismatch skill

### DIFF
--- a/skills/debugging-argparse-ambiguous-flag-silent-mismatch.md
+++ b/skills/debugging-argparse-ambiguous-flag-silent-mismatch.md
@@ -1,0 +1,163 @@
+---
+name: debugging-argparse-ambiguous-flag-silent-mismatch
+description: "Python argparse silently accepts prefix-matching flag abbreviations by default — `--require X` may be parsed as `--requirement X` (or any other `--req...` flag) without warning. Combined with `|| true` or `|| echo \"::warning::\"`, the resulting argparse exit-2 is swallowed and the command appears advisory while doing nothing. Use when: (1) a Python CLI in CI has been silently no-op'ing for an unknown duration, (2) you removed a `|| true` wrapper around a `pip-audit` / `pytest` / similar tool and discovered the underlying invocation was broken all along, (3) reviewing CLI invocations after a forbid-suppressions sweep, (4) auditing scripts for ambiguous-flag risk."
+category: debugging
+date: 2026-05-11
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - argparse
+  - python-cli
+  - silent-flag-mismatch
+  - prefix-matching
+  - allow_abbrev
+  - pip-audit
+  - cli-debugging
+  - silent-noop
+---
+
+# Debugging argparse Ambiguous Flag Silent Mismatch
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-11 |
+| **Objective** | Diagnose Python CLIs that silently accept ambiguous flag abbreviations (e.g., `--require` → `--requirement`), causing the command to no-op while a `\|\| true` or `::warning::` wrapper hides the exit code. |
+| **Outcome** | Root-caused HomericIntelligence/AchaeanFleet#656's broken `pip-audit --require aider-chat` invocation — argparse was prefix-matching `--require` to `--requirement <file>` (which then failed because file `aider-chat` didn't exist). The audit step had been a complete no-op for weeks while masquerading as 'advisory'. |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A Python CLI in CI has been failing silently — you suspect it's never actually run.
+- After removing a `|| true` / `continue-on-error: true` / `::warning::` wrapper, the underlying invocation produces an argparse error (exit 2) instead of the expected output.
+- Reviewing CI workflow steps that use flags like `--require`, `--ignore`, `--exit`, `--out`, `--no-` — any short, ambiguous-prefix flag.
+- Auditing existing scripts after a forbid-suppressions sweep — search for invocations of common Python CLIs (pip-audit, pytest, mypy, ruff, sphinx-build, gunicorn) with potentially-ambiguous flags.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Diagnose: run the bare command, read stderr for the actual flag argparse picked
+<tool> <args>  # observe argparse error message; look for "--<expanded>"
+
+# Confirm: check --help for prefix-matching ambiguity
+<tool> --help 2>&1 | grep -E "^\s*--<short-form>"
+
+# Mitigation in your own argparse code:
+parser = argparse.ArgumentParser(allow_abbrev=False)
+```
+
+### Step 1: Reproduce the broken invocation directly
+
+Strip the suppression wrapper and run the bare command:
+
+```bash
+# WAS in CI:
+# if ! pip-audit --desc --require aider-chat; then echo "::warning::..."; fi
+
+# Run bare:
+pip-audit --desc --require aider-chat
+# Observe stderr — likely an argparse error
+```
+
+argparse error output:
+
+```
+pip-audit: error: argument --requirement: can't open 'aider-chat': [Errno 2] No such file or directory: 'aider-chat'
+```
+
+The clue is `--requirement` in the error message, even though the script wrote `--require`. argparse's `allow_abbrev=True` default expanded the prefix.
+
+### Step 2: Confirm with `--help` and grep for ambiguous prefixes
+
+```bash
+pip-audit --help 2>&1 | grep -E "^\s*--" | head -30
+# Output includes:
+#   --requirement REQUIREMENT, -r REQUIREMENT
+#   --require-hashes
+# Both start with --require, so any abbreviation --req or --require is ambiguous (or specific to one of them).
+```
+
+In pip-audit's case, `--require` matches the longest unique prefix of `--requirement` (because `--require-hashes` has a hyphen after `--require`). So argparse picks `--requirement`. Subtle.
+
+### Step 3: Fix the invocation
+
+Choose the correct flag from `--help`. For pip-audit (the AchaeanFleet case), there's no `--require <package>` — pip-audit audits the current environment by default, or `-r <requirements.txt>` for a file. The user clearly intended "audit only the env after installing aider-chat" — which means the wrapper should be:
+
+```bash
+# Right invocation:
+pip install --quiet aider-chat
+pip-audit  # audits the current env, including aider-chat
+```
+
+Not `pip-audit --require aider-chat` at all. The original author misremembered the CLI shape.
+
+### Step 4: Audit codebase for similar risk
+
+```bash
+# Find Python CLI invocations with short flag prefixes:
+grep -rn -E '\b(pip-audit|pytest|mypy|ruff|sphinx-build|gunicorn|uvicorn|black|isort|coverage)\b.*--[a-z]{3,5}\b' \
+  .github/ scripts/ tests/ 2>/dev/null
+
+# For each match, run `<tool> --help | grep -E '^\s*--<prefix>'` and verify
+# only ONE flag matches the abbreviation. If multiple match, argparse will
+# raise an error (newer Python) or prefix-match silently (older Python).
+```
+
+### Step 5: For your own argparse code, set `allow_abbrev=False`
+
+If you maintain a Python CLI:
+
+```python
+import argparse
+parser = argparse.ArgumentParser(allow_abbrev=False)  # Default is True in Python 3.5+
+```
+
+This forces users to spell flag names in full and surfaces typos immediately.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---|---|---|---|
+| 1 | Assumed `pip-audit --require aider-chat` was an obscure pip-audit feature for "audit only this package" | pip-audit has no `--require <package>` flag. argparse prefix-matched to `--requirement <file>`, then file-open failed. Silent fail-then-suppress for weeks. | Always check `<tool> --help` before assuming a flag exists. If a flag is unfamiliar, grep the tool's docs. |
+| 2 | Re-added `\|\| true` after seeing the bare command fail, hoping it was just a flaky run | Banned by `ci-cd-forbid-suppressions-pygrep-lint-guard` v1.0.0. Also: the failure was deterministic argparse rejection, not flakiness. | When removing a suppression surfaces a deterministic error, fix the underlying invocation. Re-suppressing hides the same bug for another N weeks. |
+| 3 | Tried `pip-audit -r aider-chat` (the short form of `--requirement`) | Same problem — `-r aider-chat` is `--requirement aider-chat`, which expects a requirements file path. Just the bug, spelled differently. | The fix isn't a flag rename; it's understanding what the tool actually does. pip-audit audits the current Python env; you install the package first, then audit. |
+| 4 | Assumed argparse would error on ambiguous flags | Default `allow_abbrev=True` (Python 3.5+) means argparse silently picks the longest unique prefix-matching flag. Only raises `unambiguous flag` if MULTIPLE flags match the same prefix; if exactly one matches, expansion happens silently. | For predictable behavior, set `allow_abbrev=False` in your own argparse code. For consumed CLIs, never abbreviate flags — always use the full name. |
+| 5 | Tried `pip-audit --require=aider-chat` (with `=`) hoping argparse handled it differently | Same expansion. Doesn't matter; `--require=X` is parsed identically to `--require X` for ambiguity purposes. | The `=` syntax doesn't change argparse's prefix-matching behavior. |
+| 6 | Searched the codebase for `--require ` (with trailing space) and found nothing else affected | Doesn't generalize to other ambiguous flags. A real audit needs to check every Python-CLI invocation systematically. | Use the broader regex in Step 4 to audit the whole codebase, not just the same flag. |
+
+## Results & Parameters
+
+The AchaeanFleet#656 root-cause analysis:
+
+- Original invocation: `if ! pip-audit --desc --require aider-chat; then echo "::warning::pip-audit reported vulnerabilities…"; fi`
+- argparse expanded: `--require` → `--requirement`
+- pip-audit attempted to open file `aider-chat`: `Errno 2 No such file or directory`
+- pip-audit exited 2 (argparse-style error exit)
+- `if !` wrapper saw non-zero, emitted `::warning::pip-audit reported vulnerabilities…`
+- **No actual audit ran** for the duration the workflow had been in this form (weeks per git log)
+
+Fixed invocation:
+
+```yaml
+- name: pip-audit
+  run: |
+    set -euo pipefail
+    pip install --quiet pip-audit aider-chat
+    # 57 transitive CVEs allowlisted per HomericIntelligence/AchaeanFleet#655 (review 2026-08-10)
+    pip-audit --desc \
+      --ignore-vuln <ID-1> \
+      --ignore-vuln <ID-2> \
+      ...
+```
+
+Result after fix: 57 unique CVE IDs across 14 packages (aiohttp, diskcache, filelock, gitpython, litellm, pillow, pip, protobuf, pyasn1, pygments, python-dotenv, requests, setuptools, urllib3) surfaced. All allowlisted with issue #655.
+
+## Verified On
+
+| Project | Context | Details |
+|---|---|---|
+| HomericIntelligence/AchaeanFleet | PR #656 + issue #655 — pip-audit step had been a silent no-op since added; argparse prefix-match was the root cause | Fixed invocation, allowlisted 57 transitive CVEs; CI security/dependency-scan now actually runs |


### PR DESCRIPTION
## Summary
- New skill: `skills/debugging-argparse-ambiguous-flag-silent-mismatch.md`
- Diagnoses Python CLIs that silently no-op due to argparse's default `allow_abbrev=True` prefix-matching, combined with `|| true` / `::warning::` suppression wrappers
- Verified via HomericIntelligence/AchaeanFleet#656: `pip-audit --require aider-chat` expanded to `--requirement aider-chat`, file-open failed with exit 2, `if !` swallowed the failure for weeks

## Verification
- `python3 scripts/validate_plugins.py`: 1035/1035 valid
- `verification: verified-ci` (CI in AchaeanFleet's `ci.yml` confirms the fix surfaces 57 transitive CVEs after invocation fix)

## Test plan
- [x] Validator passes (1035/1035)
- [x] Skill follows flat `skills/` layout
- [x] Frontmatter complete (name, description, category, date, version, user-invocable, verification, tags)
- [x] Includes Overview, When to Use, Verified Workflow (with Quick Reference h3), Failed Attempts, Results & Parameters, Verified On

🤖 Generated with [Claude Code](https://claude.com/claude-code)