### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -257,10 +257,10 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           else
             gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           fi
 
       - name: Upload Gitleaks SARIF

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -93,7 +93,6 @@ tags: []
 - ❌ `scripts/migrate_to_skills.py` — Old migration tool
 - ❌ `scripts/fix_failed_attempts_tables.py` — One-off fixup
 - ❌ `scripts/fix_validation_warnings.py` — One-off fixup
-- ❌ `scripts/fix_remaining_warnings.py` — One-off fixup
 - ❌ `scripts/add_user_invocable.py` — One-off fixup
 - ❌ `templates/experiment-skill/` — Old nested template
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-mnemosyne"
-version = "0.1.0"
+version = "2.1.0"
 description = "Skills marketplace for the HomericIntelligence agentic ecosystem"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-mnemosyne"
-version = "0.1.0"
+version = "2.1.0"
 description = "Skills marketplace for the HomericIntelligence agentic ecosystem"
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
Part of the 2026-05-11 ecosystem-wide easy-issue sweep.

## Implemented

- Closes #1474 — bump pyproject.toml + pixi.toml version 0.1.0 -> 2.1.0 to match plugin.json (pyproject.toml:3, pixi.toml:3).
- Closes #1469 — remove stale `❌ scripts/fix_remaining_warnings.py` entry from MIGRATION_STATUS.md (file still exists with 209 lines and 13 tests).
- Closes #1479 — switch Gitleaks to `--exit-code 1` so secrets findings block PRs, per HomericIntelligence/Odysseus@fa0294f (.github/workflows/_required.yml:260,263).

## Verified ALREADY-DONE (closed without commits)

- Closes #1487 — `justfile` is present at repo root with `validate`/`test`/`check`/`generate-marketplace` recipes.
- Closes #1481 — `.github/workflows/update-marketplace.yml:17` already uses `runs-on: ubuntu-24.04` (pinned).
- Closes #1478 — `.coverage` is no longer tracked (`git ls-files .coverage*` returns empty); also gitignored.
- Closes #1477 — `.gitignore:17-19` already lists `.coverage`, `.coverage.*`, and `htmlcov/`.
- Closes #1466 — `htmlcov/` is in `.gitignore:19`.

## Skipped (out of scope for this sweep)

- #1486 (pyproject simplification) — design discussion, not a one-line change.
- #1484 (path traversal in `migrate_ecosystem_skills.py`) — requires real sanitization logic + tests; >50 LoC.
- #1482 (canonical dependency-spec doc) — needs docs and team decision; not a sweep-sized change.
- #1480 (pixi-check warning when pixi.lock missing) — `pixi.lock` exists in this repo, so the warning never fires; the workflow is shared infra (`_required.yml`) and changing it is out of scope.
- #1476, #1475 (0% test coverage) — test authoring is medium difficulty, well over 50 LoC.
- #1473 (third hand-rolled `parse_frontmatter`) — refactor across 3 implementations is medium-sized.
- #1472 (duplicate `find_skill_files`) — refactor + caller updates, medium-sized.
- #1471 (`validate_skill_md` dead code) — function is actually still used by `tests/test_quick_reference_transform.py` (3 call sites); the issue's "no caller" claim is incorrect.
- #1470 (3 open MIGRATION_STATUS items lack tracking issues) — issue triage/creation work, not a code change.
- #1468 (.claude/shared/plugin-standards.md documents stale nested format) — full rewrite, >50 LoC.
- #1465 (`plugins/tooling/mnemosyne/` relic) — CLAUDE.md:79 explicitly designates this directory as the active command infrastructure for `/advise` and `/learn`; removing it would break documented behavior.