### PR TITLE
feat: amend close-issue-via-minimal-pr skill (v1.2.0) — batch ALREADY-DONE CLOSES_GAP

### DIFF
--- a/skills/close-issue-via-minimal-pr.history
+++ b/skills/close-issue-via-minimal-pr.history
@@ -1,5 +1,36 @@
 # close-issue-via-minimal-pr — History
 
+## v1.2.0 (2026-05-11)
+
+**Changed by:** HomericIntelligence ecosystem-wide easy-issue sweep 2026-05-11
+**Verification:** verified-ci
+
+### What changed
+- Added new "When to Use" trigger: batch ALREADY-DONE issue handling (≥10 issues per PR body)
+- Added new "Batch ALREADY-DONE in PR body" section to Verified Workflow with the per-issue `Closes #N` requirement
+- Added empirical CLOSES_GAP rate (3 of 11 PRs = 27% in 2026-05-11 sweep)
+- Added verifier check command for counting `Closes #` matches in PR body
+- Added fix-wave recovery snippet for closing gapped issues post-merge (with `unset GITHUB_TOKEN GH_TOKEN` chain)
+- Added 3 new Failed Attempts rows covering the batch CLOSES_GAP failure mode (`- #N: <evidence>` bullet lists, `Refs #N`, sweep-agent report-vs-body mismatch)
+- Added "Verified On" rows for Argus #502, Hermes #614, Nestor #77
+- Bumped date to 2026-05-11
+
+### Why
+During the 2026-05-11 ecosystem-wide easy-issue sweep, 3 of 11 sweep PRs (27%) listed
+ALREADY-DONE issue numbers in the PR body without the `Closes #N` keyword (using bare bullets
+like `- #N: <evidence>` or `Refs #N`). Those issues remained open after PR merge — the failure
+is silent at merge time. Implementer agents handling batches of ≥10 ALREADY-DONE issues were
+especially prone to this error, often rationalizing it as "the Closes lines elsewhere will close
+them". Each issue requires its own `Closes #N` keyword in the PR body. The v1.1.0 skill already
+covered the single-issue "Closes part of #N" failure but did not address the batch case.
+
+### Previous version (v1.1.0) snapshot
+
+See git history at the commit immediately preceding v1.2.0 for the full v1.1.0 file content.
+The diff against this version shows exactly what changed.
+
+---
+
 ## v1.1.0 (2026-04-23)
 
 **Changed by:** Odysseus issue closeout session (Issues #102, #76, #136)

--- a/skills/close-issue-via-minimal-pr.md
+++ b/skills/close-issue-via-minimal-pr.md
@@ -4,10 +4,12 @@ description: 'Close a GitHub issue when all code already exists on main but the 
   is still open. Use when: (1) a verification/CI-check issue has no outstanding code
   changes, (2) the feature branch has zero diff from main, (3) you need a minimal
   commit to create a PR that triggers CI and closes the issue, (4) a merged PR did
-  not auto-close the issue because the commit keyword was wrong.'
+  not auto-close the issue because the commit keyword was wrong, (5) a batch sweep
+  PR closes 10+ ALREADY-DONE issues at once and each one needs its own Closes #N
+  keyword in the PR body.'
 category: ci-cd
-date: 2026-04-23
-version: 1.1.0
+date: 2026-05-11
+version: 1.2.0
 user-invocable: false
 verification: verified-ci
 history: close-issue-via-minimal-pr.history
@@ -32,6 +34,8 @@ history: close-issue-via-minimal-pr.history
 - The issue is a follow-up from a prior issue ("Follow-up from #XXXX")
 - CI glob pattern already covers the relevant test files (confirmed via `grep` on workflow YAML)
 - A PR already merged but the issue remained open because the closing keyword was wrong (e.g., "Closes part of #N")
+- A batch sweep PR (chore/easy-sweep, ecosystem-wide audit) closes ≥10 ALREADY-DONE issues in a single PR body — each issue MUST have its own `Closes #N` line; bare bullet lists like `- #N: <evidence>` do NOT auto-close
+- Reviewing a sweep agent's PR before merge — count `Closes #` matches in the PR body and verify it equals (Implemented + ALREADY-DONE) issue count to detect a CLOSES_GAP
 
 ## Verified Workflow
 
@@ -155,6 +159,77 @@ gh issue close <N> --reason completed
 This is also the correct approach when you close an issue programmatically as a result of
 a pin-bump or chore commit where no individual PR carries the `Closes #N` body.
 
+### Step 6: Batch ALREADY-DONE in a single PR body (CLOSES_GAP prevention)
+
+When a sweep agent batch-closes ≥10 ALREADY-DONE issues via one PR (e.g., `chore: easy-issue
+sweep 2026-05-11`), every issue in the body MUST have its own `Closes #N` line. Listing the
+issue numbers without the keyword is the most common silent failure mode of multi-agent
+sweeps — the PR merges cleanly, but the issues stay open and someone has to manually close
+them later.
+
+**Required PR body format for batch ALREADY-DONE:**
+
+```markdown
+## ALREADY-DONE (verified, closed by this PR)
+
+- Closes #501 — verified ALREADY-DONE: `pixi.lock` exists at repo root (commit abc1234)
+- Closes #502 — verified ALREADY-DONE: SECURITY.md present, governance commit e75e3df
+- Closes #503 — verified ALREADY-DONE: `image:` lines pinned in docker-compose.yml
+- Closes #504 — verified ALREADY-DONE: defaultBranchRef is `main`, ci.yml targets `main`
+...
+```
+
+**Anti-patterns that DO NOT auto-close** (every one of these has been observed in real sweeps):
+
+```markdown
+ALREADY-DONE: 5 issues — #501, #502, #503, #504, #505      # bare list, no keyword
+- #501: pixi.lock exists                                    # bullet without keyword
+- Refs #501                                                 # `Refs` is not a close verb
+- See #501                                                  # `See` is not a close verb
+- Closes part of #501                                       # intervening words break parser
+- Re #501                                                   # `Re` is not a close verb
+```
+
+**Pre-merge verifier check** (run before merging any sweep PR):
+
+```bash
+# Count Closes/Fixes/Resolves keywords in the PR body
+PR_NUM=<num>
+REPO=<owner>/<repo>
+EXPECTED=<count of Implemented + ALREADY-DONE issues>
+
+ACTUAL=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq .body \
+  | grep -ciE '(closes|fixes|resolves) #[0-9]+')
+
+echo "Expected: $EXPECTED   Actual: $ACTUAL"
+[ "$ACTUAL" -ge "$EXPECTED" ] || echo "CLOSES_GAP — $((EXPECTED - ACTUAL)) issue(s) will not auto-close"
+```
+
+**Fix-wave recovery (when the gap is found post-merge):**
+
+```bash
+# CRITICAL: must chain unset in the same shell — gh prefers GITHUB_TOKEN over user creds
+unset GITHUB_TOKEN GH_TOKEN
+
+for N in 501 502 503 504 505; do
+  gh issue close "$N" --repo HomericIntelligence/<REPO> \
+    --comment "Verified ALREADY-DONE. Evidence in PR #<PR> body: <evidence>. Closing as no further work needed."
+done
+```
+
+**Empirical rate (2026-05-11 ecosystem-wide easy-issue sweep):**
+
+| Sweep PR | Issues batched | CLOSES_GAP? |
+|----------|---------------|-------------|
+| ProjectArgus #502 | 11 | YES — bare bullets |
+| ProjectHermes #614 | 15 | YES — bare bullets |
+| ProjectNestor #77 | 5 | YES — `Refs #N` |
+| Other 8 PRs | varied | NO — used `Closes #N` per issue |
+| **Total** | **11 PRs** | **3 / 11 (27%)** |
+
+Smaller batches (≤5) were less prone — agents tended to use `Closes` for short lists. Always
+require the keyword in the implementer brief regardless of batch size.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -163,6 +238,9 @@ a pin-bump or chore commit where no individual PR carries the `Closes #N` body.
 | Use `.claude-prompt-N.md` as the commit file | Stage and commit the prompt file | Prompt files are ephemeral implementation details, not project files — staging them pollutes history | Only commit actual project files; leave prompt files untracked |
 | Look for missing implementation | Read test files expecting to find TODOs or stubs | Tests were fully implemented; the only missing piece was the PR | Always check `git diff origin/main` first before assuming code is missing |
 | "Closes part of #N" as PR body closing keyword | PR body contained `"Closes part of #N"` expecting GitHub to auto-close | GitHub parser requires exact verb immediately followed by `#N` — intervening words ("part of") break the pattern | Use only `Closes #N`, `Fixes #N`, or `Resolves #N` — no words between verb and `#N`; fall back to `gh issue close` |
+| Bare bullet list of issue numbers in PR body for batch ALREADY-DONE | Sweep agent listed `- #501: pixi.lock exists / - #502: SECURITY.md present / ...` for 11 ALREADY-DONE issues in PR body without `Closes` keyword | GitHub auto-close parser only matches the verbs (`close`, `fix`, `resolve` and inflections) immediately followed by `#N` — bare `#N` in a bullet does nothing. PR merged green; all 11 issues stayed open. | Every ALREADY-DONE issue in a PR body MUST be prefixed with `Closes #N — verified ALREADY-DONE: <evidence>`. The implementer brief must require this format — sweep agents handling ≥10 issues regularly omit the keyword |
+| `Refs #N` in PR body expecting auto-close | Sweep agent used `Refs #501`, `Refs #502`, ... thinking it was a synonym for `Closes` | `Refs` is NOT in GitHub's auto-close keyword list (`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`). PR merged; issues stayed open. | Memorize the exact closed list of auto-close verbs. `Refs`, `See`, `Re`, `Addresses`, `Related to`, `Part of` are NOT close verbs |
+| Sweep agent's report claimed issues were closed but PR body had no Closes keywords | Implementer agent wrote in summary report: "ALREADY-DONE (closed via PR Closes lines): 5 issues — #X, #Y, ..." while the actual PR body only had `Refs #N` or bare bullets | Agents rationalize the gap as "the Closes lines elsewhere will close them" — but each issue needs its OWN `Closes #N` keyword in the PR body. Failure is silent at PR merge: the PR merges cleanly, the issues remain open. | Always run the verifier check (`gh pr view --json body --jq .body \| grep -ciE '(closes\|fixes\|resolves) #'`) BEFORE merging a sweep PR — count must equal Implemented + ALREADY-DONE |
 
 ## Results & Parameters
 
@@ -191,12 +269,31 @@ gh pr merge --auto --rebase 4811
 | `Fixes #N` | YES |
 | `Resolves #N` | YES |
 | `closes #N` (lowercase) | YES |
+| `closed #N` / `fixed #N` / `resolved #N` (past tense) | YES |
 | `Closes part of #N` | NO — intervening words break parser |
 | `Addresses #N` | NO — not a recognized verb |
 | `Related to #N` | NO — not a recognized verb |
 | `See #N` | NO — not a recognized verb |
+| `Refs #N` | NO — not a recognized verb |
+| `Re #N` | NO — not a recognized verb |
+| `- #N: <text>` (bare bullet) | NO — no verb at all |
+| `#N` mentioned in prose without verb | NO — must have a close verb directly preceding |
+
+The complete closed list of auto-close verbs (case-insensitive): `close`, `closes`, `closed`,
+`fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`. Anything else does NOT auto-close.
 
 When in doubt, use `gh issue close <N> --reason completed` after merge.
+
+### Batch ALREADY-DONE PR body — verifier one-liner
+
+```bash
+# Run before merging any sweep PR that batches ≥5 ALREADY-DONE issues
+PR_NUM=<num>; REPO=<owner>/<repo>
+gh pr view "$PR_NUM" --repo "$REPO" --json body --jq .body \
+  | grep -ciE '(closes|fixes|resolves) #[0-9]+'
+# Compare against (Implemented + ALREADY-DONE) issue count from the summary table.
+# If less, that is a CLOSES_GAP — request the PR author add per-issue Closes lines before merge.
+```
 
 ### CI coverage verification pattern
 
@@ -223,3 +320,7 @@ When the issue says "cannot verify locally due to GLIBC mismatch":
 | --------- | --------- | --------- |
 | ProjectOdyssey | Issue #3840, PR #4811 | [notes.md](../references/notes.md) |
 | Odysseus | Issue #102, PR #138 — "Closes part of #102" failed to auto-close; used `gh issue close 102 --reason completed` | 2026-04-23 |
+| ProjectArgus | PR #502 — sweep batch of 11 ALREADY-DONE issues used bare bullet list, all 11 stayed open after merge; recovered via fix-wave `gh issue close` loop | 2026-05-11 |
+| ProjectHermes | PR #614 — sweep batch of 15 ALREADY-DONE issues used bare bullet list, all 15 stayed open after merge; recovered via fix-wave `gh issue close` loop | 2026-05-11 |
+| ProjectNestor | PR #77 — sweep batch of 5 ALREADY-DONE issues used `Refs #N`, all 5 stayed open after merge; recovered via fix-wave `gh issue close` loop | 2026-05-11 |
+| HomericIntelligence ecosystem-wide easy-issue sweep | 11 sweep PRs total; 3 (27%) had CLOSES_GAP — all involved batches of ≥5 ALREADY-DONE issues; 8 PRs that used per-issue `Closes #N` had zero gap | 2026-05-11 |


### PR DESCRIPTION
## Summary

Amends the existing `close-issue-via-minimal-pr` skill from v1.1.0 to v1.2.0.

Documents the **batch ALREADY-DONE CLOSES_GAP** failure pattern observed in
the 2026-05-11 HomericIntelligence ecosystem-wide easy-issue sweep: when a
sweep agent batch-closes 10+ ALREADY-DONE issues in a single PR body without
per-issue `Closes #N` keywords (e.g., bare bullet lists `- #N: <evidence>`
or `Refs #N`), GitHub does NOT auto-close them on PR merge. The failure is
silent — the PR merges green, but issues stay open and need manual cleanup.

- Adds new "Step 6: Batch ALREADY-DONE in PR body" section with required format
- Adds pre-merge verifier one-liner: `gh pr view ... | grep -ciE '(closes|fixes|resolves) #'` compared to expected count
- Adds fix-wave recovery snippet with `unset GITHUB_TOKEN GH_TOKEN` chain
- Adds 3 new Failed Attempts rows covering the batch failure mode
- Extends auto-close keyword rules table (adds `Refs`, `Re`, bare bullet anti-patterns; adds past-tense forms `closed`/`fixed`/`resolved`)
- Documents empirical rate: 3 of 11 PRs (27%) in 2026-05-11 sweep had CLOSES_GAP

## Verification Level

**verified-ci** — confirmed across three concurrent sweep PRs:
- ProjectArgus PR #502 (11 ALREADY-DONE issues, all stayed open after merge)
- ProjectHermes PR #614 (15 ALREADY-DONE issues, all stayed open after merge)
- ProjectNestor PR #77 (5 ALREADY-DONE issues used `Refs #N`, all stayed open)

All three were recovered via the fix-wave `gh issue close` loop documented
in the new Step 6.

## Key Findings

**What Worked**:
- Per-issue `Closes #N — verified ALREADY-DONE: <evidence>` lines (8 of 11 sweep PRs used this — zero gaps)
- Pre-merge verifier check counting `Closes #` matches against expected count
- Fix-wave loop with `unset GITHUB_TOKEN GH_TOKEN` to use user creds for `gh issue close`

**What Failed**:
- Bare bullet lists `- #N: <evidence>` → no auto-close (no verb)
- `Refs #N` → no auto-close (`Refs` not a recognized verb)
- `Closes part of #N` → no auto-close (intervening words break parser)
- Agent self-reports claiming "closed via PR" while PR body had no `Closes` keywords (silent gap)

## Why amend (not new file)

The existing `close-issue-via-minimal-pr` v1.1.0 already covers the
single-issue "Closes part of #N" failure and has the auto-close keyword
rules table. The batch CLOSES_GAP is the same root cause class
(missing/wrong close verb in PR body) — extending the existing skill
keeps all auto-close-keyword guidance in one searchable place rather
than fragmenting across two skills.

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` (1047/1047 valid)
- [x] History file updated with v1.1.0 → v1.2.0 entry preserving previous changelog
- [x] Frontmatter version bumped to 1.2.0, date updated to 2026-05-11
- [x] All 5 required sections present and correctly formatted

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>