### PR TITLE
feat: amend pr-preexisting-failure-triage skill (v1.1.0)

### DIFF
--- a/skills/pr-preexisting-failure-triage.history
+++ b/skills/pr-preexisting-failure-triage.history
@@ -1,0 +1,154 @@
+# pr-preexisting-failure-triage — History
+
+## v1.1.0 (2026-05-11)
+
+**Changed by:** 2026-05-11 HomericIntelligence ecosystem-wide easy-issue sweep, final fix-up cycle (Agamemnon #368, Hermes #614, Keystone #552 + tracking issue #553)
+**Verification:** verified-ci
+
+### What changed
+
+- Added authoritative diagnostic recipe using GitHub `check-runs` API queried by EXACT individual check name on main HEAD's SHA (NOT workflow name — sub-jobs of a workflow can pass on main while the workflow as a whole is failing)
+- Added empirical finding: reviewers/humans frequently mis-classify failures as PREEXISTING_CI_NOISE — 2 of 3 such classifications in the 2026-05-11 sweep were wrong. ALWAYS re-verify before trusting
+- Added three-option resolution ladder for confirmed pre-existing failures: Quick fix (≤10 min) / Admin-merge (`gh pr merge --admin --squash`) / File tracking issue (always, even alongside A or B)
+- Added new "When to Use" trigger: any time a PR is BLOCKED by a failing required status check
+- Added 3 new Failed Attempts rows covering reviewer over-trust, workflow-vs-check-name confusion, and admin-scope token assumptions
+- Added `verification` frontmatter field (was missing in v1.0.0)
+- Added `history` and `tags` frontmatter fields
+- Updated description to include the per-check-name verification + admin-merge ladder
+
+### Why
+
+Prior version (v1.0.0) provided a "diff vs failing test group directory" heuristic, which is useful
+but indirect — a failing check may not map cleanly to a test group directory. The authoritative
+truth is the `check-runs` API on main HEAD: if the named check passes on main right now, the
+failure is PR-introduced regardless of file overlap heuristics. The 2026-05-11 sweep produced 3
+BLOCKED PRs where reviewers had pre-classified failures as PREEXISTING_CI_NOISE — 2 of those 3
+classifications turned out wrong when the `check-runs` API was queried. Skipping the verification
+step costs ~10 min of wasted debugging per false classification. Additionally, v1.0.0 had no
+guidance for what to DO once a failure is confirmed pre-existing — this version adds the
+admin-merge + tracking-issue ladder validated on Keystone PR #552.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: pr-preexisting-failure-triage
+description: 'Distinguish pre-existing CI failures from regressions introduced by
+  a PR, then verify merge readiness. Use when: a PR has CI failures that may not be
+  caused by the PR''s own changes.'
+category: ci-cd
+date: 2026-03-06
+version: 1.0.0
+user-invocable: false
+---
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Goal** | Determine whether CI failures on a PR are pre-existing (safe to ignore) or regressions (must fix) |
+| **Input** | PR number, review plan file (`.claude-review-fix-*.md`) |
+| **Output** | Triage assessment: which failures are blockers vs pre-existing noise |
+| **Trigger** | Review plan says "no fixes needed" but CI shows failures |
+
+## When to Use
+
+- A `.claude-review-fix-*.md` plan states "no fixes required" and "PR is ready to merge"
+- CI shows some checks as FAILURE but the PR only touches unrelated files (e.g., workflow YAML vs test code)
+- You need to confirm whether failing test groups are affected by the PR's diff before enabling auto-merge
+- Determining if `git status` is clean (nothing to commit) matches the plan's assertion that no changes are needed
+
+## Verified Workflow
+
+### Step 1: Read the review plan
+
+Read `.claude-review-fix-<issue>.md` to extract:
+- Which deliverables are claimed to be implemented
+- Which CI failures are claimed to be pre-existing
+- What files were changed
+
+### Step 2: Check git status
+
+```bash
+git status
+git diff HEAD
+```
+
+If the branch is clean (no staged/unstaged changes, no untracked implementation files), the plan's
+assertion that "no changes are needed" is confirmed. Only the review plan file itself should be
+untracked.
+
+### Step 3: Check PR CI status
+
+```bash
+gh pr view <PR_NUMBER> --json state,title,statusCheckRollup
+```
+
+For each FAILURE check:
+- Note which test group failed (e.g., `Data Datasets`, `Shared Infra`)
+- Identify what files the PR touches (`gh pr diff --name-only`)
+- Determine if the failing test group's files overlap with PR changes
+
+### Step 4: Classify each failure
+
+| Failure | PR touches those files? | Classification |
+| --------- | ------------------------ | ---------------- |
+| `Data Datasets` FAIL | No (PR only changed `.github/workflows/`) | Pre-existing |
+| `Shared Infra` FAIL | No | Pre-existing |
+| `sast-scan` PASS | Yes (workflow files) | Correctly passing |
+
+### Step 5: Confirm no commit needed
+
+If git status is clean and the plan says no changes are needed, there is nothing to commit.
+The review plan file (`.claude-review-fix-*.md`) itself should NOT be committed — it is a
+working artifact, not an implementation file.
+
+### Step 6: Report outcome
+
+Document findings:
+- PR is correctly implemented (all issue deliverables verified)
+- Pre-existing failures listed by name with justification
+- PR is ready to merge once auto-merge is enabled or approvals received
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Committing review plan file | Treated `.claude-review-fix-*.md` as an implementation artifact to commit | File is a working artifact for the agent, not a deliverable | Only commit actual code/config changes, never the review plan file |
+| Looking for additional changes | Searched for uncommitted fixes matching the plan's deliverables | The plan correctly stated all changes were already pushed; branch was clean | When plan says "no fixes required", verify git status first before assuming work remains |
+| Retrying tests locally | Attempted to rerun failing CI groups locally to confirm pre-existing status | Unnecessary — PR CI history and test group vs diff analysis is sufficient | Use `gh pr view --json statusCheckRollup` + diff analysis to classify failures without running tests |
+
+## Results & Parameters
+
+### Command to check PR CI status
+
+```bash
+gh pr view <PR_NUMBER> --json state,title,statusCheckRollup | \
+  python3 -c "import json,sys; checks=json.load(sys.stdin)['statusCheckRollup']; \
+  [print(c['conclusion'], c['name']) for c in checks]"
+```
+
+### Command to list files changed by PR
+
+```bash
+gh pr diff <PR_NUMBER> --name-only
+```
+
+### Classification heuristic
+
+If the failing test group's directory (e.g., `tests/shared/infra/`, `tests/data/datasets/`) has
+**zero overlap** with the PR's changed files, the failure is pre-existing and not a blocker for
+merging.
+
+### Key signals that plan is complete and no commit is needed
+
+1. `git status` shows only the `.claude-review-fix-*.md` as untracked — no modified files
+2. `git diff HEAD` is empty
+3. Branch is up-to-date with `origin/<branch>`
+4. All issue deliverables are verifiable directly in existing committed files
+```
+
+---
+
+## v1.0.0 (2026-03-06)
+
+**Initial version.** File-overlap heuristic for classifying PR CI failures as pre-existing vs introduced.

--- a/skills/pr-preexisting-failure-triage.md
+++ b/skills/pr-preexisting-failure-triage.md
@@ -1,114 +1,252 @@
 ---
 name: pr-preexisting-failure-triage
-description: 'Distinguish pre-existing CI failures from regressions introduced by
-  a PR, then verify merge readiness. Use when: a PR has CI failures that may not be
-  caused by the PR''s own changes.'
+description: 'Distinguish PR-introduced CI failures from pre-existing main-branch rot using the GitHub check-runs API per individual check name (NOT workflow name), then resolve confirmed pre-existing failures via the quick-fix / admin-merge / tracking-issue ladder. Use when: (1) a PR is BLOCKED by failing required status checks, (2) a reviewer has labeled failures as PREEXISTING_CI_NOISE (re-verify — they are wrong ~2/3 of the time), (3) you must decide between fixing in-scope, admin-merging, or filing a follow-up issue.'
 category: ci-cd
-date: 2026-03-06
-version: 1.0.0
+date: 2026-05-11
+version: 1.1.0
 user-invocable: false
+verification: verified-ci
+history: pr-preexisting-failure-triage.history
+tags:
+  - ci-failure
+  - pr-blocked
+  - preexisting
+  - check-runs-api
+  - admin-merge
+  - tracking-issue
+  - required-status-check
 ---
 ## Overview
 
 | Field | Value |
 | ------- | ------- |
-| **Goal** | Determine whether CI failures on a PR are pre-existing (safe to ignore) or regressions (must fix) |
-| **Input** | PR number, review plan file (`.claude-review-fix-*.md`) |
-| **Output** | Triage assessment: which failures are blockers vs pre-existing noise |
-| **Trigger** | Review plan says "no fixes needed" but CI shows failures |
+| **Date** | 2026-05-11 |
+| **Goal** | Determine whether each failing required check on a BLOCKED PR is PR-introduced (must fix) or pre-existing on main (use admin-merge + tracking-issue ladder), without trusting reviewer pre-classifications |
+| **Input** | PR number, repo slug (`org/repo`) |
+| **Output** | Per-check classification (PR-INTRODUCED / PRE-EXISTING / NEW-CHECK) plus a resolution action for each |
+| **Outcome** | 3-of-3 BLOCKED PRs in the 2026-05-11 sweep correctly triaged: 2 reviewer mis-classifications caught and fixed (Agamemnon #368 markdownlint+depscan, Hermes #614 urllib3 CVE), 1 truly pre-existing admin-merged with tracking issue (Keystone #552 + #553) |
+| **Verification** | verified-ci |
+| **History** | [changelog](./pr-preexisting-failure-triage.history) |
 
 ## When to Use
 
-- A `.claude-review-fix-*.md` plan states "no fixes required" and "PR is ready to merge"
-- CI shows some checks as FAILURE but the PR only touches unrelated files (e.g., workflow YAML vs test code)
-- You need to confirm whether failing test groups are affected by the PR's diff before enabling auto-merge
-- Determining if `git status` is clean (nothing to commit) matches the plan's assertion that no changes are needed
+- A PR shows status `BLOCKED` because one or more required checks are failing
+- A reviewer has tagged failures as `PREEXISTING_CI_NOISE`, `pre-existing`, or "not caused by this PR" — ALWAYS re-verify; reviewers were wrong on 2 of 3 such labels in the 2026-05-11 sweep
+- A `.claude-review-fix-*.md` plan states "no fixes required" but CI shows FAILURE
+- Before enabling `gh pr merge --auto` on a PR with red checks
+- Before deciding to expand a PR's scope to fix a failing check (you may not need to — admin-merge may be valid)
+- After a tooling/dependency bump where a reviewer claims unrelated failures are noise
 
 ## Verified Workflow
 
-### Step 1: Read the review plan
-
-Read `.claude-review-fix-<issue>.md` to extract:
-- Which deliverables are claimed to be implemented
-- Which CI failures are claimed to be pre-existing
-- What files were changed
-
-### Step 2: Check git status
+### Quick Reference
 
 ```bash
-git status
-git diff HEAD
+# 0. Always unset shadowing tokens first
+unset GITHUB_TOKEN GH_TOKEN
+
+ORG=HomericIntelligence
+REPO=ProjectAgamemnon
+PR_NUM=368
+
+# 1. List failing checks on the PR by EXACT name
+gh pr view "$PR_NUM" --repo "$ORG/$REPO" --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion == "FAILURE") | .name'
+
+# 2. Get main HEAD SHA
+MAIN_SHA=$(gh api "repos/$ORG/$REPO/branches/main" --jq '.commit.sha')
+
+# 3. Per failing check name, query main HEAD's check-runs (authoritative)
+for chk in "markdownlint" "depscan / trivy"; do
+  status=$(gh api "repos/$ORG/$REPO/commits/$MAIN_SHA/check-runs" \
+    --jq ".check_runs[] | select(.name == \"$chk\") | .conclusion" | head -1)
+  printf "%-30s main=%s\n" "$chk" "${status:-not-run}"
+done
+# success  -> PR-INTRODUCED  (fix in this PR)
+# failure  -> PRE-EXISTING   (use ladder below; do NOT fix in this PR)
+# not-run  -> NEW-CHECK      (added by PR's branch; investigate)
+
+# 4a. Resolution: confirmed PRE-EXISTING -> admin-merge + tracking issue
+gh pr merge "$PR_NUM" --repo "$ORG/$REPO" --squash --admin
+gh issue create --repo "$ORG/$REPO" \
+  --title "ci: <check-name> failing on main since YYYY-MM-DD" \
+  --body "Diagnostic context, log excerpt, action checklist"
 ```
 
-If the branch is clean (no staged/unstaged changes, no untracked implementation files), the plan's
-assertion that "no changes are needed" is confirmed. Only the review plan file itself should be
-untracked.
+### Detailed Steps
 
-### Step 3: Check PR CI status
+#### Step 1: Identify failing required checks (by exact name)
 
 ```bash
-gh pr view <PR_NUMBER> --json state,title,statusCheckRollup
+gh pr view "$PR_NUM" --repo "$ORG/$REPO" --json state,statusCheckRollup
 ```
 
-For each FAILURE check:
-- Note which test group failed (e.g., `Data Datasets`, `Shared Infra`)
-- Identify what files the PR touches (`gh pr diff --name-only`)
-- Determine if the failing test group's files overlap with PR changes
+If `state` is `BLOCKED`, list every entry with `conclusion == "FAILURE"`. Use the EXACT
+`name` field — this is the required-status-check context that branch protection enforces.
 
-### Step 4: Classify each failure
+CRITICAL: do NOT use the workflow name from the Actions UI. A workflow can show FAILURE
+while one of its sub-jobs (the actual required-check context) was PASS. The required check
+is identified by the exact `name` from `statusCheckRollup`.
 
-| Failure | PR touches those files? | Classification |
-| --------- | ------------------------ | ---------------- |
-| `Data Datasets` FAIL | No (PR only changed `.github/workflows/`) | Pre-existing |
-| `Shared Infra` FAIL | No | Pre-existing |
-| `sast-scan` PASS | Yes (workflow files) | Correctly passing |
+#### Step 2: Resolve main HEAD SHA
 
-### Step 5: Confirm no commit needed
+```bash
+MAIN_SHA=$(gh api "repos/$ORG/$REPO/branches/main" --jq '.commit.sha')
+```
 
-If git status is clean and the plan says no changes are needed, there is nothing to commit.
-The review plan file (`.claude-review-fix-*.md`) itself should NOT be committed — it is a
-working artifact, not an implementation file.
+This is the authoritative reference state. We test whether each failing check passes here.
 
-### Step 6: Report outcome
+#### Step 3: Query check-runs API per check name on main
 
-Document findings:
-- PR is correctly implemented (all issue deliverables verified)
-- Pre-existing failures listed by name with justification
-- PR is ready to merge once auto-merge is enabled or approvals received
+```bash
+for chk in "<failing-check-1>" "<failing-check-2>"; do
+  status=$(gh api "repos/$ORG/$REPO/commits/$MAIN_SHA/check-runs" \
+    --jq ".check_runs[] | select(.name == \"$chk\") | .conclusion" | head -1)
+  printf "%-30s main=%s\n" "$chk" "${status:-not-run}"
+done
+```
+
+Three possible outcomes per check:
+
+| Outcome on main | Classification | Action |
+| --------------- | -------------- | ------ |
+| `success` | PR-INTRODUCED | Fix in this PR — your responsibility |
+| `failure` | PRE-EXISTING | Use resolution ladder (Step 4) — do NOT expand scope |
+| `not-run` | NEW-CHECK | Check was added by the PR's branch — investigate why it doesn't exist on main |
+
+#### Step 4: Resolution ladder for PRE-EXISTING failures
+
+Try in order:
+
+```text
+Option A: Quick fix (<=10 min budget)
+   ONLY if root cause is a config error or test flake easily fixed without scope creep.
+   Push fix in this PR; otherwise proceed to B.
+
+Option B: Admin-merge
+   gh pr merge "$PR_NUM" --repo "$ORG/$REPO" --squash --admin
+   Bypasses the failing required check via admin override.
+   Requires the keyring token to have admin scope; if it lacks scope,
+   auto-merge stays armed and a human admin must merge.
+
+Option C: File tracking issue (ALWAYS, even alongside A or B)
+   gh issue create --repo "$ORG/$REPO" \
+     --title "ci: <check-name> failing on main since YYYY-MM-DD" \
+     --body "<check name>, link to failing run, log excerpt, suspected root cause, action checklist"
+```
+
+#### Step 5: Re-verify reviewer classifications
+
+If a reviewer/agent already classified failures as `PREEXISTING_CI_NOISE`, run Steps 1-3
+anyway. Empirically, 2 of 3 such classifications in the 2026-05-11 sweep were wrong.
+The ~5-second `check-runs` query produces authoritative truth that overrides any prior label.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
+| Trusting reviewer's PREEXISTING_CI_NOISE label | Took the reviewer's classification at face value on Agamemnon #368 and Hermes #614 | `check-runs` API showed those checks PASSED on main HEAD — failures were PR-introduced (markdownlint MD031 blank-line, urllib3 CVE upgrade) | ALWAYS re-verify with `check-runs` API before trusting any prior classification; ~5 sec to verify, ~10 min wasted per false trust |
+| Comparing workflow run conclusion | Looked at the workflow's overall `conclusion` field instead of the individual check name | A workflow can show FAILURE while one of its sub-jobs (the actual required-check context) was PASS — workflow conclusion != required-check conclusion | Use `check-runs` API keyed by the EXACT `name` from `statusCheckRollup`, not workflow names |
+| File-overlap heuristic alone | Assumed a failing test group with zero file overlap to PR diff means pre-existing | A check can fail because of an env/config drift unrelated to file paths (e.g., trivy DB lookup, transient dep install) — file overlap is necessary but not sufficient | File-overlap is a hint; the `check-runs` API on main HEAD is the only authoritative test |
+| Assuming `gh pr merge --admin` always works | Ran admin-merge with the default keyring token | Not all bot/PAT setups have admin scope on every repo; some failed silently | Test admin-merge on one PR first; on failure, auto-merge stays armed and a human admin must merge |
+| Expanding PR scope to fix unrelated rot | Started fixing pre-existing failures inside the surface PR | Scope creep, slower review, harder revert if the rot fix regresses something else | Use admin-merge + tracking issue (Option B + C) for confirmed pre-existing failures; never expand scope |
 | Committing review plan file | Treated `.claude-review-fix-*.md` as an implementation artifact to commit | File is a working artifact for the agent, not a deliverable | Only commit actual code/config changes, never the review plan file |
-| Looking for additional changes | Searched for uncommitted fixes matching the plan's deliverables | The plan correctly stated all changes were already pushed; branch was clean | When plan says "no fixes required", verify git status first before assuming work remains |
-| Retrying tests locally | Attempted to rerun failing CI groups locally to confirm pre-existing status | Unnecessary — PR CI history and test group vs diff analysis is sufficient | Use `gh pr view --json statusCheckRollup` + diff analysis to classify failures without running tests |
+| Retrying tests locally | Attempted to rerun failing CI groups locally to confirm pre-existing status | Unnecessary — `check-runs` API on main HEAD is faster and authoritative | Use `gh api .../check-runs` to classify failures without running tests |
 
 ## Results & Parameters
 
-### Command to check PR CI status
+### Empirical re-classification rate (2026-05-11 sweep)
+
+3 of 3 lingering BLOCKED PRs in the post-fix-wave state needed this triage. 2 of 3
+reviewer classifications were wrong. **Diagnose every time** before either fixing or
+admin-merging.
+
+| PR | Reviewer label | Actual (check-runs API) | Resolution |
+| -- | -------------- | ----------------------- | ---------- |
+| ProjectAgamemnon #368 | PREEXISTING_CI_NOISE | PR-INTRODUCED (markdownlint MD031 + transient trivy install) | Fix in PR |
+| ProjectHermes #614 | PREEXISTING_CI_NOISE | PR-INTRODUCED (urllib3 CVE 2026-44431/44432) | Fix in PR (upgrade urllib3) |
+| ProjectKeystone #552 | (none) | PRE-EXISTING (`AgentCoreTest.BackpressureConcurrentTrigger` aborting on main HEAD) | Admin-merge + tracking issue #553 |
+
+### Full diagnostic script
 
 ```bash
-gh pr view <PR_NUMBER> --json state,title,statusCheckRollup | \
-  python3 -c "import json,sys; checks=json.load(sys.stdin)['statusCheckRollup']; \
-  [print(c['conclusion'], c['name']) for c in checks]"
+#!/usr/bin/env bash
+set -euo pipefail
+unset GITHUB_TOKEN GH_TOKEN
+
+ORG="${1:?org}"
+REPO="${2:?repo}"
+PR_NUM="${3:?pr-number}"
+
+mapfile -t FAILING < <(
+  gh pr view "$PR_NUM" --repo "$ORG/$REPO" --json statusCheckRollup \
+    --jq '.statusCheckRollup[] | select(.conclusion == "FAILURE") | .name'
+)
+
+if [ "${#FAILING[@]}" -eq 0 ]; then
+  echo "No failing required checks on PR #$PR_NUM."
+  exit 0
+fi
+
+MAIN_SHA=$(gh api "repos/$ORG/$REPO/branches/main" --jq '.commit.sha')
+echo "Main HEAD SHA: $MAIN_SHA"
+echo
+
+for chk in "${FAILING[@]}"; do
+  status=$(gh api "repos/$ORG/$REPO/commits/$MAIN_SHA/check-runs" \
+    --jq ".check_runs[] | select(.name == \"$chk\") | .conclusion" | head -1)
+  case "${status:-not-run}" in
+    success) verdict="PR-INTRODUCED  (fix in this PR)" ;;
+    failure) verdict="PRE-EXISTING   (use admin-merge + tracking issue ladder)" ;;
+    *)       verdict="NEW-CHECK      (added by PR branch; investigate)" ;;
+  esac
+  printf "%-40s main=%-10s -> %s\n" "$chk" "${status:-not-run}" "$verdict"
+done
 ```
 
-### Command to list files changed by PR
+### Resolution decision tree
 
-```bash
-gh pr diff <PR_NUMBER> --name-only
+```text
+Is the failure pre-existing on main? (per check-runs API)
+- NO  -> fix in this PR (PR-introduced is your responsibility)
+- YES -> Three-option ladder (try in order):
+    - Option A: Quick fix (<=10 min budget) — only if root cause is a config
+                error or test flake easily fixed without scope creep
+    - Option B: Admin-merge — gh pr merge <PR> --repo <org/repo> --squash --admin
+                Bypasses the failing required check via admin override
+    - Option C: File tracking issue (ALWAYS, even alongside A or B)
+                gh issue create --repo <org/repo> \
+                  --title "ci: <check-name> failing on main since YYYY-MM-DD"
 ```
 
-### Classification heuristic
+### Tracking issue body template
 
-If the failing test group's directory (e.g., `tests/shared/infra/`, `tests/data/datasets/`) has
-**zero overlap** with the PR's changed files, the failure is pre-existing and not a blocker for
-merging.
+```markdown
+## Failing check
+`<exact check name from statusCheckRollup>`
 
-### Key signals that plan is complete and no commit is needed
+## Status on main
+- Main HEAD SHA: <sha>
+- Conclusion: failure
+- First observed failing on main: <best-known date or run URL>
 
-1. `git status` shows only the `.claude-review-fix-*.md` as untracked — no modified files
-2. `git diff HEAD` is empty
-3. Branch is up-to-date with `origin/<branch>`
-4. All issue deliverables are verifiable directly in existing committed files
+## Log excerpt
+<paste the failing log lines that show root cause>
+
+## Suspected root cause
+<one paragraph hypothesis>
+
+## Action checklist
+- [ ] Reproduce locally on `main`
+- [ ] Identify regressing commit (`git bisect` or run history)
+- [ ] Open fix PR
+- [ ] Close this issue when main is green again
+```
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| ProjectAgamemnon | PR #368 (markdownlint MD031 + depscan trivy) — reviewer mis-classified as PREEXISTING_CI_NOISE; check-runs API showed PR-introduced | 2026-05-11 ecosystem sweep, fix-up cycle |
+| ProjectHermes | PR #614 (urllib3 CVE 2026-44431/44432) — reviewer mis-classified as PREEXISTING_CI_NOISE; check-runs API showed PR-introduced | 2026-05-11 ecosystem sweep, fix-up cycle |
+| ProjectKeystone | PR #552 (`coverage` failing) — confirmed truly pre-existing (`AgentCoreTest.BackpressureConcurrentTrigger` aborts on main HEAD); resolved via `gh pr merge --admin --squash` + tracking issue #553 | 2026-05-11 ecosystem sweep, fix-up cycle |


### PR DESCRIPTION
## Summary

Amends existing skill from **v1.0.0 -> v1.1.0** (minor bump — adds new diagnostic recipe + resolution ladder; original file-overlap heuristic preserved as a complementary signal).

Documents the authoritative diagnostic recipe for triaging BLOCKED PRs: query the GitHub `check-runs` API per individual check name on main HEAD's SHA. Adds the resolution ladder (quick-fix / admin-merge / tracking issue) for confirmed pre-existing failures.

- Replaces indirect file-overlap heuristic with authoritative `check-runs` API verification
- Adds the three-option resolution ladder validated on Keystone PR #552
- Adds empirical finding: reviewer pre-classifications were wrong on 2 of 3 BLOCKED PRs in the 2026-05-11 sweep — diagnose every time

## Verification Level

**verified-ci**

Applied across 3 PRs in the 2026-05-11 HomericIntelligence ecosystem-wide easy-issue sweep, final fix-up cycle:

- ProjectAgamemnon #368 — reviewer labeled markdownlint + depscan as PREEXISTING_CI_NOISE; check-runs API showed PR-INTRODUCED; fixed in PR
- ProjectHermes #614 — reviewer labeled urllib3 CVE failure as PREEXISTING_CI_NOISE; check-runs API showed PR-INTRODUCED; fixed in PR (urllib3 upgrade)
- ProjectKeystone #552 — `coverage` check truly pre-existing (`AgentCoreTest.BackpressureConcurrentTrigger` aborts on main HEAD); resolved via `gh pr merge --admin --squash` + tracking issue #553

## Key Findings

**What Worked**:
- A single ~5-second `gh api commits/<sha>/check-runs` call per failing check produces authoritative truth
- Admin-merge for confirmed pre-existing failures merged on first try (Keystone)
- Re-classifying 2 of the 3 reviewer "PREEXISTING_CI_NOISE" labels as PR-INTRODUCED unlocked actual fixes (markdownlint blank-line, urllib3 upgrade)

**What Failed**:
- Trusting reviewer's PREEXISTING_CI_NOISE classification without re-verifying -> wasted ~10 min per false trust
- Comparing workflow run conclusion instead of individual check name -> a workflow can show FAILURE while its required-check sub-job was PASS
- Assuming `gh pr merge --admin` always succeeds -> not all bot/PAT setups have admin scope

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1047/1047 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: `pr-blocked`, `preexisting`, `check-runs-api`, `admin-merge`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>