### PR TITLE
feat: amend gh-review-pr skill

### DIFF
--- a/skills/gh-review-pr.history
+++ b/skills/gh-review-pr.history
@@ -1,0 +1,155 @@
+# gh-review-pr - History
+
+## v1.1.0 (2026-05-13)
+
+**Changed by:** Session context: Eval360-V2 PR #268 strict review comment posting
+**Verification:** verified-local
+
+### What changed
+
+- Added the self-authored PR review limitation: GitHub rejects `REQUEST_CHANGES` reviews from the PR author.
+- Added the verified fallback: submit a `COMMENT` review with inline comments and an explicit No-Go verdict in the body.
+- Updated the skill to current marketplace metadata requirements, including `verification`, `user-invocable`, `tags`, and `history`.
+- Moved quick-reference commands under `## Verified Workflow` as `### Quick Reference`.
+- Added concrete GitHub REST review payload format and verification commands.
+
+### Why
+
+During a strict review of Eval360-V2 PR #268, the review payload with `"event": "REQUEST_CHANGES"` failed with HTTP 422 because the authenticated user was also the PR author. Switching only the event to `"COMMENT"` allowed the same review body and inline comments to be posted, preserving the No-Go decision without relying on a formal request-changes state.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: gh-review-pr
+description: Comprehensively review a pull request including code changes, CI status,
+  and adherence to project standards. Use when asked to review a PR.
+category: tooling
+date: '2026-03-19'
+version: 1.0.0
+---
+# Review Pull Request
+
+## Overview
+
+| Item | Details |
+| ------ | --------- |
+| Date | N/A |
+| Objective | Evaluate PR quality and provide structured feedback. - Reviewing a PR before merge - Evaluating code quality and standards |
+| Outcome | Operational |
+
+Evaluate PR quality and provide structured feedback.
+
+## When to Use
+
+- Reviewing a PR before merge
+- Evaluating code quality and standards
+- Checking CI status and test coverage
+- Providing feedback to contributors
+
+### Quick Reference
+
+```bash
+# View PR details
+gh pr view <pr>
+
+# Check diff
+gh pr diff <pr> | less
+
+# View CI status
+gh pr checks <pr>
+
+# See review comments
+gh api repos/OWNER/REPO/pulls/PR/comments
+```
+
+## Review Checklist
+
+- [ ] Code follows project standards (CLAUDE.md)
+- [ ] All CI checks passing
+- [ ] Tests are present and passing
+- [ ] PR is linked to issue
+- [ ] Commit messages follow conventional commits
+- [ ] No security vulnerabilities
+- [ ] Documentation updated if needed
+- [ ] No unintended files included
+
+## Verified Workflow
+
+1. **Get PR info**: `gh pr view <pr>`
+2. **Review diff**: `gh pr diff <pr>`
+3. **Check CI**: `gh pr checks <pr>`
+4. **Analyze code**: Focus on quality, standards, tests
+5. **Assess security**: Look for vulnerabilities
+6. **Verify docs**: Check if documentation updated
+7. **Provide feedback**: Comment with findings
+
+## Review Focus Areas
+
+**Code Quality**:
+
+- Clean, readable, maintainable
+- Follows CLAUDE.md guidelines
+- Proper error handling
+- No code duplication
+
+**Testing**:
+
+- Tests present for new code
+- Tests passing
+- Adequate coverage
+- Edge cases covered
+
+**Documentation**:
+
+- API documentation updated
+- Complex logic explained
+- README updated if needed
+- Examples provided if applicable
+
+**Standards Compliance**:
+
+- Mojo syntax correct (for Mojo code)
+- No warnings or unused variables
+- Proper formatting
+- Conventional commit messages
+
+## Output Format
+
+Provide review with sections:
+
+1. **Summary** - Overall assessment
+2. **Strengths** - What's done well
+3. **Issues** - Problems that must be fixed
+4. **Suggestions** - Optional improvements
+5. **Verdict** - Approve / Request Changes / Comment
+
+## Error Handling
+
+| Problem | Solution |
+| --------- | ---------- |
+| PR not found | Verify PR number |
+| Auth failure | Check `gh auth status` |
+| CI pending | Note review based on current state |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| N/A | Direct approach worked | N/A | Solution was straightforward |
+## Results & Parameters
+
+N/A - this skill describes a workflow pattern.
+
+## References
+
+- See CLAUDE.md for project standards
+- See CLAUDE.md for Mojo syntax requirements
+- See CLAUDE.md for zero-warnings policy
+```
+
+---
+
+## v1.0.0 (2026-03-19)
+
+**Initial version.**

--- a/skills/gh-review-pr.md
+++ b/skills/gh-review-pr.md
@@ -1,126 +1,156 @@
 ---
 name: gh-review-pr
-description: Comprehensively review a pull request including code changes, CI status,
-  and adherence to project standards. Use when asked to review a PR.
+description: "Comprehensively review a GitHub pull request, post inline review comments, and handle self-authored PR review limitations. Use when: (1) asked to review a PR, (2) adding review comments with gh api, (3) a strict review needs Go/No-Go output, (4) GitHub rejects request-changes on the authenticated user's own PR."
 category: tooling
-date: '2026-03-19'
-version: 1.0.0
+date: 2026-05-13
+version: "1.1.0"
+user-invocable: false
+verification: verified-local
+history: gh-review-pr.history
+tags: [github, pull-request, review, gh-cli, review-comments]
 ---
-# Review Pull Request
+
+# GitHub PR Review Workflow
 
 ## Overview
 
-| Item | Details |
-| ------ | --------- |
-| Date | N/A |
-| Objective | Evaluate PR quality and provide structured feedback. - Reviewing a PR before merge - Evaluating code quality and standards |
-| Outcome | Operational |
-
-Evaluate PR quality and provide structured feedback.
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-13 |
+| **Objective** | Evaluate PR quality, provide structured findings, and post review comments through GitHub. |
+| **Outcome** | Operational. A self-authored PR cannot receive a `REQUEST_CHANGES` review from the same authenticated user, but a `COMMENT` review can still carry inline comments plus an explicit No-Go verdict in the body. |
+| **Verification** | verified-local. Executed against Eval360-V2 PR #268 with live GitHub API calls; CI validation is not applicable to this operational workflow. |
+| **History** | [changelog](./gh-review-pr.history) |
 
 ## When to Use
 
-- Reviewing a PR before merge
-- Evaluating code quality and standards
-- Checking CI status and test coverage
-- Providing feedback to contributors
+- Reviewing a PR before merge.
+- Evaluating code quality, tests, CI status, documentation, or security risk.
+- Posting inline review comments with exact file and line anchors.
+- Adding per-file grading and a Go/No-Go review summary.
+- Reviewing a PR authored by the authenticated GitHub user, where `REQUEST_CHANGES` may be rejected by GitHub.
+
+## Verified Workflow
+
+Verified locally only - CI validation is pending/not applicable because this is a GitHub CLI/API operating procedure.
 
 ### Quick Reference
 
 ```bash
-# View PR details
-gh pr view <pr>
+# Inspect PR context.
+gh pr view <pr> --repo OWNER/REPO --json author,baseRefName,headRefName,headRefOid,state,url
+gh pr diff <pr> --repo OWNER/REPO --patch
+gh pr checks <pr> --repo OWNER/REPO
 
-# Check diff
-gh pr diff <pr> | less
+# Confirm whether this is a self-authored PR.
+gh api user --jq .login
+gh pr view <pr> --repo OWNER/REPO --json author,headRefOid --jq '{author:.author.login, head:.headRefOid}'
 
-# View CI status
-gh pr checks <pr>
+# Submit a review with inline comments.
+# Use event=COMMENT when the authenticated user is also the PR author.
+gh api -X POST repos/OWNER/REPO/pulls/<pr>/reviews --input review.json
 
-# See review comments
-gh api repos/OWNER/REPO/pulls/PR/comments
+# Verify inline comments landed on the review.
+gh api repos/OWNER/REPO/pulls/<pr>/comments \
+  --jq '.[] | select(.pull_request_review_id==<review_id>) | {path,line,body,url:.html_url}'
 ```
+
+### Detailed Steps
+
+1. Gather the PR metadata, diff, checks, and existing review state. Prefer `gh pr diff`; if it fails transiently and the branch is checked out locally, use `git diff <base>...HEAD` as the evidence source.
+
+2. Identify the authenticated account and PR author before choosing the review event:
+
+   ```bash
+   gh api user --jq .login
+   gh pr view <pr> --repo OWNER/REPO --json author,headRefOid
+   ```
+
+3. Write the review body with findings first. For strict reviews, include per-file grades and an explicit Go/No-Go verdict in the summary.
+
+4. Choose the review event:
+
+   - Use `REQUEST_CHANGES` only when reviewing someone else's PR and the findings block merge.
+   - Use `COMMENT` when the authenticated user owns the PR. GitHub rejects self-request-changes reviews with HTTP 422.
+   - Use `APPROVE` only when the review is genuinely approving and the account is allowed to approve the PR.
+
+5. Submit inline comments and the summary in one review payload:
+
+   ```json
+   {
+     "commit_id": "<headRefOid>",
+     "event": "COMMENT",
+     "body": "## Review Summary\n\nPer-file grading...\n\nGo/No-Go: **NO-GO**",
+     "comments": [
+       {
+         "path": "scripts/example.sh",
+         "line": 109,
+         "side": "RIGHT",
+         "body": "[major] Explain the specific blocking issue and requested fix."
+       }
+     ]
+   }
+   ```
+
+   ```bash
+   gh api -X POST repos/OWNER/REPO/pulls/<pr>/reviews --input review.json
+   ```
+
+6. Verify the posted review and inline comments:
+
+   ```bash
+   gh api repos/OWNER/REPO/pulls/<pr>/comments \
+     --jq '.[] | select(.pull_request_review_id==<review_id>) | {path,line,body,url:.html_url}'
+   ```
 
 ## Review Checklist
 
-- [ ] Code follows project standards (CLAUDE.md)
-- [ ] All CI checks passing
-- [ ] Tests are present and passing
-- [ ] PR is linked to issue
-- [ ] Commit messages follow conventional commits
-- [ ] No security vulnerabilities
-- [ ] Documentation updated if needed
-- [ ] No unintended files included
-
-## Verified Workflow
-
-1. **Get PR info**: `gh pr view <pr>`
-2. **Review diff**: `gh pr diff <pr>`
-3. **Check CI**: `gh pr checks <pr>`
-4. **Analyze code**: Focus on quality, standards, tests
-5. **Assess security**: Look for vulnerabilities
-6. **Verify docs**: Check if documentation updated
-7. **Provide feedback**: Comment with findings
-
-## Review Focus Areas
-
-**Code Quality**:
-
-- Clean, readable, maintainable
-- Follows CLAUDE.md guidelines
-- Proper error handling
-- No code duplication
-
-**Testing**:
-
-- Tests present for new code
-- Tests passing
-- Adequate coverage
-- Edge cases covered
-
-**Documentation**:
-
-- API documentation updated
-- Complex logic explained
-- README updated if needed
-- Examples provided if applicable
-
-**Standards Compliance**:
-
-- Mojo syntax correct (for Mojo code)
-- No warnings or unused variables
-- Proper formatting
-- Conventional commit messages
-
-## Output Format
-
-Provide review with sections:
-
-1. **Summary** - Overall assessment
-2. **Strengths** - What's done well
-3. **Issues** - Problems that must be fixed
-4. **Suggestions** - Optional improvements
-5. **Verdict** - Approve / Request Changes / Comment
-
-## Error Handling
-
-| Problem | Solution |
-| --------- | ---------- |
-| PR not found | Verify PR number |
-| Auth failure | Check `gh auth status` |
-| CI pending | Note review based on current state |
+- Code follows repository standards and local contributor instructions.
+- Changed behavior is covered by tests proportional to risk.
+- CI status is understood and any unavailable checks are called out.
+- Security and destructive-operation risks are explicitly reviewed.
+- Documentation updates match the user-facing behavior.
+- Inline comments are anchored to changed lines and include severity.
+- The summary includes the merge verdict: Approve, Comment, Request Changes, Go, or No-Go.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+|---------|----------------|---------------|----------------|
+| Self-authored request-changes review | Submitted `gh api -X POST repos/OWNER/REPO/pulls/<pr>/reviews` with `"event": "REQUEST_CHANGES"` while authenticated as the PR author | GitHub returned HTTP 422: `Review Can not request changes on your own pull request` | Detect self-authored PRs before posting. Use `"event": "COMMENT"` and put the strict No-Go verdict in the review body. |
+| PR diff via GitHub during transient network issue | Ran `gh pr diff <pr> --patch` | The API call failed with a connection error to `api.github.com` | If the PR branch is checked out locally, use `git diff <base>...HEAD` for evidence, then still use GitHub API for posting once connectivity returns. |
+
 ## Results & Parameters
 
-N/A — this skill describes a workflow pattern.
+Observed parameters from the verified session:
 
-## References
+| Field | Value |
+|-------|-------|
+| Project | Eval360-V2 |
+| PR | #268 |
+| Authenticated user | `mvillmow` |
+| PR author | `mvillmow` |
+| Head commit | `0432fe73a993208f6b38ec8aad39331f7b5afe08` |
+| Rejected event | `REQUEST_CHANGES` |
+| Working event | `COMMENT` |
+| Review ID | `4284354764` |
+| Review verdict in body | `NO-GO` |
+| Inline anchors | `scripts/tools/rebuild_vllm_serving_env.sh:109`, `README.md:108` |
 
-- See CLAUDE.md for project standards
-- See CLAUDE.md for Mojo syntax requirements
-- See CLAUDE.md for zero-warnings policy
+For strict reviews, use the summary body to preserve enforcement semantics when GitHub permissions prevent a formal request-changes review:
+
+```markdown
+## Strict Review Summary
+
+Per-file grading:
+- `README.md`: B- (82/100)
+- `scripts/tools/rebuild_vllm_serving_env.sh`: C (74/100)
+
+Go/No-Go: **NO-GO** for merge under strict review.
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Eval360-V2 | PR #268 strict review posting | Self-authored PR rejected `REQUEST_CHANGES`; `COMMENT` review successfully posted summary and inline comments. |


### PR DESCRIPTION
## Summary

Amends `gh-review-pr` from v1.0.0 to v1.1.0.

Documents the GitHub limitation where `REQUEST_CHANGES` is rejected on self-authored PRs and the verified fallback of using a `COMMENT` review with inline comments plus an explicit No-Go verdict in the body.

- Adds self-authored PR detection guidance.
- Adds REST review payload examples for inline comments.
- Adds history/changelog entry with the previous version snapshot.

## Verification Level

**verified-local**

Validated with `/tmp/mnemosyne-validate-venv/bin/python scripts/validate_plugins.py` in a temporary venv. Pre-push pytest also passed: 171 tests.

## Key Findings

**What Worked**:
- `COMMENT` review event successfully posted the strict review summary and inline comments on Eval360-V2 PR #268.
- `gh api repos/OWNER/REPO/pulls/PR/comments` verified the inline comments landed on the review.

**What Failed**:
- `REQUEST_CHANGES` on a self-authored PR failed with HTTP 422: GitHub does not allow requesting changes on your own PR.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Pre-push pytest passed
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Codex <noreply@openai.com>