### PR TITLE
feat: capture PR288 strict review learnings

### DIFF
--- a/skills/review-pr-changes.history
+++ b/skills/review-pr-changes.history
@@ -1,0 +1,245 @@
+# review-pr-changes - History
+
+## v1.1.0 (2026-05-13)
+
+**Changed by:** PR288 strict review session for `LLM360/RL360`
+
+**Verification:** verified-local - live GitHub `CHANGES_REQUESTED` review was posted and read back via API; ProjectMnemosyne validation pending in this PR
+
+### What changed
+
+- Added strict GitHub review posting workflow with head-SHA and line-target verification
+- Added per-file grading and GO/NO-GO review summary guidance
+- Added triggers for strict review, review comments, and `REQUEST_CHANGES`
+- Added failed-attempt rows for stale diff lines, PR-level-only findings, and missing per-file grades
+- Added PR288 evidence: review ID, head SHA, and inline comment IDs
+- Updated frontmatter with verification metadata, history pointer, tags, and version `1.1.0`
+
+### Why
+
+The previous skill described a useful review checklist but did not capture the operational
+steps needed to post a strict GitHub review safely. PR288 required actionable inline comments,
+a `CHANGES_REQUESTED` review state, and a per-file release-readiness summary. Capturing the
+API readback step prevents stale-line or file-level comment mistakes in future strict reviews.
+
+### Previous version (v1.0.0) snapshot
+
+````markdown
+---
+name: review-pr-changes
+description: Review PR changes with structured checklist for quality and standards
+  compliance. Use for comprehensive PR code review.
+category: tooling
+date: '2026-03-19'
+version: 1.0.0
+---
+# Review PR Changes with Checklist
+
+## Overview
+
+| Item | Details |
+| ------ | --------- |
+| Date | N/A |
+| Objective | Perform structured review of PR changes against project quality standards. - Code review before approving PR |
+| Outcome | Operational |
+
+Perform structured review of PR changes against project quality standards.
+
+## When to Use
+
+- Code review before approving PR
+- Detailed evaluation of code quality
+- Checking standards compliance (Mojo, Python, documentation)
+- Verifying test coverage
+- Assessing architectural impact
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Get PR files changed
+gh pr diff <pr> --name-only
+
+# View specific file diff
+gh pr diff <pr> -- path/to/file.mojo
+
+# Get PR review status
+gh pr view <pr> --json reviews
+
+# Check file statistics
+gh pr diff <pr> | diffstat
+
+# Get PR body/description
+gh pr view <pr> --json body
+```
+
+## Review Checklist
+
+**Code Quality**:
+
+- [ ] Code is readable and well-structured
+- [ ] Functions/classes have clear purposes
+- [ ] Variable names are descriptive
+- [ ] Complex logic is commented
+- [ ] No code duplication (DRY principle)
+- [ ] Follows project naming conventions
+
+**Testing**:
+
+- [ ] Tests present for new functionality
+- [ ] Tests are passing (CI shows green)
+- [ ] Edge cases covered in tests
+- [ ] Test names describe what they test
+- [ ] No skipped or xfail tests
+- [ ] Adequate coverage for changes
+
+**Documentation**:
+
+- [ ] Docstrings for public APIs
+- [ ] README updated if needed
+- [ ] Comments for non-obvious code
+- [ ] Examples provided for complex features
+- [ ] Type hints present (Mojo/Python)
+
+**Standards Compliance**:
+
+- [ ] Mojo code uses v0.26.1+ syntax
+- [ ] No deprecated patterns (inout, @value, DynamicVector)
+- [ ] Zero compiler warnings
+- [ ] Proper indentation and formatting
+- [ ] No trailing whitespace
+- [ ] Files end with newline
+
+**Mojo-Specific**:
+
+- [ ] Constructors use `out self` not `mut self`
+- [ ] Non-copyable returns use `^` transfer operator
+- [ ] Proper trait conformances on structs
+- [ ] Memory safety validated
+- [ ] SIMD used for performance-critical code
+- [ ] Ownership patterns correct
+
+**Security & Safety**:
+
+- [ ] No hardcoded secrets/tokens
+- [ ] Input validation present
+- [ ] No unsafe operations
+- [ ] Proper error handling
+- [ ] No memory safety issues
+- [ ] No type safety violations
+
+**Git & Commit**:
+
+- [ ] PR linked to issue (in description)
+- [ ] Commit messages follow conventional commits
+- [ ] No unintended files included
+- [ ] Branch is up to date with main
+- [ ] No merge conflicts
+
+## Review Workflow
+
+1. **Check context**: View PR description and linked issue
+2. **Scan changes**: Review file list and statistics
+3. **Read code**: Examine actual changes carefully
+4. **Run checklist**: Go through each category
+5. **Test locally**: Pull and test changes if needed
+6. **Create comments**: Flag issues as code comments
+7. **Provide verdict**: Approve, request changes, or comment
+
+## Output Format
+
+Report review results with sections:
+
+1. **Summary** - Overall assessment of changes
+2. **Strengths** - Well-executed aspects
+3. **Issues Found** - Problems that must be fixed
+4. **Suggestions** - Optional improvements
+5. **Questions** - Clarifications needed
+6. **Verdict** - Approve/Request Changes/Comment
+7. **Next Steps** - What needs to happen next
+
+## Common Issues to Flag
+
+**Code Issues**:
+
+- Logic errors or off-by-one mistakes
+- Missing error handling
+- Performance problems
+- Unnecessary complexity
+
+**Style Issues**:
+
+- Inconsistent formatting
+- Poor naming choices
+- Missing comments
+- Overly long functions/files
+
+**Test Issues**:
+
+- Missing test coverage
+- Flaky tests
+- Inadequate assertions
+- Wrong expected values
+
+**Documentation Issues**:
+
+- Missing docstrings
+- Inaccurate documentation
+- Examples that don't work
+- Missing type annotations
+
+## Error Handling
+
+| Problem | Solution |
+| --------- | ---------- |
+| Can't access PR | Check gh auth status |
+| Can't understand code | Ask clarifying question in comment |
+| Needs local testing | Use worktree-create skill to test |
+| Multiple issues | Prioritize critical first, optional second |
+| Disagreement on style | Refer to CLAUDE.md for standards |
+
+## Review Standards
+
+Approve when:
+
+- All critical issues fixed
+- Code follows project standards
+- Tests passing and coverage good
+- Documentation complete
+- No security/safety concerns
+
+Request changes when:
+
+- Critical issues present
+- Standards not followed
+- Missing tests
+- Significant problems found
+
+Comment when:
+
+- Only minor suggestions
+- Questions about approach
+- Suggestions for improvement
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| N/A | Direct approach worked | N/A | Solution was straightforward |
+## Results & Parameters
+
+N/A - this skill describes a workflow pattern.
+
+## References
+
+- See CLAUDE.md for project standards
+- See verify-pr-ready for merge readiness check
+- See gh-batch-merge-by-labels for batch review workflow
+````
+
+---
+
+## v1.0.0 (2026-03-19)
+
+**Initial version.**

--- a/skills/review-pr-changes.md
+++ b/skills/review-pr-changes.md
@@ -1,51 +1,110 @@
 ---
 name: review-pr-changes
-description: Review PR changes with structured checklist for quality and standards
-  compliance. Use for comprehensive PR code review.
+description: "Review PR changes with a structured checklist, strict GitHub review posting, inline comments, per-file grading, and GO/NO-GO release readiness summary. Use when: (1) reviewing PRs before approval, (2) asked for a strict review, (3) asked to add review comments, (4) needing REQUEST_CHANGES with actionable inline findings."
 category: tooling
-date: '2026-03-19'
-version: 1.0.0
+date: 2026-05-13
+version: "1.1.0"
+user-invocable: false
+verification: verified-local
+history: review-pr-changes.history
+tags: [github, pr-review, strict-review, request-changes, inline-comments, per-file-grading]
 ---
+
 # Review PR Changes with Checklist
 
 ## Overview
 
-| Item | Details |
-| ------ | --------- |
-| Date | N/A |
-| Objective | Perform structured review of PR changes against project quality standards. - Code review before approving PR |
-| Outcome | Operational |
-
-Perform structured review of PR changes against project quality standards.
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-13 |
+| **Objective** | Perform structured PR review, attach actionable GitHub review comments, and publish a strict per-file GO/NO-GO summary |
+| **Outcome** | Operational; PR288 review was submitted as `CHANGES_REQUESTED` with five inline comments and API readback verification |
+| **Verification** | verified-local - live GitHub review workflow executed on `LLM360/RL360#288`; ProjectMnemosyne validation pending |
+| **History** | [changelog](./review-pr-changes.history) |
 
 ## When to Use
 
-- Code review before approving PR
-- Detailed evaluation of code quality
-- Checking standards compliance (Mojo, Python, documentation)
-- Verifying test coverage
-- Assessing architectural impact
+- Reviewing a PR before approving or merging
+- Performing a strict review with release-readiness grading
+- Adding GitHub review comments directly to changed lines
+- Requesting changes with an overall `GO`, `Conditional Go`, or `NO-GO` verdict
+- Producing a per-file grade table for reviewers or maintainers
+- Checking standards compliance, test coverage, security exposure, or architectural impact
+- Verifying that comments attach to the intended PR head SHA and diff lines
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# Get PR files changed
-gh pr diff <pr> --name-only
+# Fetch current PR metadata
+gh pr view <pr> --repo OWNER/REPO \
+  --json url,title,state,isDraft,mergeStateStatus,reviewDecision,headRefOid,baseRefOid
 
-# View specific file diff
-gh pr diff <pr> -- path/to/file.mojo
+# List changed files
+gh api repos/OWNER/REPO/pulls/<pr>/files --paginate \
+  --jq '.[] | [.filename, .status, .additions, .deletions] | @tsv'
 
-# Get PR review status
-gh pr view <pr> --json reviews
+# Check CI status
+gh pr checks <pr> --repo OWNER/REPO
 
-# Check file statistics
-gh pr diff <pr> | diffstat
+# Read existing reviews and comments to avoid duplicates
+gh api repos/OWNER/REPO/pulls/<pr>/reviews --jq '.[] | [.id, .user.login, .state] | @tsv'
+gh api repos/OWNER/REPO/pulls/<pr>/comments --paginate \
+  --jq '.[] | [.id, .user.login, .path, .line, .body] | @tsv'
 
-# Get PR body/description
-gh pr view <pr> --json body
+# Submit a review with inline comments
+gh api --method POST repos/OWNER/REPO/pulls/<pr>/reviews --input review.json
+
+# Verify comments landed on intended lines
+gh api repos/OWNER/REPO/pulls/<pr>/comments --paginate \
+  --jq '.[] | select(.pull_request_review_id==REVIEW_ID) | [.id, .path, .line, .side] | @tsv'
 ```
+
+### Strict Review Posting Workflow
+
+1. **Fetch PR truth first**
+
+   Capture PR URL, title, draft state, merge state, base SHA, head SHA, changed files,
+   existing reviews, existing comments, and checks. Do not review from stale browser state.
+
+2. **Review the actual diff and run targeted verification**
+
+   Read the changed files at the PR head and run checks suited to the patch:
+   shell syntax for shell scripts, Python compile/tests for Python changes, `git diff --check`
+   for whitespace, workflow validation where available, and CI status via `gh pr checks`.
+
+3. **Draft findings as actionable inline comments**
+
+   Prefer inline comments for defects that have a specific file and line. Use blocker-level
+   language for correctness, security, reproducibility, or launch failures. Keep optional
+   suggestions out of `REQUEST_CHANGES` unless they affect release readiness.
+
+4. **Build a per-file grade table**
+
+   Grade each changed file independently and assign a verdict:
+
+   - `Go`: no blocking or major issue in the file
+   - `Conditional Go`: acceptable only after specific validation or minor cleanup
+   - `No-Go`: file contains a blocker or unvalidated high-risk behavior
+
+5. **Re-fetch the PR head SHA before posting**
+
+   Confirm the head SHA has not changed since drafting. Verify every target path and line
+   still exists in the current diff. If the SHA moved, re-review the affected diff before
+   posting.
+
+6. **Submit one GitHub review**
+
+   Use one `REQUEST_CHANGES` review when there are blockers. Put the per-file grading and
+   final GO/NO-GO verdict in the review body. Put each actionable defect in the `comments`
+   array so maintainers can resolve threads line by line.
+
+7. **Read the review back**
+
+   Fetch the submitted review and comments. Confirm the review state, commit SHA, file paths,
+   lines, and comment count. If any comment became file-level or attached to the wrong line,
+   follow up immediately.
 
 ## Review Checklist
 
@@ -61,151 +120,109 @@ gh pr view <pr> --json body
 **Testing**:
 
 - [ ] Tests present for new functionality
-- [ ] Tests are passing (CI shows green)
+- [ ] Tests are passing or CI status is explicitly called out
 - [ ] Edge cases covered in tests
 - [ ] Test names describe what they test
-- [ ] No skipped or xfail tests
-- [ ] Adequate coverage for changes
+- [ ] No skipped or xfail tests without justification
+- [ ] Adequate coverage for changed behavior
 
 **Documentation**:
 
 - [ ] Docstrings for public APIs
-- [ ] README updated if needed
-- [ ] Comments for non-obvious code
+- [ ] README or operational docs updated if needed
+- [ ] Comments explain non-obvious code only
 - [ ] Examples provided for complex features
-- [ ] Type hints present (Mojo/Python)
-
-**Standards Compliance**:
-
-- [ ] Mojo code uses v0.26.1+ syntax
-- [ ] No deprecated patterns (inout, @value, DynamicVector)
-- [ ] Zero compiler warnings
-- [ ] Proper indentation and formatting
-- [ ] No trailing whitespace
-- [ ] Files end with newline
-
-**Mojo-Specific**:
-
-- [ ] Constructors use `out self` not `mut self`
-- [ ] Non-copyable returns use `^` transfer operator
-- [ ] Proper trait conformances on structs
-- [ ] Memory safety validated
-- [ ] SIMD used for performance-critical code
-- [ ] Ownership patterns correct
+- [ ] Type hints or schema changes are documented
 
 **Security & Safety**:
 
 - [ ] No hardcoded secrets/tokens
-- [ ] Input validation present
-- [ ] No unsafe operations
-- [ ] Proper error handling
-- [ ] No memory safety issues
-- [ ] No type safety violations
+- [ ] No secrets exposed through generated scripts, logs, argv, or CI summaries
+- [ ] Inputs validated before use
+- [ ] Error handling is explicit and observable
+- [ ] No unsafe or surprising side effects
 
-**Git & Commit**:
+**GitHub Review Mechanics**:
 
-- [ ] PR linked to issue (in description)
-- [ ] Commit messages follow conventional commits
-- [ ] No unintended files included
-- [ ] Branch is up to date with main
-- [ ] No merge conflicts
-
-## Review Workflow
-
-1. **Check context**: View PR description and linked issue
-2. **Scan changes**: Review file list and statistics
-3. **Read code**: Examine actual changes carefully
-4. **Run checklist**: Go through each category
-5. **Test locally**: Pull and test changes if needed
-6. **Create comments**: Flag issues as code comments
-7. **Provide verdict**: Approve, request changes, or comment
-
-## Output Format
-
-Report review results with sections:
-
-1. **Summary** - Overall assessment of changes
-2. **Strengths** - Well-executed aspects
-3. **Issues Found** - Problems that must be fixed
-4. **Suggestions** - Optional improvements
-5. **Questions** - Clarifications needed
-6. **Verdict** - Approve/Request Changes/Comment
-7. **Next Steps** - What needs to happen next
-
-## Common Issues to Flag
-
-**Code Issues**:
-
-- Logic errors or off-by-one mistakes
-- Missing error handling
-- Performance problems
-- Unnecessary complexity
-
-**Style Issues**:
-
-- Inconsistent formatting
-- Poor naming choices
-- Missing comments
-- Overly long functions/files
-
-**Test Issues**:
-
-- Missing test coverage
-- Flaky tests
-- Inadequate assertions
-- Wrong expected values
-
-**Documentation Issues**:
-
-- Missing docstrings
-- Inaccurate documentation
-- Examples that don't work
-- Missing type annotations
+- [ ] Current PR head SHA verified immediately before posting
+- [ ] Existing comments checked to avoid duplicate review noise
+- [ ] Inline comments target changed lines in the current diff
+- [ ] Review summary includes per-file grades and final GO/NO-GO
+- [ ] Submitted review read back via API
 
 ## Error Handling
 
 | Problem | Solution |
 | --------- | ---------- |
-| Can't access PR | Check gh auth status |
-| Can't understand code | Ask clarifying question in comment |
-| Needs local testing | Use worktree-create skill to test |
-| Multiple issues | Prioritize critical first, optional second |
-| Disagreement on style | Refer to CLAUDE.md for standards |
+| Cannot access PR | Check `gh auth status` and repository name |
+| No checks reported | Mention explicitly in summary; do not infer validation passed |
+| Head SHA changed | Re-review the changed diff before posting |
+| Inline line is invalid | Recompute against current diff and retry before submitting |
+| Multiple blockers | Submit one `REQUEST_CHANGES` review with multiple inline comments |
+| Only minor suggestions | Use `COMMENT`, not `REQUEST_CHANGES` |
 
 ## Review Standards
 
 Approve when:
 
-- All critical issues fixed
-- Code follows project standards
-- Tests passing and coverage good
-- Documentation complete
-- No security/safety concerns
+- No critical or major issues remain
+- Tests/checks passed for the relevant behavior
+- Documentation and operational paths are accurate
+- No security or reproducibility concerns remain
 
 Request changes when:
 
-- Critical issues present
-- Standards not followed
-- Missing tests
-- Significant problems found
+- Correctness, launchability, security, or reproducibility blockers are present
+- Tests/checks are missing for high-risk behavior
+- The PR claims safety/equivalence that the code does not prove
+- A file-level `No-Go` verdict is warranted
 
 Comment when:
 
-- Only minor suggestions
-- Questions about approach
-- Suggestions for improvement
+- Only minor suggestions remain
+- The review is informational or asks clarifying questions
+- The PR needs human confirmation but no direct code change yet
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| Stale line/head review | Drafted comments from an earlier diff snapshot | GitHub comments can attach to wrong lines or fail if the PR head moved | Re-fetch head SHA and verify target lines immediately before posting |
+| PR-level-only feedback | Put all findings in the review body | Maintainers lose line-level resolution threads and actionable context | Use inline comments for defects with a concrete file and line |
+| Summary without per-file grading | Gave only an overall verdict | Release readiness was hidden when one file was safe and another was a blocker | Include per-file grades plus an overall GO/NO-GO |
+
 ## Results & Parameters
 
-N/A — this skill describes a workflow pattern.
+PR288 evidence from `LLM360/RL360`:
+
+- Review ID: `4284402017`
+- Review state: `CHANGES_REQUESTED`
+- Head SHA: `825525d73b24be56a444ffab90de5fc3164261ed`
+- Inline comments:
+  - `3236617139`: `scripts/train/run-xllm-375B-bbq-r3-32k.sh:9`
+  - `3236617145`: `scripts/train/run-xllm-375B-bbq-r3-32k.sh:667`
+  - `3236617149`: `scripts/train/run-xllm-375B-bbq-r3-128k.sh:703`
+  - `3236617153`: `scripts/train/run-xllm-375B-bbq-r3-32k.sh:381`
+  - `3236617156`: `scripts/train/run-xllm-375B-bbq-r3-128k.sh:399`
+
+Recommended review body shape:
+
+```markdown
+## Strict review summary
+
+Overall verdict: **NO-GO / CHANGES_REQUESTED**.
+
+| File | Grade | Verdict | Notes |
+| --- | --- | --- | --- |
+| path/to/file | D | No-Go | Blocking issue summary |
+
+Required before merge:
+1. Fix blocker A.
+2. Add or attach validation B.
+```
 
 ## References
 
-- See CLAUDE.md for project standards
-- See verify-pr-ready for merge readiness check
-- See gh-batch-merge-by-labels for batch review workflow
+- See `gh-review-pr` for a lighter PR review workflow
+- See `gh-get-review-comments` for collecting existing review threads
+- See `training-rl360-xllm-launcher-review-pitfalls` for PR288 domain-specific findings

--- a/skills/training-rl360-xllm-launcher-review-pitfalls.md
+++ b/skills/training-rl360-xllm-launcher-review-pitfalls.md
@@ -1,0 +1,123 @@
+---
+name: training-rl360-xllm-launcher-review-pitfalls
+description: "Review RL360 xLLM Slurm/Ray/SGLang training launchers for launch-time log path failures, W&B secret exposure through Ray runtime envs, and native-first SGLang overlay regressions. Use when: (1) reviewing RL360 training launcher PRs, (2) scripts use Slurm #SBATCH output/error paths, (3) Ray job submit passes runtime env JSON with secrets, (4) xLLM/SGLang bridge files are copied or overlaid."
+category: training
+date: 2026-05-13
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [rl360, xllm, slurm, ray, wandb, sglang, training-launchers, security]
+---
+
+# RL360 xLLM Launcher Review Pitfalls
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-13 |
+| **Objective** | Review RL360 xLLM Slurm/Ray/SGLang launchers for failures that occur before training starts or expose training secrets |
+| **Outcome** | PR288 review on `LLM360/RL360` submitted as `CHANGES_REQUESTED` with five inline findings |
+| **Verification** | verified-local - findings were posted to GitHub and read back via API |
+
+Use this when reviewing RL360 training launcher scripts, especially long shell launchers that
+combine Slurm directives, Ray job submission, W&B setup, and SGLang/xLLM bridge installation.
+
+## When to Use
+
+- Reviewing `scripts/train/run-xllm-*.sh` or similar RL360 launchers
+- Slurm directives use `#SBATCH --output` or `#SBATCH --error`
+- A launcher builds Ray `runtime-env-json`
+- W&B credentials or other secrets are injected into training jobs
+- SGLang/xLLM bridge files are copied, overlaid, patched, or selected by install mode
+- A PR claims a local overlay is only a fallback for older images
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Find Slurm output/error directives
+rg -n '#SBATCH --(output|error)=' scripts/train
+
+# Find runtime env and W&B secret surfaces
+rg -n 'WANDB_API_KEY|runtime-env-json|RUNTIME_ENV_JSON|ray job submit' scripts/train
+
+# Find SGLang/xLLM bridge overlays
+rg -n 'xllm_sglang|xllm.py|install-mode|native|overlay|sglang' scripts/train
+
+# Static validation for shell and generated helpers
+bash -n scripts/train/run-xllm-*.sh
+python3 -m py_compile path/to/generated_or_modified.py
+git diff --check
+```
+
+### Review Steps
+
+1. **Check Slurm log directories before script body**
+
+   Slurm opens `#SBATCH --output` and `#SBATCH --error` paths before the shell body runs.
+   A `mkdir -p final_logs` inside the script cannot fix a missing parent directory. The PR
+   must either track the directory, use an existing directory, or document a launch wrapper
+   that creates the directory before `sbatch`.
+
+2. **Trace W&B secrets through every generated surface**
+
+   Search beyond exported environment variables. Check generated scripts, heredocs, Ray
+   runtime env JSON, argv, logs, and long-running submit processes. Passing
+   `WANDB_API_KEY` through `ray job submit --runtime-env-json=...` can expose it in argv
+   and in generated files that persist for the full training run.
+
+3. **Verify native-first SGLang behavior**
+
+   If the image already has a native SGLang xLLM bridge, the launcher should prefer it.
+   Local RL360 fallback overlays should run only when the image lacks native support or
+   when an explicit overlay mode is selected. Unconditional copy-over can regress current
+   source-built SGLang images.
+
+4. **Run static checks before posting**
+
+   Use `bash -n` for launch scripts, `python3 -m py_compile` for generated Python files,
+   and `git diff --check` for whitespace. These do not prove the launcher is correct, but
+   they quickly eliminate syntax-level noise before the deeper review.
+
+5. **Post findings as inline blockers**
+
+   Launcher issues are easiest to fix when comments attach to the exact directive,
+   runtime-env construction, or overlay copy line. Use `REQUEST_CHANGES` for launch-time
+   failure, secret exposure, or native-first regressions.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Relying on script-body `mkdir -p final_logs` | Assumed the launcher could create Slurm log dirs after start | Slurm opens output/error paths before the script body executes | Track the directory or create it before `sbatch` |
+| Treating Ray runtime env JSON as secret-safe | Put `WANDB_API_KEY` into `RUNTIME_ENV_JSON` and passed it via `ray job submit --runtime-env-json` | The key can remain in generated scripts and argv for the training run | Use a private `0600` file or another mechanism that never writes the key to generated executable scripts or argv |
+| Unconditional `xllm_sglang.py` overlay | Copied RL360 fallback over SGLang native bridge | It defeats native-first behavior and can regress newer images | Preserve native bridge by default and use overlay only as an explicit fallback |
+
+## Results & Parameters
+
+PR288 evidence from `LLM360/RL360`:
+
+- Review ID: `4284402017`
+- Review state: `CHANGES_REQUESTED`
+- PR head SHA: `825525d73b24be56a444ffab90de5fc3164261ed`
+- Slurm log-dir blocker:
+  - Comment `3236617139` on `scripts/train/run-xllm-375B-bbq-r3-32k.sh:9`
+- W&B/Ray runtime-env blockers:
+  - Comment `3236617145` on `scripts/train/run-xllm-375B-bbq-r3-32k.sh:667`
+  - Comment `3236617149` on `scripts/train/run-xllm-375B-bbq-r3-128k.sh:703`
+- SGLang native-first overlay concerns:
+  - Comment `3236617153` on `scripts/train/run-xllm-375B-bbq-r3-32k.sh:381`
+  - Comment `3236617156` on `scripts/train/run-xllm-375B-bbq-r3-128k.sh:399`
+
+Suggested strict review grades for these findings:
+
+- Slurm log path missing parent directory: blocker / No-Go
+- W&B secret in generated script or argv: blocker / No-Go
+- Unconditional fallback overlay over native bridge: concern or blocker depending on PR claim and runtime impact
+
+## References
+
+- `review-pr-changes` for the strict GitHub review posting workflow
+- PR288 review: `https://github.com/LLM360/RL360/pull/288#pullrequestreview-4284402017`

--- a/skills/training-rl360-xllm-launcher-review-pitfalls.notes.md
+++ b/skills/training-rl360-xllm-launcher-review-pitfalls.notes.md
@@ -1,0 +1,34 @@
+# PR288 RL360 xLLM Launcher Review Notes
+
+Source PR: `https://github.com/LLM360/RL360/pull/288`
+
+Review:
+
+- ID: `4284402017`
+- State: `CHANGES_REQUESTED`
+- Head SHA: `825525d73b24be56a444ffab90de5fc3164261ed`
+
+Inline comments posted by `mvillmow`:
+
+| Comment ID | Path | Line | Finding |
+| --- | --- | ---: | --- |
+| `3236617139` | `scripts/train/run-xllm-375B-bbq-r3-32k.sh` | 9 | Missing `final_logs/` parent directory for Slurm output before shell body starts |
+| `3236617145` | `scripts/train/run-xllm-375B-bbq-r3-32k.sh` | 667 | `WANDB_API_KEY` written into Ray runtime env JSON, generated script, and argv |
+| `3236617149` | `scripts/train/run-xllm-375B-bbq-r3-128k.sh` | 703 | Same W&B/runtime-env exposure in 128k launcher |
+| `3236617153` | `scripts/train/run-xllm-375B-bbq-r3-32k.sh` | 381 | Unconditional fallback `xllm_sglang.py` overlay defeats native-first SGLang behavior |
+| `3236617156` | `scripts/train/run-xllm-375B-bbq-r3-128k.sh` | 399 | Same native-first overlay concern in 128k launcher |
+
+Raw review summary shape:
+
+```markdown
+Overall: NO-GO / CHANGES_REQUESTED
+
+Per-file grading:
+- 32k launcher: D / No-Go
+- 128k launcher: D / No-Go
+
+Blocking themes:
+- Slurm output directory must exist before `sbatch`
+- W&B secrets must not be placed in generated scripts or argv
+- SGLang native bridge must remain preferred over fallback overlay
+```


### PR DESCRIPTION
## Summary

Adds one new skill and amends one existing skill.

- Amends `review-pr-changes` with strict per-file grading and `REQUEST_CHANGES` posting workflow
- Adds RL360 xLLM launcher review pitfalls for Slurm log dirs, W&B/Ray secret exposure, and SGLang native-first overlays
- Archives the previous `review-pr-changes` version in history

## Verification Level

verified-local

The PR288 review was executed live on GitHub and read back via API.

## Test Plan

- [x] `/tmp/mnemosyne-validate-venv/bin/python scripts/validate_plugins.py`
- [x] `git diff --cached --check`
- [x] pre-push `pytest -q` (`171 passed`)
- [ ] Search discovery by: strict review, REQUEST_CHANGES, final_logs, runtime-env-json, SGLang overlay
