### PR TITLE
chore: easy-issue sweep bundle (2026-05-16)

### DIFF
--- a/.claude/shared/plugin-standards.md
+++ b/.claude/shared/plugin-standards.md
@@ -2,31 +2,38 @@
 
 Standards for creating and validating skills in the ProjectMnemosyne marketplace.
 
+> **Format:** ProjectMnemosyne uses the **flat-file skill format** introduced in v2.0.0.
+> Each skill is a single markdown file at `skills/<name>.md`. There is no
+> nested `<name>/SKILL.md`, no per-skill `plugin.json`, and no `.claude-plugin/`
+> directory inside each skill. The only documented exception is
+> `plugins/tooling/mnemosyne/` (command infrastructure), which is *not* a skill.
+> See `CLAUDE.md` for repo structure and `templates/skill-template.md` for a
+> ready-to-copy template.
+
 ## Required Structure
 
 ```text
-skills/<category>/<name>/
-├── .claude-plugin/
-│   └── plugin.json           # Metadata (REQUIRED)
-├── skills/<name>/
-│   └── SKILL.md              # Main knowledge (REQUIRED)
-└── references/
-    └── notes.md              # Additional context (optional)
+skills/
+└── <name>.md                  # Single flat skill file (REQUIRED)
 ```
 
-## plugin.json Requirements
+Optional sibling files alongside `<name>.md`:
+
+- `<name>.notes.md` / `<name>.notes-<topic>.md` — session notes (excluded from marketplace)
+- `<name>.history*` — historical revisions (excluded from marketplace)
+
+## SKILL Metadata (YAML Frontmatter in `<name>.md`)
 
 | Field | Required | Description |
 | ------- | ---------- | ------------- |
-| `name` | Yes | Lowercase kebab-case identifier |
-| `version` | Yes | Semantic version (e.g., "1.0.0") |
+| `name` | Yes | Lowercase kebab-case identifier (matches the filename stem) |
 | `description` | Yes | Trigger conditions (20+ chars) |
-| `author.name` | Yes | Author name |
-| `date` | Yes | Creation date (YYYY-MM-DD) |
-| `category` | Yes | One of 8 approved categories |
-| `tags` | Yes | Array of searchable keywords |
-| `skills` | Yes | Path to skills directory |
-| `source_project` | No | Source project name |
+| `version` | Yes | Semantic version (e.g., "1.0.0") |
+| `date` | Yes | Last-updated date (YYYY-MM-DD) |
+| `category` | Yes | One of the approved categories below |
+| `tags` | Yes | YAML list of searchable keywords |
+| `verification` | Yes | One of `verified-ci`, `verified-local`, `verified-precommit`, `unverified` |
+| `source` | No | Originating project (e.g., `ProjectOdyssey`) |
 
 ## SKILL.md Requirements
 
@@ -35,10 +42,14 @@ skills/<category>/<name>/
 ```yaml
 ---
 name: skill-name
-description: "Trigger conditions"
+description: "Trigger conditions (≥20 chars)"
 category: category-name
-source: source-project
+version: "1.0.0"
 date: YYYY-MM-DD
+verification: verified-local
+tags:
+  - keyword-1
+  - keyword-2
 ---
 ```
 
@@ -67,12 +78,13 @@ date: YYYY-MM-DD
 
 ## Validation Rules
 
-1. **plugin.json must exist** in `.claude-plugin/` directory
-2. **SKILL.md must exist** in `skills/<name>/` directory
-3. **Failed Attempts section required** - validation fails without it
-4. **Description must be specific** - 20+ characters with trigger conditions
-5. **Category must be valid** - one of 8 approved categories
-6. **Date format** - YYYY-MM-DD
+1. **`skills/<name>.md` must exist** — the flat file *is* the skill
+2. **Frontmatter must be valid YAML** delimited by `---` lines
+3. **Failed Attempts section required** — validation fails without it
+4. **Description must be specific** — 20+ characters with trigger conditions
+5. **Category must be valid** — one of the approved categories above
+6. **Date format** — YYYY-MM-DD
+7. **`verification` must be one of** `verified-ci` / `verified-local` / `verified-precommit` / `unverified`
 
 ## Quality Guidelines
 

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -138,10 +138,15 @@ These are **pre-existing issues** from the old format. The flat migration preser
 
 ### Recommended
 1. ✅ Test CI workflows (validate and marketplace generation)
-2. 📋 Implement retrospective command updates (clone to $HOME/.agent-brain/)
-3. 📋 Implement advise command updates (direct file reading from flat files)
-4. 📋 Address validation errors in skills (gradually improve quality)
-5. 📋 Update retrospective plugin hook to use new workflow
+2. 📋 Implement retrospective command updates (clone to $HOME/.agent-brain/) — tracked in #1470
+3. 📋 Implement advise command updates (direct file reading from flat files) — tracked in #1470
+4. 📋 Address validation errors in skills (gradually improve quality) — tracked in #1470
+5. 📋 Update retrospective plugin hook to use new workflow — tracked in #1470
+
+> **Note:** The four "📋" items above are open work items that previously
+> lacked tracking issues. They are now consolidated under #1470. File a
+> dedicated issue per item before starting work; #1470 itself is closed
+> once each line above has its own ticket (or is removed).
 
 ### Optional (Quality Improvement)
 - Fix invalid categories in 291 skills

--- a/scripts/generate_marketplace.py
+++ b/scripts/generate_marketplace.py
@@ -18,12 +18,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
-
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
     import tomli as tomllib  # type: ignore[no-redef]
+
+# Use the canonical skill_utils helpers instead of duplicating logic here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from skill_utils import find_skill_files, parse_frontmatter  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -45,24 +47,19 @@ def _load_project_version() -> str:
 
 
 def load_skill_metadata(skill_file: Path) -> Optional[Dict[str, Any]]:
-    """Load metadata from a flat skill file's YAML frontmatter."""
+    """Load metadata from a flat skill file's YAML frontmatter.
+
+    Thin wrapper around skill_utils.parse_frontmatter to keep call-sites
+    in this module unchanged while reusing the canonical implementation.
+    """
     try:
         with open(skill_file, "r") as f:
             content = f.read()
     except IOError:
         return None
 
-    # Extract YAML frontmatter
-    if not content.startswith("---"):
-        return None
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return None
-
-    try:
-        frontmatter = yaml.safe_load(parts[1]) or {}
-    except yaml.YAMLError:
+    frontmatter, _body, errors = parse_frontmatter(content)
+    if errors:
         return None
 
     # Add path relative to repo root
@@ -70,20 +67,9 @@ def load_skill_metadata(skill_file: Path) -> Optional[Dict[str, Any]]:
     return frontmatter
 
 
-def find_skills() -> List[Path]:
-    """Find all flat skill files (skills/*.md, exclude *.notes.md)."""
-    skills_dir = Path("skills")
-
-    if not skills_dir.exists():
-        return []
-
-    files = sorted([f for f in skills_dir.glob("*.md") if not f.name.endswith(".notes.md") and f.is_file()])
-    return files
-
-
 def generate_marketplace() -> Dict[str, Any]:
     """Generate marketplace index from flat skill files."""
-    skills = find_skills()
+    skills = find_skill_files()
     plugin_entries = []
     seen_names: set = set()
 

--- a/scripts/generate_marketplace.py
+++ b/scripts/generate_marketplace.py
@@ -16,7 +16,7 @@ import sys
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 try:
     import tomllib  # Python 3.11+
@@ -26,7 +26,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 # Use the canonical skill_utils helpers instead of duplicating logic here.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from skill_utils import find_skill_files, parse_frontmatter  # noqa: E402
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 

--- a/scripts/generate_marketplace.py
+++ b/scripts/generate_marketplace.py
@@ -20,6 +20,29 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_project_version() -> str:
+    """Read the marketplace version from pyproject.toml.
+
+    Falls back to "0.0.0" if pyproject.toml is missing or unreadable so
+    the generator never hard-fails on environments without the file.
+    """
+    pyproject = REPO_ROOT / "pyproject.toml"
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        return str(data.get("project", {}).get("version", "0.0.0"))
+    except (OSError, KeyError, ValueError):
+        return "0.0.0"
+
 
 def load_skill_metadata(skill_file: Path) -> Optional[Dict[str, Any]]:
     """Load metadata from a flat skill file's YAML frontmatter."""
@@ -94,12 +117,13 @@ def generate_marketplace() -> Dict[str, Any]:
     # Compute category statistics
     category_counts = dict(sorted(Counter(entry["category"] for entry in plugin_entries).items()))
 
-    # Official marketplace format
+    # Official marketplace format. Version is sourced from pyproject.toml
+    # so the marketplace tracks the project's semver instead of a literal.
     marketplace = {
         "name": "ProjectMnemosyne",
         "owner": {"name": "HomericIntelligence", "url": "https://github.com/HomericIntelligence"},
         "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
-        "version": "1.0.0",
+        "version": _load_project_version(),
         "total_plugins": len(plugin_entries),
         "categories": category_counts,
         "last_updated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/scripts/migrate_ecosystem_skills.py
+++ b/scripts/migrate_ecosystem_skills.py
@@ -14,6 +14,7 @@ Options:
 """
 
 import argparse
+import datetime
 import os
 import re
 import sys
@@ -27,7 +28,8 @@ from typing import Optional
 REPO_ROOT = Path(__file__).parent.parent
 SKILLS_DIR = REPO_ROOT / "skills"
 
-TODAY = "2026-03-25"
+# Use today's date so re-runs stamp current dates on migrated skills.
+TODAY = datetime.date.today().isoformat()
 
 # Source definitions: name -> base_path
 # Override via environment variables:


### PR DESCRIPTION
## Summary

Easy-issue sweep bundle for ProjectMnemosyne (2026-05-16 wave). Five
bundled fixes targeting generator scripts (`migrate_ecosystem_skills.py`,
`generate_marketplace.py`) and `.claude/shared/*` / migration docs. **No
skill `verification:` field was modified anywhere** — the quirk from the
brief is honored. Each issue lands as its own commit for bisect-friendliness.

## Bundled fixes

| Commit | Issue | Summary |
| --- | --- | --- |
| `6c142a06` | #1461 | Replace hardcoded `TODAY = "2026-03-25"` with `datetime.date.today().isoformat()` |
| `5bfb4656` | #1460 | Source `marketplace.version` from `pyproject.toml [project.version]` |
| `11589168` | #1459, #1472 | Wire `generate_marketplace.py` to import `find_skill_files` + `parse_frontmatter` from `scripts/skill_utils.py` |
| `b9bb70df` | #1468 | Update `.claude/shared/plugin-standards.md` to flat-file v2.0.0+ format (incl. `verification` field) |
| `7bc9e327` | #1470 | Link 4 open `📋` items in `MIGRATION_STATUS.md` to tracking issue #1470 |

## Policy

- **Squash-only**: please use `gh pr merge --auto --squash` (no `--rebase`, no `--admin`).
- **Review required**: bundled PR, no auto-merge.
- One commit per logical issue cluster.

## Stale-check closures (closed in-place, NOT in this bundle)

- **#1517** — Resolved by #1713 (`fix(ci): unblock main — markdownlint + secrets-scan`, merged as `3ad38f8e`). Markdownlint Required-Checks job is unblocked on `main`.

## Deferred (left in MEDIUM)

- **#1473** — `migrate_ecosystem_skills.py` has a third hand-rolled `parse_frontmatter()`. Swapping it for `skill_utils.parse_frontmatter` would change return semantics (string-only vs `yaml.safe_load`-typed) and risk downstream `_format_yaml_value`/`frontmatter_to_yaml` regression, so this was not bundled. Pairs naturally with #1462 (silent list-discard) — recommend tackling together.
- **#1465** — `plugins/tooling/mnemosyne/` relic. The CLAUDE.md footnote already documents it as an explicit exception; needs a design call (remove vs. amend footnote further) before EASY merge.

## Quirks honored

- **No skill `verification:` field touched.** All changes are to generator scripts and `.claude/shared/*` / `MIGRATION_STATUS.md` docs only.
- **All commits use `--no-verify`** per cold-worktree guidance.
- Branch cut from current `origin/main` (`71b99008`) — post #1713, #1711, #1712, #1714–#1716 merges.
- In-flight PRs #1705 / #1706 do not collide with bundled files (verified before push).
