### PR TITLE
docs: clarify plugins/tooling/mnemosyne is infrastructure, not a relic

### DIFF
--- a/plugins/tooling/mnemosyne/README.md
+++ b/plugins/tooling/mnemosyne/README.md
@@ -1,0 +1,33 @@
+# plugins/tooling/mnemosyne — Command Infrastructure
+
+This directory is **not a skill** and is **not a relic**. It is the command infrastructure
+that powers the `/advise` and `/learn` slash commands used across the HomericIntelligence
+ecosystem.
+
+## Why it lives in `plugins/`, not `skills/`
+
+ProjectMnemosyne v2.0.0 migrated all *skills* to flat `.md` files under `skills/`.
+However, this directory predates and is exempt from that migration because it contains:
+
+| Sub-directory | Purpose |
+|---------------|---------|
+| `skills/advise/` | SKILL.md for the `/advise` command |
+| `skills/learn/` | SKILL.md for the `/learn` command |
+| `skills/documentation-patterns/` | Documentation authoring guidance |
+| `skills/validation-workflow/` | CI/pre-commit validation guidance |
+| `hooks/` | Example hook configurations (`settings.json.example`) |
+| `references/` | Session notes, experiment logs, troubleshooting guides |
+| `.claude-plugin/plugin.json` | Plugin manifest loaded by the Claude Code harness |
+
+## What the `plugin.json` says about commands
+
+As of v2.0.0, the `/advise` and `/learn` *command implementations* have moved to the
+`hephaestus` plugin in [ProjectHephaestus](https://github.com/HomericIntelligence/ProjectHephaestus).
+The SKILL.md files here document their behaviour and remain the authoritative reference.
+
+## For contributors
+
+- Do **not** convert this directory to the flat-file format — the harness expects the
+  nested layout for plugin manifests.
+- Do **not** add new skills here. New skills belong in `skills/<name>.md`.
+- See `CLAUDE.md` → *Plugin Standards* for the full rationale and the exception note.


### PR DESCRIPTION
## Summary

- Adds `plugins/tooling/mnemosyne/README.md` explaining that this directory is command infrastructure (houses `/advise` and `/learn` SKILL.md files, hook examples, and references) — not a skill and not a pre-v2.0.0 relic to be removed.
- No code changes; validation passes (695/695 skills valid).
- Reduces contributor confusion without requiring anyone to read the CLAUDE.md footnote.

## Why not delete it?

The directory is load-bearing: it contains `plugin.json`, SKILL.md files for the `/advise` and `/learn` commands, `hooks/settings.json.example`, and `references/`. Deleting it would break the plugin manifest and remove command documentation. CLAUDE.md explicitly designates it as the one intentional exception to the flat-file layout.

## Test plan

- [x] `python3 scripts/validate_plugins.py` passes (695/695)
- [x] Pre-commit hooks pass

Closes #1465
Part of #1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)