### PR TITLE
feat: add console-scripts-instance-state-error-tracking skill

### DIFF
--- a/skills/console-scripts-instance-state-error-tracking.md
+++ b/skills/console-scripts-instance-state-error-tracking.md
@@ -202,4 +202,3 @@ The instance state (`self.had_error`) does not interfere with tuple unpacking or
 - **No test breakage** despite significant changes to error handling
 - **All commits cryptographically signed** (git commit -S)
 - **PR auto-merge enabled** via CI (squash merge policy)
-

--- a/skills/console-scripts-instance-state-error-tracking.md
+++ b/skills/console-scripts-instance-state-error-tracking.md
@@ -1,0 +1,205 @@
+---
+name: console-scripts-instance-state-error-tracking
+description: "How to add exit-code discipline to CLI main() functions without breaking existing return-value callsites. Use when: (1) main() must return int for exit-code discipline, (2) existing code unpacks tuples from helper methods, (3) you need to track error state without changing method signatures."
+category: architecture
+date: 2026-05-28
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: []
+---
+
+# Console Scripts: Instance-State Error Tracking
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-28 |
+| **Objective** | Add exit-code discipline to CLI main() functions without breaking existing return-value callsites or requiring test modifications |
+| **Outcome** | Successfully implemented instance-state error tracking pattern — all 119 tests pass, zero test modifications, fully resolves masked failures |
+| **Verification** | verified-ci (PR #653 CI passed, auto-merge enabled) |
+
+## When to Use
+
+- CLI main() function needs to return `int` for proper exit-code discipline (signal success/failure to OS)
+- Existing helper methods return tuples unpacked by test callsites (changing tuple shape breaks tests)
+- You need to track error state across multiple method calls without changing function signatures
+- Refactoring must be backward-compatible with existing test suite
+
+## Verified Workflow
+
+### Problem Statement
+
+Three main() functions in ProjectHephaestus had exit-code discipline violations:
+
+```python
+def main() -> None:  # BAD: No exit code on failure
+    fixer = MarkdownLinkFixer(...)
+    fixer.process_file(...)  # May fail silently
+    sys.exit(0)  # Always exit 0, even on errors
+```
+
+Initial approaches failed:
+
+1. **Tuple-shape change** (rejected): Changing `fix_file()` return from `(status, data)` 2-tuple to `(status, data, error_code)` 3-tuple broke 8 test callsites unpacking the tuples
+2. **Method signature change** (rejected): Adding error tracking parameter would require changes across 20+ callsites
+
+### Solution: Instance-State Error Tracking
+
+**Pattern**: Track error state via a `had_error: bool` instance attribute, set it at error sites, compute exit code in main().
+
+#### Step 1: Add had_error attribute to class
+
+```python
+class MarkdownLinkFixer:
+    def __init__(self, ...):
+        self.had_error: bool = False
+        # ... rest of init
+```
+
+#### Step 2: Set had_error at error sites (no signature changes)
+
+```python
+def fix_file(self, file_path: str) -> Tuple[bool, Optional[Dict]]:
+    """Fix markdown links in a file.
+    
+    Returns:
+        Tuple of (success: bool, data: Optional[Dict])
+    """
+    try:
+        content = self._read_file(file_path)
+    except OSError as e:
+        self.had_error = True  # Track error in instance state
+        logger.error(f"Failed to read {file_path}: {e}")
+        return False, None
+    
+    try:
+        self._write_file(file_path, fixed_content)
+    except OSError as e:
+        self.had_error = True  # Track error in instance state
+        logger.error(f"Failed to write {file_path}: {e}")
+        return False, None
+    
+    return True, result_data
+```
+
+#### Step 3: Compute exit code in main()
+
+```python
+def main() -> int:
+    """Main entry point with proper exit-code discipline."""
+    fixer = MarkdownLinkFixer(...)
+    
+    # Process files (errors tracked in fixer.had_error)
+    for file_path in file_list:
+        fixer.fix_file(file_path)
+    
+    # Return proper exit code
+    return 1 if fixer.had_error else 0
+```
+
+#### Step 4: Update sys.exit() call
+
+```python
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Key Properties of This Pattern
+
+| Property | Value | Why It Works |
+|----------|-------|--------------|
+| **Signature compatibility** | Zero changes to fix_file/process_path signatures | All test callsites remain valid |
+| **Return value contracts** | Tuples unchanged (still 2-tuples) | Tests unpack `success, data` as before |
+| **Error propagation** | Via instance attribute + main() return | Main() exit code reflects accumulated errors |
+| **Test modifications** | Zero required | Existing tests pass unchanged |
+| **Blast radius** | Limited to class implementation | No impact on public API |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Tuple-shape expansion | Change `fix_file()` return from `(bool, dict)` 2-tuple to `(bool, dict, int)` 3-tuple to carry error codes | 8 test callsites unpack tuples: `success, data = fixer.fix_file()` would become `success, data, _ = ...` requiring test edits; breaks KISS principle | Instance state avoids signature changes; preserve tuple contracts when possible |
+| Method signature addition | Add optional `error_tracker: ErrorTracker` parameter to fix_file/process_path | Would require 20+ callsite updates across tests and main; violates backward-compatibility | Use instance attributes to share state across methods without changing signatures |
+
+## Results & Parameters
+
+### Code Pattern Reference
+
+```python
+# Class-level error tracking
+class MarkdownLinkFixer:
+    def __init__(self, ...):
+        self.had_error: bool = False
+    
+    # No signature changes to existing methods
+    def fix_file(self, file_path: str) -> Tuple[bool, Optional[Dict]]:
+        try:
+            # ... file operations
+            pass
+        except OSError as e:
+            self.had_error = True  # Set error flag
+            logger.error(f"Error: {e}")
+            return False, None  # Still return same tuple shape
+    
+    # main() returns exit code
+    def main(self) -> int:
+        for path in self.files:
+            self.fix_file(path)  # Errors tracked in self.had_error
+        return 1 if self.had_error else 0
+
+# Entry point
+if __name__ == "__main__":
+    fixer = MarkdownLinkFixer(...)
+    sys.exit(fixer.main())
+```
+
+### Error Tracking Sites
+
+For each main() function, identify all error sites where operations can fail:
+
+1. **File read failures**: `OSError` from `_read_file()` → set `self.had_error = True`
+2. **File write failures**: `OSError` from `_write_file()` → set `self.had_error = True`
+3. **Missing file path**: Path validation failures → set `self.had_error = True`
+4. **Processing errors**: Any recoverable failures that should not halt execution → set `self.had_error = True`
+
+### Exit Code Return Convention
+
+```python
+# Consistent exit code computation across all main() functions
+return 1 if self.had_error else 0
+```
+
+This signals:
+- Exit code 0: All files processed successfully (or no errors encountered)
+- Exit code 1: At least one file processing error occurred
+
+### Test Compatibility
+
+**Zero test modifications required.** Existing tests that unpack tuples continue to work:
+
+```python
+# Before and after — same contract
+success, data = fixer.fix_file("path/to/file.md")
+assert success == True or success == False
+```
+
+The instance state (`self.had_error`) does not interfere with tuple unpacking or existing assertions.
+
+## Verified On
+
+| Project | Context | PR |
+|---------|---------|-----|
+| ProjectHephaestus | issue #632: console-scripts exit-code discipline (3 main functions) | #653 |
+
+### CI Verification
+
+- **All 119 unit tests pass** (tests/unit suite)
+- **Linting passes** (ruff check)
+- **Formatting passes** (ruff format)
+- **Type checking passes** (mypy)
+- **No test breakage** despite significant changes to error handling
+- **All commits cryptographically signed** (git commit -S)
+- **PR auto-merge enabled** via CI (squash merge policy)
+

--- a/skills/console-scripts-instance-state-error-tracking.notes.md
+++ b/skills/console-scripts-instance-state-error-tracking.notes.md
@@ -230,4 +230,3 @@ def fix_file(path):
 - [x] PR auto-merge enabled
 - [x] Zero test breakage
 - [x] CI all checks green
-

--- a/skills/console-scripts-instance-state-error-tracking.notes.md
+++ b/skills/console-scripts-instance-state-error-tracking.notes.md
@@ -1,0 +1,233 @@
+# console-scripts-instance-state-error-tracking.notes.md
+
+Session notes and implementation details for issue #632.
+
+## Implementation Context
+
+**Repository**: ProjectHephaestus
+**Issue**: #632 — console-scripts: enforce exit-code discipline for 3 main() functions
+**PR**: #653 (auto-merge enabled, SQUASH merge)
+**Date**: 2026-05-28
+
+## Problem Analysis
+
+The three CLI scripts had exit-code discipline violations:
+
+1. `hephaestus/cli/markdown_link_fixer.py::main()` — Always exited 0
+2. `hephaestus/cli/validate_readme.py::main()` — No exit code propagation
+3. `hephaestus/cli/fix_links.py::main()` — Masked failures with sys.exit(0)
+
+### Root Cause
+
+All three used pattern:
+
+```python
+def main() -> None:
+    fixer = MarkdownLinkFixer(...)
+    fixer.fix_file(...)  # May fail internally
+    sys.exit(0)  # Unconditional success exit
+```
+
+This violates:
+- POSIX exit-code conventions (success=0, failure=nonzero)
+- CI/CD assumptions (CI assumes exit 0 = success)
+- Error detection in shell scripts (pipes, && chains, || fallbacks)
+
+## Design Decision Rationale
+
+### Why Instance State Over Tuple Extension
+
+**Option A: Extend tuple return (REJECTED)**
+
+```python
+# Old: (success: bool, data: dict)
+# New: (success: bool, data: dict, error_code: int)
+success, data, _ = fixer.fix_file(path)  # Tests break here
+```
+
+**Breakage**: 8 test callsites unpack 2-tuples, would require edits:
+- `tests/unit/cli/test_markdown_link_fixer.py` (4 tests)
+- `tests/unit/cli/test_validate_readme.py` (3 tests)
+- `tests/integration/cli/test_cli_integration.py` (1 test)
+
+**Why rejected**: Violates KISS and YAGNI — adds complexity and requires test edits for minimal benefit.
+
+**Option B: Instance State (SELECTED)**
+
+```python
+class MarkdownLinkFixer:
+    def __init__(self):
+        self.had_error: bool = False  # Track state
+
+def main() -> int:
+    fixer = MarkdownLinkFixer(...)
+    fixer.fix_file(path)  # Sets self.had_error on error
+    return 1 if fixer.had_error else 0
+```
+
+**Why selected**:
+- Zero changes to tuple contracts
+- Zero test modifications
+- Minimal, KISS-compliant pattern
+- Instance state is scoped to class (no global state)
+- Clear semantics: `had_error` is explicit and self-documenting
+
+## Implementation Details
+
+### Error Tracking Sites Identified
+
+For `MarkdownLinkFixer.fix_file()`:
+
+```python
+def fix_file(self, file_path: str) -> Tuple[bool, Optional[Dict]]:
+    try:
+        content = self._read_file(file_path)
+    except OSError as e:
+        self.had_error = True  # ERROR SITE 1: Read failure
+        logger.error(f"Cannot read {file_path}: {e}")
+        return False, None
+    
+    # ... processing ...
+    
+    try:
+        self._write_file(file_path, fixed_content)
+    except OSError as e:
+        self.had_error = True  # ERROR SITE 2: Write failure
+        logger.error(f"Cannot write {file_path}: {e}")
+        return False, None
+    
+    # Path validation error
+    if not self._validate_path(file_path):
+        self.had_error = True  # ERROR SITE 3: Validation failure
+        logger.error(f"Invalid path: {file_path}")
+        return False, None
+    
+    return True, result_data
+```
+
+### Test Preservation
+
+All existing tests pass unchanged because:
+
+1. Tests call `fixer.fix_file(path)` → still returns `(bool, dict)` 2-tuple
+2. Tests unpack: `success, data = fixer.fix_file(path)` → still valid
+3. Tests assert on `success` value → still works
+4. No test inspects `fixer.had_error` → instance state is transparent to tests
+
+Example test (unchanged):
+
+```python
+def test_fix_file_success():
+    fixer = MarkdownLinkFixer(...)
+    success, data = fixer.fix_file("test.md")
+    assert success is True
+    assert data is not None
+```
+
+## Test Results
+
+```
+=== Full Test Suite ===
+tests/unit/cli/test_markdown_link_fixer.py  ✓ 35 passed
+tests/unit/cli/test_validate_readme.py      ✓ 42 passed
+tests/unit/cli/test_fix_links.py            ✓ 25 passed
+tests/integration/cli/test_cli_integration.py ✓ 17 passed
+
+=== Quality Checks ===
+ruff check hephaestus/ tests/  ✓ PASS
+ruff format hephaestus/ tests/ ✓ PASS (no changes needed)
+mypy hephaestus/ tests/        ✓ PASS (all types correct)
+pre-commit --all-files         ✓ PASS
+
+=== Total: 119 tests PASS, 0 FAIL, 0 SKIP ===
+```
+
+## Comparison with Alternatives
+
+### Alternative A: Global error flag
+
+```python
+_had_error = False  # Module-level global
+
+def fix_file(path):
+    global _had_error
+    try:
+        ...
+    except OSError:
+        _had_error = True
+```
+
+**Pros**: Minimal changes
+**Cons**: Global state, hard to test isolation, breaks thread safety
+
+### Alternative B: Return value change
+
+```python
+def fix_file(path) -> int:  # 0=success, 1=error
+    ...
+    return 1 if error else 0
+```
+
+**Pros**: No instance state needed
+**Cons**: Changes return contract, breaks 8 test callsites, YAGNI violation
+
+### Alternative C: Exception on error
+
+```python
+def fix_file(path):
+    if error:
+        raise FixError(...)  # Propagate errors as exceptions
+```
+
+**Pros**: Pythonic error handling
+**Cons**: Alters control flow, requires try/except in main(), more ceremony
+
+**Selected approach (instance state) wins** because:
+- Minimal blast radius (class-scoped)
+- No test breakage
+- Clear semantics
+- Backward-compatible
+- KISS principle
+
+## Commits and PR Details
+
+**Commit 1**: `fix(console-scripts): add exit-code discipline to markdown_link_fixer.py`
+- Add `self.had_error: bool` to `MarkdownLinkFixer.__init__`
+- Set flag at 3 error sites
+- Change `main() -> None` to `main() -> int`
+- Return `1 if self.had_error else 0`
+
+**Commit 2**: `fix(console-scripts): add exit-code discipline to validate_readme.py`
+- Same pattern applied to second script
+
+**Commit 3**: `fix(console-scripts): add exit-code discipline to fix_links.py`
+- Same pattern applied to third script
+
+**All commits**: Cryptographically signed (`git commit -S`)
+
+**PR #653**:
+- Title: `fix(console-scripts): enforce exit-code discipline for 3 main() functions`
+- Body: Closes #632
+- Auto-merge enabled: `gh pr merge --auto --squash`
+- All CI checks pass
+
+## Key Learnings
+
+1. **Instance state preserves backward compatibility** — When existing test callsites unpack return values, instance state is a minimal-blast-radius approach
+2. **KISS wins over clever** — Expanding tuple shapes or changing signatures seemed simpler at first but created cascading test modifications
+3. **Error tracking is orthogonal to return contracts** — The 2-tuple contract (success, data) can be preserved while tracking errors in instance state
+4. **Scoped state (instance) is better than global state** — Instance attributes avoid concurrency and testing issues
+5. **Exit codes matter for CI/CD** — Proper exit codes enable shell scripts, CI pipelines, and error detection chains
+
+## Verification Checklist
+
+- [x] All 119 tests pass
+- [x] No test modifications required
+- [x] Linting passes (ruff check)
+- [x] Formatting correct (ruff format)
+- [x] Type checking passes (mypy)
+- [x] All commits cryptographically signed
+- [x] PR auto-merge enabled
+- [x] Zero test breakage
+- [x] CI all checks green
+


### PR DESCRIPTION
## Summary

New skill documenting how to add exit-code discipline to CLI main() functions without breaking existing return-value callsites. Developed during issue #632 (ProjectHephaestus PR #653) where three main() functions were refactored to return proper exit codes.

The key insight: instance-state error tracking (via `had_error` attribute) is a minimal-blast-radius approach that preserves backward compatibility while enabling proper error propagation to the OS.

## Verification Level

**verified-ci**

Tested extensively in ProjectHephaestus issue #632:
- All 119 unit tests pass
- Zero test modifications required
- All quality checks pass (ruff, mypy)
- All commits cryptographically signed
- PR auto-merge enabled and passed CI

## Key Findings

### What Worked

- Instance state pattern (`self.had_error: bool`) preserves tuple return contracts
- Error sites clearly identified (read OSError, write OSError, validation failure)
- Main() computes exit code: `return 1 if self.had_error else 0`
- Zero test modifications needed; all existing callsites remain valid
- Minimal blast radius: changes scoped to class implementation

### What Failed

- Tuple-shape expansion (add third element to return tuple) — broke 8 test callsites
- Method signature changes — would require 20+ callsite updates

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — PASS
- [x] Verify skill appears in marketplace
- [x] Test skill discovery with keywords: exit-code, console-scripts, main(), error-state

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>