### PR TITLE
feat: amend pr-merged-state-not-proof-of-remote-sync skill (v1.1.0)

### DIFF
--- a/skills/pr-merged-state-not-proof-of-remote-sync.history
+++ b/skills/pr-merged-state-not-proof-of-remote-sync.history
@@ -1,0 +1,77 @@
+# pr-merged-state-not-proof-of-remote-sync — History
+
+## v1.1.0 (2026-05-29)
+
+**Changed by:** ProjectKeystone session — near-miss where a local `512-impl` branch
+(pointing at a background agent's commit) was about to be merged-and-pushed to PR #571,
+whose remote head `origin/512-impl` was actually a DIFFERENT implementation pushed by a
+parallel `.issue_implementer` automation process. Caught before pushing.
+**Verification:** verified-local
+
+### What changed
+
+- Generalized the core insight from "API state vs local refs diverge until fetch (READ
+  direction)" to also cover the WRITE direction: a local branch and `origin/<same-name>`
+  can point at completely different commits when a parallel process pushes to the same
+  branch name. A matching branch NAME does not imply matching CONTENT.
+- Added a new "Pushing to a PR branch you do not own end-to-end" section to the Verified
+  Workflow, with the re-derive-from-remote-head procedure and the
+  `git merge-base --is-ancestor origin/<branch> HEAD` fast-forward gate.
+- Added the `git rev-parse HEAD` vs `git rev-parse origin/<branch>` divergence check and
+  the commit-subject comparison to Quick Reference.
+- Added 2 new Failed Attempts rows (trusting a name-matched local branch as the PR head;
+  assuming `git worktree add <dir> <branch>` checks out the remote head).
+- Added ProjectKeystone (PR #571 / `512-impl`, 2026-05-29) to Verified On.
+- Bumped version 1.0.0 → 1.1.0 (minor: new findings, new failed attempts, extended
+  workflow). Added `history` frontmatter field.
+
+### Why
+
+v1.0.0 covered only the read/audit direction: "`gh pr view` says MERGED, but local refs
+are stale — fetch before you trust them." The same root cause (GitHub state, local
+remote-tracking refs, and the working tree are three independent surfaces) bites in the
+write direction too. When a parallel automation process pushes a different implementation
+to `origin/512-impl`, a local `512-impl` branch carrying your own agent's commit is stale
+relative to the real PR head. Merging main into the local branch and pushing it would
+fast-forward-clobber the wrong implementation onto PR #571. The fix is symmetric to v1.0.0:
+fetch, compare `rev-parse HEAD` vs `rev-parse origin/<branch>`, re-derive from the remote
+head, and gate the push on `merge-base --is-ancestor`.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: pr-merged-state-not-proof-of-remote-sync
+description: "`gh pr view --json state` returning MERGED does NOT prove the merge commit is in your local main, your origin/main ref, or even in any local checkout. The GitHub API and local git refs diverge until `git fetch` runs. Use when: (1) about to report `PR is merged` to the user based on `gh pr view`, (2) auditing whether a file is still present/absent in main after a deletion or rename PR, (3) spawning sub-agents that will grep or scan the working tree expecting it matches main, (4) running deletion-validation or migration-completeness workflows, (5) reasoning about whether `origin/main` reflects the latest merges, (6) a sub-agent reports `feature X didn't execute / files missing / wave didn't run` immediately after PRs were marked merged."
+category: ci-cd
+date: 2026-05-26
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - gh-cli
+  - git-fetch
+  - audit
+  - sub-agents
+  - merge-verification
+  - working-tree
+---
+
+# `gh pr view` MERGED Is Not Proof Of Local/Remote Sync
+
+(v1.0.0 body: established that gh pr view queries GitHub directly while local refs —
+including origin/main — only refresh on git fetch, and that sub-agents auditing the
+working tree silently scan whatever branch is checked out, not main. Verified on
+HomericIntelligence/ProjectOdyssey PRs #5458/#5459/#5460 where the audit swarm
+hallucinated "Wave 2 didn't execute" with 10+ false positives per agent. Full v1.0.0
+content preserved in git history at commit f56173ef and prior.)
+```
+
+---
+
+## v1.0.0 (2026-05-26)
+
+**Initial version.** Established that `gh pr view --json state` returning MERGED proves
+only GitHub API state, not local `origin/main` ref state (refreshes only on `git fetch`)
+nor working-tree state (whatever branch is checked out). Verified on ProjectOdyssey
+PRs #5458/#5459/#5460 audit-swarm false positives.

--- a/skills/pr-merged-state-not-proof-of-remote-sync.md
+++ b/skills/pr-merged-state-not-proof-of-remote-sync.md
@@ -1,11 +1,12 @@
 ---
 name: pr-merged-state-not-proof-of-remote-sync
-description: "`gh pr view --json state` returning MERGED does NOT prove the merge commit is in your local main, your origin/main ref, or even in any local checkout. The GitHub API and local git refs diverge until `git fetch` runs. Use when: (1) about to report `PR is merged` to the user based on `gh pr view`, (2) auditing whether a file is still present/absent in main after a deletion or rename PR, (3) spawning sub-agents that will grep or scan the working tree expecting it matches main, (4) running deletion-validation or migration-completeness workflows, (5) reasoning about whether `origin/main` reflects the latest merges, (6) a sub-agent reports `feature X didn't execute / files missing / wave didn't run` immediately after PRs were marked merged."
+description: "GitHub API state, your local `origin/<branch>` ref, and your working tree are three independent surfaces that diverge until `git fetch` runs — in BOTH the read direction (`gh pr view` says MERGED but refs are stale) and the write direction (a local branch and `origin/<same-name>` point at different commits because a parallel process pushed). A matching branch NAME does not imply matching CONTENT. Use when: (1) about to report `PR is merged` based on `gh pr view`, (2) auditing whether a file is present/absent in main after a deletion or rename PR, (3) spawning sub-agents that grep or scan the working tree expecting it matches main, (4) running deletion-validation or migration-completeness workflows, (5) reasoning about whether `origin/main` reflects the latest merges, (6) a sub-agent reports `feature X didn't execute / files missing / wave didn't run` immediately after PRs were marked merged, (7) about to push a local `<issue>-impl` / feature branch to update a PR when a parallel automation process may have pushed to the same branch name, (8) merging main into a local branch and pushing it to a PR branch you did not author end-to-end."
 category: ci-cd
-date: 2026-05-26
-version: "1.0.0"
+date: 2026-05-29
+version: "1.1.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
+history: pr-merged-state-not-proof-of-remote-sync.history
 tags:
   - gh-cli
   - git-fetch
@@ -13,6 +14,10 @@ tags:
   - sub-agents
   - merge-verification
   - working-tree
+  - branch-divergence
+  - parallel-automation
+  - fast-forward-gate
+  - rev-parse
 ---
 
 # `gh pr view` MERGED Is Not Proof Of Local/Remote Sync
@@ -21,11 +26,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-26 |
-| **Objective** | Stop reporting "PRs merged" or "files deleted from main" based on `gh pr view --json state` alone; require remote-ref verification before any claim and pin audit sub-agents to a specific git ref |
-| **Outcome** | Successful — established that `gh pr view` queries GitHub directly while local refs (including `origin/main`) only refresh on `git fetch`, and that sub-agents auditing the working tree silently scan whatever branch is checked out (not main) |
-| **Verification** | verified-ci — protocol grounded in real session events where PRs #5458/#5459/#5460 on HomericIntelligence/ProjectOdyssey reported MERGED within ~30s of auto-merge arming, yet a subsequent audit swarm scanning the working tree on branch `5452-autograd-phase2-substrate` hallucinated "Wave 2 didn't execute" with 10+ false positives per agent because local refs were stale and the working tree wasn't main |
-| **History** | n/a (initial version) |
+| **Date** | 2026-05-29 (v1.1.0) |
+| **Objective** | Stop trusting a local ref as the source of truth for a remote PR — in BOTH directions: (READ) reporting "PRs merged / files deleted from main" based on `gh pr view --json state` alone, and (WRITE) pushing a local branch to update a PR when a parallel process may have pushed a different commit to the same branch name. Require remote-ref verification before any claim or push, and pin audit sub-agents to a specific git ref |
+| **Outcome** | Successful — established that GitHub API state, local `origin/<branch>` refs (refresh only on `git fetch`), and the working tree (whatever branch is checked out) are three independent surfaces. v1.1.0 adds the write direction: a local `<issue>-impl` branch and `origin/<issue>-impl` can point at entirely different implementations when a parallel automation process pushes to the same name; gate pushes on a `merge-base --is-ancestor` fast-forward check |
+| **Verification** | verified-local — v1.0.0 (read direction) grounded in ProjectOdyssey PRs #5458/#5459/#5460 audit-swarm false positives; v1.1.0 (write direction) grounded in ProjectKeystone PR #571 / branch `512-impl`, where a parallel `.issue_implementer` automation pushed a different implementation to `origin/512-impl` than the local background-agent commit, caught before a clobbering push |
+| **History** | [changelog](./pr-merged-state-not-proof-of-remote-sync.history) |
 
 ## When to Use
 
@@ -36,16 +41,21 @@ tags:
 - Reasoning about whether `origin/main` reflects the latest merges (it doesn't, until you fetch)
 - A sub-agent reports "feature X didn't execute / files missing / wave didn't run" immediately after PRs were marked merged — likely a stale-ref or wrong-branch hallucination
 - Coordinating multiple stacked PRs and you need to confirm earlier ones landed in main before basing later work on that assumption
+- **(WRITE direction)** About to push a local `<issue>-impl` / feature branch to update an open PR, when a **parallel automation process** (e.g. `.issue_implementer`, an issue-backlog runner, or another agent) may have pushed to the **same branch name**
+- The local branch and `origin/<same-name>` were produced by **different processes** for the **same issue** — branch names collide but contents may differ
+- Merging `main` into a local branch and pushing it to a PR branch you **did not author end-to-end** — verify you are fast-forwarding the real PR head, not overwriting it
 
 ## The Core Insight
 
-Three independent state surfaces diverge:
+Three independent state surfaces diverge, and `git fetch` is the only thing that reconciles the local view:
 
-1. **GitHub API state** — what `gh pr view --json state,mergedAt,mergeCommit` returns. Authoritative for "did GitHub accept the merge", lags ≤ seconds behind reality.
-2. **Local remote-tracking ref** — `origin/main`. Only updates when you run `git fetch origin`. Can be hours/days stale.
-3. **Working tree** — whatever branch is currently checked out. Reflects that branch's files, not main's. Sub-agents that grep the working tree are auditing the checked-out branch, not main.
+1. **GitHub API state** — what `gh pr view --json state,mergedAt,mergeCommit,headRefOid` returns. Authoritative for "did GitHub accept the merge" / "what commit backs the PR right now", lags ≤ seconds behind reality.
+2. **Local remote-tracking ref** — `origin/main`, `origin/<branch>`. Only updates when you run `git fetch origin`. Can be hours/days stale.
+3. **Working tree / local branch** — whatever branch is currently checked out, and whatever commit your **local** `<branch>` ref points at. Reflects that local commit's files, not the remote PR head's. Sub-agents that grep the working tree are auditing the checked-out branch, not main.
 
-`gh pr view` returning MERGED only proves (1). Reporting "merged to main" or auditing "what's in main" requires verifying (2) and choosing the right ref for (3).
+**Read direction:** `gh pr view` returning MERGED only proves (1). Reporting "merged to main" or auditing "what's in main" requires verifying (2) and choosing the right ref for (3).
+
+**Write direction (the symmetric trap):** A local branch named `512-impl` proves nothing about what backs PR #571. If a parallel process pushed a different implementation to `origin/512-impl`, then your local `512-impl` (carrying your own agent's commit) is **stale relative to the real PR head**. A matching branch **NAME** does not imply matching **CONTENT**. Merging `main` into the local branch and pushing it would fast-forward-clobber the wrong implementation onto the PR. Before pushing to any PR branch you did not author end-to-end, re-derive your work from `origin/<pr-branch>` and gate the push on a `merge-base --is-ancestor` fast-forward check.
 
 ## Verified Workflow
 
@@ -73,6 +83,33 @@ git clone --depth 5 --branch main "$REPO_URL" "/tmp/${REPO_NAME}-audit"
 # "Audit the state of origin/main (NOT the current working tree). Use
 #  `git show origin/main:<path>` or run inside /tmp/<repo>-audit. The working
 #  tree is on branch <X> which is NOT main."
+
+# === WRITE direction: before pushing a local branch to update a PR ===
+git fetch origin --quiet
+
+# 1. Divergence check — does your local branch match the remote PR head?
+git rev-parse HEAD                      # your local commit
+git rev-parse origin/<pr-branch>        # the commit backing the open PR
+# If these DIFFER, your local branch is NOT the PR head. STOP and investigate.
+
+# 2. Confirm by comparing commit subjects (different implementations look different)
+git log --oneline -3 HEAD
+git log --oneline -3 origin/<pr-branch>
+# e.g. "...automatic off-host forwarding" (yours) vs
+#      "...automatic off-host NATS promotion" (the parallel automation's) = DIVERGED
+
+# 3. Re-derive your work from the REAL remote PR head, not the local ref:
+git worktree add /tmp/sync-<branch> --detach origin/<pr-branch>   # --detach pins remote head
+cd /tmp/sync-<branch>
+git switch -c sync-<branch>
+git merge origin/main                   # do your update on top of the real PR head
+
+# 4. Fast-forward GATE — must be an ancestor or you'd overwrite someone else's PR:
+git merge-base --is-ancestor origin/<pr-branch> HEAD && echo "FF-safe" || \
+  { echo "NOT a fast-forward of the PR head — STOP, do not push"; exit 1; }
+
+# 5. Only now push (updates the PR by fast-forward, never clobbers):
+unset GH_TOKEN GITHUB_TOKEN; git push origin HEAD:<pr-branch>
 ```
 
 ### Detailed Steps
@@ -99,12 +136,66 @@ git clone --depth 5 --branch main "$REPO_URL" "/tmp/${REPO_NAME}-audit"
 
 6. **For stacked PRs, verify the parent landed in `origin/main` before reporting the child is "ready to merge to main"** — auto-merge on a child whose parent has only the API-state of MERGED can race in obvious and non-obvious ways.
 
+### Pushing to a PR branch you do not own end-to-end (WRITE direction)
+
+When a **parallel automation process** (an issue-backlog runner like `.issue_implementer`,
+or another agent) targets the **same `<issue>-impl` branch names** as your own background
+agents, the local branch and the remote PR head can be **completely different
+implementations of the same feature**. The trap: your worktree's `512-impl` points at your
+background agent's commit (files in `core/`), while the OPEN PR #571 is backed by the
+automation's commit on `origin/512-impl` (files in `transport/`). The branch names match;
+the contents diverged.
+
+7. **Divergence check before any push to a PR branch.** Fetch, then compare:
+
+   ```bash
+   git fetch origin --quiet
+   git rev-parse HEAD                 # local commit
+   git rev-parse origin/512-impl      # commit backing PR #571
+   ```
+
+   If they differ, your local branch is **not** the PR head. Confirm with subjects —
+   different implementations have different commit messages:
+
+   ```bash
+   git log --oneline -3 HEAD              # "...automatic off-host forwarding"
+   git log --oneline -3 origin/512-impl   # "...automatic off-host NATS promotion"
+   ```
+
+   Different subject + different files = a parallel process owns the PR head. STOP.
+
+8. **Re-derive your work from the remote PR head, not the local ref.** A plain
+   `git worktree add <dir> <branch>` checks out the **local** branch ref (which has
+   diverged). Pin to the remote head explicitly with `--detach origin/<branch>`:
+
+   ```bash
+   git worktree add /tmp/sync-512-impl --detach origin/512-impl
+   cd /tmp/sync-512-impl
+   git switch -c sync-512-impl
+   git merge origin/main            # do the update on top of the REAL PR head
+   ```
+
+9. **Gate the push on a fast-forward check.** The remote PR head MUST be an ancestor of
+   what you are about to push, or you would rewrite/overwrite someone else's PR:
+
+   ```bash
+   git merge-base --is-ancestor origin/512-impl HEAD \
+     && echo "FF-safe — origin/512-impl is an ancestor of HEAD" \
+     || { echo "NOT a fast-forward — STOP, you'd clobber the PR"; exit 1; }
+   unset GH_TOKEN GITHUB_TOKEN; git push origin HEAD:512-impl
+   ```
+
+   If `--is-ancestor` returns non-zero, do not push. Investigate who owns the PR head and
+   reconcile, or open your own separate PR.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Trusted `gh pr view <N> --json state` returning MERGED as proof commits were in main | After arming auto-merge on PRs #5458/#5459/#5460, `gh pr view` returned MERGED within ~30s for all three. Reported "all merged" to the user without running `git fetch`. Subsequent audit sub-agents scanned the stale feature-branch working tree and reported "files not deleted" | API state and remote-ref state diverge: `gh pr view` queries GitHub directly; local refs (`origin/main`) only refresh on `git fetch`. Working-tree scans on feature branches show that branch's files, not main's | Always `git fetch origin && git log origin/main --oneline -10` before claiming a merge propagated. For deletion audits, use `git show origin/main:<path>` or a fresh shallow clone — never the working tree |
 | Spawned 4 audit sub-agents against the working tree without specifying which branch they should audit | 3 of 4 sub-agents reported "Wave 2 didn't execute" with 10+ false positives each. Working tree was checked out on branch `5452-autograd-phase2-substrate`, not main. Sub-agents trusted the working tree as ground truth for "what's in main" | Sub-agents default to scanning whatever the working tree shows. If the prompt doesn't pin them to a ref, they silently audit the wrong branch and produce confident, wrong answers | Pin every audit sub-agent to a specific git ref in the prompt: either `cd /tmp/<repo>-audit` (fresh clone of main), or instruct them to use `git show origin/main:<path>`. Tell them the actual current branch and that it is NOT main |
+| Trusted the local branch named `512-impl` as the PR's content and merged main into it | A parallel `.issue_implementer` automation and my own background agents both produced `512-impl` branches. My worktree's `512-impl` pointed at my agent's commit (files in `core/`); the OPEN PR #571 was backed by the automation's commit on `origin/512-impl` (files in `transport/`). I was about to `git merge origin/main` into the local branch and push to update the PR | It was a stale local commit, not the PR head. Pushing would have fast-forward-clobbered PR #571 with the wrong implementation. A matching branch **NAME** does not mean matching **CONTENT** when an external process pushes to the same name | Before pushing to a PR branch, `git fetch` then compare `git rev-parse HEAD` vs `git rev-parse origin/<branch>` and the `git log --oneline` subjects. If they differ, your local branch is not the PR head — re-derive from `origin/<branch>` |
+| Assumed `git worktree add <dir> <branch>` checks out the remote PR head | Ran `git worktree add /tmp/wt 512-impl` expecting it to give me the commit backing PR #571 | `git worktree add <dir> <branch>` checks out the **local** branch ref, which had diverged from `origin/512-impl`. I'd have continued working on the wrong (local) implementation | Use `git worktree add <dir> --detach origin/<branch>` to pin to the remote head explicitly, then `git switch -c sync-<branch>`. Gate the eventual push on `git merge-base --is-ancestor origin/<branch> HEAD` |
 
 ## Results & Parameters
 
@@ -116,6 +207,30 @@ git fetch origin --quiet && \
   git log origin/main --oneline | grep -q "${COMMIT:0:8}" && \
   echo "VERIFIED: $COMMIT is in origin/main" || \
   echo "NOT YET IN origin/main — wait and re-fetch"
+```
+
+**Push-safety one-liner** (before pushing a local branch to update a PR you didn't author end-to-end):
+
+```bash
+# B = the PR branch name (e.g. 512-impl)
+git fetch origin --quiet && \
+  if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/$B)" ]; then
+    echo "IN SYNC: local HEAD == origin/$B"
+  elif git merge-base --is-ancestor "origin/$B" HEAD; then
+    echo "FF-safe: origin/$B is an ancestor of HEAD — push is a fast-forward"
+  else
+    echo "DIVERGED: origin/$B is NOT an ancestor of HEAD — pushing would clobber the PR. STOP."
+  fi
+```
+
+**Re-derive-from-remote-head pattern** (when the divergence check says DIVERGED):
+
+```bash
+B=512-impl
+git fetch origin --quiet
+git worktree add "/tmp/sync-$B" --detach "origin/$B"   # --detach pins the REMOTE head
+( cd "/tmp/sync-$B" && git switch -c "sync-$B" && git merge origin/main )
+# then re-run the push-safety one-liner inside /tmp/sync-$B before pushing
 ```
 
 **Fresh-clone audit pattern**:
@@ -154,3 +269,4 @@ Before starting, run: git fetch origin --quiet
 | Project | Context | Details |
 |---------|---------|---------|
 | HomericIntelligence/ProjectOdyssey | JIT demolition Wave 1.5 — PRs #5458/#5459/#5460 reported MERGED by `gh pr view`; audit swarm on stale feature-branch working tree hallucinated "Wave 2 didn't execute" with 10+ false positives per agent (2026-05-26 session) | Working tree branch: `5452-autograd-phase2-substrate`; local `origin/main` was stale because no `git fetch` ran between merge and audit |
+| ProjectKeystone | WRITE direction (2026-05-29) — parallel `.issue_implementer` automation + own background agents both produced `<issue>-impl` branches. Local `512-impl` pointed at the background agent's commit (files in `core/`); OPEN PR #571 was backed by the automation's commit on `origin/512-impl` (files in `transport/`). About to merge main + push, which would have clobbered #571 | Caught via `git rev-parse HEAD` ≠ `git rev-parse origin/512-impl` and divergent commit subjects ("off-host forwarding" vs "off-host NATS promotion"). Re-derived from `origin/512-impl` via `--detach`, merged main, confirmed `merge-base --is-ancestor` fast-forward, pushed safely |


### PR DESCRIPTION
## Summary

Amends existing skill `pr-merged-state-not-proof-of-remote-sync` from v1.0.0 to v1.1.0.

Extends the core insight (GitHub API state, local `origin/<branch>` refs, and the working tree are three independent surfaces that only reconcile on `git fetch`) from the **read** direction to the **write** direction.

- **Read (v1.0.0):** `gh pr view` says MERGED but local refs are stale.
- **Write (v1.1.0, new):** a local `<issue>-impl` branch and `origin/<same-name>` can point at entirely different implementations when a **parallel automation process** pushes to the same branch name. A matching branch NAME does not imply matching CONTENT. Merging main into the local branch and pushing would fast-forward-clobber the real PR.

## Verification Level

**verified-local** — caught a real near-miss on ProjectKeystone PR #571 / branch `512-impl` before pushing; re-derived from `origin/512-impl`, merged main, confirmed fast-forward, pushed safely. CI validation pending.

## Key Findings

**What Worked**:
- Divergence check: `git rev-parse HEAD` vs `git rev-parse origin/<branch>` + commit-subject comparison surfaced the collision ("off-host forwarding" vs "off-host NATS promotion").
- Re-derive from the remote head with `git worktree add <dir> --detach origin/<branch>`, then merge main onto THAT.
- `git merge-base --is-ancestor origin/<branch> HEAD` as a fast-forward gate before any push to a shared PR branch.

**What Failed**:
- Trusting the name-matched local `512-impl` as the PR head → it was a stale local commit; pushing would have clobbered PR #571 with the wrong implementation.
- Assuming `git worktree add <dir> <branch>` checks out the remote PR head → it checks out the diverged LOCAL ref; use `--detach origin/<branch>`.

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py` (passed locally: 426/426)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>