### PR TITLE
fix(marketplace): quote numeric YAML tags + regenerate to remove stale entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,166 +5,104 @@
     "url": "https://github.com/HomericIntelligence"
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
-  "version": "1.0.0",
-  "total_plugins": 1060,
+  "version": "2.1.0",
+  "total_plugins": 515,
   "categories": {
-    "architecture": 123,
-    "ci-cd": 237,
-    "debugging": 117,
-    "documentation": 103,
-    "evaluation": 70,
-    "optimization": 17,
-    "testing": 152,
-    "tooling": 236,
-    "training": 5
+    "architecture": 66,
+    "ci-cd": 134,
+    "debugging": 38,
+    "documentation": 44,
+    "evaluation": 11,
+    "optimization": 3,
+    "testing": 65,
+    "tooling": 147,
+    "training": 7
   },
-  "last_updated": "2026-05-13T06:01:10Z",
+  "last_updated": "2026-06-07T14:43:48Z",
   "plugins": [
     {
-      "name": "agent-coverage-check",
-      "description": "Check agent configuration coverage across hierarchy levels and phases. Use to ensure complete agent system coverage.",
+      "name": "agent-config-and-tier-architecture",
+      "description": "Design, validate, and consolidate agent tier configurations in the HomericIntelligence agentic hierarchy. Use when: (1) merging redundant junior/senior agent tiers into a parent level with overlapping scope, (2) consolidating many review specialists with identical tooling into a single general specialist, (3) validating YAML frontmatter and configuration correctness before committing agent changes, (4) fixing inconsistent root-level field mapping in tier configurations or enhancing resource prompt suffixes, (5) routing each pipeline phase to the right Claude model tier via a centralized module with env-var overrides, (6) adding REST API client integration wired into a Pydantic config hierarchy.",
       "version": "1.0.0",
-      "source": "./skills/agent-coverage-check.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-hierarchy-diagram",
-      "description": "Generate visual hierarchy diagrams of agent system showing levels and delegation. Use for documentation or onboarding.",
-      "version": "1.0.0",
-      "source": "./skills/agent-hierarchy-diagram.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-run-orchestrator",
-      "description": "Run section orchestrators to coordinate multi-component workflows. Use when starting work on a section.",
-      "version": "1.0.0",
-      "source": "./skills/agent-run-orchestrator.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-test-delegation",
-      "description": "Test agent delegation patterns to verify hierarchy and escalation paths. Use after modifying agent structure.",
-      "version": "1.0.0",
-      "source": "./skills/agent-test-delegation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-tier-consolidation",
-      "description": "Pattern for merging a redundant junior agent tier into its parent level. Use when: a lowest-level junior tier duplicates the parent scope with simpler tasks and the distinction adds configuration overhead without meaningful value.",
-      "version": "1.0.0",
-      "source": "./skills/agent-tier-consolidation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-to-skill-conversion",
-      "description": "Convert agent configurations to skills when tasks are fixed/predictable. Use when: (1) agent performs repeatable automation steps without adaptive reasoning, (2) reducing agent count to simplify hierarchy, (3) moving fixed-step workflows to the right abstraction layer.",
-      "version": "1.0.0",
-      "source": "./skills/agent-to-skill-conversion.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "agent-validate-config",
-      "description": "Validate agent YAML frontmatter and configuration. Use before committing agent changes or in CI.",
-      "version": "1.0.0",
-      "source": "./skills/agent-validate-config.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "arch-research-myrmidon-swarm-review",
-      "description": "Parallel AI architecture research review using Myrmidon Swarm pattern: 1 lead agent per idea + 5 parallel sub-agents (citation verifier, complexity auditor, literature gap finder, comparison validator, feasibility checker) + coordinator. Use when: (1) reviewing a corpus of 10+ research documents for correctness, (2) verifying citations, Big-O claims, and baseline comparisons at scale, (3) producing independent review documents that can be cross-checked, (4) reviewing ideas involving weight factorization or LoRA-style parameterization, (5) reviewing ideas involving learned layer skipping, residual gating, or static-at-inference pruning, (6) auditing inference speedup claims (merged vs unmerged, frozen gates vs model surgery, compute-bound vs bandwidth-bound), (7) verifying that training and inference benefit claims are internally consistent across cases.",
-      "version": "2.0.0",
-      "source": "./skills/arch-research-myrmidon-swarm-review.md",
+      "source": "./skills/agent-config-and-tier-architecture.md",
       "category": "architecture",
       "tags": [
-        "arch-research",
-        "lora",
-        "low-rank",
-        "complexity-audit",
-        "citation-verification",
-        "inference",
-        "myrmidon",
-        "swarm-review",
-        "layer-pruning",
-        "residual-gating",
-        "static-inference"
-      ]
-    },
-    {
-      "name": "architect-review-implementation",
-      "description": "Implement post-merge recommendations from a chief architect or code review covering documentation gaps, test coverage gaps, comment accuracy, and rebase with conflict resolution",
-      "version": "1.0.0",
-      "source": "./skills/architect-review-implementation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "architecture-crosshost-nats-compose-deployment",
-      "description": "Deploy HomericIntelligence ecosystem across two Tailscale hosts using Docker Compose overlays and direct NATS connections. Use when: (1) splitting the E2E stack across multiple machines, (2) configuring NATS leafnode or direct connections over Tailscale, (3) debugging cross-host service communication, (4) setting up NATS-to-Loki log forwarding bridges.",
-      "version": "1.1.0",
-      "source": "./skills/architecture-crosshost-nats-compose-deployment.md",
-      "category": "architecture",
-      "tags": [
-        "cross-host",
-        "deployment",
-        "compose",
-        "tailscale",
-        "nats",
-        "leafnode",
-        "podman",
-        "e2e",
-        "homeric-intelligence",
-        "loki",
-        "native-binary",
-        "pythonpath"
-      ]
-    },
-    {
-      "name": "architecture-hierarchical-agent-command-creation",
-      "description": "Create a Claude Code custom command that orchestrates hierarchical multi-agent workflows with model tier assignments. Use when: (1) building a reusable /command that spawns sub-agents at different model tiers (Opus/Sonnet/Haiku), (2) integrating ProjectOdyssey's 6-level agent hierarchy into a portable command, (3) implementing wave-based parallel agent execution with approval gates.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-hierarchical-agent-command-creation.md",
-      "category": "architecture",
-      "tags": [
-        "claude-code",
-        "agent-hierarchy",
-        "model-tiers",
-        "custom-command",
-        "orchestration"
-      ]
-    },
-    {
-      "name": "architecture-homeric-ecosystem-ground-truth",
-      "description": "Map the actual implementation state of every HomericIntelligence component against documentation claims. Use when: (1) verifying what's real code vs aspirational docs, (2) planning deployment of the agent mesh, (3) assessing component readiness, (4) checking submodule pin freshness, (5) onboarding to the ecosystem.",
-      "version": "1.1.0",
-      "source": "./skills/architecture-homeric-ecosystem-ground-truth.md",
-      "category": "architecture",
-      "tags": [
-        "architecture",
-        "ecosystem",
-        "ground-truth",
-        "component-inventory",
-        "deployment-readiness"
-      ]
-    },
-    {
-      "name": "architecture-io-return-type-alignment",
-      "description": "Fix functions that return bool redundantly when they raise on failure. Use when: (1) audit finds return type mismatches vs changelog/docs, (2) functions return True but raise on error making bool redundant, (3) POLA violations from documented vs actual return types.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-io-return-type-alignment.md",
-      "category": "architecture",
-      "tags": [
-        "return-type",
-        "documentation-drift",
-        "POLA",
-        "io-utils",
+        "agent-config",
+        "tier-consolidation",
+        "yaml-validation",
+        "model-selection",
+        "claude-cli",
+        "pydantic",
+        "httpx",
+        "rest-api",
+        "prompt-engineering",
         "hephaestus"
+      ]
+    },
+    {
+      "name": "architecture-bot-pr-discovery-synthetic-issue-key",
+      "description": "When an automation tool resolves work via the issue\u2192PR direction ('for each open issue, find its closing PR'), Dependabot PRs and other bot-authored PRs are architecturally invisible \u2014 they have no `Closes #N` link, so the resolver returns nothing. The fix is to union the issue-driven set with every open `user.type == 'Bot'` PR from `gh api --paginate /repos/.../pulls`, using the PR number as a synthetic issue key (same int in both positions of the dedup map). Downstream code that would call `gh issue view <issue_number>` must then short-circuit: a tiny helper `_is_bot_pr_mode(issue_number, pr_number)` returns `True` iff `issue_number == pr_number`, which is the synthetic-key invariant. The discriminator is `user.type == 'Bot'` (REST snake_case), NOT the login string `app/dependabot` \u2014 new bot apps continually appear, and login-based detection ages out. Use when: (1) building a driver that enumerates work by issue and discovers PRs through `Closes #N` parsing, (2) Dependabot or Renovate PRs are open but the driver reports 'nothing to do', (3) an `--all` flag changes the AUTHOR filter but not the discovery DIRECTION and bot PRs are still missed, (4) you're tempted to pass PR numbers as `--issues <pr-number>` and the downstream `gh issue view` 404s on you, (5) you're tempted to add a second pass (`--bot-prs-only`) and want to know why a unioned single pass is cleaner, (6) reviewing automation that calls human-only steps (advise / planning / Mnemosyne lookup) and needs to short-circuit them for synthetic-key bot PRs.",
+      "version": "1.0.0",
+      "source": "./skills/architecture-bot-pr-discovery-synthetic-issue-key.md",
+      "category": "architecture",
+      "tags": [
+        "dependabot",
+        "bot-pr",
+        "issue-driven-discovery",
+        "synthetic-issue-key",
+        "ci-driver",
+        "automation-loop",
+        "user-type-bot",
+        "gh-api-paginate",
+        "closes-link",
+        "include-bot-prs",
+        "short-circuit-guard",
+        "hephaestus-automation"
+      ]
+    },
+    {
+      "name": "architecture-estimate-rewrite-read-substrate-first",
+      "description": "Before estimating a large refactor or rewrite, read the existing substrate code in full \u2014 TODO.md and roadmap LOC estimates are commonly pessimistic by 3-5x because they don't credit infrastructure that already exists. Use when: (1) starting a substrate-rewrite epic, (2) a TODO.md or roadmap estimates thousands of LOC or weeks of work, (3) an audit flags a CRITICAL gap based on docs, (4) before committing to a multi-week refactor estimate to a user or stakeholder.",
+      "version": "1.0.0",
+      "source": "./skills/architecture-estimate-rewrite-read-substrate-first.md",
+      "category": "architecture",
+      "tags": []
+    },
+    {
+      "name": "architecture-function-local-imports-coupling-avoidance",
+      "description": "Use function-local imports when a child module would create undesirable coupling or circular dependencies by importing the parent module at module level. Trade-off: one-line import lookup cost on first call (cached) vs. cleaner module graph. Use when: child module needs ambient state from parent but module-level import creates circular dep or import graph bloat.",
+      "version": "1.0.0",
+      "source": "./skills/architecture-function-local-imports-coupling-avoidance.md",
+      "category": "architecture",
+      "tags": [
+        "import-strategy",
+        "circular-dependency",
+        "coupling-avoidance",
+        "module-graph",
+        "ambient-state"
+      ]
+    },
+    {
+      "name": "architecture-github-labels-as-state-vocabulary",
+      "description": "Use mutually-exclusive `state:*` GitHub labels as the single source of truth for per-issue pipeline state instead of parsing free-text comment bodies. Use when: (1) an automated pipeline gates work on a verdict regex-parsed from the latest comment, (2) free-text comment-based state machine is fragile because pre-contract or off-format comments are unparseable and leave issues permanently stuck, (3) you need a gh issue label state vocabulary that the planner, reviewer, and implementer all read identically, (4) a plan-review GO/NOGO gate needs to short-circuit cheaply across 100s of issues without re-parsing every comment every loop iteration, (5) you need to self-heal stuck issues without manual cleanup \u2014 backfill a state label from an existing parseable comment on a one-time fallback, (6) two pipeline components share a gate but read it via different signals causing infinite-loop drift (planner skips because plan exists, implementer defers because review unparseable), (7) you want to harden the state-tagging GitHub Action against the Actions injection class while still tagging issues:opened with `state:needs-plan`, (8) you need to provision the 3 labels across an org without races against the first reviewer write.",
+      "version": "1.0.0",
+      "source": "./skills/architecture-github-labels-as-state-vocabulary.md",
+      "category": "architecture",
+      "tags": [
+        "github-labels",
+        "state-vocabulary",
+        "state-machine",
+        "plan-review",
+        "go-nogo-gate",
+        "free-text-fragile",
+        "structured-state",
+        "self-healing-backfill",
+        "actions-injection",
+        "org-provisioning",
+        "gh-issue-edit",
+        "mutually-exclusive-labels",
+        "source-of-truth",
+        "shared-gate-divergence"
       ]
     },
     {
@@ -195,57 +133,6 @@
         "namespace",
         "api-design",
         "layered-api"
-      ]
-    },
-    {
-      "name": "architecture-odysseus-ai-maestro-integration-gap",
-      "description": "Deep analysis of ai-maestro's internal architecture vs actual ecosystem usage, identifying the 90% integration gap. Use when: (1) analyzing ai-maestro REST/WebSocket API surface, (2) planning new satellite repo integrations, (3) auditing endpoint usage, (4) investigating the webhook/NATS pipeline gap, (5) evaluating unused capabilities (memory, AMP, AID, lifecycle).",
-      "version": "1.0.0",
-      "source": "./skills/architecture-odysseus-ai-maestro-integration-gap.md",
-      "category": "architecture",
-      "tags": [
-        "ai-maestro",
-        "odysseus",
-        "integration-gap",
-        "api-audit",
-        "webhook",
-        "nats",
-        "memory",
-        "amp",
-        "aid"
-      ]
-    },
-    {
-      "name": "architecture-odysseus-ruflo-comparison",
-      "description": "Deep architectural comparison of multi-repo agent ecosystem (Odysseus) vs in-process agent orchestration framework (Ruflo). Use when: (1) comparing infrastructure-centric vs application-centric agent architectures, (2) evaluating integration opportunities between container-based and in-process orchestration, (3) performing ecosystem audit of HomericIntelligence repos against external agent frameworks.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-odysseus-ruflo-comparison.md",
-      "category": "architecture",
-      "tags": [
-        "odysseus",
-        "ruflo",
-        "agent-orchestration",
-        "multi-repo",
-        "comparison",
-        "ecosystem-audit"
-      ]
-    },
-    {
-      "name": "architecture-parametric-load-store-bitcast-elimination",
-      "description": "Add parametric load[dtype]/store[dtype]/data_ptr[dtype] API to AnyTensor to eliminate raw _data.bitcast UAF vulnerabilities. Use when: (1) raw _data.bitcast[T]() patterns cause ASAP destruction UAF in Mojo, (2) designing safe element access for runtime-typed tensors, (3) migrating bulk pointer patterns to a centralized API, (4) uniform test weights cause numerical overflow through deep networks.",
-      "version": "1.1.0",
-      "source": "./skills/architecture-parametric-load-store-bitcast-elimination.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "tensor",
-        "bitcast",
-        "uaf",
-        "asan",
-        "load-store",
-        "parametric",
-        "api-design",
-        "numerical-stability"
       ]
     },
     {
@@ -290,46 +177,40 @@
       ]
     },
     {
-      "name": "architecture-rest-api-httpx-integration",
-      "description": "Pattern for adding REST API client integration to a Python project using httpx. Use when: (1) adding HTTP client to codebase with no existing HTTP dependency, (2) integrating external REST API with Pydantic config system, (3) wiring optional feature into existing config hierarchy.",
+      "name": "architecture-shipping-mojo-package-prefix-dev",
+      "description": "End-to-end pattern for making a Mojo library installable via `pixi add <pkg>` from the modular-community channel: idiomatic `src/<package_name>/` layout, `conda.recipe/recipe.yaml` (rattler-build), PR to `modular/modular-community`, and optional Python wheel that bundles the `.mojopkg`. Use when: (1) planning to publish a Mojo library, (2) converting an in-tree `shared/` directory into a distributable package, (3) replacing fictional `mojo install`/`mojo publish` CLI references in docs, (4) deciding between conda channel vs Python wheel vs git dependency for distribution.",
       "version": "2.0.0",
-      "source": "./skills/architecture-rest-api-httpx-integration.md",
+      "source": "./skills/architecture-shipping-mojo-package-prefix-dev.md",
       "category": "architecture",
       "tags": [
-        "httpx",
-        "rest-api",
-        "pydantic",
-        "config-integration",
-        "http-client"
+        "mojo-packaging",
+        "prefix-dev",
+        "modular-community",
+        "rattler-build",
+        "mojopkg",
+        "python-wheel",
+        "conda",
+        "org-fork",
+        "upstream-pr"
       ]
     },
     {
-      "name": "are-shapes-broadcastable-ndim-guard",
-      "description": "Documents the pattern of adding an ndim guard to broadcasting compatibility checks. Use when: a broadcastability helper silently returns True for (source, fewer-dim target) pairs due to a vacuous loop, or when protecting callers that rely on the helper directly.",
+      "name": "asymptotic-safety-quantum-gravity-refs",
+      "description": "Key papers, formulas, and physical facts for asymptotic safety quantum gravity and spectral dimension flow in sci-fi mechanism design. Use when: (1) designing a fictional device based on Planck-scale RG-flow physics, (2) citing real quantum gravity results about dimensional reduction to d_s=2, (3) grounding a sci-fi simulation engine in asymptotic-safety or CDT results.",
       "version": "1.0.0",
-      "source": "./skills/are-shapes-broadcastable-ndim-guard.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "atlas-dashboard-epic-mesh-review-wave",
-      "description": "Design and file a GitHub Epic + child issues for a new service, then run a multi-dimension Myrmidon review wave (arch/code/security/ux/ops/docs) against the plan. Use when: (1) starting a new HomericIntelligence service from scratch and need a fully filed epic with milestones and labels, (2) running a parallel 6-agent review wave against an architecture plan before implementation begins, (3) tracking and resolving critical findings from a multi-dimension agent review.",
-      "version": "1.0.0",
-      "source": "./skills/atlas-dashboard-epic-mesh-review-wave.md",
+      "source": "./skills/asymptotic-safety-quantum-gravity-refs.md",
       "category": "architecture",
       "tags": [
-        "atlas",
-        "dashboard",
-        "github-epic",
-        "mesh-review",
-        "nats",
-        "htmx",
-        "go",
-        "templ",
-        "sse",
-        "tailscale",
-        "grafana",
-        "mnemosyne"
+        "physics",
+        "quantum-gravity",
+        "asymptotic-safety",
+        "spectral-dimension",
+        "CDT",
+        "Planck-scale",
+        "renormalization-group",
+        "scifi",
+        "worldbuilding",
+        "mechanism-design"
       ]
     },
     {
@@ -354,83 +235,41 @@
       ]
     },
     {
-      "name": "atlas-mesh-bringup-first-run",
-      "description": "Patterns for bringing up the HomericIntelligence mesh natively or via containers across single or multiple Tailnet hosts from a cold state. Use when: (1) bringing up Agamemnon/Nestor/Hermes natively or via podman on any new host, (2) launching myrmidon workers across Tailnet hosts, (3) running the Atlas epic, (4) troubleshooting Agamemnon task completion API, (5) cold-starting the full 6-host Tailnet mesh.",
-      "version": "2.0.0",
-      "source": "./skills/atlas-mesh-bringup-first-run.md",
+      "name": "automation-lazy-exports-sdk-surface-pattern",
+      "description": "Pattern for extending public SDK surfaces with peer classes using lazy-loading infrastructure. Use when: (1) adding peer classes to __all__, (2) extending TYPE_CHECKING imports, (3) preventing eager-load regressions, (4) avoiding architectural restructuring.",
+      "version": "1.0.0",
+      "source": "./skills/automation-lazy-exports-sdk-surface-pattern.md",
       "category": "architecture",
       "tags": [
-        "atlas",
-        "mesh",
-        "bringup",
-        "nats",
-        "agamemnon",
-        "nestor",
-        "hermes",
-        "myrmidon",
-        "tailscale",
-        "multi-host",
-        "review-wave",
-        "binary-paths",
-        "podman",
-        "cold-start",
-        "pixi"
+        "sdk-surface",
+        "lazy-loading",
+        "public-interface",
+        "automation",
+        "phase-entrypoint",
+        "pola",
+        "isp"
       ]
     },
     {
-      "name": "audit-driven-dry-cli-cleanup",
-      "description": "Fix DRY violations and remove legacy CLI after strict repo audit. Use when: (1) audit identifies duplicate functions across modules, (2) legacy CLI needs removal with dependent module preservation, (3) doc consistency hooks need updating after content changes.",
+      "name": "automation-session-naming-pr-scoped-not-commit-scoped",
+      "description": "When an automation loop drives a long-lived artifact (issue / PR) with short-lived Claude sessions via `claude --resume <session_id>`, the deterministic session id MUST be scoped to the artifact, not to the live trunk commit. Tuple-scoping the id as `(repo, issue, agent, githash)` produces a new UUID on every main-bump and silently fragments transcripts: `invoke_claude_with_session` cannot `--resume` an id it never minted, so it falls back to `--session-id` (create) and the agent starts from scratch every iteration. Fix: drop `githash` from the session-name and session-uuid tuples (`session_name(repo, issue, agent)`, `session_uuid(repo, issue, agent)`), drop the matching kwarg from `invoke_claude_with_session`, and walk EVERY caller (typical sites: planner, plan_reviewer, implementer, address_review, pr_reviewer, ci_driver \u2014 8 in this repo). Pin the regression with a `**kwargs`-unpacked TypeError test so static analyzers (github-code-quality, mypy, ruff) don't flag the intentional bad kwarg. Use when: building automation that resumes Claude sessions across runs, session resume is silently failing because the deterministic id drifts, a long-lived artifact is being worked on by short-lived sessions, or pinning a removed-argument invariant against a static analyzer that resolves names.",
       "version": "1.0.0",
-      "source": "./skills/audit-driven-dry-cli-cleanup.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "automation-6phase-issue-pr-pipeline",
-      "description": "6-phase automation pipeline for GitHub issue processing across HomericIntelligence repos. Use when: (1) building a multi-phase GitHub issue automation loop (plan, review-plan, implement, review-PR, address-review, drive-green), (2) implementing inline PR review comments via GitHub GraphQL addPullRequestReview mutation, (3) resuming a Claude session from a prior implementer's session_id, (4) preventing Claude workers from launching for issues without open PRs (pre-discovery no-PR guard), (5) implementing dry-run discipline where side-effectful calls are gated but Claude analysis still runs.",
-      "version": "1.0.0",
-      "source": "./skills/automation-6phase-issue-pr-pipeline.md",
+      "source": "./skills/automation-session-naming-pr-scoped-not-commit-scoped.md",
       "category": "architecture",
       "tags": [
         "automation",
-        "github",
-        "pipeline",
-        "pr-review",
-        "address-review",
-        "ci-driver",
-        "graphql",
-        "session-reuse",
-        "dry-run",
-        "multi-repo"
+        "claude-session",
+        "session-resume",
+        "session-id",
+        "deterministic-uuid",
+        "invoke-claude-with-session",
+        "architecture",
+        "regression-test",
+        "static-analyzer",
+        "github-code-quality",
+        "kwargs-unpacking",
+        "session-scope"
       ]
-    },
-    {
-      "name": "automation-claude-model-per-phase",
-      "description": "Route each phase of a Claude-CLI automation pipeline to its own model tier (Opus for planning, Haiku for implementation, Sonnet for review) via a centralized module with HEPH_<PHASE>_MODEL env-var overrides, while leaving --resume sites unflagged so they inherit the originating session's model. Use when: (1) a multi-phase Claude-CLI pipeline (planner -> reviewer -> implementer -> CI driver) is dying with HTTP 429 on one tier while another tier's quota is untouched, (2) every `claude` invocation in the pipeline runs without `--model` and silently picks up the user's default, (3) you need an operator escape hatch to flip a phase to a cheaper model without code changes when one tier exhausts, (4) you are wiring `--model` into a pipeline that also has `--resume` sites and need to know which sites must NOT pass the flag.",
-      "version": "1.0.0",
-      "source": "./skills/automation-claude-model-per-phase.md",
-      "category": "architecture",
-      "tags": [
-        "claude-cli",
-        "model-selection",
-        "opus",
-        "haiku",
-        "sonnet",
-        "automation",
-        "planner",
-        "implementer",
-        "resume",
-        "cost-optimization",
-        "hephaestus"
-      ]
-    },
-    {
-      "name": "backward-compat-removal",
-      "description": "Systematically remove deprecated backward compatibility code and tests",
-      "version": "1.0.0",
-      "source": "./skills/backward-compat-removal.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "bf16-apple-silicon-guard",
@@ -456,14 +295,6 @@
       ]
     },
     {
-      "name": "claude-code-settings-config",
-      "description": "Configure Claude Code settings.json per test workspace to control thinking mode via API rather than prompt injection. Use when implementing workspace-level configuration for E2E tests.",
-      "version": "2.0.0",
-      "source": "./skills/claude-code-settings-config.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
       "name": "cli-audit-subcommand",
       "description": "Skill: cli-audit-subcommand",
       "version": "1.0.0",
@@ -472,77 +303,53 @@
       "tags": []
     },
     {
-      "name": "cluster-extraction-to-modules",
-      "description": "Decompose a large Python class file (>1000 lines) by extracting cohesive method clusters into dedicated sub-modules with thin delegation wrappers. Use when a class file exceeds 1000 lines and contains 3+ independent method clusters.",
-      "version": "1.0.0",
-      "source": "./skills/cluster-extraction-to-modules.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "collaborator-extraction-tdd",
-      "description": "TRIGGER CONDITIONS: Extracting method groups from an oversized class (>800 lines) into dedicated collaborator classes using TDD. Use when: (1) a class has grown beyond its target line count and contains identifiable method groups with shared state, (2) extracting without behavior change (pure structural refactoring), (3) avoiding circular imports between the host class and extracted collaborators.",
-      "version": "1.0.0",
-      "source": "./skills/collaborator-extraction-tdd.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "config-dir-consolidation",
-      "description": "Move config files from a dedicated config/ directory into tests/ when config is only consumed by test infrastructure. Use when: config dir contains files superseded by a test-side system, loaders have hardcoded config/ paths, or a legacy config directory needs full elimination.",
-      "version": "1.0.0",
-      "source": "./skills/config-dir-consolidation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "config-env-double-underscore-nesting",
-      "description": "Fix ambiguous env var to config key mapping by using __ as nesting delimiter. Use when: (1) env var names collide with underscore-containing config keys, (2) implementing env var config override with nested keys.",
-      "version": "1.0.0",
-      "source": "./skills/config-env-double-underscore-nesting.md",
+      "name": "computation-hard-walls-analysis",
+      "description": "Framework for analyzing 14 fundamental hard walls against exotic computation schemes in sci-fi mechanism design. Use when: (1) evaluating how many physical limits a fictional compute device breaks, (2) scoring mechanism plausibility against known physics limits, (3) writing scientifically rigorous speculative technology documents.",
+      "version": "1.3.0",
+      "source": "./skills/computation-hard-walls-analysis.md",
       "category": "architecture",
       "tags": [
-        "config",
-        "environment-variables",
-        "nesting",
-        "convention"
+        "physics",
+        "computation",
+        "limits",
+        "hard-walls",
+        "scifi",
+        "worldbuilding",
+        "mechanism-design",
+        "tqc",
+        "topological",
+        "bekenstein",
+        "planck-density",
+        "offload-architecture",
+        "lloyd",
+        "holevo",
+        "landauer",
+        "reality-computes",
+        "computational-universe"
       ]
     },
     {
-      "name": "config-loader-schema-validation",
-      "description": "TRIGGER CONDITIONS: Fixing a config loader method that bypasses schema validation by calling _load_yaml() directly instead of routing through a validated loader method. Use when a load() merge path or similar aggregation method skips Pydantic validation on a required config file.",
+      "name": "console-scripts-exit-code-discipline",
+      "description": "Enforce exit-code discipline for Python console-script main() functions using instance state for error tracking. Use when: (1) a console-script main() exits 0 unconditionally despite errors, (2) updating error signaling for methods with existing tuple-return callers, (3) preventing pre-commit pipelines from masking failures.",
       "version": "1.0.0",
-      "source": "./skills/config-loader-schema-validation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "consolidate-review-agents",
-      "description": "Merge overlapping review specialist agents into a single general-review-specialist. Use when: (1) multiple review agents have overlapping scopes, (2) project complexity doesn't justify 10+ specialists, (3) you want to reduce total agent count while keeping full review coverage.",
-      "version": "1.0.0",
-      "source": "./skills/consolidate-review-agents.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "constant-centralization",
-      "description": "Centralize shared constants to their canonical module and update importers. Use when: duplicate constants exist across modules, or a higher-level module defines values that belong in a lower-level dependency.",
-      "version": "1.0.0",
-      "source": "./skills/constant-centralization.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "corpus-surgical-correction-batch",
-      "description": "Surgical batch correction of a large research document corpus (50+ files) after a review pass. Use when: (1) a review process has identified specific errors across many documents that share a common root cause, (2) you need corrections to be traceable (auditable inline markers), (3) stripping correction-narrative text from a document corpus after corrections have been accepted and made permanent, (4) you want to preserve all surrounding text and structure, (5) corrections span multiple independent document groups that can be parallelized.",
-      "version": "1.1.0",
-      "source": "./skills/corpus-surgical-correction-batch.md",
+      "source": "./skills/console-scripts-exit-code-discipline.md",
       "category": "architecture",
       "tags": [
-        "latex",
-        "narrative-removal",
-        "corpus-edit"
+        "python",
+        "console-scripts",
+        "exit-codes",
+        "error-tracking",
+        "tuple-contracts",
+        "architecture"
       ]
+    },
+    {
+      "name": "console-scripts-instance-state-error-tracking",
+      "description": "How to add exit-code discipline to CLI main() functions without breaking existing return-value callsites. Use when: (1) main() must return int for exit-code discipline, (2) existing code unpacks tuples from helper methods, (3) you need to track error state without changing method signatures.",
+      "version": "1.0.0",
+      "source": "./skills/console-scripts-instance-state-error-tracking.md",
+      "category": "architecture",
+      "tags": []
     },
     {
       "name": "cpp-http-client-wrapper-lifetime-equals-object-not-per-call",
@@ -561,29 +368,24 @@
       ]
     },
     {
-      "name": "credential-mount-context-manager",
-      "description": "TRIGGER CONDITIONS: Temp credential dirs leaking in home after Docker runs; silent rmtree failures in finally blocks on WSL2; need to safely mount host credentials into Docker containers with guaranteed cleanup.",
+      "name": "cross-repo-boundary-and-ecosystem-audit",
+      "description": "Enforce repo charters, audit ecosystem health, and remediate scope creep across multi-repo HomericIntelligence projects. Use when: (1) validating multi-repo integration boundaries and hunting cross-repo contract bugs, (2) a repo has suffered scope creep and needs charter enforcement via stacked deletion PRs, (3) mapping actual vs documented component state before deployment or onboarding, (4) auditing ai-maestro REST/WebSocket API surface vs ecosystem usage, (5) performing multi-domain code-quality remediation (logging, exceptions, DRY, CI) across a shared library.",
       "version": "1.0.0",
-      "source": "./skills/credential-mount-context-manager.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "crosshost-per-component-launcher-pattern",
-      "description": "Per-component install and launch commands for cross-host HomericIntelligence deployment. Use when: (1) deploying individual services on separate Tailscale hosts, (2) adding justfile recipes that launch C++ binaries or delegate to submodule justfiles, (3) connecting services via NATS_URL across a mesh, (4) deciding between compose-based vs native binary deployment.",
-      "version": "1.0.0",
-      "source": "./skills/crosshost-per-component-launcher-pattern.md",
+      "source": "./skills/cross-repo-boundary-and-ecosystem-audit.md",
       "category": "architecture",
       "tags": [
-        "cross-host",
-        "deployment",
-        "launcher",
-        "justfile",
+        "cross-repo",
+        "ecosystem-audit",
+        "charter",
+        "scope-creep",
+        "stacked-prs",
+        "integration-gap",
+        "ground-truth",
+        "multi-repo",
+        "component-inventory",
+        "ai-maestro",
         "nats",
-        "tailscale",
-        "per-component",
-        "podman",
-        "homeric-intelligence"
+        "remediation"
       ]
     },
     {
@@ -619,6 +421,21 @@
       "tags": []
     },
     {
+      "name": "dry-consolidate-to-canonical-refactor",
+      "description": "Canonical workflow for finding code duplication and refactoring to a single canonical source: discovery via grep/AST, classifying true duplicates vs incidental similarity, bulk file migration, type-alias consolidation, decomposing oversized modules by SRP, dict structure consolidation, preserving git history via git mv. Use when: (1) noticing duplicate functions/constants across modules, (2) centralizing path or config constants, (3) decomposing a >2k-line module into SRP-aligned pieces, (4) consolidating duplicate Pydantic models or type aliases, (5) same dict structure built in multiple call sites, (6) bulk-renaming symbols across a codebase.",
+      "version": "1.1.0",
+      "source": "./skills/dry-consolidate-to-canonical-refactor.md",
+      "category": "architecture",
+      "tags": [
+        "merged",
+        "dry",
+        "consolidation",
+        "refactor",
+        "canonical-source",
+        "deduplication"
+      ]
+    },
+    {
       "name": "dry-consolidation-workflow",
       "description": "Complete workflow for analyzing codebase duplications and implementing DRY consolidation",
       "version": "1.0.0",
@@ -633,17 +450,9 @@
       ]
     },
     {
-      "name": "dry-mojo-test-helper-extraction",
-      "description": "Extract duplicated Mojo test tensor setup into a private helper returning a tuple. Use when: two or more test functions share identical tensor construction blocks, or when planning to add test variants that would repeat the same setup.",
-      "version": "1.0.0",
-      "source": "./skills/dry-mojo-test-helper-extraction.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
       "name": "dry-refactoring-workflow",
-      "description": "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods",
-      "version": "1.0.0",
+      "description": "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Covers private module extraction patterns, test structure mirroring enforcement, and cryptographic commit signing requirements in PR workflows.",
+      "version": "1.1.0",
       "source": "./skills/dry-refactoring-workflow.md",
       "category": "architecture",
       "tags": []
@@ -657,164 +466,92 @@
       "tags": []
     },
     {
-      "name": "e2e-hermes-hub-remote-myrmidon",
-      "description": "Hub+remote-worker topology for HomericIntelligence E2E: hermes runs full stack (NATS JetStream, Agamemnon, Nestor, Hermes bridge, observability), epimetheus runs only the hello-myrmidon Python worker over Tailscale. Use when: (1) validating cross-host myrmidon dispatch end-to-end, (2) setting up a hub+single-remote-worker topology distinct from the symmetric crosshost split, (3) troubleshooting remote myrmidon NATS connectivity, (4) excluding a compose service via overlay profiles.",
-      "version": "1.1.0",
-      "source": "./skills/e2e-hermes-hub-remote-myrmidon.md",
+      "name": "exception-discriminator-enums-state-machine-pola",
+      "description": "Add a discriminator enum field to exceptions in state machines to distinguish semantic reasons for the same exception type. Use when: (1) same exception type is raised in multiple states with different recovery strategies; (2) callers need to distinguish error reasons without parsing message strings; (3) a single field has context-dependent semantics across states, violating POLA.",
+      "version": "1.0.0",
+      "source": "./skills/exception-discriminator-enums-state-machine-pola.md",
       "category": "architecture",
       "tags": [
-        "e2e",
+        "exception-handling",
+        "state-machine",
+        "discriminator",
+        "enum",
+        "pola",
+        "circuit-breaker",
+        "python",
+        "semantic-clarity"
+      ]
+    },
+    {
+      "name": "hephaestus-env-var-fallback-path-resolution",
+      "description": "Centralize fragile __file__.parents[N] patterns with env-var + walk-up fallback resolvers. Use when: (1) multiple files use __file__.parents[N] to resolve paths, (2) paths differ between editable installs and CI, (3) need single source of truth for repo_root() or scripts_dir().",
+      "version": "1.0.0",
+      "source": "./skills/hephaestus-env-var-fallback-path-resolution.md",
+      "category": "architecture",
+      "tags": [
+        "path-resolution",
+        "__file__-parents",
+        "env-var-fallback",
+        "dry-principle",
+        "editable-install",
+        "constants"
+      ]
+    },
+    {
+      "name": "holographic-adscft-mechanism-design",
+      "description": "Design patterns for exotic physics computation devices in sci-fi world-building, covering three physics domains: (1) AdS/CFT holographic boundary computers, (2) Deutsch CTC oracle (closed timelike curve) computation, and (3) TSVF / weak-value retrocausal oracle devices. Use when: (1) designing a fictional device that uses holographic or causality-breaking physics, (2) grounding a sci-fi simulation engine in real physics, (3) needing real citations for boundary/bulk duality mechanics, CTC fixed-point computation, or weak-value amplification, (4) designing a time-oracle or weak-value amplification based device, (5) evaluating which of the 14 computational hard walls a mechanism defeats, (6) identifying the single root break from which all other wall defeats cascade.",
+      "version": "1.2.0",
+      "source": "./skills/holographic-adscft-mechanism-design.md",
+      "category": "architecture",
+      "tags": [
+        "physics",
+        "holography",
+        "adscft",
+        "scifi",
+        "worldbuilding",
+        "mechanism-design",
+        "ctc",
+        "closed-timelike-curves",
+        "deutsch",
+        "causality",
+        "pspace",
+        "tsvf",
+        "weak-values",
+        "retrocausality",
+        "post-selection"
+      ]
+    },
+    {
+      "name": "homeric-crosshost-deployment-and-mesh-topology",
+      "description": "Deploy and operate the HomericIntelligence mesh across multiple Tailscale hosts using NATS JetStream, compose overlays, and justfile launchers. Use when: (1) splitting the E2E stack across multiple physical hosts via compose overlay or per-component launchers, (2) bringing up Agamemnon/Nestor/Hermes natively or via containers on any new Tailnet host from cold state, (3) running hub+remote-worker topology for cross-host myrmidon dispatch, (4) configuring NATS connections (direct or leafnode) over Tailscale, (5) implementing NATS JetStream publish retry with exponential backoff, (6) debugging Hermes webhook event types, compose healthchecks, or podman rootlessport/DNS quirks.",
+      "version": "1.0.0",
+      "source": "./skills/homeric-crosshost-deployment-and-mesh-topology.md",
+      "category": "architecture",
+      "tags": [
         "cross-host",
-        "hermes-hub",
-        "myrmidon",
+        "deployment",
+        "compose",
         "tailscale",
         "nats",
-        "compose-overlay",
-        "podman",
-        "homeric-intelligence",
-        "remote-worker"
-      ]
-    },
-    {
-      "name": "e2e-homeric-compose-cpp-pipeline",
-      "description": "Wire HomericIntelligence C++20 services into a podman/docker compose E2E stack with NATS JetStream, Prometheus, Grafana. Use when: (1) setting up the full E2E pipeline, (2) adding new C++20 services to the compose stack, (3) debugging multi-container C++ service orchestration, (4) troubleshooting podman vs docker runtime differences, (5) running on hosts without rootlessport or external internet access, (6) debugging Hermes webhook event type mapping (only task.updated/completed/failed/agent.* supported), (7) writing healthchecks compatible with podman-compose 1.5.0 and Docker Compose v2+v5 (use YAML string form \u2014 no array; Docker Compose v5 splits array elements on spaces).",
-      "version": "1.6.0",
-      "source": "./skills/e2e-homeric-compose-cpp-pipeline.md",
-      "category": "architecture",
-      "tags": [
-        "e2e",
-        "compose",
+        "jetstream",
         "podman",
         "docker",
-        "cpp20",
-        "nats",
-        "prometheus",
-        "grafana",
-        "homeric-intelligence",
-        "dual-runtime",
-        "wsl2",
-        "host-network",
-        "grafana-analytics"
-      ]
-    },
-    {
-      "name": "e2e-phase-dir-split-agent-commit",
-      "description": "Split E2E run directories into in_progress/ and completed/ phases with atomic promotion, agent git commit, and off-peak scheduling. Use when: (1) agent crashes or interrupted runs pollute results with phantom 0.0 scores, (2) judging must be isolated from in-flight runs, (3) rm -rf in_progress/ must be safe for clean restart, (4) Stage 3 ENOENT on promote after multi-stage execution.",
-      "version": "1.1.0",
-      "source": "./skills/e2e-phase-dir-split-agent-commit.md",
-      "category": "architecture",
-      "tags": [
+        "justfile",
+        "per-component",
+        "launcher",
+        "mesh",
+        "hermes",
+        "agamemnon",
+        "nestor",
+        "myrmidon",
+        "atlas",
+        "cold-start",
+        "retry",
+        "backoff",
         "e2e",
-        "directory-structure",
-        "state-machine",
-        "agent-commit",
-        "off-peak",
-        "phase-split",
-        "run-lifecycle",
-        "debugging",
-        "idempotency"
+        "cpp20",
+        "homeric-intelligence"
       ]
-    },
-    {
-      "name": "e2e-resume-refactor",
-      "description": "Refactoring E2E test framework resume behavior with directory restructure and checkpoint schema upgrade. Use when implementing checkpoint systems with detailed status tracking or separating outputs by execution phase.",
-      "version": "1.0.0",
-      "source": "./skills/e2e-resume-refactor.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "ecosystem-audit-remediation",
-      "description": "Systematic cross-repo ecosystem audit and remediation. Use when: validating multi-repo integration boundaries, hunting cross-repo contract bugs, or remediating documentation drift.",
-      "version": "1.0.0",
-      "source": "./skills/ecosystem-audit-remediation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extensor-parametric-dtype-migration",
-      "description": "Documents why ExTensor needs compile-time dtype parameterization for SIMD-like subscript assignment. Use when: (1) designing tensor types with subscript assignment in Mojo, (2) debugging type conversion errors in ExTensor, (3) planning the parametric ExTensor migration.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-parametric-dtype-migration.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extensor-slice-view-strides",
-      "description": "Add stride-aware slice() view semantics and _nd_index_to_flat_offset to Mojo ExTensor for zero-copy slicing of non-contiguous tensors. Use when: implementing slice() that must work on transposed/strided views, fixing element access bugs in non-contiguous tensors, or adding a reusable view_with_strides primitive.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-slice-view-strides.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extensor-view-semantics",
-      "description": "Add view/zero-copy semantics to tensor operations in Mojo ExTensor. Use when: implementing stride-based tensor views, adding ravel()/transpose() view support, or debugging non-contiguous tensor access.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-view-semantics.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extract-detection-utils",
-      "description": "Pattern for extracting private detection/validation functions into centralized, reusable modules with optional caching",
-      "version": "1.0.0",
-      "source": "./skills/extract-detection-utils.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extract-helper-method-tdd",
-      "description": "Skill: Extract Helper Method (TDD Workflow)",
-      "version": "1.0.0",
-      "source": "./skills/extract-helper-method-tdd.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "extract-method-refactoring",
-      "description": "Decompose large methods and inline closures into focused helper methods. Use when: (1) methods exceed 50-100 LOC or have high cyclomatic complexity, (2) code review requests decomposition, (3) a method defines multiple closures over 3+ variables from the enclosing scope, (4) closures use nonlocal rebinding signaling they should be private methods, or (5) inline closures prevent direct unit testing of guards.",
-      "version": "2.0.0",
-      "source": "./skills/extract-method-refactoring.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "fix-resource-prompt-consistency",
-      "description": "Workflow for fixing inconsistent root-level field mapping in tier configurations and enhancing resource prompt suffixes",
-      "version": "1.0.0",
-      "source": "./skills/fix-resource-prompt-consistency.md",
-      "category": "architecture",
-      "tags": [
-        "tier-config",
-        "prompt-engineering",
-        "resource-mapping",
-        "testing"
-      ]
-    },
-    {
-      "name": "immutable-method-refactor",
-      "description": "Refactoring a class method to follow an immutable (purely functional) pattern by removing in-place self.attribute mutation and returning a new value instead. Use when a class has mixed patterns \u2014 some methods mutate self and some return new values \u2014 and consistency is needed.",
-      "version": "1.0.0",
-      "source": "./skills/immutable-method-refactor.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "implementation-alignment-validation",
-      "description": "Systematic workflow for validating implementation code against research documentation and fixing discrepancies",
-      "version": "1.1.0",
-      "source": "./skills/implementation-alignment-validation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "judge-rerun-workspace-corruption",
-      "description": "Fix judge reruns producing incorrect results due to workspace corruption",
-      "version": "1.0.0",
-      "source": "./skills/judge-rerun-workspace-corruption.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "llm-baseline-spec-verification",
@@ -823,6 +560,45 @@
       "source": "./skills/llm-baseline-spec-verification.md",
       "category": "architecture",
       "tags": []
+    },
+    {
+      "name": "llm-output-verdict-parse-last-line-not-substring",
+      "description": "Parse discrete LLM-emitted verdicts (APPROVED/REVISE/BLOCK, GO/NOGO, SAFE/UNSAFE) using last-line regex extraction, not substring `in` checks. Use when: (1) adding a Python/shell consumer that reads a classification marker from LLM output, (2) the prompt instructs the LLM that 'readers take the LAST matching line', (3) the LLM may discuss multiple options before settling on a verdict, (4) a substring-in check would fire on quoted/discussed markers, (5) auditing an existing parser for false-positive verdict reads, (6) a reviewer comment exists but its verdict is never parsed \u2014 causing the pipeline to re-review the same issue every pass forever (#615 infinite loop), (7) diagnosing a re-review loop where the log gives no clue what the reviewer wrote, (8) deciding whether a verdict parser should be first-match or last-match \u2014 persisted/accumulating comment gates need last-match-wins, single-line fresh-output parsers can use first-match, (9) auditing a 'parser unification' refactor that may have silently dropped a last-wins safety guarantee.",
+      "version": "1.2.0",
+      "source": "./skills/llm-output-verdict-parse-last-line-not-substring.md",
+      "category": "architecture",
+      "tags": [
+        "llm-output-parsing",
+        "verdict-gate",
+        "regex",
+        "last-line-wins",
+        "claude-output",
+        "prompt-parser-contract",
+        "false-positive",
+        "substring-vs-regex",
+        "bounded-retry",
+        "infinite-loop",
+        "observability",
+        "first-match-vs-last-match",
+        "parser-unification-regression",
+        "input-contract"
+      ]
+    },
+    {
+      "name": "logging-contextvars-ambient-state",
+      "description": "Use contextvars.ContextVar for ambient logging/tracing state (correlation IDs, trace IDs) instead of mutable globals or explicit parameters. Thread-safe and async-safe by design. Use when: propagating context across function call stacks, thread boundaries, and async contexts without explicitly threading it as a parameter.",
+      "version": "1.0.0",
+      "source": "./skills/logging-contextvars-ambient-state.md",
+      "category": "architecture",
+      "tags": [
+        "contextvars",
+        "logging",
+        "correlation-id",
+        "trace-id",
+        "ambient-state",
+        "thread-safety",
+        "async-safety"
+      ]
     },
     {
       "name": "meta-repo-build-root-pattern",
@@ -842,308 +618,205 @@
       ]
     },
     {
-      "name": "model-id-normalization-resume-fix",
-      "description": "Add model ID normalization via Pydantic field_validator to handle legacy dot-notation and short aliases in saved experiment configs. Use when: (1) model IDs with old naming conventions persist in saved experiment configs and cause CLI failures on resume, (2) CLI argument defaults use short aliases with no expansion function.",
+      "name": "mojo-tensor-type-and-view-semantics",
+      "description": "Design and migrate Mojo tensor/ExTensor types with parametric dtypes, view semantics, stride-aware slices, and safe load/store APIs. Use when: (1) designing ExTensor/AnyTensor subscript assignment with compile-time dtype parameterization, (2) implementing zero-copy view semantics (transpose, slice, ravel) for stride-aware tensor access, (3) eliminating raw _data.bitcast UAF patterns via parametric load/store API, (4) inverting runtime-typed wrapper ops to Tensor[dtype] typed cores with AnyTensor dispatch, (5) fixing vacuous-loop bugs in broadcastability helpers or refactoring validate() to return tuple results.",
       "version": "1.0.0",
-      "source": "./skills/model-id-normalization-resume-fix.md",
-      "category": "architecture",
-      "tags": [
-        "model-ids",
-        "pydantic",
-        "normalization",
-        "resume",
-        "backward-compatibility"
-      ]
-    },
-    {
-      "name": "module-decomposition-pattern",
-      "description": "Decompose large Python modules (1000+ lines) into focused sub-modules while preserving backward compatibility, updating all import sites or re-exporting from the original, and fixing mock patch targets in tests. Use when a single file has 4+ logical clusters of functions with distinct responsibilities.\n",
-      "version": "2.0.0",
-      "source": "./skills/module-decomposition-pattern.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-boolable-trait-conformance",
-      "description": "Split a raising __bool__ into a non-raising Boolable-conformant __bool__ plus bool_strict(). Use when: a struct has fn __bool__(self) raises -> Bool preventing Boolable trait conformance, you want Bool(t) syntax to work without try/except, or you need NumPy-style silent False for multi-element containers alongside PyTorch-style strict raising.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-boolable-trait-conformance.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-circular-import-type-identity-fix",
-      "description": "Fix Mojo 'cannot implicitly convert X to X' errors caused by circular imports that trigger dual type compilation. Use when: (1) Mojo compiler reports 'cannot implicitly convert Type to Type' where both types have the same name, (2) cross-package imports create A->B->A cycles in Mojo, (3) struct operators delegate to external modules that import the struct back, (4) typed dispatch files create reverse dependencies back to the public API package, (5) Tensor[dtype] and AnyTensor coexist in the same file causing overload ambiguity, (6) designing dual-type tensor APIs or reviewing parametric struct migrations.",
-      "version": "2.4.0",
-      "source": "./skills/mojo-circular-import-type-identity-fix.md",
+      "source": "./skills/mojo-tensor-type-and-view-semantics.md",
       "category": "architecture",
       "tags": [
         "mojo",
-        "circular-imports",
-        "type-identity",
-        "operators",
-        "architecture",
         "tensor",
-        "overload-ambiguity",
-        "method-wrappers"
-      ]
-    },
-    {
-      "name": "mojo-deprecated-alias-removal",
-      "description": "Workflow for removing deprecated Mojo comptime type aliases and replacing usages with canonical types. Use when: removing DEPRECATED-marked comptime aliases from Mojo modules, cleaning up backward-compat test files, updating __init__.mojo exports and layer imports after alias consolidation.",
-      "version": "1.2.0",
-      "source": "./skills/mojo-deprecated-alias-removal.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-fp16-simd-upgrade-pattern",
-      "description": "Replace scalar FP16\u2194FP32 conversion loops with SIMD vectorized paths after upgrading to Mojo 0.26.3. Use when: (1) upgrading from Mojo 0.26.1 where FP16 SIMD was unsupported, (2) finding scalar element-by-element conversion loops with comments like 'FP16 SIMD blocked', (3) implementing mixed-precision tensor conversion in Mojo 0.26.3+.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-fp16-simd-upgrade-pattern.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "fp16",
-        "simd",
-        "mixed-precision",
-        "vectorization",
-        "upgrade",
-        "float16"
-      ]
-    },
-    {
-      "name": "mojo-getitem-slice-multidim",
-      "description": "Pattern for extending a rank-restricted Mojo __getitem__(Slice) to N-D tensors with axis-0 semantics. Use when: a Mojo tensor raises an error for non-1D slicing but the logic generalises to higher ranks.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-getitem-slice-multidim.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-gradient-type-naming",
-      "description": "Fix naming inconsistency between generic gradient containers and domain-specific backward pass results in Mojo ML code. Use when: backward functions return GradientPair with opaque grad_a/grad_b fields but callers know the semantic meaning (e.g. input vs kernel gradients).",
-      "version": "1.0.0",
-      "source": "./skills/mojo-gradient-type-naming.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-package-level-reexports",
-      "description": "Add convenience top-level re-exports to a Mojo package __init__.mojo. Use when: enabling `from shared import X` style imports, activating commented-out import lines after implementation is ready, adding optimizer structs (AdaGrad/RMSprop/AdamW), or extending an existing re-export group with new symbols.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-package-level-reexports.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-parametric-dtype-migration",
-      "description": "Pattern for migrating a Mojo runtime-typed struct to a parametric compile-time typed struct with backward-compat alias and parallel sub-agent workflow. Use when: (1) splitting a runtime-typed Mojo struct into parametric + type-erased pair, (2) orchestrating large-scale codebase renames with parallel agents in worktrees, (3) resolving circular imports between parametric and type-erased Mojo types.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-parametric-dtype-migration.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
+        "extensor",
+        "anytensor",
+        "dtype",
         "parametric",
-        "refactoring",
+        "view-semantics",
+        "bitcast",
+        "uaf",
+        "strides",
+        "load-store",
+        "broadcasting",
+        "slice",
+        "transpose"
+      ]
+    },
+    {
+      "name": "mojo-type-and-api-migration",
+      "description": "Canonical guide to Mojo type and API migration across language versions: parametric dtype migration, Writable -> WritableTo transition, API version baselines, trait/conformance refactors, method API symmetry, parametric vs runtime dtype, decorator/method-wrapper changes. Use when: (1) upgrading Mojo to a new API baseline, (2) migrating callers after a Mojo stdlib breaking change, (3) reconciling parametric dtype usage with new runtime dtype patterns, (4) fixing trait-conformance compile errors after a stdlib upgrade.",
+      "version": "1.0.0",
+      "source": "./skills/mojo-type-and-api-migration.md",
+      "category": "architecture",
+      "tags": [
+        "merged",
+        "mojo",
+        "type-migration",
+        "api-migration",
+        "parametric-dtype",
+        "trait"
+      ]
+    },
+    {
+      "name": "myrmidon-one-agent-per-item-portfolio-research-pattern",
+      "description": "Dispatch ONE Myrmidon agent per item (not 3-4 items per agent) when researching N independent items (10+ startup holdings, contractor invoices, paper citations, etc.). Each agent fully focuses on one item, picks up item-specific evidence, handles identity-disambiguation per-item, and writes a discrete evidence file. Commander synthesizes by reading files. Use when: (1) N >= 10 independent items, (2) each item needs ~5-6 web searches, (3) one-document-per-item is the natural output, (4) batching agents (3-4 items per agent) produced lower quality.",
+      "version": "1.0.0",
+      "source": "./skills/myrmidon-one-agent-per-item-portfolio-research-pattern.md",
+      "category": "architecture",
+      "tags": [
+        "myrmidon",
+        "swarm",
         "parallel-agents",
-        "worktrees"
+        "l0-commander",
+        "one-agent-per-item",
+        "portfolio-research",
+        "due-diligence",
+        "evidence-file-per-item",
+        "wave-dispatch",
+        "identity-disambiguation"
       ]
     },
     {
-      "name": "mojo-python-interop-patterns-guide",
-      "description": "Canonical Mojo-Python interop patterns from Modular. Use when: (1) calling Python libraries from Mojo, (2) converting between PythonObject and Mojo types, (3) building Python extension modules in Mojo, (4) exposing Mojo structs to Python.",
+      "name": "myrmidon-research-grounding-swarm-with-counterfactual-track",
+      "description": "Ground a speculative or creative premise (sci-fi story device, invented computing concept) in real, cited science using a Myrmidon Opus swarm: one agent per research dimension writing a tagged, cited, feasibility-graded briefing, PLUS a parallel counterfactual track that re-examines each dimension under the assumption a core physical law is false, all converging in a single synthesis agent. Use when: (1) grounding a creative/speculative premise in rigorous real science (no narrative injected), (2) you need per-claim feasibility tags (established vs frontier vs speculative vs impossible) with real citations, (3) you want to separate what real physics says from what a story's new-physics lever would change via a counterfactual track, (4) one cited briefing per research dimension is the natural deliverable, (5) you want a pure synthesis (recurring-walls + tiered feasibility tables) deferring thematic/narrative integration.",
       "version": "1.0.0",
-      "source": "./skills/mojo-python-interop-patterns-guide.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "python",
-        "interop",
-        "pythonobject",
-        "extension-module",
-        "modular-upstream"
-      ]
-    },
-    {
-      "name": "mojo-python-interop-to-stdlib",
-      "description": "Replace Python.import_module calls with Mojo native stdlib, bridge filesystem gaps with Python interop, and migrate PythonObject placeholder parameters to native Mojo struct types. Use when: (1) eliminating Python interop for file system ops (os, pathlib, builtins), (2) a Mojo function has a no-op stub body due to missing stdlib (os.remove, os.rename), (3) a function accepts PythonObject as a stopgap while the native struct is now ready, (4) refactoring load_named_tensors or similar functions, (5) migrating from Python glob/sorted to native Mojo os.listdir + sort.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-python-interop-to-stdlib.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "python",
-        "interop",
-        "pythonobject",
-        "stdlib",
-        "migration",
-        "placeholder",
-        "dataloader"
-      ]
-    },
-    {
-      "name": "mojo-sequential-parametric-containers",
-      "description": "Pattern for implementing Sequential neural network module containers in Mojo using parametric compile-time types. Use when: composing Module-conforming layers into a chain, hitting ImplicitlyCopyable/UnsafePointer errors from List[Trait] usage, or designing reusable containers that propagate train/eval modes.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-sequential-parametric-containers.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-tensor-multidim-setitem",
-      "description": "Add multi-dimensional mutable indexing to Mojo ExTensor via List[Int] __setitem__ overload. Use when: (1) adding multi-dim write access to a flat-storage tensor, (2) converting per-dimension indices to a flat offset via strides, (3) mirroring an existing multi-dim __getitem__ with a matching __setitem__.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-tensor-multidim-setitem.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-tuple-return-types",
-      "description": "Correct Mojo v0.26.1 syntax for multi-value returns from fn methods. Use when: writing helpers that return multiple computed values, seeing 'no matching function in initialization' on tuple return types, or extracting shared logic that needs to return (start, end, step, size) style tuples.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-tuple-return-types.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "mojo-version-migration-strategy",
-      "description": "Strategy for migrating a large Mojo codebase across versions. Use when: (1) planning a Mojo version upgrade across many files, (2) coordinating multi-agent migration work, (3) deciding fix order for cascading compile errors.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-version-migration-strategy.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "migration",
-        "version-upgrade",
-        "agent-coordination",
-        "strategy"
-      ]
-    },
-    {
-      "name": "mojo-writable-write-to-migration",
-      "description": "Migrate Mojo structs from __str__/Stringable to write_to/Writable for Mojo 0.26.3+ conformance. Use when: (1) auditing a codebase for deprecated Stringable/\\_\\_str\\_\\_ patterns in Mojo 0.26.3+, (2) a struct declares Writable in its trait list but implements \\_\\_str\\_\\_ instead of write_to, (3) migrating from Stringable to Writable with optional transitional delegation for backward compatibility.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-writable-write-to-migration.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "writable",
-        "stringable",
-        "write_to",
-        "__str__",
-        "trait",
-        "migration",
-        "modernization"
-      ]
-    },
-    {
-      "name": "multi-domain-audit-remediation",
-      "description": "Workflow for implementing a multi-domain production-grade audit remediation plan touching exception handling, logging hygiene, DRY violations, CI alignment, and documentation. Use when: (1) an audit report surfaces critical/major/minor issues across several independent dimensions simultaneously, (2) converting f-string logging anti-patterns and print() calls to structured logger calls across a library codebase, (3) consolidating duplicated file discovery logic into a shared utility.",
-      "version": "1.0.0",
-      "source": "./skills/multi-domain-audit-remediation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "multiprocess-to-multithread-conversion",
-      "description": "Converting ProcessPoolExecutor to ThreadPoolExecutor for Python 3.14t compatibility. Use when: multiprocessing hangs on free-threaded Python, or workers run external subprocesses making threads sufficient.",
-      "version": "1.0.0",
-      "source": "./skills/multiprocess-to-multithread-conversion.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "myrmidon-container-execution-volume-mapping",
-      "description": "Replace bare subprocess.run(['claude', ...]) with containerized execution via achaean-claude image. Use when: (1) claude-myrmidon NATS pipeline invokes claude CLI directly on host, (2) agent processes need container isolation with proper volume mappings, (3) migrating host-based CLI invocations to ephemeral Docker/Podman containers with network access to NATS, (4) debugging why Claude CLI loops retrying inside a container, (5) NATS connection drops after a long container subprocess invocation, (6) --resume fails with 'No conversation found' across ephemeral containers.",
-      "version": "2.0.0",
-      "source": "./skills/myrmidon-container-execution-volume-mapping.md",
+      "source": "./skills/myrmidon-research-grounding-swarm-with-counterfactual-track.md",
       "category": "architecture",
       "tags": [
         "myrmidon",
-        "container",
-        "podman",
-        "docker",
-        "claude-cli",
-        "achaean-fleet",
-        "volume-mapping",
-        "pipeline",
-        "asyncio",
-        "nats",
-        "session-resume",
-        "ephemeral-container"
+        "swarm",
+        "parallel-agents",
+        "l0-commander",
+        "opus",
+        "research-grounding",
+        "counterfactual-track",
+        "evidence-file-per-dimension",
+        "feasibility-tagging",
+        "citations",
+        "synthesis-agent",
+        "creative-premise",
+        "science-grounding",
+        "wave-dispatch"
       ]
     },
     {
-      "name": "myrmidon-swarm-end-to-end-orchestration-full-workflow",
-      "description": "Full end-to-end L0 commander pattern for complex myrmidon orchestration sessions. Use when: (1) task spans 3+ phases (cleanup + rebase + merge + CI + knowledge), (2) 10+ sub-tasks with mixed agent tiers required, (3) cross-repo work requiring /advise and /learn coordination, (4) feedback loops and decision gates are needed before committing to destructive operations, (5) auto-merge assumption cannot be made (CI may fail).",
-      "version": "1.6.0",
-      "source": "./skills/myrmidon-swarm-end-to-end-orchestration-full-workflow.md",
+      "name": "objective-collapse-compute-diosi-penrose-gates",
+      "description": "Physics facts and no-go results for using objective wavefunction collapse (GRW/CSL/Di\u00f3si-Penrose) as a computational primitive in sci-fi mechanism design. Use when: (1) designing a fictional device that uses gravitational collapse as a compute gate, (2) citing real papers on collapse models for worldbuilding, (3) evaluating no-go cascades (FTL signaling, energy non-conservation, decoherence) for collapse-based compute proposals.",
+      "version": "1.0.0",
+      "source": "./skills/objective-collapse-compute-diosi-penrose-gates.md",
+      "category": "architecture",
+      "tags": [
+        "physics",
+        "quantum-foundations",
+        "collapse-models",
+        "diosi-penrose",
+        "grw",
+        "csl",
+        "scifi",
+        "worldbuilding",
+        "mechanism-design"
+      ]
+    },
+    {
+      "name": "optimizer-conflict-resolution-numeric-equivalence",
+      "description": "Resolve merge-conflicted numerical/optimizer PRs (Mojo, but generalizes) where main independently merged its own version of a shared module after the branch was cut \u2014 WITHOUT silently merging wrong math. Adapt dependent call-sites to main's changed API while PROVING and documenting numeric equivalence, test the math, and DEFER provably-broken algorithms instead of merging stubs. Use when: (1) a feature PR adding an optimizer/numerical kernel is DIRTY because main merged its own version of a shared module (e.g. muon.mojo) after the branch was cut \u2192 add/add conflict; (2) the conflicted PR imports a function whose signature CHANGED on main (e.g. muon_step(momentum=...) vs muon_step(momentum_beta=...)) so dropping the PR copy breaks dependent code; (3) a PR's tests assert numeric thresholds that encoded its now-superseded implementation's hyperparameter defaults; (4) you must decide whether a conflicted optimizer is salvageable vs provably broken (defer it); (5) resolving a multi-optimizer PR where one optimizer is sound and another is broken \u2014 ship the sound one, defer the broken one.",
+      "version": "1.0.0",
+      "source": "./skills/optimizer-conflict-resolution-numeric-equivalence.md",
+      "category": "architecture",
+      "tags": [
+        "optimizer",
+        "conflict-resolution",
+        "numeric-equivalence",
+        "mojo",
+        "merge-conflict",
+        "muon",
+        "defer-broken-math"
+      ]
+    },
+    {
+      "name": "optional-scoped-discovery-pola-gate",
+      "description": "POLA (Principle of Least Astonishment) pattern for optional CLI flags that gate discovery behavior. When a discovery flag is optional (e.g., `--issues`), gate discovery on its PRESENCE, not its value: operator-provided scope stays narrow (issue-driven); empty/absent scope widens to all candidates (PR-driven). Prevents user surprise when optional flag silently ignores what they meant to scope. Use when: (1) designing CLI with optional filtering that switches between discovery modes, (2) feature toggles need intuitive defaults, (3) preventing 'operator provided --issues but they weren't used' bugs.",
+      "version": "1.0.0",
+      "source": "./skills/optional-scoped-discovery-pola-gate.md",
+      "category": "architecture",
+      "tags": [
+        "POLA",
+        "argparse",
+        "cli-design",
+        "discovery-scope",
+        "optional-flags",
+        "principle-of-least-astonishment",
+        "automation-loop",
+        "user-experience",
+        "feature-toggles"
+      ]
+    },
+    {
+      "name": "org-wide-planned-issue-implementation-swarm",
+      "description": "Org-wide swarm that implements every open GitHub issue already carrying a `# Implementation Plan` comment across all ~12 HomericIntelligence repos, one signed auto-merge PR per issue, at high parallelism. Use when: (1) implementing the entire planned-issue backlog across many HomericIntelligence repos in one session, (2) the 'has a plan' signal is a `# Implementation Plan` issue comment (not the GitHub `planning` label), (3) deciding whether per-repo dispatcher sub-agents can spawn their own implementer sub-agents (they cannot), (4) deduplicating PRs against already-open issue PRs without substring false positives, (5) arming squash auto-merge org-wide where rebase-merge is disabled, (6) telling implementer agents to reconcile a stale plan against current code.",
+      "version": "1.0.0",
+      "source": "./skills/org-wide-planned-issue-implementation-swarm.md",
+      "category": "architecture",
+      "tags": [
+        "org-wide",
+        "multi-repo",
+        "implementation-plan-comment",
+        "myrmidon",
+        "swarm",
+        "l0-fan-out",
+        "sub-agent-tool-limit",
+        "pr-dedup",
+        "closing-keywords",
+        "squash-auto-merge",
+        "signed-commits",
+        "plan-reconciliation",
+        "homeric-intelligence"
+      ]
+    },
+    {
+      "name": "parallel-agent-research-and-swarm-orchestration",
+      "description": "Orchestrate parallel Myrmidon swarm agents for architecture research review, corpus audit, multi-phase task execution, and automated GitHub pipelines. Use when: (1) reviewing a corpus of 10+ research documents using 1 lead + 5 parallel sub-agents per idea, (2) running a 10-dimension quality audit of research corpora with parallel agent delegation, (3) executing a complex multi-phase session spanning 3+ phases (cleanup, rebase, CI, merge, knowledge capture) with feedback loops and decision gates, (4) building or running a 6-phase GitHub issue automation pipeline (plan \u2192 review-plan \u2192 implement \u2192 review-PR \u2192 address-review \u2192 drive-green), (5) implementing post-merge recommendations from a chief architect review with parallel doc/test fixes and branch rebase.",
+      "version": "1.0.0",
+      "source": "./skills/parallel-agent-research-and-swarm-orchestration.md",
       "category": "architecture",
       "tags": [
         "myrmidon",
-        "orchestration",
+        "swarm",
+        "parallel-agents",
         "l0-commander",
         "multi-phase",
-        "planning",
-        "wave",
-        "ci",
-        "auto-merge",
+        "orchestration",
+        "arch-research",
+        "corpus-audit",
+        "lora",
+        "layer-pruning",
+        "citation-verification",
+        "github-pipeline",
+        "pr-review",
+        "ci-driver",
+        "architect-review",
+        "wave-based",
         "feedback-loop",
-        "end-to-end",
         "knowledge-capture"
       ]
     },
     {
-      "name": "nats-publish-retry-backoff",
-      "description": "Exponential backoff with jitter for NATS JetStream publish retries in Python. Use when: (1) building a NATS publisher that must survive transient broker outages, (2) implementing retry logic that distinguishes retryable from non-retryable NATS errors, (3) configuring publish retry parameters via Pydantic Settings, (4) designing envelope schema versioning for NATS messages.",
-      "version": "1.0.0",
-      "source": "./skills/nats-publish-retry-backoff.md",
-      "category": "architecture",
-      "tags": [
-        "nats",
-        "nats-py",
-        "jetstream",
-        "retry",
-        "backoff",
-        "jitter",
-        "asyncio",
-        "python",
-        "publisher",
-        "resilience",
-        "schema-versioning"
-      ]
-    },
-    {
-      "name": "odysseus-submodule-symlink-to-gitlink",
-      "description": "Convert absolute-path symlinks masquerading as git submodules into real git submodules (mode 160000 gitlinks). Use when: (1) git ls-tree shows mode 120000 entries that should be submodules, (2) submodule paths resolve to local absolute symlinks instead of remote-cloned repos, (3) git submodule update --init fails to clone repos because entries are symlinks not gitlinks.",
+      "name": "parallel-swarm-pr-conflict-reconciliation",
+      "description": "Detect and reconcile overlapping PRs from a parallel issue-implementation swarm, AND turn a coupled repo into a pure-X library via the verified decouple\u2192port\u2192delete extraction playbook (not a deletion-only PR). Use when: (1) you launched one-PR-per-issue across a backlog and multiple PRs auto-merge-race on the same paths so only one squash-merges cleanly, (2) a CONFLICTING PR must be rebased onto an already-merged sibling rather than merging main into it, (3) you are extracting a coupled subsystem out of a repo (e.g. ProjectKeystone \u2192 pure C++20 transport) and a deletion-only PR STALLS because the retained core still references the doomed module or the destination port is incomplete \u2014 decouple FIRST behind a tiny interface, port verify-or-port to the destination, then delete in build-refs\u2192sources\u2192dead-deps order, (4) two sibling PRs both edit a shared lockfile/script so the second goes CONFLICTING and must be rebased (git auto-drops already-upstream commits; re-sign on rebase), (5) several PRs implement the same end-state and you must pick a canonical superset to land and close the subsumed ones, (6) Edit-tool exact-match fails on conflict markers in files with em-dashes or alignment whitespace, or git restore/checkout to discard stale worktree mods is Safety-Net-BLOCKED.",
       "version": "2.0.0",
-      "source": "./skills/odysseus-submodule-symlink-to-gitlink.md",
+      "source": "./skills/parallel-swarm-pr-conflict-reconciliation.md",
       "category": "architecture",
       "tags": [
-        "submodule",
-        "symlink",
-        "gitlink",
-        "git",
-        "meta-repo",
-        "gitmodules"
+        "parallel-swarm",
+        "pr-conflict",
+        "rebase",
+        "file-overlap",
+        "extraction",
+        "decouple-before-delete",
+        "pure-library-refactor",
+        "superset-pr",
+        "force-with-lease",
+        "signed-commits",
+        "nats"
       ]
-    },
-    {
-      "name": "orphan-module-subpackage-relocation",
-      "description": "Relocate an orphaned root-level module into the correct sub-package using copy, import update, re-export, and deletion workflow.",
-      "version": "1.0.0",
-      "source": "./skills/orphan-module-subpackage-relocation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "parallel-test-generation-for-module-decomposition",
-      "description": "Parallel Test Generation for Module Decomposition",
-      "version": "1.0.0",
-      "source": "./skills/parallel-test-generation-for-module-decomposition.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "parametric-type-migration-review",
@@ -1154,67 +827,86 @@
       "tags": []
     },
     {
-      "name": "pydantic-base-class-hierarchy",
-      "description": "Skill: pydantic-base-class-hierarchy",
+      "name": "phase-skip-semantics-already-done-success",
+      "description": "Distinguish orchestrator-level phase skips (disabled/gated/not-final-loop/shutdown) from worker-internal already-done idempotency, and enforce that 'already done' returns success not failure. Use when: (1) building a multi-phase pipeline driver, (2) a phase's worker has any 'already exists / already done' check, (3) debugging why phase N's downstream phases stopped running, (4) auditing rc semantics across an orchestrator \u2192 worker boundary, (5) reviewing whether a worker's success count includes idempotent skips.",
       "version": "1.0.0",
-      "source": "./skills/pydantic-base-class-hierarchy.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "pydantic-type-consolidation",
-      "description": "Pattern for consolidating duplicate types into Pydantic-based inheritance hierarchies with full backward compatibility",
-      "version": "1.0.0",
-      "source": "./skills/pydantic-type-consolidation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "python-circular-import-symbol-extraction",
-      "description": "Fix Python circular import errors caused by partially-initialized modules. Use when: (1) Python raises ImportError or partially-initialized module error on startup, (2) module A imports module B which imports back into A while A is still loading, (3) __init__.py eagerly re-exports heavyweight CLI modules that import back into the same package, (4) making imports lazy inside functions does not fix the error. Fix: remove eager re-exports from __init__.py, extract the shared symbol to a true leaf module, redirect all importers to the leaf. After moving symbols, all mock patches must target the new module where the name is looked up at call time.",
-      "version": "1.1.0",
-      "source": "./skills/python-circular-import-symbol-extraction.md",
+      "source": "./skills/phase-skip-semantics-already-done-success.md",
       "category": "architecture",
       "tags": [
-        "python",
-        "circular-imports",
-        "symbol-extraction",
-        "mock-patch",
-        "testing",
-        "eager-init-exports"
+        "orchestrator",
+        "pipeline",
+        "idempotency",
+        "exit-code",
+        "phase-skip",
+        "worker-contract",
+        "already-done",
+        "rc-semantics",
+        "multi-phase",
+        "automation"
       ]
     },
     {
-      "name": "python-mypy-explicit-reexport-pattern",
-      "description": "mypy with implicit_reexport=false requires `from X import Y as Y` (explicit re-export) for symbols re-exported from a module. Use when: (1) moving a symbol to a leaf module and re-exporting for backward compatibility, (2) mypy raises 'does not explicitly export attribute X', (3) maintaining mock.patch-compatible namespace bindings after a module refactor.",
+      "name": "private-module-extraction-helper-pattern",
+      "description": "Extract duplicated internal function calls (especially importlib.metadata version resolution) into a private leaf module with leading-underscore naming. Use when: (1) the same function is called from multiple modules with identical arguments, (2) creating a module to centralize the call, (3) PyPI distribution names or other arbitrary constants must be stored at module level, (4) avoiding circular imports by using leaf modules instead of packages, (5) consolidating version resolution or other metadata lookups across the codebase.",
       "version": "1.0.0",
-      "source": "./skills/python-mypy-explicit-reexport-pattern.md",
+      "source": "./skills/private-module-extraction-helper-pattern.md",
       "category": "architecture",
       "tags": [
-        "mypy",
+        "dry-principle",
+        "private-modules",
+        "code-extraction",
+        "importlib-metadata",
+        "helper-pattern",
+        "circular-imports",
+        "leaf-modules"
+      ]
+    },
+    {
+      "name": "python-module-decomposition-and-refactor-patterns",
+      "description": "Use when: (1) a Python module or class exceeds 800\u20131000 lines and contains identifiable method clusters with distinct responsibilities, (2) extracting method groups into dedicated collaborator classes or sub-modules via TDD, (3) fixing circular import errors caused by partially-initialized modules or eager __init__.py re-exports, (4) refactoring class methods to purely functional/immutable style, (5) preparing a codebase for extensibility through extraction, parameterization, and protocol-based abstraction, (6) extracting a CLI entry point or main() out of a module while preserving existing patch-based tests without edits (reverse-delegation pattern).",
+      "version": "1.2.0",
+      "source": "./skills/python-module-decomposition-and-refactor-patterns.md",
+      "category": "architecture",
+      "tags": [
         "python",
+        "refactoring",
+        "srp",
+        "tdd",
+        "dry",
+        "circular-imports",
+        "module-decomposition",
+        "collaborator-extraction",
+        "extensibility",
+        "cli-extraction",
+        "patch-routing",
+        "entry-point"
+      ]
+    },
+    {
+      "name": "python-type-system-and-api-alignment",
+      "description": "Use when: (1) mypy with implicit_reexport=false raises 'does not explicitly export attribute X' after a module refactor or symbol move; (2) Pydantic base class hierarchy is incomplete \u2014 domain models inherit directly from BaseModel while siblings have dedicated *Base classes; (3) type aliases shadow explicit domain-specific names causing import ambiguity; (4) functions return bool redundantly when they raise on failure (POLA violation \u2014 return type should be None); (5) auditing or tightening broad except Exception clauses across Python files; (6) legacy model IDs in saved configs cause failures on experiment resume and need a Pydantic field_validator normalization chokepoint; (7) bulk-migrating @dataclass classes to Pydantic BaseModel; (8) enforcing frozen=True immutability consistency across sibling Pydantic base classes.",
+      "version": "1.0.0",
+      "source": "./skills/python-type-system-and-api-alignment.md",
+      "category": "architecture",
+      "tags": [
+        "python",
+        "mypy",
+        "pydantic",
+        "type-system",
         "reexport",
         "implicit_reexport",
-        "mock",
-        "patch",
+        "type-aliases",
+        "frozen",
+        "immutability",
+        "return-type",
+        "POLA",
+        "exceptions",
+        "BLE001",
+        "normalization",
+        "field_validator",
+        "dataclass-migration",
         "backward-compatibility"
       ]
-    },
-    {
-      "name": "quality-complexity-check",
-      "description": "Analyze code complexity metrics including cyclomatic complexity and nesting depth",
-      "version": "1.0.0",
-      "source": "./skills/quality-complexity-check.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "quality-security-scan",
-      "description": "Scan code for security vulnerabilities and unsafe patterns",
-      "version": "1.0.0",
-      "source": "./skills/quality-security-scan.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "rebase-full-file-rewrite-conflict",
@@ -1232,70 +924,35 @@
       ]
     },
     {
-      "name": "refactor-for-extensibility",
-      "description": "Systematic workflow for preparing codebases for extensibility through extraction, parameterization, and protocol-based abstraction",
+      "name": "resilience-circuit-breaker-error-translation",
+      "description": "Translate CircuitBreakerOpenError to domain exception at integration boundary to preserve caller exception semantics. Use when: wrapping low-level circuit breaker in a service-layer function where callers expect domain-specific exceptions.",
       "version": "1.0.0",
-      "source": "./skills/refactor-for-extensibility.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "repo-hygiene-audit-implementation",
-      "description": "Workflow for implementing repository hygiene audit fixes. Use when: (1) an automated audit surfaces actionable code quality issues, (2) migrating Pydantic to_dict() to model_dump(), (3) adding debug logging to silent exception catches.",
-      "version": "1.0.0",
-      "source": "./skills/repo-hygiene-audit-implementation.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "research-corpus-audit-parallel-agent-pattern",
-      "description": "Strict 10-dimension quality audit of AI architecture research corpora using parallel agent delegation. Use when: (1) auditing a large set of research/summary docs for structural compliance, (2) enforcing citation standards and TPOT framing conventions across a corpus, (3) grading research output with file:line evidence, (4) reviewing individual idea research docs for KV cache / quantization numerical correctness, (5) writing or reviewing numeric claims not backed by a paper (inline derivation format), (6) auditing exec summaries where FLOPs and TPOT overhead diverge.",
-      "version": "2.0.0",
-      "source": "./skills/research-corpus-audit-parallel-agent-pattern.md",
+      "source": "./skills/resilience-circuit-breaker-error-translation.md",
       "category": "architecture",
       "tags": [
-        "research",
-        "audit",
-        "corpus",
-        "tpot",
-        "citation",
-        "parallel-agents",
-        "myrmidon",
-        "kv-cache",
-        "quantization",
-        "remediation",
-        "wave-based",
-        "terminology-drift",
-        "derivation",
-        "inline",
-        "exec-summary",
-        "overhead",
-        "honesty"
+        "circuit-breaker",
+        "error-handling",
+        "exception-translation",
+        "integration-boundary",
+        "resilience"
       ]
     },
     {
-      "name": "resource-manager-pattern",
-      "description": "Replace global mutable semaphores with a dependency-injected ResourceManager class using context managers. Use when: concurrent threads share global locks/semaphores, semaphore leaks cause hangs, or shutdown signals bypass finally blocks.",
+      "name": "scifi-mechanism-pr-box-trivial-communication-complexity",
+      "description": "Documents the PR-box / super-quantum correlation processor mechanism for a Planck-scale reality simulator, including the van Dam trivial communication complexity theorem, information causality (Tsirelson bound), NPA hierarchy characterization, and the M-file writing style used in the HomericIntelligence/Story research corpus. Use when: (1) writing a new M-file mechanism for the Story project, (2) researching super-quantum correlations or PR-boxes, (3) applying communication complexity theory to distributed computation design.",
       "version": "1.0.0",
-      "source": "./skills/resource-manager-pattern.md",
+      "source": "./skills/scifi-mechanism-pr-box-trivial-communication-complexity.md",
       "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "resumable-state-machine-until-halt",
-      "description": "Fix --until semantics in resumable state machines: sentinel exception that transitions state before stopping, additive CLI tier merging, ephemeral CLI arg preservation. Use when advance() leaves subtest/tier stuck at prior state because sentinel exception fires before the state update.",
-      "version": "1.0.0",
-      "source": "./skills/resumable-state-machine-until-halt.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "resume-manager-zombie-delegation",
-      "description": "Skill: ResumeManager Zombie Delegation",
-      "version": "1.0.0",
-      "source": "./skills/resume-manager-zombie-delegation.md",
-      "category": "architecture",
-      "tags": []
+      "tags": [
+        "scifi",
+        "physics",
+        "pr-box",
+        "quantum-foundations",
+        "communication-complexity",
+        "nonlocality",
+        "planck-scale",
+        "mechanism-design"
+      ]
     },
     {
       "name": "security-pep508-parser-replaces-regex",
@@ -1320,12 +977,23 @@
       "tags": []
     },
     {
-      "name": "single-responsibility-extraction",
-      "description": "Extracting a complex multi-concern method into a dedicated collaborator class using TDD. Use when a method violates SRP, triggers complexity suppressions (C901), or mixes 3+ distinct concerns.",
+      "name": "silent-boundary-observability-exception-classification",
+      "description": "Add observability to broad exception boundaries in orchestrator code without changing fail-safe behavior. Use when: (1) a broad `except Exception` boundary is designed for fail-safe/non-blocking behavior but swallows errors silently making bugs hard to debug, (2) you need to surface exceptions to observability systems (logging, monitoring) while preserving the safety contract (returns None, never blocks), (3) exception classification (expected vs unexpected) enables aggregation in log analysis, (4) modules like run_follow_up_issues, planner, or ci_driver need better observability for post-mortem debugging. Pattern: define a module-level tuple of expected exception types, use isinstance() to route to WARNING (expected) or ERROR (unexpected) severity, capture full traceback with exc_info=True, and include exception type as discrete log argument for aggregation.",
       "version": "1.0.0",
-      "source": "./skills/single-responsibility-extraction.md",
+      "source": "./skills/silent-boundary-observability-exception-classification.md",
       "category": "architecture",
-      "tags": []
+      "tags": [
+        "orchestrator",
+        "exception-handling",
+        "observability",
+        "silent-boundaries",
+        "fail-safe",
+        "logging",
+        "exception-classification",
+        "debugging",
+        "incident-response",
+        "hephaestus-automation"
+      ]
     },
     {
       "name": "skill-unify-config-structure",
@@ -1336,108 +1004,58 @@
       "tags": []
     },
     {
-      "name": "standardize-matmul-calls",
-      "description": "Convert A.__matmul__(B) dunder method calls to matmul(A, B) function syntax. Use when: codebase has mixed matmul call patterns or standardizing operator syntax in Mojo ML code.",
+      "name": "state-machine-and-resource-lifecycle-patterns",
+      "description": "Use when: (1) a resumable state machine's advance() leaves a subtest stuck in the prior state after a sentinel exception fires before the state update; (2) Ctrl+C/SIGINT must leave long-running agent runs resumable instead of FAILED across a 4-level SM hierarchy; (3) global mutable semaphores leak or hang on shutdown and need replacing with a dependency-injected ResourceManager; (4) temp credential dirs accumulate in home after Docker runs due to silent rmtree failures; (5) ProcessPoolExecutor hangs on Python 3.14t free-threaded and workers only run external subprocesses.",
       "version": "1.0.0",
-      "source": "./skills/standardize-matmul-calls.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "state-machine-interrupt-handling",
-      "description": "Pattern for handling Ctrl+C/SIGINT interrupts in multi-level state machine hierarchies without marking states FAILED. Use when subprocess.run() returns normally after SIGINT but you want runs to stay resumable; or when a sentinel exception must propagate through 4 state machine levels (run\u2192subtest\u2192tier\u2192experiment) without triggering FAILED at any level. Also covers wiring hierarchical state machines (Experiment \u2192 Tier \u2192 Run) into a production runner using closure-based action maps.",
-      "version": "1.1.0",
-      "source": "./skills/state-machine-interrupt-handling.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "strict-review-with-audit-epic-exclusion",
-      "description": "Strict architectural review of a multi-phase pipeline that already has a tracked audit epic. Builds an exclusion list from open issues + parent epic FIRST, then dispatches parallel Explore sub-agents sliced by phase (not by file), then spot-verifies every concrete claim before writing the plan. Use when: (1) reviewing code that has an existing audit epic with N findings already filed, (2) reviewing a multi-phase pipeline where phases are natural agent boundaries, (3) running myrmidon-swarm fan-out for code review and need to filter noise from already-tracked findings, (4) producing a strict review document where the deliverable is a plan file (not ExitPlanMode), (5) implementing 15+ findings in one PR with grouped commits.",
-      "version": "1.0.0",
-      "source": "./skills/strict-review-with-audit-epic-exclusion.md",
+      "source": "./skills/state-machine-and-resource-lifecycle-patterns.md",
       "category": "architecture",
       "tags": [
-        "strict-review",
-        "audit-epic",
-        "exclusion-list",
-        "parallel-explore",
-        "spot-verification",
-        "defence-in-depth",
-        "pipeline-review",
-        "myrmidon-swarm"
+        "state-machine",
+        "resumable",
+        "interrupt-handling",
+        "sigint",
+        "resource-manager",
+        "semaphore",
+        "context-manager",
+        "credentials",
+        "multiprocessing",
+        "threading",
+        "python"
       ]
     },
     {
-      "name": "tensor-dtype-native-ops-inversion",
-      "description": "Invert wrapper pattern for parametric tensor operations: Tensor[dtype] typed cores with AnyTensor ordinal dispatch. Use when: migrating runtime-typed tensor ops to compile-time typed, eliminating dtype branching, designing 3-layer typed architecture.",
+      "name": "stdlib-json-decoder-raw-decode-string-extraction",
+      "description": "Use json.JSONDecoder.raw_decode() to extract the first JSON object from mixed text (with preamble, trailing text, whitespace, or nested objects). Canonical stdlib pattern replacing custom balanced-brace parsers. Use when: (1) extracting JSON from LLM responses with preamble/postamble text, (2) parsing JSON from markdown code blocks with surrounding text, (3) handling edge cases like nested JSON objects, leading whitespace, or multiple trailing comment lines, (4) avoiding reinvention of the balanced-brace parser wheel.",
       "version": "1.0.0",
-      "source": "./skills/tensor-dtype-native-ops-inversion.md",
+      "source": "./skills/stdlib-json-decoder-raw-decode-string-extraction.md",
       "category": "architecture",
       "tags": [
-        "mojo",
-        "tensor",
-        "dtype",
-        "parametric",
-        "refactor",
-        "typed-ops",
-        "dispatch",
-        "architecture"
+        "json",
+        "stdlib",
+        "parsing",
+        "jsondecoderraw_decode",
+        "robustness",
+        "edge-cases",
+        "refactoring"
       ]
     },
     {
-      "name": "tighten-except-exception-clauses",
-      "description": "Audit and tighten broad except Exception clauses in Python \u2014 replacing with specific types where feasible and annotating legitimate broad catches with justification comments",
+      "name": "typing-callable-generic-return-preserve",
+      "description": "Use Callable[..., R] + TypeVar(R) instead of ParamSpec when a wrapper function interleaves keyword-only parameters between *args and **kwargs. ParamSpec violates PEP 612 in this case. Use when: (1) replacing object type-erased signatures with proper generics; (2) wrapping functions with complex parameter layouts (interleaved keyword-only params); (3) the wrapper needs to preserve the return type of the wrapped callable; (4) mypy requires full type coverage without # type: ignore comments.",
       "version": "1.0.0",
-      "source": "./skills/tighten-except-exception-clauses.md",
+      "source": "./skills/typing-callable-generic-return-preserve.md",
       "category": "architecture",
       "tags": [
-        "python",
-        "exceptions",
-        "refactoring",
-        "code-quality",
-        "ruff",
-        "pre-commit",
-        "subprocess",
-        "OSError",
-        "json"
+        "typing",
+        "generic",
+        "callable",
+        "typevar",
+        "paramspec",
+        "pep-612",
+        "return-type-preservation",
+        "wrapper-pattern",
+        "mypy"
       ]
-    },
-    {
-      "name": "type-alias-consolidation",
-      "description": "Use when: (1) multiple modules define TypeName = DomainVariant aliases causing naming confusion and you need to remove redundant type aliases that shadow domain-specific variant names; (2) applying the Pydantic inheritance pattern to metrics/judgment/cost types (MetricsInfo, JudgmentInfo) or other evaluation data types; (3) a Pydantic base class lacks frozen=True while its sibling base types all use ConfigDict(frozen=True) and you need an immutability consistency audit; (4) discovering and categorizing duplicate code (true-vs-intentional-variant taxonomy) for codebase-wide consolidation; (5) migrating Python @dataclass classes to Pydantic BaseModel in bulk (24-class checklist, pytest fixture migration); (6) fixing AttributeError from Pydantic v2 .to_dict() vs .model_dump() regression.",
-      "version": "3.1.0",
-      "source": "./skills/type-alias-consolidation.md",
-      "category": "architecture",
-      "tags": [
-        "refactoring",
-        "type-consolidation",
-        "python",
-        "architecture",
-        "pydantic",
-        "frozen",
-        "immutability",
-        "dataclass",
-        "migration",
-        "serialization",
-        "duplicate-discovery"
-      ]
-    },
-    {
-      "name": "validate-tuple-return",
-      "description": "Refactor Mojo validation functions to return Tuple[Float64, Float64] (loss, accuracy) to eliminate redundant data loader passes. Use when: validate() discards accuracy internally and the caller re-computes it with a second loop.",
-      "version": "1.0.0",
-      "source": "./skills/validate-tuple-return.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "wave-based-bulk-issue-triage",
-      "description": "Fix 5+ independent GitHub issues in parallel waves using Task isolation:worktree. No manual worktree setup \u2014 Claude Code auto-manages isolation. Also covers bulk gh issue create via myrmidon swarm (plain Agent calls, no worktrees needed). Includes pre-fix classification phase using parallel Explore agents.",
-      "version": "1.4.0",
-      "source": "./skills/wave-based-bulk-issue-triage.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "xterm-plan-mode-fix",
@@ -1456,6 +1074,49 @@
       "tags": []
     },
     {
+      "name": "automation-ci-driver-honest-success-path-no-silent-noop",
+      "description": "When a CI driver (e.g. `drive_prs_green`) reports 'pushed CI fixes for PR #N' but the remote PR head SHA is unchanged, the driver is silently no-op'ing. Three compounding bugs cause this: (1) bare `git push origin HEAD` pushes to whatever branch HEAD switched to inside the agent session instead of the PR head, (2) worktree setup creates a NEW branch off `main` when the local branch ref doesn't exist instead of resetting to `origin/<pr-head>`, (3) per-issue 'success' is treated as 'repo done' even with open PRs still outstanding. Fix all three: pre-sync the worktree to `origin/<pr-head>`, snapshot HEAD before/after the agent and fail if unchanged, push with explicit refspec `HEAD:<pr-head-branch>`, and gate 'repo done' on `gh api /repos/.../pulls?state=open --paginate` returning 0. Use when: (1) automation driver logs success but remote PR tips are unchanged, (2) `git push --force-with-lease` exits 0 with no remote update, (3) agent session resumed an old transcript and returned in seconds without a commit, (4) multi-repo run script's success/failed buckets don't match GitHub reality, (5) reviewing a driver that pushes commits to many PR branches across many repos.",
+      "version": "1.2.0",
+      "source": "./skills/automation-ci-driver-honest-success-path-no-silent-noop.md",
+      "category": "ci-cd",
+      "tags": [
+        "hephaestus-automation-loop",
+        "drive-prs-green",
+        "ci-driver",
+        "silent-failure",
+        "git-push-refspec",
+        "worktree-sync",
+        "honest-reporting",
+        "repo-done-state",
+        "wait-for-merge",
+        "auto-merge-armed",
+        "dependabot-arming",
+        "re-arm-after-fix",
+        "session-id-collision",
+        "dirty-merge-conflict",
+        "markdownlint-blocker",
+        "homericintelligence"
+      ]
+    },
+    {
+      "name": "automation-learn-on-merge-per-issue-arming-state",
+      "description": "When automation that runs `/learn` (or any learnings-capture step) after CI work fires on the optimistic point (auto-merge enabled) instead of on the truth (detected merge), Mnemosyne fills with lessons from PRs that never shipped AND shared-PR groups silently collapse N issues into 1 capture. Fix: a per-issue arming-record state machine driven by detected-merge, fanned out via the shared-PR dedupe map. Use when: (1) building post-CI learnings-capture in `loop_runner.py` / `ci_driver.py`-style pipelines, (2) capturing lessons keyed on `_enable_auto_merge` succeeding, (3) a dedupe step in `_discover_prs` collapses N issues to 1 worker and each issue is a distinct lesson, (4) you need post-merge detection that survives across runs without polling, (5) deciding when to set `learn_captured_at` (success-only vs best-effort).",
+      "version": "1.0.0",
+      "source": "./skills/automation-learn-on-merge-per-issue-arming-state.md",
+      "category": "ci-cd",
+      "tags": [
+        "automation",
+        "learn-capture",
+        "drive-green",
+        "arming-record",
+        "state-machine",
+        "shared-pr",
+        "detected-merge",
+        "hephaestus-automation-loop",
+        "homericintelligence"
+      ]
+    },
+    {
       "name": "badge-count-drift-prevention",
       "description": "Automate README badge count validation to prevent drift. Use when: README badge reflects a file count that grows over time, badge has drifted from actual count, or adding pre-commit enforcement for badge accuracy.",
       "version": "1.0.0",
@@ -1464,65 +1125,9 @@
       "tags": []
     },
     {
-      "name": "ban-matmul-call-sites",
-      "description": "Add a system-language pre-commit hook and belt-and-suspenders CI step to ban dunder method call sites (e.g. .__matmul__()) in Mojo files while excluding function definition lines. Use when: (1) codebase has been standardized on a free-function form and you need to prevent dunder-call-site regression, (2) pygrep cannot express the exclusion you need, (3) you need both pre-commit and CI enforcement.",
-      "version": "1.0.0",
-      "source": "./skills/ban-matmul-call-sites.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "bandit-config-migration",
-      "description": "Move bandit skip flags from pre-commit hook CLI args to a .bandit INI config file so suppressions are visible when running bandit directly. Use when: bandit --skip flags live in .pre-commit-config.yaml making them invisible to developers, or pyproject.toml [tool.bandit] is desired but bandit doesn't natively read it.",
-      "version": "1.0.0",
-      "source": "./skills/bandit-config-migration.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "bandit-precommit-security-scanner",
-      "description": "Pattern for replacing a pygrep shell=True pre-commit hook with bandit AST-based Python security scanning. Use when: upgrading naive regex security hooks to AST analysis, distinguishing PR-introduced CI failures from pre-existing infrastructure crashes.",
-      "version": "1.0.0",
-      "source": "./skills/bandit-precommit-security-scanner.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "bandit-replace-pygrep-security-hook",
-      "description": "Replace a naive pygrep shell=True pre-commit hook with bandit for AST-based Python security scanning. Use when: false positives from pygrep, need to catch os.system/subprocess misuse, upgrading pre-commit security checks.",
-      "version": "1.0.0",
-      "source": "./skills/bandit-replace-pygrep-security-hook.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "bare-mojo-call-lint-guard",
-      "description": "Add a pre-commit hook and CI step to prevent bare 'pixi run mojo test/run' calls in workflow YAMLs without retry wrappers. Use when: (1) bare mojo calls were patched with retry but no guardrail prevents regression, (2) enforcing retry discipline in GitHub Actions workflow lint.",
-      "version": "1.0.0",
-      "source": "./skills/bare-mojo-call-lint-guard.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "batch-fix-implementation",
-      "description": "Implement coordinated batch fixes across multiple files using minimal edits. Use when fixing multiple low-complexity issues in a single PR.",
-      "version": "1.0.0",
-      "source": "./skills/batch-fix-implementation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "batch-pr-ci-fix-workflow",
-      "description": "Use when: (1) multiple PRs have failing CI checks (formatting, pre-commit, broken links, broken JSON, mypy), (2) a common CI failure pattern affects many PRs and needs a root-cause fix before rebasing, (3) PRs need batch auto-merge after fixes, (4) JSON files are bulk-corrupted and must be repaired before merging, (5) identifying required vs non-required checks, (6) recovering auto-merge after force-push, (7) reconstructing a branch that conflicts with a src-layout migration, (8) pytest caplog test failures with LogRecord.message, (9) gcovr coverage reports 0% in CI, (10) ruff F841 unused variable not auto-fixable, (11) dependabot PR blocked by pre-existing main-branch workflow bug, (12) check-yaml fails on duplicate GHA job keys, (13) small-batch rebase-then-resolve in a worktree, (14) git restore --theirs or git checkout --theirs blocked by Safety Net during automated rebase waves, (15) C library via FetchContent causing global -Werror CI failures, (16) coverage script missing Conan toolchain, (17) clang-format version mismatch with multi-line lambda formatting, (18) diagnosing all-5-required-checks failing vs benchmarks/coverage skipped pattern, (19) just v1.14+ import keyword reservation breaks inline Python heredocs causing all CI Code Quality fails, (20) gitleaks asset URL 404 because uname -s/-m produces wrong case/arch string for download URL, (21) GHA workflow uses manual pixi install instead of composite setup-pixi action causing pixi command not found, (22) bats PATH test for missing tool includes /bin or /usr/bin which pixi activation already polluted, (23) shell script calls companion script via SCRIPT_DIR but unit tests copy only the main script to a temp dir, (24) a repo has legacy ci.yml or security.yml alongside _required.yml each with their own secrets-scan job using gitleaks-action@v2 \u2014 must grep ALL workflow files per repo, (25) yamllint default config fails on workflow files with lines >80 chars \u2014 fix with -d relaxed flag, (26) mypy run on scripts/ tests/ traverses pytest internals causing Python 3.10 pattern matching errors \u2014 fix with --no-namespace-packages --python-version 3.11, (27) multi-line python3 -c in run: | blocks breaks YAML parsing when Python code starts at column 1, (28) PR mergeStateStatus lags after force-push \u2014 verify via workflow run head_sha directly, (29) cppcheck danglingLifetime error on a global raw pointer that is assigned but never read (dead scaffolding leftover in signal-handler test), (30) coverage job is advisory-only (extras.yml) but failing every PR because threshold is too high \u2014 needs threshold lowering and promotion to required (_required.yml), (29) markdownlint-cli2 CI job scans .claude/plugins/ directory which contains XML-like Claude prompt files using <system>, <task>, <section> tags \u2014 produces ~12000 false-positive MD013/MD033 violations; fix by adding .markdownlintignore to exclude .claude/, (30) prefix-dev/setup-pixi with cache: true fails with \"Failed to generate cache key\" when pixi.lock is absent, crashing the job before any conditional install step runs; fix by setting cache: false, (31) aquasecurity/trivy-action tag without v prefix (e.g. @0.36.0) causes action not found \u2014 always use @v0.36.0, (32) gitleaks/gitleaks-action@v2 on org repos requires paid license \u2014 replace with direct binary curl download, (33) prefix-dev/setup-pixi@v0.9.5 does not exist \u2014 correct latest is v0.9.4; rolling forward to nonexistent tag breaks pixi setup immediately, (34) markdownlint-cli2-action globs: \"**/*.md\" bypasses .markdownlintignore \u2014 explicit glob overrides the ignore file; remove globs: or add explicit exclusion, (35) git push --force-with-lease fails on dependabot branches because GitHub rebases them automatically between fetch and push making the lease stale \u2014 use git push --force, (36) yamllint braces rule: {name: \"unit\" path: \"tests/unit\"} must not have space before closing brace \u2014 depends on braces forbid-flow-sequences config, (37) pixi.lock must be regenerated after pyproject.toml changes from rebase \u2014 pixi lock regenerates it; pixi install --locked fails if SHA changed, (38) schema-validation check-jsonschema fails on boolean default: 'false' (string) \u2014 must be default: false (unquoted boolean), (39) some repos allow only squash merge \u2014 auto-merge --rebase will fail; always use --squash for Charybdis-style repos, (40) check-jsonschema downloads github-workflow schema from schemastore.org which returns HTTP 503 intermittently \u2014 use --builtin-schema vendor.github-workflows instead, (41) required check failing on main itself blocks all PRs from ever satisfying that check \u2014 auto-merge deadlock until main is fixed, (42) yamllint indent-sequences: true causes all existing YAML fixtures with sequences at parent-key indent level to fail \u2014 use indent-sequences: consistent instead",
-      "version": "2.15.0",
-      "source": "./skills/batch-pr-ci-fix-workflow.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "batch-pr-rebase-workflow",
-      "description": "Use when: (1) many PRs show DIRTY/CONFLICTING/BLOCKED merge state after main advances, (2) a major refactor causes mass conflicts across 10-160+ PRs, (3) PRs have inter-dependencies requiring sequential wave merging, (4) CI queue is backed up with 50+ queued runs and PRs need consolidation via cherry-pick, (5) PRs conflict on the same files (pixi.lock, plugin.json, core source files), (6) delegating mass rebase to a Myrmidon swarm of parallel agents, (7) orphaned branches need PRs created and CI fixed, (8) a PR expanded a pre-commit hook scope causing self-catch failures on pre-existing violations, (9) small batch (2-10) stale branches need rebase with subsume-vs-integrate conflict analysis, (10) GitHub issue backlog (20+ issues) needs triage, batched PRs, and stale worktree/branch cleanup, (11) 10+ branches all conflict on the same 3-5 core files and are being merged serially \u2014 take HEAD (origin/main) for all conflicted core files since main already contains the union of all prior merged features, (12) main is advancing rapidly via auto-merge during the rebase session and PRs keep going DIRTY again \u2014 repeat rebase in waves until stable, (13) stale worktrees from a previous session are listed in `git worktree list` as unlinked \u2014 check before removing, they may already be detached with no git state to clean up, (14) a rebase 'succeeds' but the branch tip equals main HEAD \u2014 the commit was silently dropped as empty, recover the original SHA and rebase again keeping the PR's file additions, (15) a rebased PR's tests fail because the PR's own implementation was incomplete \u2014 the commit message described a feature but the actual diff didn't include a critical file (e.g., server route for an endpoint the tests expect), (16) stale worktrees from a prior session need auditing \u2014 always diff each one against origin/main before deciding to discard or push, (17) CI overall conclusion shows 'failure' but all required branch-protection checks passed \u2014 use per-job inspection not top-level conclusion, (18) a conanfile.py lacks return annotations on ConanFile subclass methods causing mypy failures, (19) a Dependabot PR and a fix PR both target the same file \u2014 apply the fix directly in the Dependabot branch to avoid a circular dependency chain, (20) branches live in .claude/worktrees/agent-<id>/ paths from sub-agent runs and need rebase using git -C <worktree-path>, (21) rebase in a .claude/worktree ends in detached HEAD \u2014 use git branch -f to reattach before pushing, (22) CHANGELOG.md conflicts during rebase \u2014 always take HEAD/main (consolidation PR handles it separately), (23) two PRs fired with `gh pr merge` concurrently \u2014 one fails with GraphQL 'Base branch was modified' error because the first merge advanced main between API calls, (24) two PRs both add add_executable/gtest_discover_tests blocks at the same CMakeLists.txt location \u2014 additive conflict, keep both sides, (25) a PR removes the %.native: Makefile pattern rule \u2014 CI breaks with make deps.native exit 2, (26) a new CI job (markdownlint or pixi-check) was added to main via a rollout PR and immediately blocks all open skill PRs even though those PRs didn't touch CI config \u2014 root cause is pre-existing violations in shared files (.claude/plugins/) or missing pixi.lock; fix the root cause on main first, then rebase all PRs, (27) two PRs independently amend the same skill file to the same version number (e.g., both v2.9.0) with different content \u2014 treat as additive conflict: read both diffs, produce one merged version with all new learnings, close the redundant PR as superseded, (28) a batch of PRs all show stale CI results (old failing run) after a fix lands on main \u2014 they need a rebase push to trigger a fresh CI run even if their branch content didn't change, (29) before rebasing any Mnemosyne skill PRs, first confirm main itself is green \u2014 rebasing onto a broken main cannot unblock PRs (run `gh run list --branch main --limit 3` to verify main CI is passing before starting any rebase session), (30) a dependabot branch requires `git push --force` rather than `--force-with-lease` \u2014 GitHub auto-rebases dependabot branches between fetch and push, making the lease ref stale, (31) the repo only allows squash merge \u2014 `gh pr merge --auto --rebase` fails with GraphQL error; always check merge methods with `gh api repos/OWNER/REPO --jq '.allow_squash_merge,.allow_rebase_merge,.allow_merge_commit'` before enabling auto-merge, (32) a PR touches `pixi.lock` and was rebased after `pyproject.toml` conflict resolution \u2014 the lock SHA changes after any pyproject.toml edit; always run `pixi lock` before pushing if `pixi.lock` exists in the repo, (33) all open Mnemosyne skill PRs are BLOCKED with markdownlint failures not caused by the PRs themselves \u2014 main's markdownlint workflow uses `globs: \"**/*.md\"` which overrides `.markdownlintignore`; fix the workflow on main first, then rebase all skill PRs, (34) a bulk markdown table reformatter commit touched 1000+ files and all open PRs for those files became CONFLICTING \u2014 the conflict pattern is always add/add or modify/modify on the same .md files; take the PR branch's content then re-apply the formatter, (35) `git checkout --theirs <file>` is blocked by the Safety Net hook during rebase \u2014 use `git show REBASE_HEAD:<file> > /tmp/theirs && cp /tmp/theirs <file>` to extract the PR branch content without triggering the hook, (36) `marketplace.json` conflict during rebase \u2014 always take main's version (`git checkout --ours marketplace.json`) because it has more entries than the PR's stale regenerated version, (37) `gh pr rebase` command does not exist in the gh CLI \u2014 use `git fetch origin && git rebase origin/main` locally instead, (38) enabling auto-merge BEFORE rebasing a CONFLICTING PR has no effect \u2014 GitHub's CONFLICTING state prevents auto-merge from activating; rebase and push first, then enable auto-merge, (39) `git checkout --ours <files>` during rebase conflict resolution is blocked by Safety Net when run from a sub-agent \u2014 the Safety Net hook fires in the sub-agent's context too; escalate the specific `git checkout --ours -- <files>` command to the main conversation to run directly, then resume the sub-agent or continue the rebase from the main conversation, (40) `.pre-commit-config.yaml` has an additive conflict where main added `check-xtrace-exposure` hook and the PR independently added its own new hook at the same position \u2014 resolution is always keep BOTH hooks (they are independent features), (41) a shell script (`run_automation_loop.sh` or similar) has a structural rewrite conflict where main has a 6-phase expanded version and PR has a 2-phase refactored version \u2014 take main's structural skeleton (more phases), apply PR's specific fix (e.g., entry-point binary variables) to the relevant section, (42) a C++ `isSubordinateResult` or similar method conflicts where main added a TASK_FAILED exclusion and the PR has the older version without it \u2014 always take main's version (the exclusion was a deliberate bugfix), (43) a multi-commit PR (14+ commits) being rebased produces conflicts in the same file on multiple sequential commits \u2014 resolve each conflict individually; git rebase will stop once per conflicting commit, (44) `git rebase --continue` does not accept `--no-edit` flag \u2014 use `git rebase --continue` alone (it opens an editor only if explicitly invoked with `-i`; non-interactive rebase continues silently), (45) when cloning a fresh temp dir for rebase work, use `mktemp -d` for each operation rather than pre-cleaning a fixed path \u2014 `rm -rf $FIXED_PATH` may be blocked by Safety Net hooks even for temp dirs outside the workspace, (46) `gh pr merge --auto --squash` returns \"Pull request is in clean status\" for some PRs on first attempt but succeeds on retry seconds later \u2014 this is GitHub API lag; retry immediately before trying a direct merge, (47) a PR's rebase produces a commit whose content is identical to a prior commit that was already on main (e.g., a fix that was cherry-picked to main independently) \u2014 git drops it silently with \"dropping <sha> -- patch contents already upstream\"; this is correct behavior, not data loss, (48) tier-by-complexity merge ordering reduces cascade churn \u2014 sort PRs by total churn (additions+deletions) and process simplest first; smaller PRs cause less DIRTY-flag cascade on siblings than landing big refactors first, (49) 'strict subset' PR pairs (smaller PR \u2282 larger PR with same intent + extras) should be merged in size order: smaller first; larger becomes auto-empty after rebase or self-closes via natural drop, (50) before deploying any rebase swarm, run a single Opus triage agent to dedupe (identify exact-duplicate diffs and obviously-mooted-by-main PRs) \u2014 9 of 46 PRs in our session were close-as-superseded after triage, saving the equivalent of 3 rebase waves, (51) two PRs solving the same problem with different mechanisms (e.g., X-Dead-Letter-Key header vs Authorization Bearer; tomllib pyproject extraction vs requirements.txt sync script) are DESIGN COLLISIONS, not duplicates \u2014 flag for human decision; never silently pick one mechanism over the other, (52) when a hotfix lands mid-flight on main (e.g., regenerated pixi.lock or coverage-gate fix), every already-rebased PR needs ANOTHER rebase pass to inherit it; this second pass is fast (clean rebases) but mandatory before the queue can drain, (53) cascade churn during auto-merge wave: as PRs land in quick succession (e.g., 7 in 5 minutes), siblings touching the same files repeatedly go DIRTY; expect to run 2-3 re-rebase waves on diminishing subsets, not just one",
-      "version": "2.15.0",
+      "description": "Use when: (1) many PRs show DIRTY/CONFLICTING/BLOCKED merge state after main advances, (2) a major refactor causes mass conflicts across 10-160+ PRs, (3) PRs have inter-dependencies requiring sequential wave merging, (4) CI queue is backed up with 50+ queued runs and PRs need consolidation via cherry-pick, (5) PRs conflict on the same files (pixi.lock, plugin.json, core source files), (6) delegating mass rebase to a Myrmidon swarm of parallel agents, (7) orphaned branches need PRs created and CI fixed, (8) a PR expanded a pre-commit hook scope causing self-catch failures on pre-existing violations, (9) small batch (2-10) stale branches need rebase with subsume-vs-integrate conflict analysis, (10) GitHub issue backlog (20+ issues) needs triage, batched PRs, and stale worktree/branch cleanup, (11) 10+ branches all conflict on the same 3-5 core files and are being merged serially \u2014 take HEAD (origin/main) for all conflicted core files since main already contains the union of all prior merged features, (12) main is advancing rapidly via auto-merge during the rebase session and PRs keep going DIRTY again \u2014 repeat rebase in waves until stable, (13) stale worktrees from a previous session are listed in `git worktree list` as unlinked \u2014 check before removing, they may already be detached with no git state to clean up, (14) a rebase 'succeeds' but the branch tip equals main HEAD \u2014 the commit was silently dropped as empty, recover the original SHA and rebase again keeping the PR's file additions, (15) a rebased PR's tests fail because the PR's own implementation was incomplete \u2014 the commit message described a feature but the actual diff didn't include a critical file (e.g., server route for an endpoint the tests expect), (16) stale worktrees from a prior session need auditing \u2014 always diff each one against origin/main before deciding to discard or push, (17) CI overall conclusion shows 'failure' but all required branch-protection checks passed \u2014 use per-job inspection not top-level conclusion, (18) a conanfile.py lacks return annotations on ConanFile subclass methods causing mypy failures, (19) a Dependabot PR and a fix PR both target the same file \u2014 apply the fix directly in the Dependabot branch to avoid a circular dependency chain, (20) branches live in .claude/worktrees/agent-<id>/ paths from sub-agent runs and need rebase using git -C <worktree-path>, (21) rebase in a .claude/worktree ends in detached HEAD \u2014 use git branch -f to reattach before pushing, (22) CHANGELOG.md conflicts during rebase \u2014 always take HEAD/main (consolidation PR handles it separately), (23) two PRs fired with `gh pr merge` concurrently \u2014 one fails with GraphQL 'Base branch was modified' error because the first merge advanced main between API calls, (24) two PRs both add add_executable/gtest_discover_tests blocks at the same CMakeLists.txt location \u2014 additive conflict, keep both sides, (25) a PR removes the %.native: Makefile pattern rule \u2014 CI breaks with make deps.native exit 2, (26) a new CI job (markdownlint or pixi-check) was added to main via a rollout PR and immediately blocks all open skill PRs even though those PRs didn't touch CI config \u2014 root cause is pre-existing violations in shared files (.claude/plugins/) or missing pixi.lock; fix the root cause on main first, then rebase all PRs, (27) two PRs independently amend the same skill file to the same version number (e.g., both v2.9.0) with different content \u2014 treat as additive conflict: read both diffs, produce one merged version with all new learnings, close the redundant PR as superseded, (28) a batch of PRs all show stale CI results (old failing run) after a fix lands on main \u2014 they need a rebase push to trigger a fresh CI run even if their branch content didn't change, (29) before rebasing any Mnemosyne skill PRs, first confirm main itself is green \u2014 rebasing onto a broken main cannot unblock PRs (run `gh run list --branch main --limit 3` to verify main CI is passing before starting any rebase session), (30) a dependabot branch requires `git push --force` rather than `--force-with-lease` \u2014 GitHub auto-rebases dependabot branches between fetch and push, making the lease ref stale, (31) the repo only allows squash merge \u2014 `gh pr merge --auto --rebase` fails with GraphQL error; always check merge methods with `gh api repos/OWNER/REPO --jq '.allow_squash_merge,.allow_rebase_merge,.allow_merge_commit'` before enabling auto-merge, (32) a PR touches `pixi.lock` and was rebased after `pyproject.toml` conflict resolution \u2014 the lock SHA changes after any pyproject.toml edit; always run `pixi lock` before pushing if `pixi.lock` exists in the repo, (33) all open Mnemosyne skill PRs are BLOCKED with markdownlint failures not caused by the PRs themselves \u2014 main's markdownlint workflow uses `globs: \"**/*.md\"` which overrides `.markdownlintignore`; fix the workflow on main first, then rebase all skill PRs, (34) a bulk markdown table reformatter commit touched 1000+ files and all open PRs for those files became CONFLICTING \u2014 the conflict pattern is always add/add or modify/modify on the same .md files; take the PR branch's content then re-apply the formatter, (35) `git checkout --theirs <file>` is blocked by the Safety Net hook during rebase \u2014 use `git show REBASE_HEAD:<file> > /tmp/theirs && cp /tmp/theirs <file>` to extract the PR branch content without triggering the hook, (36) `marketplace.json` conflict during rebase \u2014 always take main's version (`git checkout --ours marketplace.json`) because it has more entries than the PR's stale regenerated version, (37) `gh pr rebase` command does not exist in the gh CLI \u2014 use `git fetch origin && git rebase origin/main` locally instead, (38) enabling auto-merge BEFORE rebasing a CONFLICTING PR has no effect \u2014 GitHub's CONFLICTING state prevents auto-merge from activating; rebase and push first, then enable auto-merge, (39) `git checkout --ours <files>` during rebase conflict resolution is blocked by Safety Net when run from a sub-agent \u2014 the Safety Net hook fires in the sub-agent's context too; escalate the specific `git checkout --ours -- <files>` command to the main conversation to run directly, then resume the sub-agent or continue the rebase from the main conversation, (40) `.pre-commit-config.yaml` has an additive conflict where main added `check-xtrace-exposure` hook and the PR independently added its own new hook at the same position \u2014 resolution is always keep BOTH hooks (they are independent features), (41) a shell script (`run_automation_loop.sh` or similar) has a structural rewrite conflict where main has a 6-phase expanded version and PR has a 2-phase refactored version \u2014 take main's structural skeleton (more phases), apply PR's specific fix (e.g., entry-point binary variables) to the relevant section, (42) a C++ `isSubordinateResult` or similar method conflicts where main added a TASK_FAILED exclusion and the PR has the older version without it \u2014 always take main's version (the exclusion was a deliberate bugfix), (43) a multi-commit PR (14+ commits) being rebased produces conflicts in the same file on multiple sequential commits \u2014 resolve each conflict individually; git rebase will stop once per conflicting commit, (44) `git rebase --continue` does not accept `--no-edit` flag \u2014 use `git rebase --continue` alone (it opens an editor only if explicitly invoked with `-i`; non-interactive rebase continues silently), (45) when cloning a fresh temp dir for rebase work, use `mktemp -d` for each operation rather than pre-cleaning a fixed path \u2014 `rm -rf $FIXED_PATH` may be blocked by Safety Net hooks even for temp dirs outside the workspace, (46) `gh pr merge --auto --squash` returns \"Pull request is in clean status\" for some PRs on first attempt but succeeds on retry seconds later \u2014 this is GitHub API lag; retry immediately before trying a direct merge, (47) a PR's rebase produces a commit whose content is identical to a prior commit that was already on main (e.g., a fix that was cherry-picked to main independently) \u2014 git drops it silently with \"dropping <sha> -- patch contents already upstream\"; this is correct behavior, not data loss, (48) tier-by-complexity merge ordering reduces cascade churn \u2014 sort PRs by total churn (additions+deletions) and process simplest first; smaller PRs cause less DIRTY-flag cascade on siblings than landing big refactors first, (49) 'strict subset' PR pairs (smaller PR \u2282 larger PR with same intent + extras) should be merged in size order: smaller first; larger becomes auto-empty after rebase or self-closes via natural drop, (50) before deploying any rebase swarm, run a single Opus triage agent to dedupe (identify exact-duplicate diffs and obviously-mooted-by-main PRs) \u2014 9 of 46 PRs in our session were close-as-superseded after triage, saving the equivalent of 3 rebase waves, (51) two PRs solving the same problem with different mechanisms (e.g., X-Dead-Letter-Key header vs Authorization Bearer; tomllib pyproject extraction vs requirements.txt sync script) are DESIGN COLLISIONS, not duplicates \u2014 flag for human decision; never silently pick one mechanism over the other, (52) when a hotfix lands mid-flight on main (e.g., regenerated pixi.lock or coverage-gate fix), every already-rebased PR needs ANOTHER rebase pass to inherit it; this second pass is fast (clean rebases) but mandatory before the queue can drain, (53) cascade churn during auto-merge wave: as PRs land in quick succession (e.g., 7 in 5 minutes), siblings touching the same files repeatedly go DIRTY; expect to run 2-3 re-rebase waves on diminishing subsets, not just one, (54) a conflicted file shows as 'both modified' with no visible conflict markers after rebase starts \u2014 git may have auto-applied one side without fully resolving; use `git show :2:<file> | wc -l` vs `git show :3:<file> | wc -l` to identify which version is present, then run `git diff :2:<file> :3:<file>` to see semantic differences; manually apply security fixes from main's version that the PR's side lacks (e.g., `int()` cast for GraphQL parameters, input validation added as a security patch), (55) a Myrmidon swarm dispatched two agents to implement the same GitHub issue concurrently \u2014 both produced identical PRs (same title, same diff, same target files); the first to merge wins; the second PR's commit is silently dropped on rebase with 'patch contents already upstream'; confirm via `git log --oneline origin/main..HEAD` returning empty, then close the duplicate with `gh pr close <N> --comment 'Superseded: identical change merged via PR #<M>'`, (56) a PR's only failing required check is `pr-policy` and the failure message is 'Auto-merge is not enabled on this PR' \u2014 the body already has `Closes #N` and commits are signed; the fix is simply `gh pr merge <N> --auto --squash`; always read the pr-policy job log before rebasing to avoid unnecessary force-push when only auto-merge is missing, (57) several already-rebased sibling PRs go DIRTY again the instant the FIRST one merges because they all touch the same hot files (routes.cpp, CMakeLists.txt, shared test files) \u2014 parallel re-rebase waves never converge here; switch to a strict SERIAL MERGE TRAIN: rebase one \u2192 wait for it to MERGE \u2192 fetch fresh main \u2192 rebase the next; each car rebases onto a main already containing all prior cars, so zero re-conflict churn, (58) order the serial train simplest-footprint-first / widest-footprint-last (sort by count of hot-file hunks) so the biggest PR rebases last onto a main that already absorbed the smaller ones, (59) never block the train on one car \u2014 if a single PR hits an ambiguous conflict (NEEDS-AUTHOR) or its own genuine test failure (RED-OWN-TESTS), flag it and move to the next PR; do not stall the whole train, (60) an automation agent (e.g. a CI-fix bot) committed to a Dependabot PR branch and now `@dependabot rebase` refuses with 'Looks like this PR has been edited by someone other than Dependabot' \u2014 use `@dependabot recreate` to rebuild the PR fresh from clean main (dropping the agent's commits) or rebase manually; also expect `@dependabot rebase` to warn about missing `automated`/`dependencies` labels but still attempt; LESSON: don't let automation commit to bot PRs, (61) a PR is permanently BLOCKED (`mergeStateStatus: BLOCKED`) while `mergeable: MERGEABLE` with ZERO check-runs and ZERO statuses on its head SHA \u2014 branch protection requires named contexts that were never produced because the workflow simply didn't trigger (CI paused/skipped at PR-open, or a `paths:` filter excluded the PR's files); diagnose by comparing required contexts (`gh api .../branches/main/protection --jq '.required_status_checks.contexts[]'`) against actual check-runs (`gh api repos/O/R/commits/<sha>/check-runs`) and statuses (`.../status`); FIX: push an empty signed commit (`git commit --allow-empty -S`) to re-trigger workflows, or fix the workflow `paths:` if it's a genuine path-filter mismatch, (62) a PR is marked 'needs author fix' on a `lint`/syntax-validation failure \u2014 READ THE ACTUAL ERROR first; most are mechanical and self-fixable (e.g. ProjectOdyssey Mojo Syntax Validation rejects the deprecated variadic `List[Type](args)` constructor: convert `var x = List[Int](10, 5)` \u2192 `var x: List[Int] = [10, 5]`, leave empty `List[Int]()` alone), verify by compiling (`pixi run mojo --Werror -I src -I . <file>`) and pre-commit; reserve real 'needs author' only for domain decisions you lack, (63) a `Dependency vulnerability scan` (pip-audit) goes red on EVERY PR because a transitive dep gained new advisories (e.g. `pyjwt 2.12.1` via pygithub \u2192 PYSEC-2026-175/177/178/179, fixed in 2.13.0) \u2014 FIX with an explicit version pin in pixi.toml `[dependencies]` (`pyjwt = \">=2.13.0\"`, same pattern as `pygments = \">=2.20.0\" # CVE-...`), NOT `--ignore-vuln`; check conda-forge availability first (`curl -s https://api.anaconda.org/package/conda-forge/<pkg>`), regenerate `pixi.lock`, verify `pixi run -e lint pip-audit` reports 'No known vulnerabilities found'; ship as a SEPARATE small PR so it merges fast and unblocks ALL repo PRs, then rebase dependents onto it, (64) a CLEAN, mergeable PR that the driver fixed but left with auto-merge NOT armed \u2014 scan for `mergeStateStatus: CLEAN` + no autoMergeRequest and arm directly with `gh pr merge <n> --auto --squash`; they merge immediately, (65) an automation agent committed a self-inflicted lint-failing artifact (e.g. a markdownlint-failing `CI_BLOCKER.md`) to a bot/Dependabot branch \u2014 fix the branch directly via a detached worktree: `git worktree add <tmp> origin/<branch> --detach`, `git rm CI_BLOCKER.md`, signed commit, `git push --force-with-lease origin HEAD:<branch>`, (66) N sibling PRs auto-generated from one backlog all carry their OWN earlier commit touching a shared-infra file (script/config/workflow) that has since landed on main \u2014 every plain `git rebase origin/main` conflicts on that shared file; do NOT rely on rebase conflict-resolution, instead overwrite the file with main's exact version after rebasing (`git show origin/main:path > path; git commit -S`), (67) `git checkout --theirs <shared-file>` during a rebase produces a hybrid/stale tree \u2014 'take theirs' resolves to main-at-that-replay-step, not main's final HEAD, and a PR's own later commit can re-introduce a stale assertion (e.g. `>= 1` instead of main's `== 0`); conflict-resolution \u2260 'make this file match main', (68) a post-rebase CI check (e.g. branch-protection-drift) reports `conclusion=failure` and you assume it is a transient/lagging read \u2014 verify the file at the exact sha (`gh api repos/<o>/<r>/contents/<path>?ref=<sha> --jq .content | base64 -d`) and diff against main before assuming stale; it may be a REAL failure on a stale synced file, (69) a red non-required check (markdownlint, docker-build) looks like the merge blocker but isn't \u2014 compute the REAL required set as the UNION of the ruleset's required_status_checks AND the classic protection's contexts; the classic-layer check (e.g. branch-protection-drift) is often the actual gate (cross-ref [[hi-branch-protection-two-layer]])",
+      "version": "2.20.0",
       "source": "./skills/batch-pr-rebase-workflow.md",
       "category": "ci-cd",
       "tags": [
@@ -1538,7 +1143,11 @@
         "pixi",
         "mypy",
         "ruff",
-        "cherry-pick"
+        "cherry-pick",
+        "dependabot-recreate",
+        "required-checks-never-ran",
+        "transitive-cve-pin",
+        "mechanical-not-author"
       ]
     },
     {
@@ -1550,20 +1159,21 @@
       "tags": []
     },
     {
-      "name": "bats-action-version-missing",
-      "description": "Documents that bats-core/bats-action@2 does not exist on the GitHub Actions marketplace. Use when: (1) GHA fails with 'Unable to resolve action bats-core/bats-action@X', (2) merging branches that introduce new uses: action references for bats, (3) setting up BATS shell testing in GitHub Actions.",
+      "name": "central-version-manifest-drift-from-automation-bypass",
+      "description": "When a repo declares `versions.yml`/`versions.json`/`versions.toml` as single source of truth for pinned versions, automated bumps (Dependabot, weekly cron, hand-edits) often update only the consumer files (Dockerfiles, workflows) and bypass the manifest. Result: drift + automation silently breaks. Use when: (1) reviewing a base-image / pinned-tool bump PR, (2) auditing why a digest-refresh cron has stopped producing PRs, (3) onboarding a repo that has a centralized versions manifest, (4) writing or modernizing an update workflow that touches Dockerfiles or pinned-tool scripts.",
       "version": "1.0.0",
-      "source": "./skills/bats-action-version-missing.md",
+      "source": "./skills/central-version-manifest-drift-from-automation-bypass.md",
       "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "build-run-local",
-      "description": "Run local builds with proper environment setup matching CI pipeline",
-      "version": "1.0.0",
-      "source": "./skills/build-run-local.md",
-      "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "manifests",
+        "dependabot",
+        "drift",
+        "base-images",
+        "supply-chain",
+        "single-source-of-truth",
+        "dockerfile",
+        "github-actions"
+      ]
     },
     {
       "name": "cherry-pick-fix-diverged-pr",
@@ -1574,25 +1184,9 @@
       "tags": []
     },
     {
-      "name": "ci-benchmark-host-container-path-mismatch",
-      "description": "Fix GitHub Actions benchmark workflow failures where mkdir runs on host but benchmark output is written inside a container. Use when: (1) benchmark CI step fails to write output files, (2) workflow uses 'podman compose exec' or 'docker exec' for the benchmark run but creates output dirs on the host, (3) directory exists on host but is not accessible inside the container due to volume/UID mismatch.",
-      "version": "1.0.0",
-      "source": "./skills/ci-benchmark-host-container-path-mismatch.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci",
-        "benchmark",
-        "podman",
-        "docker",
-        "container",
-        "volume-mount",
-        "filesystem-mismatch"
-      ]
-    },
-    {
       "name": "ci-cd-achaean-fleet-ci-cascade-patterns",
-      "description": "AchaeanFleet Docker infrastructure CI cascade failure sequence and fixes. Use when: (1) running a myrmidon swarm on HomericIntelligence/AchaeanFleet, (2) diagnosing cascading CI failures in a Docker image build pipeline, (3) fixing base-image ENTRYPOINT, OCI multi-arch build, vendor download URL, YAML column-0, caddy overlay, or branch-protection push issues in AchaeanFleet vessels.",
-      "version": "2.0.0",
+      "description": "AchaeanFleet Docker infrastructure CI cascade failure sequence and fixes. Use when: (1) running a myrmidon swarm on HomericIntelligence/AchaeanFleet, (2) diagnosing cascading CI failures in a Docker image build pipeline, (3) fixing base-image ENTRYPOINT, OCI multi-arch build, vendor download URL, YAML column-0, caddy overlay, branch-protection push, or required-signatures ruleset / signed-commit merge-block issues in AchaeanFleet vessels.",
+      "version": "2.1.0",
       "source": "./skills/ci-cd-achaean-fleet-ci-cascade-patterns.md",
       "category": "ci-cd",
       "tags": [
@@ -1607,95 +1201,12 @@
         "qemu",
         "caddy",
         "yaml",
-        "branch-protection"
-      ]
-    },
-    {
-      "name": "ci-cd-broken-main-parallel-fix-wave",
-      "description": "Triage and fix broken CI/main across multiple repos simultaneously using Agamemnon task registry + parallel myrmidon fix agents. Use when: (1) 3+ repos have broken main branch CI, (2) need to register tasks in Agamemnon before dispatching agents, (3) CI failures are diverse (conan profile, dependabot config, GitHub Actions auth, BATS helper, Python imports, clang-format violations, annotated-tag SHA pinning, stale pixi.lock, markdownlint CHANGELOG exclusion, release.yml direct push to main, duplicate module re-export, Pydantic model_dump bypass).",
-      "version": "1.3.0",
-      "source": "./skills/ci-cd-broken-main-parallel-fix-wave.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci",
-        "broken-main",
-        "agamemnon",
-        "parallel-agents",
-        "myrmidon",
-        "conan",
-        "dependabot",
-        "bats",
-        "github-actions",
-        "fix-wave",
-        "clang-format",
-        "monitor",
-        "annotated-tags",
-        "sha-pinning",
-        "pixi-lock",
-        "markdownlint",
-        "changelog",
-        "rebase-onto",
-        "transient-vs-reproducible",
-        "issue-triage",
-        "all-repos",
-        "release-workflow",
-        "circuit-breaker",
-        "pydantic",
-        "model-dump",
-        "deprecation-shim"
-      ]
-    },
-    {
-      "name": "ci-cd-cascading-dockerfile-ci-failure-remediation",
-      "description": "Diagnose and fix cascading CI failures specific to Docker/compose infrastructure repos. Use when: (1) a Docker infrastructure repo has 10+ open PRs all failing CI, (2) Dockerfile RUN inline comments cause 'unknown instruction' parse errors, (3) Nomad job validator is run against non-job HCL files (vault policies, etc.), (4) BATS tests fail under set -euo pipefail due to unset BUILD_DATE or VCS_REF variables, (5) pixi.lock is stale after adding dependencies causing CI lockfile gate to fail, (6) pytest pin-enforcement checks fail for yarn or pip install invocations, (7) compose service uses bare WORKSPACE_ROOT mount rejected by CI validator, (8) hardcoded service counts in compose validation break when new services are added, (9) base image FROM line lacks SHA256 digest pinning, (10) OCI layout artifact pipeline uses wrong format (tar vs directory), (11) multi-arch buildx fails because QEMU is not set up before buildx initialization.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-cascading-dockerfile-ci-failure-remediation.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "dockerfile",
-        "cascading-failures",
-        "compose",
-        "nomad",
-        "bats",
-        "pixi",
-        "multi-arch",
-        "qemu",
-        "oci",
-        "digest-pinning"
-      ]
-    },
-    {
-      "name": "ci-cd-coredump-capture-container-namespace-fix",
-      "description": "GHA workflow capturing core dumps from a process that crashes inside a Podman/Docker container must use a path that exists in BOTH host and container mount namespaces, AND must always write metadata + symbols even when no cores exist. Use when: (1) wiring up coredump capture for libKGEN/Mojo or any other JIT runtime that crashes opaquely in CI, (2) debugging why an actions/upload-artifact step uploads nothing despite a known crash, (3) deciding where to point /proc/sys/kernel/core_pattern when the crashing PID is in a non-host mount namespace.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-coredump-capture-container-namespace-fix.md",
-      "category": "ci-cd",
-      "tags": [
-        "coredump",
-        "gdb",
-        "podman",
-        "docker",
-        "mojo",
-        "libkgen",
-        "github-actions",
-        "mount-namespace"
-      ]
-    },
-    {
-      "name": "ci-cd-docker-base-entrypoint-all-bases",
-      "description": "All Docker base images in AchaeanFleet require an ENTRYPOINT instruction or CI verification will fail. Use when: (1) adding a new base Dockerfile to AchaeanFleet, (2) debugging CI failures on 'Verify ENTRYPOINT is set' step, (3) copying an existing base Dockerfile to create a new variant, (4) writing entrypoint scripts that load Docker secrets before exec'ing CMD.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-docker-base-entrypoint-all-bases.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "dockerfile",
-        "entrypoint",
-        "base-image",
-        "ci",
-        "achaeanfleet",
-        "secrets"
+        "branch-protection",
+        "required-signatures",
+        "branch-rulesets",
+        "signed-commits",
+        "force-with-lease",
+        "auto-merge-disarm"
       ]
     },
     {
@@ -1724,68 +1235,37 @@
       ]
     },
     {
-      "name": "ci-cd-forbid-suppressions-pygrep-lint-guard",
-      "description": "Pygrep pre-commit hook + matching CI job that rejects `|| true` and `continue-on-error: true` suppressions in committed source. Use when: (1) auditing a codebase for silent-failure workarounds, (2) a CI build mysteriously passes despite an obvious tool failure, (3) adding a regression guard so a refactored idiom cannot return, (4) refactoring `cmd || true` into explicit `if`-guards across multiple files, (5) deciding whether a `|| true` is masking a real failure (Bucket A) or guarding legitimate teardown (Bucket B), (6) widening a regex after an agent feedback loop discovers a missed control-flow boundary, (7) reviewing a sweep PR that converted `continue-on-error: true` to `if ! cmd; then echo \"::warning::...\"; fi` \u2014 that's Bucket F, the advisory anti-pattern, also forbidden, (8) auditing CI for tool-level suppression flags (`--exit-code 0`, `--exit-zero`, `--no-fail`) that mimic `continue-on-error: true`'s effect at the tool layer, (9) a CI tool runs but its findings (CVEs, leaked secrets, format diffs, type errors) never gate the merge \u2014 fix the policy by making the tool fail-fast and allowlisting specific findings with tracked issues.",
-      "version": "2.0.0",
-      "source": "./skills/ci-cd-forbid-suppressions-pygrep-lint-guard.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "pygrep",
-        "silent-failures",
-        "lint-guard",
-        "or-true",
-        "continue-on-error",
-        "github-actions",
-        "regression-prevention",
-        "workaround-removal",
-        "bucket-classification"
-      ]
-    },
-    {
       "name": "ci-cd-gha-cancelled-runs-after-force-push",
-      "description": "After git push --force-with-lease (e.g. post-rebase), GitHub Actions marks all in-flight runs on the prior sha as CANCELLED, and these CANCELLED entries appear in the PR's status-check rollup as failure indicators alongside the new sha's runs. PR looks broken even though the current tip's runs are healthy. Use when: (1) a PR shows 50+ failed checks but mergeStateStatus is BLOCKED with mergeable=MERGEABLE, (2) you need to distinguish real failures from rebase-orphaned cancelled runs, (3) deciding whether to manually relaunch or just wait.",
-      "version": "1.0.0",
+      "description": "CANCELLED GitHub Actions runs masquerade as PR failures from TWO distinct triggers. Trigger 1 (force-push): after git push --force-with-lease (e.g. post-rebase), GHA marks in-flight runs on the prior sha as CANCELLED, and these appear in the PR's status-check rollup as failure indicators alongside the new sha's runs. Trigger 2 (concurrency supersession): a rerun's jobs CANCELLED with 'Canceling since a higher priority waiting request for required-Required Checks-<branch> exists' \u2014 gh pr checks shows N fail but they are superseded/cancelled runs, not real failures (concurrency-group supersession reads as failure). PR looks broken even though the current tip / latest run is healthy. Use when: (1) a PR shows many failed checks but mergeStateStatus is BLOCKED with mergeable=MERGEABLE, (2) you need to distinguish real failures from rebase-orphaned or concurrency-superseded cancelled runs, (3) gh pr checks reports 'N fail' right after a rerun, (4) deciding whether to manually relaunch or just wait.",
+      "version": "1.1.0",
       "source": "./skills/ci-cd-gha-cancelled-runs-after-force-push.md",
       "category": "ci-cd",
       "tags": [
         "github-actions",
         "rebase",
         "force-push",
+        "concurrency",
+        "supersession",
         "status-checks",
         "mergeability",
         "gh-cli"
       ]
     },
     {
-      "name": "ci-cd-github-actions-bot-protected-branch-push",
-      "description": "Use when: (1) a GitHub Actions workflow regenerates an artifact (marketplace.json, lockfile, generated code) and tries to push it directly to a protected branch, (2) you see GH006 Protected Branch Update Failed in CI logs, (3) an auto-commit workflow is failing because branch protection requires PRs and status checks, (4) you need loop-safe auto-update CI with no manual intervention",
+      "name": "ci-cd-gha-required-checks-workflow-drop",
+      "description": "GitHub Actions Required Checks downstream gate workflows stuck pending forever after a push. Use when: (1) gh pr checks shows the real test workflows (Test, CodeQL, Security, Pre-commit) running and passing but downstream gates (pr-policy, shellcheck, markdownlint, justfile-check, symlink-check, pixi-check, integration-tests) sit at pending:0 and never start; (2) PR cannot auto-merge because branch protection requires those gates green; (3) waiting / gh run rerun / close+reopen did not help. Fix: push one empty signed commit to re-trigger workflow scheduling.",
       "version": "1.0.0",
-      "source": "./skills/ci-cd-github-actions-bot-protected-branch-push.md",
+      "source": "./skills/ci-cd-gha-required-checks-workflow-drop.md",
       "category": "ci-cd",
       "tags": [
         "github-actions",
-        "protected-branch",
-        "GH006",
-        "auto-commit",
-        "create-pull-request",
-        "loop-prevention",
-        "marketplace",
+        "required-checks",
+        "workflow_run",
+        "workflow-drop",
+        "branch-protection",
+        "empty-commit",
+        "re-trigger",
         "auto-merge"
-      ]
-    },
-    {
-      "name": "ci-cd-github-actions-sha-pinning",
-      "description": "Use when: (1) pinning GitHub Actions to immutable commit SHAs for supply-chain security, (2) resolving annotated vs lightweight tags to find the underlying commit SHA, (3) auditing a workflow file for mutable @vN or @vN.N.N tags that should be SHA-pinned, (4) verifying that a newly added or updated action is using the correct commit SHA",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-github-actions-sha-pinning.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "sha-pinning",
-        "supply-chain",
-        "security",
-        "annotated-tags"
       ]
     },
     {
@@ -1806,35 +1286,75 @@
       ]
     },
     {
-      "name": "ci-cd-github-api-rate-limit-ci-monitoring",
-      "description": "Avoid and recover from GitHub API rate limit exhaustion (5000/hr) during intensive CI diagnostic loops using gh CLI. Use when: (1) running batch PR investigation across many open PRs, (2) fetching CI job logs in a loop, (3) hitting HTTP 403 rate limit errors from gh CLI during CI monitoring sessions.",
+      "name": "ci-cd-github-actions-workflow-platform-scope-documentation",
+      "description": "Document platform asymmetries in GitHub Actions workflows using top-level header comment blocks with issue references. Use when: (1) CI workflows intentionally target only some platforms (e.g., Linux-only), (2) documenting why certain platforms are out of scope, (3) clarifying capability claims despite CI gaps.",
       "version": "1.0.0",
-      "source": "./skills/ci-cd-github-api-rate-limit-ci-monitoring.md",
+      "source": "./skills/ci-cd-github-actions-workflow-platform-scope-documentation.md",
       "category": "ci-cd",
       "tags": [
-        "github-api",
-        "rate-limit",
-        "gh-cli",
-        "ci-monitoring",
-        "pr-investigation",
-        "loop"
+        "github-actions",
+        "platform-scope",
+        "documentation",
+        "honesty",
+        "ci-cd"
       ]
     },
     {
-      "name": "ci-cd-hatchling-force-include-sdist-wheel-break",
-      "description": "Fix hatchling CI build failures caused by force-include paths breaking the sdist\u2192wheel two-step build. Use when: (1) CI build job fails with FileNotFoundError on a force-include path, (2) wheel builds from source work locally but fail in CI using python -m build --no-isolation, (3) hatchling force-include paths cannot be resolved inside an unpacked sdist directory.",
+      "name": "ci-cd-github-code-quality-findings-no-api",
+      "description": "Fixing GitHub Code Quality (/security/quality) findings \u2014 a product distinct from CodeQL code-scanning, with NO public REST API. Use when: (1) a /security/quality/rules/py%2F... URL reports open findings, (2) deciding how to locate Code Quality violations when the code-scanning alerts API returns them empty, (3) reconciling ruff vs CodeQL semantic differences for py/unused-local-variable, py/unused-global-variable, py/repeated-import, py/import-and-import-from, py/empty-except, py/undefined-export, (4) a Copilot/AI-findings autofix PR fails to merge, (5) a Code Quality finding is a false positive and you must refactor working code to satisfy the analyser without changing behaviour.",
       "version": "1.0.0",
-      "source": "./skills/ci-cd-hatchling-force-include-sdist-wheel-break.md",
+      "source": "./skills/ci-cd-github-code-quality-findings-no-api.md",
       "category": "ci-cd",
       "tags": [
-        "hatchling",
-        "force-include",
-        "sdist",
-        "wheel",
-        "python-build",
-        "pyproject",
-        "packaging",
-        "ci-cd"
+        "github-code-quality",
+        "codeql",
+        "ruff",
+        "code-quality",
+        "static-analysis"
+      ]
+    },
+    {
+      "name": "ci-cd-homeric-intelligence-merge-gotchas",
+      "description": "Recurring HomericIntelligence CI/merge traps that block PR auto-merge even when the code is correct. Use when: (1) pixi-check fails 'lock-file not up-to-date with the workspace' or Lint/Type-Check break after removing pypi-dependencies; (2) a Keystone-style lint job fails fast (~20s) at 'Install build dependencies (just + linters)'; (3) CodeQL cpp/unused-{local,static}-variable flags a genuinely-used C++ variadic template parameter pack; (4) a PR is MERGEABLE with all REQUIRED checks green but auto-merge won't fire; (5) you are driving a chain of dependency-gated PRs and need to auto-arm each downstream PR when its gate merges; (6) a PR is MERGEABLE with every REQUIRED status check green, but mergeStateStatus stays BLOCKED and auto-merge won't fire \u2014 the gate is `required_review_thread_resolution: true` plus unresolved CodeQL/github-advanced-security review threads; detect via GraphQL reviewThreads (the REST field is empty), assess each finding before resolving, document accept-rationale, then resolveReviewThread; (7) the pr-policy required gate fails 'Auto-merge is enabled before implementation review GO' \u2014 do not pre-arm auto-merge before the state:implementation-go label (the inverse 'PR has state:implementation-go but auto-merge is not enabled' also fails); disable premature auto-merge and let the label workflow arm it.",
+      "version": "1.2.0",
+      "source": "./skills/ci-cd-homeric-intelligence-merge-gotchas.md",
+      "category": "ci-cd",
+      "tags": [
+        "pixi",
+        "pixi-lock",
+        "codeql",
+        "auto-merge",
+        "branch-protection",
+        "just-systems",
+        "keystone",
+        "agamemnon",
+        "dependency-gated-pr",
+        "review-thread-resolution",
+        "github-advanced-security",
+        "pr-policy",
+        "implementation-go"
+      ]
+    },
+    {
+      "name": "ci-cd-no-commit-retry-with-review-thread-injection",
+      "description": "When an agent-driven CI-fix loop returns from a session without producing a new commit AND the PR's required CI checks are still red, that combination is itself a bug \u2014 not a 'do nothing' condition. The correct response is exactly ONE bounded retry on the SAME PR-scoped session with a force-engagement prompt that (1) names the failing required check names verbatim, (2) restates the branch invariant (do not create/switch branches), (3) restates the signed-commit + no-`--no-verify` policy, and (4) prepends ALL unresolved PR review threads (fetched via GraphQL `reviewThreads { isResolved, comments { body, path, line } }`) verbatim \u2014 because an unresolved bot or human review comment is usually the actual blocker behind the red CI, and the agent cannot fix what it cannot see. Inject the review-thread block into BOTH the initial CI-fix prompt AND the retry prompt, not just one. Gate the retry on `gh pr checks --required` exit code (don't retry if CI went green via concurrent activity). After the retry, if HEAD still has not advanced, write a `state_dir/repeated-no-commit-<pr>.json` forensics marker and move on \u2014 never loop, never open a new PR. Use when: (1) an agent CI-fix driver logs 'agent session produced no new commit (HEAD unchanged at \u2026); skipping push', (2) the same PR is being skipped run after run while its required checks stay red, (3) reviewing/extending a `_run_ci_fix_session` or `drive_prs_green`-style driver, (4) a no-commit honesty guard (#836-style) is already in place but the driver still gives up after one no-commit turn, (5) a PR review bot left an unresolved comment naming the actual blocker and the fix agent never references it.",
+      "version": "1.0.0",
+      "source": "./skills/ci-cd-no-commit-retry-with-review-thread-injection.md",
+      "category": "ci-cd",
+      "tags": [
+        "automation",
+        "ci-driver",
+        "force-engagement-retry",
+        "no-commit-honesty-guard",
+        "review-thread-injection",
+        "agent-contract-violation",
+        "drive-green",
+        "same-session-retry",
+        "gh-pr-checks",
+        "graphql-review-threads",
+        "signed-commit-invariant",
+        "forensics-marker",
+        "bounded-retry"
       ]
     },
     {
@@ -1846,67 +1366,22 @@
       "tags": []
     },
     {
-      "name": "ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue",
-      "description": "Allowlist specific pip-audit CVE findings inline via repeated `--ignore-vuln <ID>` flags with a tracking issue + planned review date. Use when: (1) pip-audit step is being flipped from advisory (`|| echo \"::warning::\"`, `--exit-code 0`, or wrapped in `if !`) to fail-fast and real CVE findings surface, (2) findings are in baseline runner-image packages (pip, setuptools, urllib3, etc.) that the repo doesn't directly control, (3) findings are in transitive deps with no upstream fix yet, (4) need a documented allowlist mechanism that's clearly NOT `|| true`/`::warning::`/`--exit-zero` (per the no-silent-failures policy), (5) replacing `pixi-pip-audit-cve-pinning` (bump deps) or `pixi-pip-audit-severity-filter` (filter by severity) \u2014 those work when you control the dep version; this skill is for when you don't.",
+      "name": "ci-cd-podman-host-container-build-dir-permissions",
+      "description": "Fix 'mkdir: Permission denied' / PermissionError [Errno 13] when a justfile recipe runs ON THE HOST but writes into build/ or dist/ that a prior rootless-Podman container recipe populated as a subuid-mapped uid. Use when: (1) a just recipe fails writing to build/ or dist/ after another recipe ran in-container, (2) rootless Podman left files owned by a high subuid (e.g. 524288) the host user cannot write, (3) 'pixi: not found' on a CI runner because a recipe ran host-side instead of in-container, (4) chmod -R fails with EPERM on foreign-owned sibling files in a shared dir, (5) deciding whether a justfile recipe belongs host-side or in the container _run wrapper.",
       "version": "1.0.0",
-      "source": "./skills/ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue.md",
+      "source": "./skills/ci-cd-podman-host-container-build-dir-permissions.md",
       "category": "ci-cd",
       "tags": [
-        "pip-audit",
-        "cve",
-        "allowlist",
-        "ignore-vuln",
-        "tracking-issue",
-        "fail-fast",
-        "security-scan",
-        "baseline-runner-cve",
-        "transitive-deps"
-      ]
-    },
-    {
-      "name": "ci-cd-pixi-lock-stale-multi-pr-triage",
-      "description": "Use when: (1) multiple PR branches failing CI with 'lock-file not up-to-date' or pixi.lock stale errors, (2) CI runs show failures but on an old commit SHA (not current HEAD) \u2014 pixi.lock was pushed but CI ran on old commit, (3) need to re-trigger CI on a PR branch without making a real code change (gh run rerun --failed is the only reliable method), (4) pixi platform added (e.g. linux-aarch64) but a dependency (e.g. bats-core) isn't available for that platform in conda-forge, (5) Security Scan failing with 'missing gitleaks license' (infrastructure issue \u2014 GITLEAKS_LICENSE secret missing from org, skip these), (6) LRU-cached FastAPI settings mutation in tests causes wrong HTTP status codes, (7) Protocol method missing from async client implementation.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-pixi-lock-stale-multi-pr-triage.md",
-      "category": "ci-cd",
-      "tags": [
-        "pixi",
-        "pixi.lock",
-        "stale-lock",
-        "ci-triage",
-        "multi-pr",
-        "gh-run-rerun",
-        "sha-mismatch",
-        "bats-core",
-        "gitleaks",
-        "lru-cache",
-        "protocol",
-        "platform-dependency"
-      ]
-    },
-    {
-      "name": "ci-cd-pre-commit-ci-hook-failures",
-      "description": "Diagnose and fix multiple distinct pre-commit hook failures in CI on a PR branch. Use when: (1) CI pre-commit/lint/precommit-benchmark jobs are failing, (2) a PR introduces changes that trigger 2+ different hook types simultaneously, (3) custom hooks fire in CI but are designed for developer machines only, (4) `no-commit-to-branch` pre-commit hook fires on push-to-main CI runs because HEAD is genuinely on `main`; the hook is incompatible with `pre-commit run --all-files` in CI by design and cannot be made to 'always run, always pass' \u2014 remove the hook (branch protection is the real gate) rather than bypassing, (5) consolidating `pre-commit run --all-files` into a `_required.yml` lint job; mirror the Odyssey/Scylla pattern: `actions/cache` keyed on `.pre-commit-config.yaml`, `fetch-depth: 0` checkout, `--show-diff-on-failure` flag.",
-      "version": "1.1.0",
-      "source": "./skills/ci-cd-pre-commit-ci-hook-failures.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-cd-remove-upstream-fixed-workaround-fan-out-matrix",
-      "description": "Pattern for safely removing a CI matrix workaround once an upstream bug is fixed: convert sequential single-runner steps back to a multi-entry matrix. Each `just test-group` (or equivalent) invocation must remain its OWN step gated by `if: matrix.group == 'X'` so coverage-validation parsers (which scan `run:` blocks for literal command invocations) keep working. Use when: (1) a memory/concurrency limit was lifted upstream, (2) you have a sequential job to fan out into a parallel matrix, (3) a coverage-checking script complains about missing test files after collapsing steps into a case statement.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-remove-upstream-fixed-workaround-fan-out-matrix.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "matrix",
-        "fan-out",
-        "sequential",
-        "validate_test_coverage",
-        "mojo",
-        "modular",
-        "workaround-removal"
+        "podman",
+        "rootless",
+        "subuid",
+        "justfile",
+        "permissions",
+        "build-dir",
+        "dist",
+        "container-host-boundary",
+        "chmod",
+        "pixi"
       ]
     },
     {
@@ -1956,20 +1431,39 @@
       ]
     },
     {
-      "name": "ci-cd-throttle-container-publish-nightly-paths-filter",
-      "description": "Throttle a container-publish GHA workflow that was rebuilding on every push and PR. Replace per-push triggers with: schedule cron (nightly), workflow_dispatch (on-demand), and push/PR with paths-filter restricted to container-affecting files (Dockerfile, compose, dependency manifests, the workflow itself). Code-only changes reuse the latest nightly image. Use when: (1) container build minutes dominate the CI bill, (2) image content only changes when deps or Dockerfile change but the workflow rebuilds on every commit, (3) you want a 'security update' refresh cadence without per-commit overhead.",
+      "name": "ci-cd-split-advisory-check-out-of-required-gate",
+      "description": "Split a timing-sensitive / orchestration sub-check out of a REQUIRED CI gate (e.g. pr-policy) into its own non-required advisory job so it reports status but never blocks merge. Use when: (1) a required gate bundles a timing-sensitive/orchestration check that fails a correct PR (e.g. `::error::Auto-merge is enabled before implementation review GO.`) and blocks merge; (2) you want a CI check to report status but never block merge (make a check non-blocking / advisory); (3) move the auto-merge \u2194 state:implementation-go state machine out of the pr-policy gate; (4) a required job's sub-check is flaky/timing-dependent and shouldn't gate merge.",
       "version": "1.0.0",
-      "source": "./skills/ci-cd-throttle-container-publish-nightly-paths-filter.md",
+      "source": "./skills/ci-cd-split-advisory-check-out-of-required-gate.md",
       "category": "ci-cd",
       "tags": [
         "github-actions",
-        "container",
-        "ghcr",
-        "podman",
-        "docker",
-        "paths-filter",
-        "cron",
-        "workflow_dispatch"
+        "branch-protection",
+        "required-checks",
+        "pr-policy",
+        "auto-merge",
+        "advisory-check",
+        "ruleset",
+        "implementation-go",
+        "non-blocking",
+        "workflow-split"
+      ]
+    },
+    {
+      "name": "ci-cd-summary-aggregator-job-skip-required-context",
+      "description": "Fix PRs permanently BLOCKED because a required status-check context is a job gated `if: github.event_name != 'pull_request'`: a whole-job skip does NOT satisfy a required check. Replace per-job required contexts with a single `summary` aggregator job (`if: always()`) that asserts `needs.X.result == 'success'` for must-run jobs and `success|skipped` for jobs designed to skip on PRs; then remove the per-job contexts from branch protection. Use when: (1) branch protection requires a context that the workflow legitimately skips on `pull_request`, (2) PRs are BLOCKED with `skipped` (not failing) required checks, (3) extending a CI workflow with registry/secret-dependent jobs that must skip on forked PRs.",
+      "version": "1.0.0",
+      "source": "./skills/ci-cd-summary-aggregator-job-skip-required-context.md",
+      "category": "ci-cd",
+      "tags": [
+        "github-actions",
+        "branch-protection",
+        "required-status-checks",
+        "aggregator",
+        "if-always",
+        "job-skip",
+        "skipped-conclusion",
+        "summary-job"
       ]
     },
     {
@@ -1989,9 +1483,26 @@
       ]
     },
     {
-      "name": "ci-complexity-extract-method-fix",
-      "description": "Fix C901 cyclomatic complexity CI failures by extracting helper functions. Use when: (1) pre-commit or CI fails with 'is too complex (N > 10)', (2) adding conditional blocks to an existing function pushes it over the CC limit.",
+      "name": "ci-cd-verify-merged-prs-end-to-end",
+      "description": "Treat closing an umbrella issue that tracks N sequential implementation PRs as a distinct end-to-end verification task: merged-and-green PRs do not compose. Each PR's CI exercises only its own changed files, so the full pipeline (e.g. packaging: rename \u2192 recipe \u2192 wheel \u2192 release.yml) has never run as a whole. Use when: (1) an umbrella issue stays OPEN after all its child PRs merged, (2) acceptance criteria have not been driven end-to-end, (3) a tag-triggered or rarely-run workflow (release.yml, nightly, weekly E2E) has never actually fired, (4) you suspect 'all PRs merged green so it must work', (5) budgeting effort for a verification pass that uncovers a sequential defect cascade.",
       "version": "1.0.0",
+      "source": "./skills/ci-cd-verify-merged-prs-end-to-end.md",
+      "category": "ci-cd",
+      "tags": [
+        "verification",
+        "merged-prs",
+        "acceptance-criteria",
+        "end-to-end",
+        "release-pipeline",
+        "defect-cascade",
+        "umbrella-issue",
+        "smoke-test"
+      ]
+    },
+    {
+      "name": "ci-complexity-extract-method-fix",
+      "description": "Fix C901 cyclomatic complexity CI failures by extracting helper functions. Use when: (1) pre-commit or CI fails with 'is too complex (N > 10)', (2) adding conditional blocks to an existing function pushes it over the CC limit, (3) multiple rendering/processing passes can be isolated.",
+      "version": "1.1.0",
       "source": "./skills/ci-complexity-extract-method-fix.md",
       "category": "ci-cd",
       "tags": [
@@ -1999,7 +1510,9 @@
         "complexity",
         "refactoring",
         "ruff",
-        "C901"
+        "C901",
+        "method-extraction",
+        "rendering-passes"
       ]
     },
     {
@@ -2017,35 +1530,21 @@
       ]
     },
     {
-      "name": "ci-dependency-security-scanning",
-      "description": "Skill: ci-dependency-security-scanning",
+      "name": "ci-dependency-floor-semantic-version-guard",
+      "description": "Use when: (1) comparing version specs across manifest files (pyproject.toml, pixi.toml), (2) ensuring dependency floors stay consistent without string-equality surprises (e.g., '9.0' vs '9.0.0'), (3) implementing regression guards for manifest drift, (4) testing that pinned versions are semantically equivalent across files using PEP 440 version comparison.",
       "version": "1.0.0",
-      "source": "./skills/ci-dependency-security-scanning.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-deprecation-enforcement",
-      "description": "Promote a CI grep warning into a hard exit-1 enforcement gate for deprecated symbols",
-      "version": "1.0.0",
-      "source": "./skills/ci-deprecation-enforcement.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-docker-hub-rate-limit-mcr-mirror",
-      "description": "Fix Docker Hub anonymous pull rate limit failures in GitHub Actions CI by switching ubuntu base image to MCR mirror. Use when: (1) CI container build fails with 'toomanyrequests' pulling ubuntu:24.04, (2) multiple parallel build variants exhaust the 100 pulls/6h anonymous limit, (3) no Docker Hub credentials are configured.",
-      "version": "1.0.0",
-      "source": "./skills/ci-docker-hub-rate-limit-mcr-mirror.md",
+      "source": "./skills/ci-dependency-floor-semantic-version-guard.md",
       "category": "ci-cd",
       "tags": [
-        "ci",
-        "docker",
-        "podman",
-        "rate-limit",
-        "mcr",
-        "ubuntu",
-        "base-image"
+        "dependencies",
+        "version-comparison",
+        "regression-guard",
+        "pytest",
+        "pixi",
+        "pyproject",
+        "semver",
+        "pep-440",
+        "manifest-consistency"
       ]
     },
     {
@@ -2066,73 +1565,30 @@
       ]
     },
     {
-      "name": "ci-github-actions-pull-request-trigger",
-      "description": "GitHub Actions pull_request workflows not triggering after push. Use when: (1) commits pushed to a PR branch don't trigger on: pull_request workflows, (2) path-filtered CI is silently skipped after normal commits, (3) required status checks are missing after push and PR can't merge, (4) workflow_dispatch passed but the required check still shows missing.",
+      "name": "ci-failure-triage-and-diagnosis",
+      "description": "Canonical workflow for triaging CI failures: log analysis, core dump capture, subprocess hang diagnosis, container forensics, libKGEN/JIT crash retrieval, GHA-only vs cross-environment failures, PR-specific vs systemic failure separation. Use when: (1) a CI run failed and you need to identify the root cause, (2) deciding whether a failure is PR-induced or pre-existing, (3) capturing core dumps from container environments, (4) reproducing a GHA-only crash locally, (5) GraphQL/REST rate-limited CI monitoring.",
       "version": "1.0.0",
-      "source": "./skills/ci-github-actions-pull-request-trigger.md",
+      "source": "./skills/ci-failure-triage-and-diagnosis.md",
       "category": "ci-cd",
       "tags": [
+        "merged",
+        "ci-failure",
+        "triage",
+        "log-analysis",
+        "core-dump",
+        "forensics",
+        "coredump",
+        "gdb",
+        "podman",
+        "mojo",
+        "libkgen",
         "github-actions",
-        "pull_request",
-        "force-push",
-        "rebase",
-        "status-checks",
-        "path-filter",
-        "branch-protection"
-      ]
-    },
-    {
-      "name": "ci-github-actions-secrets-context-unavailable-job-if",
-      "description": "Fix actionlint error: context 'secrets' is not allowed here \u2014 available contexts are github, inputs, needs, vars. Use when: (1) job-level if: condition references secrets.SOME_SECRET, (2) you want to skip a job when a secret is absent, (3) actionlint rejects the workflow with 'context secrets is not allowed here'.",
-      "version": "1.0.0",
-      "source": "./skills/ci-github-actions-secrets-context-unavailable-job-if.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "secrets",
-        "vars",
-        "actionlint",
-        "job-if",
-        "context"
-      ]
-    },
-    {
-      "name": "ci-github-ruleset-matrix-status-context",
-      "description": "GitHub matrix jobs emit expanded context names (job-id (matrix-value)) that must be registered verbatim in branch rulesets. Use when: (1) a required status check shows 'Expected \u2014 Waiting for status to be reported' forever even after all matrix jobs pass, (2) a ruleset uses the bare job ID for a matrix job and the PR merge box is permanently blocked, (3) debugging why classic branch protection returns 404 but the PR is still blocked.",
-      "version": "1.0.0",
-      "source": "./skills/ci-github-ruleset-matrix-status-context.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
-        "rulesets",
-        "matrix",
-        "status-checks",
-        "branch-protection",
-        "github-actions"
-      ]
-    },
-    {
-      "name": "ci-gitleaks-sarif-false-positive-fix",
-      "description": "Fix gitleaks SARIF false-positive detection causing security-report required check to always fail, blocking PR auto-merges. Use when: (1) security-report required check fails on every run even with no real secrets, (2) gitleaks SARIF check uses grep with \\s instead of jq, (3) swarm session is blocked because security-report is a required status check that never passes.",
-      "version": "1.1.0",
-      "source": "./skills/ci-gitleaks-sarif-false-positive-fix.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-glob-pattern-conversion",
-      "description": "Use when: (1) CI test groups have explicit filename lists that miss new split test files or silently exclude new test files, (2) a catch-all test_*.mojo pattern is causing timeouts by matching unintended files in a directory with multiple test groups, (3) needing to verify whether a CI pattern is already a wildcard (check before editing), (4) determining if CI needs updating after adding or splitting Mojo test files.",
-      "version": "1.0.0",
-      "source": "./skills/ci-glob-pattern-conversion.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "github-actions",
-        "glob-patterns",
-        "test-splitting",
-        "comprehensive-tests",
-        "wildcard",
-        "timeout"
+        "rate-limit",
+        "subprocess",
+        "signal",
+        "avx-512",
+        "cpu-survey",
+        "workflow-dispatch"
       ]
     },
     {
@@ -2142,6 +1598,24 @@
       "source": "./skills/ci-grep-deprecation-guard.md",
       "category": "ci-cd",
       "tags": []
+    },
+    {
+      "name": "ci-library-migration-audit-pip-install-coverage",
+      "description": "After migrating a Python helper from a local module to a pip-installed library (e.g. `from common import X` \u2192 `from hephaestus.utils import X`), audit every CI job that invokes the migrated scripts to confirm each job either (a) installs the library via `pip install`, or (b) routes the invocation through an env-manager (`pixi run`, `poetry run`, `uv run`) that already has it. Use when: (1) a library migration PR was green in pre-commit/local but CI jobs crash with `ModuleNotFoundError: No module named '<lib>'`, (2) a workflow step calls `python3 scripts/...` directly even though the job ran `setup-pixi`/`setup-poetry` (env-manager bypass), (3) a workflow YAML pins `<lib>>=X,<Y` in a `pip install` line that has drifted from the version pin in `pixi.toml`/`pyproject.toml`.",
+      "version": "1.0.0",
+      "source": "./skills/ci-library-migration-audit-pip-install-coverage.md",
+      "category": "ci-cd",
+      "tags": [
+        "python",
+        "library-migration",
+        "pip-install",
+        "pixi",
+        "github-actions",
+        "module-not-found",
+        "env-manager-bypass",
+        "version-pin-drift",
+        "single-source-of-truth"
+      ]
     },
     {
       "name": "ci-local-reproduction-environment-conditions",
@@ -2177,23 +1651,33 @@
       ]
     },
     {
-      "name": "ci-matrix-group-management",
-      "description": "Use when: (1) a CI matrix group has 30+ files causing long jobs and poor failure isolation and needs splitting, (2) promoting subdirectory-scoped patterns into separate per-subdirectory matrix entries with wildcard auto-discovery, (3) a CI matrix has >20 groups with startup overhead that needs consolidation by merging related groups, (4) CI test files run in multiple jobs due to wildcard overlap (deduplication), (5) disabling or re-enabling flaky test groups while keeping coverage validation in sync, (6) adding inline timeout guidance comments to matrix entries.",
+      "name": "ci-markdownlint-md060-table-separator-spaces",
+      "description": "Use when: (1) CI markdownlint job fails with MD060/table-column-style 'Table pipe is missing space to the right/left for style compact', (2) local pre-commit Markdown Lint hook passes but CI's separate markdownlint job fails on the same .md file, (3) adding or modifying any markdown table in docs/ and you want to pre-empt the CI gate.",
       "version": "1.0.0",
-      "source": "./skills/ci-matrix-group-management.md",
+      "source": "./skills/ci-markdownlint-md060-table-separator-spaces.md",
       "category": "ci-cd",
       "tags": [
+        "markdownlint",
+        "markdownlint-cli2",
+        "MD060",
+        "tables",
+        "table-column-style",
         "ci-cd",
+        "pre-commit-divergence",
+        "docs"
+      ]
+    },
+    {
+      "name": "ci-merge-preview-coverage-gate",
+      "description": "GitHub CI computes coverage against the merge-preview tree (PR's HEAD merged with main's HEAD), NOT the PR branch alone. This means local coverage on the branch tree can be HIGHER than CI sees, and adding entries to `[tool.coverage.run].omit` for files that aren't on the branch IS the correct fix when those files exist on main. Use when: (1) CI coverage % is lower than local pytest run on same SHA, (2) coverage gate fails despite the PR not touching the flagged files, (3) you're behind main and considering whether to omit files you don't have in your tree.",
+      "version": "1.0.0",
+      "source": "./skills/ci-merge-preview-coverage-gate.md",
+      "category": "ci-cd",
+      "tags": [
         "github-actions",
-        "test-matrix",
-        "auto-discovery",
-        "wildcard-patterns",
-        "test-splitting",
-        "glob-patterns",
-        "consolidation",
-        "deduplication",
-        "timeout",
-        "flaky-tests"
+        "coverage",
+        "pytest",
+        "merge-preview"
       ]
     },
     {
@@ -2215,23 +1699,6 @@
       ]
     },
     {
-      "name": "ci-mojo-podman-root-cause-fixes",
-      "description": "Fix four distinct CI root-cause classes that co-occur in Mojo/Podman-based projects: (1) mkdocs --strict broken relative links, (2) Podman container PermissionError writing to host-side paths (fix: write to /tmp inside container, then podman cp), (3) wiring up Mojo ASAN builds via justfile + libasan8 in Dockerfile, (4) breaking Mojo circular imports by extracting shared constants to a zero-dependency leaf module. Use when: docs deploy fails with broken link, benchmark workflow gets PermissionError, ASAN variable is unused in justfile, or mojo build fails with 'cannot implicitly convert X to X' due to circular import through a constants file.",
-      "version": "1.0.0",
-      "source": "./skills/ci-mojo-podman-root-cause-fixes.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "podman",
-        "mojo",
-        "mkdocs",
-        "asan",
-        "circular-imports",
-        "dockerfile",
-        "justfile"
-      ]
-    },
-    {
       "name": "ci-package-workflow",
       "description": "Create GitHub Actions workflows for automated package building and distribution. Use in package phase to automate .mojopkg building and release creation.",
       "version": "2.0.0",
@@ -2242,23 +1709,6 @@
         "github-actions",
         "packaging",
         "release"
-      ]
-    },
-    {
-      "name": "ci-pixi-lock-check-setup-order",
-      "description": "Fix GitHub Actions workflows that run pixi commands before pixi is installed, causing 'pixi: command not found'. Use when: (1) a workflow fails with 'pixi: command not found' on any pixi command, (2) adding a new workflow that uses pixi but forgot to install it first, (3) a lock-check or dependency-verification workflow runs pixi install --locked without a prior pixi setup step.",
-      "version": "1.0.0",
-      "source": "./skills/ci-pixi-lock-check-setup-order.md",
-      "category": "ci-cd",
-      "tags": [
-        "pixi",
-        "ci",
-        "github-actions",
-        "setup-order",
-        "lock-check",
-        "command-not-found",
-        "setup-pixi",
-        "composite-action"
       ]
     },
     {
@@ -2274,54 +1724,6 @@
         "pre-commit",
         "drift-detection",
         "pyproject"
-      ]
-    },
-    {
-      "name": "ci-precommit-lock-file-stash-conflict",
-      "description": "Use when: (1) a commit fails because pre-commit stash pop conflicts with ruff auto-fix staged changes, (2) pixi.lock or another lock file is modified but unstaged and pre-commit hooks auto-fix and stage files causing stash pop conflicts, (3) the repository is left in a dirty state after a failed commit with unstaged auto-generated files.",
-      "version": "1.0.0",
-      "source": "./skills/ci-precommit-lock-file-stash-conflict.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "stash",
-        "pixi",
-        "lock-file",
-        "ruff",
-        "conflict",
-        "commit"
-      ]
-    },
-    {
-      "name": "ci-precommit-parity-single-source-of-truth",
-      "description": "Architecture pattern: make .pre-commit-config.yaml the single source of truth for all linting; CI runs `pre-commit run --all-files` instead of duplicating lint steps. Use when: (1) CI and pre-commit run different linters or different file scopes causing silent divergence, (2) a new linter exists in CI but not locally (or vice versa), (3) shellcheck in CI covers .sh but not .bats while pre-commit covers both, (4) yamllint in CI covers agents/ but pre-commit covers all .yaml, (5) consolidating N separate CI lint jobs into one pre-commit parity job.",
-      "version": "1.0.0",
-      "source": "./skills/ci-precommit-parity-single-source-of-truth.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "shellcheck",
-        "yamllint",
-        "actionlint",
-        "gitleaks",
-        "parity",
-        "lint",
-        "ci-cd"
-      ]
-    },
-    {
-      "name": "ci-precommit-ruff-version-mismatch",
-      "description": "Diagnose and resolve CI failures where pre-commit ruff-format disagrees with pixi ruff. Use when: (1) pixi run ruff format --check passes locally but pre-commit ruff-format fails in CI with 'file would be reformatted', (2) ruff formatting results differ between pre-commit hooks and direct pixi invocations at the same version string.",
-      "version": "1.0.0",
-      "source": "./skills/ci-precommit-ruff-version-mismatch.md",
-      "category": "ci-cd",
-      "tags": [
-        "ruff",
-        "pre-commit",
-        "formatting",
-        "pixi",
-        "ci",
-        "version-isolation"
       ]
     },
     {
@@ -2404,81 +1806,39 @@
       ]
     },
     {
-      "name": "ci-workflow-file-consolidation",
-      "description": "Use when: (1) a repo has >15 GitHub Actions workflow files with overlapping triggers that need merging into fewer files, (2) adding new CI matrix entry types (e.g., mypy, ruff) to existing workflow files, (3) CI maintenance burden is high from editing many files for one trigger change.",
-      "version": "1.0.0",
-      "source": "./skills/ci-workflow-file-consolidation.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "github-actions",
-        "workflow-files",
-        "consolidation",
-        "yaml"
-      ]
-    },
-    {
-      "name": "ci-workflow-hardening-checklist",
-      "description": "Harden GitHub Actions workflows with concurrency controls, least-privilege permissions, timeouts, and gitleaks allowlist for test fixtures. Use when: (1) workflows lack concurrency/cancel-in-progress controls, (2) gitleaks finds false positives in test fixtures or example data, (3) workflows missing permissions blocks or timeouts, (4) adding Trivy scanning to Docker build jobs.",
-      "version": "1.0.0",
-      "source": "./skills/ci-workflow-hardening-checklist.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-workflow-optimization-phase5",
-      "description": "CI/CD speedup via path filters, hook deduplication, job inlining, and timing collection. Use when: CI runs unnecessarily on doc PRs, pre-commit duplicates CI jobs, or serial single-command jobs add runner overhead.",
-      "version": "1.0.0",
-      "source": "./skills/ci-workflow-optimization-phase5.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ci-zero-discovery-guard",
-      "description": "Fix silent CI false-passes caused by zero test files discovered. Use when: (1) just test-group exits 0 on empty glob matches, (2) a CI matrix entry uses parent-path + subdirectory glob patterns, (3) splitting merged CI matrix entries to prevent undetected directory renames.",
-      "version": "1.0.0",
-      "source": "./skills/ci-zero-discovery-guard.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "close-issue-via-minimal-pr",
-      "description": "Close a GitHub issue when all code already exists on main but the issue is still open. Use when: (1) a verification/CI-check issue has no outstanding code changes, (2) the feature branch has zero diff from main, (3) you need a minimal commit to create a PR that triggers CI and closes the issue, (4) a merged PR did not auto-close the issue because the commit keyword was wrong, (5) a batch sweep PR closes 10+ ALREADY-DONE issues at once and each one needs its own Closes #N keyword in the PR body.",
+      "name": "claude-code-scheduled-tasks-lockfile-gitignore",
+      "description": "Untrack and gitignore Claude Code's .claude/scheduled_tasks.lock runtime lockfile to stop two distinct failure modes: (a) end-of-file-fixer pre-commit failures in CI, (b) CLI tools like hephaestus-tidy that abort because `git status --porcelain` reports the untracked lockfile as dirty. Use when: (1) CI pre-commit / lint check fails on `Fixing .claude/scheduled_tasks.lock`, (2) a CLI tool refuses to run with `Working tree has uncommitted changes` and `git status --porcelain` shows `?? .claude/scheduled_tasks.lock`, (3) the same failure recurs across unrelated PRs in the same repo, (4) the `/schedule` skill is in use.",
       "version": "1.2.0",
-      "source": "./skills/close-issue-via-minimal-pr.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "cmake-cxx-warnings-fetchcontent-c-lib",
-      "description": "Scope CMake warning flags to C++ only when using FetchContent C libraries. Use when: (1) a C library pulled via FetchContent fails to compile with -Werror,-Wunused-parameter or -Wunused-function, (2) you see compiler errors in third-party C files you did not author, (3) adding any C library (nats.c, libuv, etc.) to a C++20 project with global -Wall -Wextra -Wpedantic -Werror flags.",
-      "version": "1.0.0",
-      "source": "./skills/cmake-cxx-warnings-fetchcontent-c-lib.md",
+      "source": "./skills/claude-code-scheduled-tasks-lockfile-gitignore.md",
       "category": "ci-cd",
       "tags": [
-        "cmake",
-        "compiler-warnings",
-        "fetchcontent",
-        "c-library",
-        "generator-expressions",
-        "nats",
-        "werror",
-        "cpp20"
+        "claude-code",
+        "gitignore",
+        "pre-commit",
+        "end-of-file-fixer",
+        "lockfile",
+        "scheduled-tasks",
+        "ci-flake",
+        "runtime-state",
+        "hephaestus-tidy",
+        "dirty-working-tree",
+        "git-status-porcelain"
       ]
     },
     {
-      "name": "cmake-library-main-gtest-conflict",
-      "description": "Fix ctest 'No tests were found' when library target contains main() that conflicts with GTest::gtest_main. Use when: (1) ctest reports zero tests despite test binary being built, (2) test binary runs but prints version instead of running tests, (3) CI coverage step fails with 'No tests were found'.",
+      "name": "code-quality-enforcement-gates",
+      "description": "Canonical guide to code-quality enforcement THRESHOLDS and decisions: when to fail builds on complexity, when to enable mypy strict modes, when to promote warnings to errors, how to scope override subsets, deprecation removal policy. Use when: (1) deciding fix-vs-suppress for a new lint rule, (2) enabling mypy check-untyped-defs or new ruff rules, (3) promoting CI warnings to exit-1, (4) tuning markdownlint MD024 / ruff C901 thresholds, (5) narrowing mypy module override globs to specific paths.",
       "version": "1.0.0",
-      "source": "./skills/cmake-library-main-gtest-conflict.md",
+      "source": "./skills/code-quality-enforcement-gates.md",
       "category": "ci-cd",
       "tags": [
-        "cmake",
-        "gtest",
-        "ctest",
-        "coverage",
-        "main-conflict",
-        "cpp20"
+        "merged",
+        "code-quality",
+        "quality-gate",
+        "mypy",
+        "ruff",
+        "complexity-budget",
+        "deprecation"
       ]
     },
     {
@@ -2490,28 +1850,16 @@
       "tags": []
     },
     {
-      "name": "complexity-regression-gate",
-      "description": "Add a named CI step and pre-commit hook to enforce McCabe complexity limits (C901) so violations block PRs and local commits. Use when pyproject.toml already has C901 in ruff select but complexity regressions can still merge undetected.\\n",
+      "name": "composite-action-expr-in-description",
+      "description": "GitHub Actions evaluates `${{ ... }}` expressions inside composite-action input `description` fields even though that field is documentation-only. Including `${{ runner.os }}` (or any non-`inputs.*` context name) inside an input description \u2014 even backtick-quoted as documentation \u2014 makes the action fail to load with `Unrecognized named-value: 'runner'`. Use plain placeholder text or escape the expression. Use when: (1) writing a composite action that documents the cache-key shape or other runner-context-using value in its input description, (2) seeing `TemplateValidationException` at action-load time with `runner.os` / `github.X` / other context names.",
       "version": "1.0.0",
-      "source": "./skills/complexity-regression-gate.md",
+      "source": "./skills/composite-action-expr-in-description.md",
       "category": "ci-cd",
       "tags": [
-        "ruff",
-        "c901",
-        "mccabe",
-        "complexity",
-        "pre-commit",
         "github-actions",
-        "regression-gate"
+        "composite-action",
+        "template-expression"
       ]
-    },
-    {
-      "name": "composite-action-checkout-order",
-      "description": "Enforce that actions/checkout precedes ./.github/actions/ references in every GitHub Actions job. Use when: adding checkout-order validation CI, auditing workflows for composite action ordering bugs, or documenting the checkout-first invariant.",
-      "version": "1.0.0",
-      "source": "./skills/composite-action-checkout-order.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "comprehensive-pr-review-orchestration",
@@ -2522,127 +1870,54 @@
       "tags": []
     },
     {
-      "name": "conan-2-profile-all-and-gcc-version-docker-chain",
-      "description": "Two-step Conan-2 + Docker failure chain hit during the 2026-05-10 multi-repo CI sweep in ProjectCharybdis PR #219. Stage 1: Conan 2 requires both host and build profiles, so `--profile=` (host only) blows up with 'default build profile doesn't exist' in a freshly-built image; fix is `--profile:all=`. Stage 2: after the profile fix, Conan dependencies (e.g. gtest) fail with 'CMAKE_C_COMPILER not set' because the profile pins `compiler.version=14` while Ubuntu 24.04 ships gcc-13 by default. Use when: (1) containerized C++ build using Conan 2 fails with 'default build profile doesn\u2019t exist', (2) after fixing the profile chain a Conan dep fails with 'CMAKE_C_COMPILER not set', (3) Conan profile declares `compiler.version=14` but the base image is Ubuntu 24.04, (4) migrating from Conan 1 to Conan 2 in CI.",
-      "version": "1.0.0",
-      "source": "./skills/conan-2-profile-all-and-gcc-version-docker-chain.md",
+      "name": "container-build-and-runtime-patterns",
+      "description": "Canonical guide to container build and runtime patterns spanning Docker, Podman, and rootless: multi-stage builds, multi-arch OCI, UID/GID mismatch fixes, layer caching strategies, entrypoint patterns, healthchecks, pixi-volume isolation, GHA cache extraction, Conan-in-Docker chains, dockerfile extras validation. Use when: (1) writing or refactoring a Dockerfile, (2) diagnosing a rootless Podman or UID mismatch crash, (3) extracting / sharing image cache between local and GHA, (4) integrating Conan profiles with a multistage build, (5) container-based E2E test infra.",
+      "version": "1.1.0",
+      "source": "./skills/container-build-and-runtime-patterns.md",
       "category": "ci-cd",
       "tags": [
-        "conan",
-        "conan-2",
+        "merged",
         "docker",
-        "gcc",
-        "gcc-14",
-        "cmake",
-        "gtest",
-        "ubuntu-24.04",
-        "ci",
-        "profile",
-        "charybdis",
-        "homeric-intelligence"
+        "podman",
+        "container",
+        "dockerfile",
+        "multistage",
+        "rootless",
+        "hadolint",
+        "buildx-driver",
+        "gha-cache",
+        "load-true"
       ]
     },
     {
-      "name": "conan-ci-github-actions-missing-install",
-      "description": "Add conan install step to GitHub Actions CI when cmake --preset fails with missing conan_toolchain.cmake. Use when: (1) CI fails at cmake configure with 'Could not find toolchain file: build/*/conan_toolchain.cmake', (2) adding CI to a CMake+Conan project for the first time, (3) CI installs ninja but skips conan, (4) build-test, static-analysis, and code-coverage workflows all fail at configure step.",
+      "name": "cpp-cmake-ci-build-and-test-fixes",
+      "description": "Fix C++/CMake CI build and test failures. Use when: (1) FetchContent C library breaks build with -Werror due to global warning flags, (2) ctest reports 'No tests found' because library target contains main() conflicting with GTest::gtest_main, (3) Ubuntu 24.04 apt Docker build fails with 'GTest::gmock target not found', (4) TSan reports data races or hangs tests, (5) clang-tidy floods warnings from _deps/ vendor headers.",
       "version": "1.0.0",
-      "source": "./skills/conan-ci-github-actions-missing-install.md",
+      "source": "./skills/cpp-cmake-ci-build-and-test-fixes.md",
       "category": "ci-cd",
       "tags": [
-        "conan",
         "cmake",
-        "github-actions",
-        "cmake-presets",
-        "cpp",
-        "toolchain"
-      ]
-    },
-    {
-      "name": "conan-cmake-toolchain-coverage-scripts",
-      "description": "Coverage scripts in Conan-managed C++ projects must explicitly pass the Conan toolchain file to cmake or find_package() calls will fail. Use when: (1) Code Coverage CI job fails with cmake find_package errors while other CI jobs (tests, benchmarks) pass, (2) generate_coverage.sh or similar scripts invoke cmake without -DCMAKE_TOOLCHAIN_FILE, (3) GTest/other Conan-managed deps are missing only in coverage builds.",
-      "version": "1.0.0",
-      "source": "./skills/conan-cmake-toolchain-coverage-scripts.md",
-      "category": "ci-cd",
-      "tags": [
-        "conan",
-        "cmake",
-        "coverage",
-        "toolchain",
-        "gtest",
+        "cpp20",
         "ci-cd",
-        "cpp20"
-      ]
-    },
-    {
-      "name": "consolidate-pre-commit-excludes",
-      "description": "Skill: Consolidate Pre-commit Exclude Patterns",
-      "version": "1.0.0",
-      "source": "./skills/consolidate-pre-commit-excludes.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "container-image-security-patching",
-      "description": "Fix Trivy container scan failures by bumping pinned base image digests, adding apt-get upgrade, and running npm audit fix. Use when: Trivy CI step fails with HIGH/CRITICAL CVEs, docker-build-timing workflow fails on all branches, or base image has known vulnerabilities.",
-      "version": "1.0.0",
-      "source": "./skills/container-image-security-patching.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "cpp-ci-sanitizer-tsan-data-race-fixes",
-      "description": "Diagnose and fix C++ CI failures from ThreadSanitizer (TSan) data races, hung tests under sanitizers, MSan build failures, and ConcurrentQueue false positives. Also covers repo audit methodology and batch issue filing from audit findings. Use when: (1) TSan reports data races in C++ CI, (2) a test hangs indefinitely under TSan causing job timeout, (3) MSan build fails due to uninstrumented stdlib in CMake probing steps, (4) Docker COPY paths are wrong after CMake changes CMAKE_RUNTIME_OUTPUT_DIRECTORY, (5) after fixing CI failures run a strict repo audit, (6) filing batch GitHub issues from audit findings, (7) moodycamel::ConcurrentQueue triggers TSan false positives needing suppression.",
-      "version": "1.2.0",
-      "source": "./skills/cpp-ci-sanitizer-tsan-data-race-fixes.md",
-      "category": "ci-cd",
-      "tags": [
+        "fetchcontent",
+        "compiler-warnings",
+        "generator-expressions",
+        "gtest",
+        "gmock",
+        "ctest",
+        "ubuntu",
+        "apt",
+        "dockerfile",
         "tsan",
         "sanitizers",
         "data-race",
         "msan",
-        "cmake",
-        "dockerfile",
-        "cpp20",
-        "github-actions",
-        "repo-audit",
-        "issue-filing",
-        "concurrentqueue",
-        "tsan-suppression",
-        "thread-pool"
-      ]
-    },
-    {
-      "name": "cpp-clang-tidy-deps-header-filter-fix",
-      "description": "Fix clang-tidy HeaderFilterRegex accidentally matching FetchContent _deps/ third-party headers. Use when: (1) clang-tidy CI floods warnings from _deps/ vendor headers, (2) HeaderFilterRegex uses bare directory names like src/ that match _deps/*/src/ paths, (3) ExcludeHeaderFilterRegex causes unknown key errors in older clang-tidy, (4) -llvm-* suppressor does not silence llvmlibc-* checks.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-clang-tidy-deps-header-filter-fix.md",
-      "category": "ci-cd",
-      "tags": [
         "clang-tidy",
-        "cmake",
-        "fetchcontent",
-        "cpp",
         "header-filter",
         "static-analysis",
-        "ci-cd"
-      ]
-    },
-    {
-      "name": "cpp-coverage-container-pinned-clang-format",
-      "description": "Fix C++ code coverage CI and pin clang-format via Podman container. Use when: (1) gcovr coverage threshold failing because ENABLE_COVERAGE option is declared but not wired, (2) clang-format version mismatch between local and CI, (3) need testable library target separate from server executable, (4) C++ project needs unit tests for store/routes/nats-client pattern, (5) need container-based clang-format for CI/local parity.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-coverage-container-pinned-clang-format.md",
-      "category": "ci-cd",
-      "tags": [
-        "cpp20",
-        "cmake",
-        "gcovr",
-        "coverage",
-        "clang-format",
-        "podman",
-        "container",
-        "googletest",
-        "github-actions"
+        "github-actions",
+        "concurrentqueue",
+        "tsan-suppression"
       ]
     },
     {
@@ -2664,33 +1939,21 @@
       ]
     },
     {
-      "name": "cpp-prometheus-conan-pull-target-missing-with-pull-false",
-      "description": "Fix CMake error 'target prometheus-cpp::pull was not found' when Conan sets with_pull=False. Use when: (1) CMake configure fails with missing prometheus-cpp::pull or ::core target, (2) setting up Prometheus metrics in a C++ project with Conan, (3) deciding which prometheus-cpp CMake target to link based on conanfile options.",
+      "name": "cryptographic-signed-commits-pr-policy-validation",
+      "description": "Understand pr-policy CI gate validation of cryptographic commit signatures at the GraphQL layer. Use when: (1) a PR shows auto-merge armed but BLOCKED despite all CI green, (2) gh pr view --json shows mergeStateStatus:BLOCKED but all checks are SUCCESS, (3) pushing unsigned commits when pr-policy validation is in effect, (4) crafting PRs in repositories with required_signatures branch protection, (5) dispatching sub-agents that must create commits with cryptographic signatures, (6) auditing multi-agent sweeps for invisible signing failures, (7) understanding why unsigned commits block auto-merge even when other CI checks pass.",
       "version": "1.0.0",
-      "source": "./skills/cpp-prometheus-conan-pull-target-missing-with-pull-false.md",
+      "source": "./skills/cryptographic-signed-commits-pr-policy-validation.md",
       "category": "ci-cd",
       "tags": [
-        "cpp",
-        "cmake",
-        "conan",
-        "prometheus",
-        "metrics"
-      ]
-    },
-    {
-      "name": "cross-repo-dep-pypi-publish-fix",
-      "description": "Fix CI failures in consumer repos caused by a shared dependency not yet published to PyPI. Use when: (1) pixi install --locked fails because a new version of an internal package isn't on PyPI yet, (2) PRs import from a dependency at a path dep or unpublished version, (3) need to publish a shared library, then fix lock files and import paths across multiple dependent PRs, (4) concurrent PRs on a consumer repo all fail because the shared dep version bump wasn't released.",
-      "version": "1.0.0",
-      "source": "./skills/cross-repo-dep-pypi-publish-fix.md",
-      "category": "ci-cd",
-      "tags": [
-        "pypi",
-        "pixi",
-        "cross-repo",
-        "dependency",
-        "lock-file",
-        "rebase",
-        "shellcheck"
+        "git-signing",
+        "gpg",
+        "commit-signatures",
+        "pr-policy",
+        "ci-cd",
+        "required-signatures",
+        "graphql",
+        "branch-protection",
+        "auto-merge"
       ]
     },
     {
@@ -2718,6 +1981,25 @@
       "tags": []
     },
     {
+      "name": "dependabot-pr-scope-contamination-check-the-diff",
+      "description": "Before reviewing a Dependabot PR, always run `gh pr diff --name-only` and inspect the commit list. Dependabot PRs frequently arrive contaminated with lockfile-format upgrades or maintainer fixup commits that the title doesn't mention. The title describes the bot's intent; the actual diff may include unrelated cascades. Use this skill when reviewing ANY bot-authored PR to avoid landing surprises. Pattern A: silent lockfile/format upgrades (e.g. pixi.lock v6\u2192v7, 226 add/228 del on a 4-line npm bump). Pattern B: maintainer fixup commits stacked on the bot branch (12 unrelated files added by a `fix: Address CI failures for PR #N` follow-up). Mandatory phase-1 scope check before any verdict: enumerate the actual file scope, count and attribute commits, and REQUEST_CHANGES if scope doesn't match the title.",
+      "version": "1.0.0",
+      "source": "./skills/dependabot-pr-scope-contamination-check-the-diff.md",
+      "category": "ci-cd",
+      "tags": [
+        "dependabot",
+        "pr-review",
+        "scope-bloat",
+        "lockfiles",
+        "supply-chain",
+        "phase-1-verification",
+        "bot-prs",
+        "srp-violation",
+        "pixi-lock",
+        "maintainer-fixup"
+      ]
+    },
+    {
       "name": "dependency-consolidation-pixi-single-source",
       "description": "Consolidate Python dependency declarations across pixi.toml, pyproject.toml, and requirements*.txt into pixi.toml as the single source of truth. Use when: (1) dependencies are declared in multiple files with divergent version constraints, (2) pinned versions in requirements.txt conflict with pixi.toml ranges, (3) pyproject.toml duplicates dependency declarations already managed by pixi.",
       "version": "1.0.0",
@@ -2730,6 +2012,35 @@
         "requirements",
         "consolidation",
         "ci-guardrail"
+      ]
+    },
+    {
+      "name": "dependency-floor-consistency-regression-guard",
+      "description": "Detect and prevent dependency floor skew across manifests (pyproject.toml, pixi.toml). Use when managing dependencies with API-incompatible major versions to ensure published install contracts align with tested environments.",
+      "version": "1.0.0",
+      "source": "./skills/dependency-floor-consistency-regression-guard.md",
+      "category": "ci-cd",
+      "tags": [
+        "dependencies",
+        "manifest-sync",
+        "regression-testing",
+        "pyproject",
+        "pixi",
+        "PyGithub"
+      ]
+    },
+    {
+      "name": "dependency-upper-cap-constraint-alignment",
+      "description": "Synchronize version upper-cap constraints across all install manifests when packages have API-incompatible major versions. Use when: (1) aligning upper-cap constraints (e.g., <2) across pyproject.toml and pixi.toml, (2) ensuring pip-install and dev-env see same tested versions, (3) preventing version skew that bypasses CI testing when major versions have incompatible APIs.",
+      "version": "1.0.0",
+      "source": "./skills/dependency-upper-cap-constraint-alignment.md",
+      "category": "ci-cd",
+      "tags": [
+        "dependency-management",
+        "version-constraints",
+        "manifest-consistency",
+        "regression-testing",
+        "upper-cap"
       ]
     },
     {
@@ -2747,33 +2058,6 @@
       "source": "./skills/doc-config-drift-check.md",
       "category": "ci-cd",
       "tags": []
-    },
-    {
-      "name": "docker-build-timing-ci-measurement",
-      "description": "Add a CI job that performs two consecutive Docker builds (cold + source-only change) and reports layer-cache hit/miss times, confirming a \u226530% build-time reduction claim with actual measured data",
-      "version": "1.0.0",
-      "source": "./skills/docker-build-timing-ci-measurement.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "docker-buildx-multiarch-local-image",
-      "description": "Use when: (1) a multi-arch Docker buildx job fails with 'pull access denied' for a locally-built base image, (2) chaining two buildx multi-arch builds where the second depends on the first's image, (3) using docker-container buildx driver and needing to pass a base image to a downstream build, (4) oci-layout reference fails with 'not a directory' error, (5) arm64 binary check silently passes despite QEMU missing.",
-      "version": "1.1.0",
-      "source": "./skills/docker-buildx-multiarch-local-image.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "buildx",
-        "multi-arch",
-        "oci",
-        "local-image",
-        "base-image",
-        "github-actions",
-        "ci",
-        "qemu",
-        "oci-layout"
-      ]
     },
     {
       "name": "docker-ci-dead-step-cleanup",
@@ -2810,155 +2094,10 @@
       "tags": []
     },
     {
-      "name": "docker-pixi-isolation",
-      "description": "Fix Docker container Mojo stdlib failures caused by host .pixi/ bind-mount contamination. Use when: CI tests fail with 'unable to locate module std' inside Docker containers.",
-      "version": "1.0.0",
-      "source": "./skills/docker-pixi-isolation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "docker-to-podman-migration",
-      "description": "Migrate a project from Docker to Podman, removing NATIVE=1 escape hatches. Use when: (1) replacing Docker with Podman in GitHub Actions or Makefile/justfile ecosystems, (2) eliminating NATIVE=1 workarounds that bypass container-based builds, (3) rewriting GHCR publish workflows, (4) adopting Containerfile over Dockerfile in C++/CMake or Mojo/Python projects.",
-      "version": "1.1.0",
-      "source": "./skills/docker-to-podman-migration.md",
-      "category": "ci-cd",
-      "tags": [
-        "podman",
-        "docker",
-        "containerfile",
-        "makefile",
-        "justfile",
-        "native",
-        "migration",
-        "cmake",
-        "cpp"
-      ]
-    },
-    {
-      "name": "dockerfile-cargo-to-prebuilt-binary",
-      "description": "Replace slow cargo install in Dockerfiles with pre-built binary installers to eliminate Rust compilation. Use when: Dockerfile uses cargo install for a tool (just, ripgrep, fd, etc.) that provides an official binary installer, and builds are slow due to Rust compilation overhead.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-cargo-to-prebuilt-binary.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-env-version-pin",
-      "description": "Pin installer versions in Dockerfiles via ENV variable injection (e.g. PIXI_VERSION, NVM_VERSION) for reproducible builds. Use when a Dockerfile curl-installs a tool without a pinned version, or when Dockerfile.ci is pinned but the main Dockerfile is not.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-env-version-pin.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-extras-validation",
-      "description": "Validate Docker build-arg EXTRAS group names against pyproject.toml [project.optional-dependencies] at build time. Use when a Dockerfile uses a python3 -c snippet to resolve optional-dependency groups from EXTRAS and typos should fail fast rather than silently omitting deps.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-extras-validation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-from-inline-comment",
-      "description": "Use when: (1) Docker build fails with 'FROM requires either one or three arguments', (2) a Dockerfile FROM line has a comment after the image digest or tag, (3) adding comments to FROM lines in Dockerfiles.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-from-inline-comment.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "dockerfile",
-        "from",
-        "comment",
-        "parse-error",
-        "sha256",
-        "digest"
-      ]
-    },
-    {
-      "name": "dockerfile-layer-caching",
-      "description": "Optimize Docker layer caching for Python packages when source changes more often than dependencies to prevent pip from reinstalling all dependencies on every source-only change.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-layer-caching.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-tomllib-fallback",
-      "description": "Add a tomllib/tomli try/except fallback to a Dockerfile dependency-extraction RUN layer to support Python 3.10 as well as 3.11+. Use when a Dockerfile builder stage must work on Python 3.10 (e.g. musl/Alpine variants) and needs to parse pyproject.toml for dependencies.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-tomllib-fallback.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-version-guard",
-      "description": "Use when: (1) a Dockerfile pip install lacks a version specifier and needs pinning, (2) a Dockerfile Python base image version needs a regression guard against downgrades, (3) you need cross-validation between Dockerfile pins and pyproject.toml constraints, (4) SHA256 digest consistency across multi-stage build FROM lines must be enforced, (5) optional-dependency group names in pyproject.toml may drift from Dockerfile comment blocks",
-      "version": "2.0.0",
-      "source": "./skills/dockerfile-version-guard.md",
-      "category": "ci-cd",
-      "tags": [
-        "dockerfile",
-        "pinning",
-        "version-guard",
-        "pyproject",
-        "digest",
-        "regression-test"
-      ]
-    },
-    {
-      "name": "docstring-fragment-validator",
-      "description": "Pattern for adding a pre-commit hook that validates Python docstrings as complete semantic units (not line-by-line), preventing false-positive fragment detection during audits of correctly-wrapped multi-line docstrings",
-      "version": "1.0.0",
-      "source": "./skills/docstring-fragment-validator.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "enable-mccabe-complexity-c901",
-      "description": "Enable C901 McCabe complexity rule in ruff for an existing Python project. Use when the codebase has complex functions (15+ branches) or when enabling C901 as a follow-up to ruff rule set expansion.",
-      "version": "1.0.0",
-      "source": "./skills/enable-mccabe-complexity-c901.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "enable-mypy-check-untyped-defs",
-      "description": "Enable mypy --check-untyped-defs for full Python body type coverage and fix surfaced errors. Use when: mypy reports untyped function bodies are not checked, or when enabling stricter type coverage.",
-      "version": "1.0.0",
-      "source": "./skills/enable-mypy-check-untyped-defs.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "enable-yaml-markdown-linting",
-      "description": "Enable yamllint and markdownlint-cli2 pre-commit hooks with proper configuration for GitHub Actions and documentation quality",
-      "version": "1.0.0",
-      "source": "./skills/enable-yaml-markdown-linting.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "enforce-unit-test-structure-hook",
-      "description": "Pattern for adding a pre-commit hook that enforces tests/unit/ mirroring convention \u2014 fails on test_*.py files at the root level of the unit test directory",
-      "version": "1.0.0",
-      "source": "./skills/enforce-unit-test-structure-hook.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "exclude-build-targets-from-linker-errors",
       "description": "Fix Mojo AOT linker errors by excluding directories that depend on unsupported system libraries (e.g. libm) from the build find command. Use when: mojo build fails with 'undefined reference to fmaxf/sincos/libm' symbols, build recipe silences errors with FAIL_ON_ERROR=0, or example/benchmark files fail AOT but run fine via mojo run.",
       "version": "1.0.0",
       "source": "./skills/exclude-build-targets-from-linker-errors.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "extend-precommit-bandit-scope",
-      "description": "Extend bandit pre-commit hook file scope to additional directories. Use when: adding new Python-containing dirs, broadening security scanning coverage in .pre-commit-config.yaml.",
-      "version": "1.0.0",
-      "source": "./skills/extend-precommit-bandit-scope.md",
       "category": "ci-cd",
       "tags": []
     },
@@ -2969,6 +2108,25 @@
       "source": "./skills/extend-workflow-smoke-tests.md",
       "category": "ci-cd",
       "tags": []
+    },
+    {
+      "name": "failing-pr-discovery-gh-enumeration",
+      "description": "Discover failing open PRs via gh CLI using `gh pr list --json number,isDraft,statusCheckRollup,mergeStateStatus`. Filter by check conclusions (FAILURE/CANCELLED/TIMED_OUT) and mergeStateStatus==BLOCKED. Use synthetic-issue-key pattern (pr_num==issue_num) for consistency with issue-driven discovery. Use when: (1) automating PRs without relying on Closes #N issue mapping, (2) need to enumerate BLOCKED PRs from CI failures, (3) discovering work via PR-enumeration instead of issue-enumeration.",
+      "version": "1.0.0",
+      "source": "./skills/failing-pr-discovery-gh-enumeration.md",
+      "category": "ci-cd",
+      "tags": [
+        "gh-pr-list",
+        "statusCheckRollup",
+        "mergeStateStatus",
+        "pr-discovery",
+        "check-failures",
+        "BLOCKED-state",
+        "synthetic-issue-key",
+        "gh-json",
+        "automation-loop",
+        "drive-green-pattern"
+      ]
     },
     {
       "name": "feature-on-refactor-rebase-port",
@@ -2995,53 +2153,6 @@
       "tags": []
     },
     {
-      "name": "fix-composite-action-migration",
-      "description": "Fix incomplete GitHub Actions composite action migration and redundant double-caching. Use when: jobs still call a third-party action directly instead of using a composite wrapper, or a composite action duplicates caching the wrapped action already handles.",
-      "version": "1.0.0",
-      "source": "./skills/fix-composite-action-migration.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-docker-platform",
-      "description": "Fix Docker build failures caused by platform mismatches between workflow config and pixi.toml",
-      "version": "1.0.0",
-      "source": "./skills/fix-docker-platform.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "ghcr",
-        "arm64",
-        "pixi",
-        "platform",
-        "ci"
-      ]
-    },
-    {
-      "name": "fix-docker-shell-tty",
-      "description": "Fix Docker interactive shell failures caused by missing or incorrect TTY flags",
-      "version": "1.0.0",
-      "source": "./skills/fix-docker-shell-tty.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-mypy-ruff-script-ci",
-      "description": "Fix mypy and ruff CI failures in Python scripts. Use when CI fails with F841 unused variables, F541 bare f-strings, or mypy list invariance errors.",
-      "version": "1.0.0",
-      "source": "./skills/fix-mypy-ruff-script-ci.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-mypy-valid-type-errors",
-      "description": "Workflow for fixing mypy valid-type violations (lowercase callable/any) to re-enable suppressed error codes",
-      "version": "1.0.0",
-      "source": "./skills/fix-mypy-valid-type-errors.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "fix-podman-rootless-ci",
       "description": "Fix rootless Podman CI failures: Dockerfile ARG scoping, workspace UID mapping, compose provider compatibility. Use when: container builds fail with empty ARG values across FROM boundaries, bind-mounted files have Permission denied, or docker-compose doesn't support Podman extensions.",
       "version": "1.0.0",
@@ -3050,42 +2161,10 @@
       "tags": []
     },
     {
-      "name": "fix-precommit-pass-filenames",
-      "description": "Fix pre-commit hooks that use pass_filenames: false when they should use pass_filenames: true, removing hardcoded directory args so pre-commit passes only changed files. Use when: hooks always scan entire directories instead of only changed files, or linter entry commands have hardcoded directory paths.",
-      "version": "1.0.0",
-      "source": "./skills/fix-precommit-pass-filenames.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "fix-rebased-ci-pr-stack",
-      "description": "Fix CI failures in a stacked PR series after rebase onto main. Use when: multiple PRs diverged from main have CI failures from missing files, expired digests, paid-license actions, or unit tests that test the old structure.",
-      "version": "1.0.0",
-      "source": "./skills/fix-rebased-ci-pr-stack.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-ruff-linting-errors",
-      "description": "Fix all CI/CD failures by systematically resolving ruff linting errors (F841, D401, D102, E741, D103, D413, N806, E501, ruff-format) with automation for repetitive fixes",
-      "version": "2.0.0",
-      "source": "./skills/fix-ruff-linting-errors.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-security-scan-gaps",
-      "description": "Fix common GitHub Actions security scanning gaps: missing PR triggers, silenced Semgrep failures, and Gitleaks history blindness. Use when: (1) security scans only run on push to main, (2) Semgrep has continue-on-error masking failures, (3) Gitleaks uses --no-git missing history secrets.",
-      "version": "1.0.0",
-      "source": "./skills/fix-security-scan-gaps.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-skill-validation-warnings",
-      "description": "Fix CI validation errors and markdownlint failures in skill files. Use when: (1) CI reports validation failures in skill .md files, (2) bulk fixing missing sections or converting Failed Attempts to table format, (3) validate check says \"Failed Attempts table missing required columns\" (must be: Attempt | What Was Tried | Why It Failed | Lesson Learned), (4) markdownlint MD033 inline HTML error caused by bare angle-bracket placeholders like `<existing-issue-number>` in prose.",
+      "description": "Fix CI failures in a stacked PR series after rebase onto main. Use when: (1) multiple PRs diverged from main have CI failures from missing files, expired digests, paid-license actions, or unit tests that test the old structure, (2) a unit test patches or mocks a function by name that was renamed/replaced in the same PR (AttributeError: module does not have attribute 'old_name'), (3) a test was written for the old API that the PR itself replaces and now calls the nonexistent old function.",
       "version": "1.1.0",
-      "source": "./skills/fix-skill-validation-warnings.md",
+      "source": "./skills/fix-rebased-ci-pr-stack.md",
       "category": "ci-cd",
       "tags": []
     },
@@ -3114,7 +2193,7 @@
     {
       "name": "gh-check-ci-status",
       "description": "Check CI/CD status of a pull request including workflow runs and test results",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./skills/gh-check-ci-status.md",
       "category": "ci-cd",
       "tags": []
@@ -3136,28 +2215,9 @@
       "tags": []
     },
     {
-      "name": "gha-mojo-coredump-capture",
-      "description": "Use when: (1) investigating a CI-only Mojo crash whose published trace ends in `<unmapped>` at frame 4 (real fault is in JIT-emitted code or freed heap and unreachable from the printed stack), (2) cannot reproduce a libKGEN crash locally and need a real coredump from CI, (3) setting up GitHub Actions infrastructure to capture coredumps from a containerized test run, (4) bundling a coredump with its matching `mojo` binary and the relevant `libKGEN*` / `libAsync*` / `libMojo*` / `libMSupport*` shared libs into a reasonably-sized artifact, (5) deciding which GHA host-side settings need root vs which container-side settings can run as the test user, (6) the artifact must survive container teardown, and (7) wanting to keep the artifact under ~1 GB by filtering shared libraries to the four JIT-related families.",
-      "version": "1.0.0",
-      "source": "./skills/gha-mojo-coredump-capture.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "coredump",
-        "mojo",
-        "debugging",
-        "libKGEN",
-        "core-pattern",
-        "gdb",
-        "ci",
-        "podman",
-        "artifact"
-      ]
-    },
-    {
       "name": "git-gpg-sign-email-mismatch-silent-unsigned-blocks-merge",
-      "description": "Diagnose and fix the silent failure mode where commit.gpgsign=true plus a user.email that does not match any UID on the GPG signing key produces UNSIGNED commits with no error, causing PRs to be BLOCKED at merge time by required_signatures even when all CI checks are green. Use when: (1) a PR shows mergeStateStatus BLOCKED but mergeable MERGEABLE with all CI green, (2) gh api .../commits returns verification.reason=no_user, (3) dispatching sub-agents that override user.email to a bot identity while keeping a personal GPG key, (4) auditing multi-repo sweeps for invisible signing failures.",
-      "version": "1.0.0",
+      "description": "Diagnose and fix silent GPG-signing failure modes that BLOCK PR merge under required_signatures / pr-policy 'every commit is signed' even with green CI. Covers: (a) commit.gpgsign=true plus author/committer email that does not match any UID on the GPG signing key producing commits GitHub reports verified=false reason=no_user (signs fine locally \u2014 %G?=G \u2014 but GitHub rejects); (b) GraphQL pullRequest.commits.signature.state lagging 10+ minutes behind reality so commits appear UNSIGNED in `gh pr view --json commits` while REST /commits/<sha> confirms verified=true; (c) sub-agent shells inheriting commit.gpgsign=true but silently failing to sign because gpg-agent was not pre-warmed (needs GPG_TTY + a priming gpg --batch call); (d) a GitHub +suffix noreply variant (e.g. user+bot@users.noreply.github.com) CANNOT be verified on a GitHub account so adding it as a key UID does NOT fix no_user \u2014 only {id}+{username}@users.noreply.github.com or a real verified email works; (e) bare `git commit -S` picking the wrong default signing key (%G?=E 'No public key') so pass `git -c user.signingkey=<subkey>`; (f) a commit that silently failed (pre-commit hook non-zero) leaves HEAD unchanged and `git log` shows the PREVIOUS commit's signature, masquerading as corruption. Use when: (1) PR shows mergeStateStatus BLOCKED with mergeable MERGEABLE and all CI green, (2) gh api .../commits returns verification.reason=no_user, (3) dispatching sub-agents that override user.email to a bot identity while keeping a personal GPG key, (4) auditing multi-repo sweeps for invisible signing failures, (5) `gh pr view --json commits` shows signature.state=null for newly-pushed commits, (6) sub-agent push produces unsigned commits despite global commit.gpgsign=true config, (7) global ~/.gitconfig sets a bot/automation email that hand-authored commits inherit and that fails verification, (8) building automated re-sign tooling that must validate the resign email against the signing key UIDs.",
+      "version": "2.2.0",
       "source": "./skills/git-gpg-sign-email-mismatch-silent-unsigned-blocks-merge.md",
       "category": "ci-cd",
       "tags": [
@@ -3168,45 +2228,67 @@
         "branch-protection",
         "pull-requests",
         "agent-dispatch",
-        "silent-failure"
+        "silent-failure",
+        "graphql-lag",
+        "gpg-agent"
       ]
     },
     {
-      "name": "github-actions-ci-patterns",
-      "description": "Use when: (1) setting up GitHub Actions CI for Mojo or Python/pytest projects with pixi, (2) CI pipeline is slow due to broken pixi caching, (3) artifact upload/download fails due to empty directories or special characters in names, (4) migrating manual binary downloads to official actions, (5) adding a build-only gate workflow, (6) securing workflows against command injection via user-controlled inputs, (7) CI Summary job fails with 'HttpError: Resource not accessible by integration' when posting PR comments \u2014 missing pull-requests:write permission, (8) aligning workflow job names to branch protection required status check contexts, deleting orphan workflows, removing duplicate CI jobs",
-      "version": "2.2.0",
-      "source": "./skills/github-actions-ci-patterns.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "permissions",
-        "github-token",
-        "pull-requests",
-        "pr-comments",
-        "branch-protection",
-        "required-checks",
-        "status-checks"
-      ]
-    },
-    {
-      "name": "github-actions-required-fanin-conflict-resolution",
-      "description": "Pattern for resolving rebase conflicts in _required.yml GitHub Actions fan-in workflows when sibling PRs each add new upstream workflows. Use when: (1) rebasing a sibling PR onto a main that absorbed other siblings adding fan-in entries (CodeQL SAST, Sanitizers, Lock Check, Integration Tests, etc.), (2) conflict in workflows: array under on.workflow_run, (3) conflict in fan-in jobs section, (4) rebase conflict on actions/checkout SHA pin where main has newer SHA than branch, (5) Dockerfile conflict where main added security packages and branch added build packages.",
+      "name": "github-actions-env-var-lift-for-workflow-injection-hook",
+      "description": "PreToolUse security_reminder_hook (or actionlint / zizmor / CodeQL workflow-injection query) blocks an Edit to a `.github/workflows/*.yml` file because the surrounding `run:` block contains a `${{ \u2026 }}` template expression \u2014 even when the expression is a trusted `steps.*.outputs.*` or `inputs.*` value and your edit does not touch it. Use when: (1) you need to make an unrelated change inside a `run:` block (e.g. prefix a command with `pixi run`) and the hook rejects the diff; (2) the hook fires on `github.event.issue.title`, `.body`, `github.head_ref`, `head_commit.message`, etc.; (3) any linter flags `${{ ... }}` interpolation directly in a shell command line. Fix: lift the templated expression out of `run:` into an `env:` block on the same step, then reference it as a quoted shell variable (`\"$VAR\"`) inside `run:`. Do NOT bypass the hook \u2014 it points at a real injection sink class.",
       "version": "1.0.0",
-      "source": "./skills/github-actions-required-fanin-conflict-resolution.md",
+      "source": "./skills/github-actions-env-var-lift-for-workflow-injection-hook.md",
       "category": "ci-cd",
       "tags": [
         "github-actions",
-        "rebase",
-        "merge-conflict",
-        "workflow_run",
-        "fan-in",
-        "branch-protection"
+        "workflow-injection",
+        "security-hook",
+        "pretooluse",
+        "env-var-lift",
+        "run-block",
+        "actionlint",
+        "zizmor",
+        "codeql",
+        "pixi"
+      ]
+    },
+    {
+      "name": "github-actions-security-scanning-setup",
+      "description": "Use when: (1) adding CodeQL SAST analysis to TypeScript/JavaScript workflows, (2) implementing npm audit with production-only dependency scanning, (3) enforcing Gitleaks on PRs while keeping main branch advisory, (4) isolating security-events:write permissions from base required checks, (5) managing pre-existing CVEs in transitive dependencies.",
+      "version": "1.0.0",
+      "source": "./skills/github-actions-security-scanning-setup.md",
+      "category": "ci-cd",
+      "tags": [
+        "codeql",
+        "npm-audit",
+        "gitleaks",
+        "github-actions",
+        "sast",
+        "dependency-scanning",
+        "secrets-scanning",
+        "typescript",
+        "workflow-isolation"
+      ]
+    },
+    {
+      "name": "github-actions-workflow-required-checks",
+      "description": "Canonical guide to GitHub Actions workflow configuration and required status check management. Use when: (1) a PR is blocked because a required status context never posts, (2) reconciling branch protection rulesets with actual job names, (3) diagnosing fan-in / paths-filter / job-skip patterns, (4) adding or removing a required check without breaking open PRs, (5) workflow_dispatch + composite-action wiring, (6) hardening workflows with permissions/concurrency/timeouts, (7) SHA-pinning actions for supply-chain security, (8) runner pool saturation in swarm sessions, (9) pixi caching failures, (10) bot push to protected branch pattern, (11) batch PR CI triage.",
+      "version": "1.0.0",
+      "source": "./skills/github-actions-workflow-required-checks.md",
+      "category": "ci-cd",
+      "tags": [
+        "merged",
+        "github-actions",
+        "workflow",
+        "required-checks",
+        "branch-protection",
+        "ruleset"
       ]
     },
     {
       "name": "github-auto-merge-no-ci-runs",
-      "description": "GitHub auto-merge stalls indefinitely on a CLEAN PR when no CI workflow ever runs on the branch. Use when: (1) PR has mergeStateStatus: CLEAN and auto-merge armed but hasn't merged after hours, (2) gh pr view --json statusCheckRollup returns empty array [], (3) docs-only, pod-spec, or non-code PRs stuck with armed auto-merge, (4) investigating why auto-merge didn't fire on a PR that looks ready, (5) gh pr list returns fewer PRs than expected \u2014 default limit is 30 and silently omits older PRs, (6) gh pr merge --auto --squash returns GraphQL 'Pull request is in clean status' error on a CLEAN PR, (7) gh pr merge --auto --squash returns GraphQL 'Pull request is in unstable status' \u2014 transient; retry after a few seconds, (8) squash-only repos reject --rebase flag on gh pr merge --auto, (9) scheduled workflow (apply.yml) shows failure on main but required checks all pass, (10) PRs armed with --auto --squash do not auto-fire after branch protection rules are relaxed (e.g., review requirement removed) \u2014 must be nudged with manual `gh pr merge <n> --squash`.",
-      "version": "1.2.0",
+      "description": "GitHub auto-merge stalls indefinitely on a CLEAN PR when no CI workflow ever runs on the branch. Use when: (1) PR has mergeStateStatus: CLEAN and auto-merge armed but hasn't merged after hours, (2) gh pr view --json statusCheckRollup returns empty array [], (3) docs-only, pod-spec, or non-code PRs stuck with armed auto-merge, (4) investigating why auto-merge didn't fire on a PR that looks ready, (5) gh pr list returns fewer PRs than expected \u2014 default limit is 30 and silently omits older PRs, (6) gh pr merge --auto --squash returns GraphQL 'Pull request is in clean status' error on a CLEAN PR, (7) gh pr merge --auto --squash returns GraphQL 'Pull request is in unstable status' \u2014 transient; retry after a few seconds, (8) squash-only repos reject --rebase flag on gh pr merge --auto, (9) scheduled workflow (apply.yml) shows failure on main but required checks all pass, (10) PRs armed with --auto --squash do not auto-fire after branch protection rules are relaxed (e.g., review requirement removed) \u2014 must be nudged with manual `gh pr merge <n> --squash`, (11) a required-check gate job (e.g. pr-policy) fails with 'Auto-merge is not enabled' immediately after PR creation though auto-merge IS enabled \u2014 a propagation race; re-run the failed job, (12) PR shows failed/cancelled checks but is actually fine \u2014 a pr-policy auto-merge check failed on the FIRST run and cancelled all sibling jobs (lint/tests/security/markdownlint/shellcheck all show cancelled) via the concurrency group, but the workflow re-ran on the auto_merge_enabled event and went green, (13) auto-merge not firing right after open but pr-policy failing \u2014 the workflow self-heals once gh pr merge --auto --squash propagates and the auto_merge_enabled trigger re-runs it; no manual rerun needed, (14) cancelled CI jobs after opening a PR \u2014 diagnose by comparing statusCheckRollup entries' startedAt: the earlier pr-policy run is the race, the later (re-run) one is authoritative, (15) pr-policy fails 'Auto-merge is enabled before implementation review GO' on a freshly-armed PR \u2014 the repo now gates auto-merge behind a state:implementation-go label (NOT the old propagation race); apply the label with gh pr edit --add-label to make the armed state compliant, (16) you want a pull_request_target labeled workflow to enable squash auto-merge only after state:implementation-go without running PR code, (17) pr-policy fails after an already-merged PR because GitHub cleared autoMergeRequest \u2014 fetch PR state and treat non-OPEN as terminal.",
+      "version": "1.6.0",
       "source": "./skills/github-auto-merge-no-ci-runs.md",
       "category": "ci-cd",
       "tags": [
@@ -3215,79 +2297,24 @@
         "ci-cd",
         "path-filter",
         "status-checks",
-        "docs-only"
+        "docs-only",
+        "implementation-go",
+        "pull-request-target",
+        "pr-policy"
       ]
     },
     {
-      "name": "github-branch-protection-org-standardize",
-      "description": "Standardize GitHub branch protection across all repositories in an org using repository rulesets. Use when: (1) rolling out a required-checks baseline to all repos on the free GitHub plan, (2) onboarding new repos to a shared CI policy, (3) auditing ruleset drift across an org.",
-      "version": "2.0.0",
-      "source": "./skills/github-branch-protection-org-standardize.md",
+      "name": "github-branch-protection-api-validation",
+      "description": "GitHub branch protection API enforcement with response validation and synthetic testing. Use when: (1) implementing new branch protection rules, (2) adding API PUT calls that need validation, (3) testing bash scripts with environment fixtures.",
+      "version": "1.0.0",
+      "source": "./skills/github-branch-protection-api-validation.md",
       "category": "ci-cd",
       "tags": [
         "github",
         "branch-protection",
-        "rulesets",
-        "gh-api",
-        "org-admin",
-        "policy-standardization",
-        "required-status-checks"
-      ]
-    },
-    {
-      "name": "github-branch-protection-strict-false-stale-ci-merge",
-      "description": "GitHub branch protection with `strict_required_status_checks_policy: false` allows stale-but-passing CI on any historical commit SHA to satisfy required checks \u2014 enabling auto-merge to fire on the current HEAD even when the latest commit's CI is still queued. Use when: (1) running a high-volume cascade-rebase or PR drainage session and CI runners are under heavy contention, (2) investigating why a PR merged even though the latest commit had no CI run yet, (3) configuring branch protection and deciding whether to enable strict mode, (4) diagnosing why 80+ PRs successfully drained despite GitHub Actions runs being queued for 30+ minutes.",
-      "version": "1.0.0",
-      "source": "./skills/github-branch-protection-strict-false-stale-ci-merge.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
-        "branch-protection",
-        "required-status-checks",
-        "strict",
-        "stale-ci",
-        "auto-merge",
-        "cascade-rebase",
-        "gh-api",
-        "pr-drainage"
-      ]
-    },
-    {
-      "name": "github-ruleset-pr-blocked-diagnose-missing-check-requirements",
-      "description": "Diagnose GitHub PRs blocked by active rulesets that require checks a repository cannot currently produce. Use when: (1) gh pr view reports mergeStateStatus as BLOCKED with no review comments, (2) gh pr checks reports no checks on the branch, (3) repository rulesets require code quality or code scanning results that the repo is not configured to emit.",
-      "version": "1.0.0",
-      "source": "./skills/github-ruleset-pr-blocked-diagnose-missing-check-requirements.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
-        "rulesets",
-        "pull-requests",
-        "codeql",
-        "branch-governance"
-      ]
-    },
-    {
-      "name": "gitleaks-version-upgrade",
-      "description": "Upgrade Gitleaks binary version in GitHub Actions security workflows. Use when: pinned Gitleaks version is outdated, SHA256 needs refreshing, or a new stable release should be adopted.",
-      "version": "1.0.0",
-      "source": "./skills/gitleaks-version-upgrade.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "hadolint-failure-threshold-config",
-      "description": "Use when: (1) hadolint-action CI job fails on warnings despite rules being in the ignore list, (2) configuring .hadolint.yaml for a project that explicitly ignores certain warning-level rules, (3) hadolint CI is too strict or too permissive.",
-      "version": "1.0.0",
-      "source": "./skills/hadolint-failure-threshold-config.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "hadolint",
-        "dockerfile",
-        "lint",
-        "failure-threshold",
-        "ci",
-        "github-actions"
+        "api",
+        "bash-testing",
+        "validation"
       ]
     },
     {
@@ -3299,33 +2326,9 @@
       "tags": []
     },
     {
-      "name": "haiku-wave-pr-remediation",
-      "description": "Fix 40+ failing PRs across multiple repos using wave-based haiku sub-agents in worktrees. Use when: many PRs fail CI across heterogeneous categories (ruff/mojo-format/deprecated-syntax/missing-ci-matrix/JIT-crash), wave-0 diagnosis identifies per-cluster root causes, parallel haiku agents in isolated worktrees are needed.",
-      "version": "1.0.0",
-      "source": "./skills/haiku-wave-pr-remediation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "hatch-vcs-editable-pixi-locked-incompatibility",
-      "description": "Fix CI failures caused by hatch-vcs auto-versioning making pixi.lock perpetually stale. Use when: (1) CI fails with 'lock-file not up-to-date with the workspace' on every push after switching from a hardcoded version to hatch-vcs, (2) all pixi-based CI jobs (lint, pre-commit, security) fail identically while the local editable package uses hatch-vcs, (3) regenerating pixi.lock immediately becomes stale on the next commit.",
-      "version": "1.0.0",
-      "source": "./skills/hatch-vcs-editable-pixi-locked-incompatibility.md",
-      "category": "ci-cd",
-      "tags": [
-        "hatch-vcs",
-        "pixi",
-        "pixi-lock",
-        "editable-install",
-        "setup-pixi",
-        "locked",
-        "ci-cd"
-      ]
-    },
-    {
       "name": "hatch-vcs-pyproject-auto-versioning-setup",
-      "description": "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily.",
-      "version": "1.0.0",
+      "description": "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, and update downstream tooling that assumed the static-version world. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily, (5) post-migration, importlib.metadata.version() raises PackageNotFoundError because the import name differs from the distribution name, (6) a version-consistency or single-source check script grep's pyproject.toml for a version field that no longer exists.",
+      "version": "1.1.0",
       "source": "./skills/hatch-vcs-pyproject-auto-versioning-setup.md",
       "category": "ci-cd",
       "tags": [
@@ -3335,24 +2338,66 @@
         "auto-versioning",
         "git-tags",
         "dynamic-version",
+        "importlib-metadata",
+        "distribution-name",
+        "single-source-versioning",
         "ci-cd"
       ]
     },
     {
-      "name": "just-recipe-heredoc-fix",
-      "description": "Fix heredoc-in-just-recipe whitespace errors by replacing with printf. Use when: just recipe uses <<EOF heredoc and fails with 'inconsistent leading whitespace'. Also covers parameter alias/normalization patterns enabled by the bash shebang.",
+      "name": "hi-branch-protection-two-layer",
+      "description": "HomericIntelligence main-branch protection is split across TWO layers (repo ruleset + classic branch protection) whose UNION GitHub enforces. Use when: (1) managing HI main-branch protection or deciding whether a rule belongs in a ruleset vs classic branch protection, (2) a PR is BLOCKED by a review/check that the ruleset reports as 0/absent (the OTHER layer adds it), (3) a ruleset PUT returns HTTP 422 on required_conversation_resolution, (4) `gh api .../branches/main/protection` 404 body gets parsed as fake required-check contexts, (5) a `branch-protection-drift` required check fails on every PR with HTTP 403 'Resource not accessible by integration' (admin endpoint with the default token) or fails on review-count/dismiss-stale assertions that disagree with the in-repo canonical policy.",
       "version": "1.1.0",
-      "source": "./skills/just-recipe-heredoc-fix.md",
+      "source": "./skills/hi-branch-protection-two-layer.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "github",
+        "rulesets",
+        "branch-protection",
+        "classic-protection",
+        "required-signatures",
+        "conversation-resolution",
+        "linear-history",
+        "gh-api",
+        "branch-protection-drift",
+        "drift-check",
+        "rules-endpoint"
+      ]
     },
     {
-      "name": "justfile-build-recipe-silent-noop",
-      "description": "Detect and fix build recipes that silently compile nothing due to over-eager find filter exclusions. Use when: (1) build succeeds suspiciously fast, (2) build/<mode>/ contains 0-1 files, (3) adding `-Werror` to a build that previously appeared green.",
+      "name": "installer-bash-security-pinning-verification",
+      "description": "Use when: (1) adding new curl|bash installers to shell scripts, (2) auditing installer security for unverified pipe-to-shell patterns, (3) porting installers to new projects, (4) hardening existing installation workflows with SHA-256 verification and multi-platform support.",
       "version": "1.0.0",
-      "source": "./skills/justfile-build-recipe-silent-noop.md",
+      "source": "./skills/installer-bash-security-pinning-verification.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "bash",
+        "curl",
+        "installer",
+        "sha256-verification",
+        "supply-chain",
+        "pixi",
+        "dagger",
+        "just",
+        "shell-security",
+        "trust-model"
+      ]
+    },
+    {
+      "name": "justfile-and-local-build-verification",
+      "description": "Use when: (1) just recipe fails with 'inconsistent leading whitespace' due to heredoc; (2) build completes suspiciously fast with 0-1 compiled files (silent no-op from over-eager find exclusions); (3) running local builds before push to mirror CI; (4) taking a dirty working tree through verify\u2192fix\u2192commit\u2192PR.",
+      "version": "1.0.0",
+      "source": "./skills/justfile-and-local-build-verification.md",
+      "category": "ci-cd",
+      "tags": [
+        "justfile",
+        "just",
+        "heredoc",
+        "build",
+        "local-verification",
+        "pre-commit",
+        "ci"
+      ]
     },
     {
       "name": "lcov-coverage-script-ci-fixes",
@@ -3373,27 +2418,53 @@
       ]
     },
     {
-      "name": "markdown-linting-bulk-table-format-fix",
-      "description": "Use when: (1) markdownlint CI fails with 20,000+ errors across hundreds of files due to missing .markdownlint.yaml config, (2) MD060 table style errors flood CI output after a linter config is added or upgraded, (3) markdownlint-cli2 is upgraded to v0.40.0+ and adds MD060 with ~1000 violations that --fix silently ignores (requires two-pass Python script + style: compact), (4) you need to bulk-normalize markdown table formatting to compact style across an entire repository, (5) a single doc file fails MD060 with style 'aligned' because trailing pipes do not line up vertically \u2014 separator dash count must equal max content width per column",
-      "version": "1.2.0",
-      "source": "./skills/markdown-linting-bulk-table-format-fix.md",
+      "name": "lockfile-and-release-pipeline-management",
+      "description": "Recover drifted lockfiles, resync dependency lockfiles after manifest edits, fix silent release recipe failures, enforce version single-source-of-truth, and configure Renovate for multi-ecosystem repos. Use when: (1) CI rejects a generated lockfile (pixi.lock, Cargo.lock, package-lock.json) and the source manifest is unchanged vs main, (2) editing package.json without regenerating package-lock.json causes npm ci EUSAGE failures, (3) `just release X.Y.Z` exits non-zero with 'nothing to commit' because pyprojects already have the target version, (4) project version is declared in multiple files that can drift and you need a single-source-of-truth strategy with pre-commit guards, (5) adding automated dependency updates (Renovate) to a C++20 repo with Conan, FetchContent, pixi, GHA, and Dockerfiles, (6) `pixi install` fails with `No candidates were found for <pkg> ==<version>` because a pinned nightly/dev-build artifact was garbage-collected from the channel.",
+      "version": "1.1.0",
+      "source": "./skills/lockfile-and-release-pipeline-management.md",
       "category": "ci-cd",
       "tags": [
-        "markdownlint",
-        "MD060",
-        "tables",
+        "lockfile",
+        "pixi-lock",
+        "cargo-lock",
+        "package-lock",
+        "drift-recovery",
+        "npm-ci",
+        "eusage",
+        "release",
+        "just",
+        "bump-version",
+        "git-tag",
+        "versioning",
+        "importlib-metadata",
         "pre-commit",
-        "bulk-fix",
-        "ci-unblocking"
+        "renovate",
+        "conan",
+        "fetchcontent",
+        "tool-version-skew",
+        "nightly-build",
+        "artifact-gc",
+        "unsolvable-pin",
+        "mojo",
+        "pixi-install"
       ]
     },
     {
-      "name": "markdownlint-troubleshooting",
-      "description": "Diagnose and fix markdownlint CI failures that block multiple PRs due to issues in main branch",
+      "name": "logging-downgrade-noisy-happy-path",
+      "description": "Downgrade noisy WARNING and ERROR log levels to INFO for happy-path scenarios that are not failures. Use when: (1) a script checks for optional files/configs and logs WARNING when they're absent (but this is an acceptable skip path), (2) a validation function logs ERROR on format mismatch but continues successfully, (3) test suites log WARNING for expected fallback behavior, (4) any logging statement fires in scenarios that return True/success and are not genuine failures.",
       "version": "1.0.0",
-      "source": "./skills/markdownlint-troubleshooting.md",
+      "source": "./skills/logging-downgrade-noisy-happy-path.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "python",
+        "logging",
+        "observability",
+        "happy-path",
+        "noise-reduction",
+        "TDD",
+        "capsys",
+        "happy-path-logging"
+      ]
     },
     {
       "name": "mesh-dispatch-pipeline-debugging",
@@ -3419,116 +2490,49 @@
     },
     {
       "name": "mkdocs-nav-cleanup",
-      "description": "Fix MkDocs build failures from nav referencing deleted files or relative links escaping the docs/ tree. Use when: (1) CI 'Deploy Documentation' job fails after deleting doc stubs, (2) mkdocs build --strict reports missing files, (3) PR deletes placeholder docs but mkdocs.yml nav still references them, (4) --strict rejects a relative link like ../../docs/dev/file.md that escapes the docs/ root.",
-      "version": "1.1.0",
+      "description": "Fix and PREVENT MkDocs build failures from nav or cross-references pointing at deleted files. Use when: (1) about to push a PR that deletes documentation/ADR/repro files (run pre-deletion audit first), (2) CI 'Deploy Documentation' job fails after deleting doc stubs, (3) mkdocs build --strict reports missing files, (4) PR deletes placeholder docs but mkdocs.yml nav still references them, (5) --strict rejects a relative link like ../../docs/dev/file.md that escapes the docs/ root.",
+      "version": "1.2.0",
       "source": "./skills/mkdocs-nav-cleanup.md",
       "category": "ci-cd",
       "tags": []
     },
     {
-      "name": "modular-6433-vs-6413-failure-triage",
-      "description": "Distinguish modular#6433 (OOM, fixed) from modular#6413 (libKGEN JIT crash, open) when verifying upstream fixes. Use when: (1) removing a #6433 workaround, (2) CI fails after upgrading Mojo nightly, (3) deciding whether to revert a fix-verification PR.",
-      "version": "1.0.0",
-      "source": "./skills/modular-6433-vs-6413-failure-triage.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-0263-stdlib-import-migration",
-      "description": "Mojo 0.26.3 migration: stdlib modules require std. prefix and escaping keyword was removed. Use when: (1) upgrading from Mojo 0.26.1/0.26.2 to 0.26.3, (2) seeing 'module not found' errors for testing/sys/memory imports, (3) seeing 'unknown keyword escaping' errors.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-0263-stdlib-import-migration.md",
-      "category": "ci-cd",
-      "tags": [
-        "mojo",
-        "0.26.3",
-        "stdlib",
-        "migration",
-        "imports",
-        "escaping",
-        "bulk-fix"
-      ]
-    },
-    {
-      "name": "mojo-baseline-ci-compilation-fixes",
-      "description": "Fix baseline Mojo compilation errors on main that block all open PRs. Use when: CI test groups fail with errors inherited from main branch (unused variable --Werror, full() type mismatch, alias deprecation, missing re-exports).",
-      "version": "1.0.0",
-      "source": "./skills/mojo-baseline-ci-compilation-fixes.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-escaping-signature-regression",
-      "description": "OBSOLETE IN 0.26.3. Fix Mojo escaping fn type parameter regressions (0.26.1 only). In 0.26.3 escaping is removed entirely; use capturing compile-time params instead (see mojo-026-breaking-changes).",
-      "version": "1.1.0",
-      "source": "./skills/mojo-escaping-signature-regression.md",
-      "category": "ci-cd",
-      "tags": [
-        "mojo",
-        "escaping",
-        "gradient-checker",
-        "function-signatures",
-        "type-mismatch",
-        "build-failure",
-        "obsolete-026-3"
-      ]
-    },
-    {
-      "name": "mojo-flaky-segfault-mitigation",
-      "description": "Mitigate flaky Mojo runtime segfaults in GitHub Actions CI matrix jobs. Use when: CI matrix jobs fail with libKGENCompilerRTShared.so crashes that are intermittent and pass on main.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-flaky-segfault-mitigation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-format-non-blocking",
-      "description": "Use when: (1) mojo-format pre-commit hook crashes on files using new Mojo syntax (comptime_assert, etc.) and CI is blocked; (2) pre-commit CI fails because mojo-format reformatted a .mojo file due to a line exceeding the line length limit; (3) multiple PRs need parallel formatter fixes; (4) a pre-commit hook needs to be made advisory (non-blocking) without removal.",
+      "name": "mojo-jit-crash-and-retry-strategies",
+      "description": "HISTORICAL REFERENCE \u2014 most patterns OBSOLETE as of Mojo 1.0.0b2.dev2026052506 (modular/modular#6413 fixed upstream). Do NOT use the retry-wrapper, continue-on-error matrix, gdb-coredump-capture, or 4-hypothesis disproof patterns in NEW code. Use when: (1) reading historical PR/issue context that references these patterns, (2) needing the runtime-crash-bisection minimal-reproducer methodology (still useful for future Mojo bugs), (3) understanding the closed-source boundary for libKGEN/libAsyncRT/libMSupport debugging, (4) needing the AVX-512 wrong-ISA forensics for analogous CPU-feature bugs. NOT a guide for treating Mojo crashes as flakes \u2014 that posture was wrong and is now removed.",
       "version": "2.0.0",
-      "source": "./skills/mojo-format-non-blocking.md",
+      "source": "./skills/mojo-jit-crash-and-retry-strategies.md",
       "category": "ci-cd",
       "tags": [
-        "mojo-format",
-        "pre-commit",
-        "ci-cd",
-        "formatter-crash",
-        "line-length",
-        "workaround",
-        "parallel-pr-fixes",
-        "glibc"
+        "obsolete",
+        "historical",
+        "mojo",
+        "jit",
+        "crash",
+        "libkgen",
+        "forensics",
+        "avx512",
+        "bisection",
+        "ci"
       ]
     },
     {
-      "name": "mojo-retry-pattern-ci-validator",
-      "description": "Detect bare pixi run mojo test/run/build/package calls in GitHub Actions workflows not wrapped in a retry loop. Use when: (1) adding a new mojo workflow file, (2) auditing existing workflows for retry-loop compliance, (3) CI enforcement after mojo-jit-crash-retry fix.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-retry-pattern-ci-validator.md",
+      "name": "mojo-sanitizer-and-build-flags",
+      "description": "Canonical patterns for Mojo sanitizer integration and build-flag matrices: ASAN/TSAN scope, tcmalloc/sanitizer incompatibility, sanitizer-only build flavors, build-flag matrix design, AVX-512 driver-vs-sanitizer codegen asymmetry, compiler-flag conflicts that break Mojo compilation. Use when: (1) enabling a sanitizer for Mojo CI, (2) diagnosing a tcmalloc/sanitizer crash, (3) designing a multi-flag CI matrix for Mojo builds, (4) reconciling conflicting compiler flags that surface only on Mojo, (5) removing AVX-512 strip workarounds after modular/modular#6413 fix, (6) sanitizer builds SIGILL on AVX-512-masked CI runners even after the driver-path fix.",
+      "version": "1.1.0",
+      "source": "./skills/mojo-sanitizer-and-build-flags.md",
       "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-transient-crash-rerun",
-      "description": "Identify and clear transient Mojo runner crashes in CI by re-triggering failed jobs. Use when: CI fails with 'mojo: error: execution crashed' with no repo stack frames, same test passes on main, and PR has no logic changes.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-transient-crash-rerun.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-type-alias-cleanup",
-      "description": "Fix Mojo compilation errors caused by non-existent type aliases introduced when removing deprecated type aliases. Use when: CI fails with unknown type errors after removing deprecated aliases.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-type-alias-cleanup.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-unsafepointer-bitcast-fix",
-      "description": "Fix Mojo compile error where UnsafePointer.address_of() is used but is not a valid API. Use when: CI fails with 'value has no attribute address_of', implementing float-to-bits conversion for hashing, or fixing mojo format line-length violations on raise Error() calls.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-unsafepointer-bitcast-fix.md",
-      "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "merged",
+        "mojo",
+        "sanitizer",
+        "asan",
+        "tsan",
+        "build-flags",
+        "tcmalloc",
+        "avx512",
+        "target-features",
+        "codegen"
+      ]
     },
     {
       "name": "multi-repo-pr-orchestration-swarm-pattern",
@@ -3558,30 +2562,6 @@
       ]
     },
     {
-      "name": "mypy-hook-extend-coverage",
-      "description": "Extend mypy pre-commit hook coverage to additional directories with baseline suppression. Use when: ruff covers more dirs than mypy, tests/tools have annotation drift, or hyphenated directory names cause module resolution conflicts.",
-      "version": "1.0.0",
-      "source": "./skills/mypy-hook-extend-coverage.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mypy-hyphenated-dir-per-file",
-      "description": "Add mypy pre-commit coverage for directories with hyphenated names by running mypy per-file. Use when: extending mypy to examples/ with hyphenated subdirs, or fixing 'Duplicate module named' errors.",
-      "version": "1.0.0",
-      "source": "./skills/mypy-hyphenated-dir-per-file.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mypy-precommit-hook-pixi",
-      "description": "Add mypy type checking as a pre-commit hook in a pixi-managed project. Use when: (1) adding mypy enforcement to pre-commit, (2) scripts have X|Y union syntax errors with default mypy version, (3) types-PyYAML stubs missing in mirrors-mypy isolated env.",
-      "version": "1.0.0",
-      "source": "./skills/mypy-precommit-hook-pixi.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "nomad-hcl-variable-sensitive",
       "description": "Use when: (1) Nomad HCL job spec fails to parse with 'An argument named sensitive is not expected here', (2) variable blocks in .nomad.hcl files contain sensitive = true, (3) migrating Terraform variable patterns to Nomad.",
       "version": "1.0.0",
@@ -3597,29 +2577,9 @@
       ]
     },
     {
-      "name": "npm-package-lock-resync-after-package-json-edit",
-      "description": "Regenerate and commit package-lock.json in the SAME PR whenever a Node.js dependency in package.json changes (add/remove/upgrade/downgrade). CI uses `npm ci` (strict) and will fail with EUSAGE 'lock file's X@A.B.C does not satisfy X@D.E.F' if the lockfile is stale. Use when: (1) editing any dependency version in package.json, (2) an audit/easy-issue says 'downgrade X to satisfy engines constraint', (3) dispatching a sub-agent to edit package.json, (4) the repo has multiple Node sub-projects (e.g., `dagger/package.json` plus root) and you might miss the right lockfile.",
-      "version": "1.0.0",
-      "source": "./skills/npm-package-lock-resync-after-package-json-edit.md",
-      "category": "ci-cd",
-      "tags": [
-        "npm",
-        "package-json",
-        "package-lock",
-        "lockfile",
-        "npm-ci",
-        "eusage",
-        "node",
-        "dagger",
-        "sub-agent-dispatch",
-        "easy-issue",
-        "engines"
-      ]
-    },
-    {
       "name": "odysseus-multi-branch-submodule-pin-management",
-      "description": "Manage submodule pins across multiple Odysseus branches with rebase, cherry-pick avoidance, and justfile recipe collision resolution. Use when: (1) updating a submodule SHA on a feature branch while main has a different pin, (2) rebasing an Odysseus feature branch onto main after justfile changes on both sides, (3) cherry-picking a submodule pointer update between branches fails with CONFLICT (submodule), (4) CI \"Harden checks\" job fails with justfile recipe redefinition error after rebase, (5) branch-switching causes missing files/directories in the working tree.",
-      "version": "1.0.0",
+      "description": "Manage submodule pins across multiple Odysseus branches with rebase, cherry-pick avoidance, and justfile recipe collision resolution. Use when: (1) updating a submodule SHA on a feature branch while main has a different pin, (2) rebasing an Odysseus feature branch onto main after justfile changes on both sides, (3) cherry-picking a submodule pointer update between branches fails with CONFLICT (submodule), (4) CI \"Harden checks\" job fails with justfile recipe redefinition error after rebase, (5) branch-switching causes missing files/directories in the working tree, (6) running `git submodule update --remote <path>` produces unexpected modifications to OTHER submodules in `git status` (the selective-vs-all foot-gun), (7) doing a partial pin bump where only some submodules are eligible because others have open PRs.",
+      "version": "1.1.0",
       "source": "./skills/odysseus-multi-branch-submodule-pin-management.md",
       "category": "ci-cd",
       "tags": [
@@ -3630,7 +2590,9 @@
         "justfile",
         "multi-branch",
         "cherry-pick",
-        "force-with-lease"
+        "force-with-lease",
+        "submodule-update-remote",
+        "selective-pin-bump"
       ]
     },
     {
@@ -3642,118 +2604,27 @@
       "tags": []
     },
     {
-      "name": "parallel-test-fix-orchestration",
-      "description": "Orchestrate mass parallel test fixes using worktree-isolated agents with one PR per fix. Use when: CI has many independent test failures that need systematic resolution.",
-      "version": "1.0.0",
-      "source": "./skills/parallel-test-fix-orchestration.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pin-action-shas-to-commit",
-      "description": "Pin GitHub Actions version tags to full commit SHAs for supply chain security. Use when: composite action files use mutable tags like @v8 or @v0.9.4 instead of full 40-char commit SHAs.",
-      "version": "1.0.0",
-      "source": "./skills/pin-action-shas-to-commit.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pin-install-script-tag",
-      "description": "Pin a curl-piped install script to a specific version tag for reproducible Docker builds. Use when: (1) a Dockerfile uses curl | bash install.sh without a --tag or version flag, (2) a previously-pinned cargo/apt install was replaced with a pre-built binary installer but the version pin was dropped.",
-      "version": "1.0.0",
-      "source": "./skills/pin-install-script-tag.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pin-npm-dockerfile",
-      "description": "Skill: pin-npm-dockerfile. Use when working with pin npm dockerfile.",
-      "version": "1.0.0",
-      "source": "./skills/pin-npm-dockerfile.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "pixi-cache-true-unreliable",
-      "description": "Fixes unreliable Pixi caching caused by setup-pixi's built-in cache: true option. Replace with explicit actions/cache@v5 caching both .pixi and ~/.cache/rattler/cache keyed on pixi.lock. Use when: (1) CI logs show 'Saved cache with ID -1', (2) cache hits are inconsistent despite cache: true, (3) consolidating Pixi setup into a shared composite action.",
-      "version": "2.0.0",
+      "description": "Fixes unreliable Pixi caching from setup-pixi's built-in cache: true, AND warns that under locked: true a SECOND actions/cache over .pixi poisons the locked env (downgrades packages, fails pip-audit/dependency-scan). Replace cache: true with explicit actions/cache (non-locked); with locked: true rely ONLY on setup-pixi's built-in cache. Use when: (1) CI logs show 'Saved cache with ID -1', (2) cache hits inconsistent despite cache: true, (3) consolidating Pixi setup into a composite action, (4) dependency-scan/pip-audit fails on an already-patched pixi.lock, (5) setup-pixi installs a newer version than pip-audit then audits.",
+      "version": "2.1.0",
       "source": "./skills/pixi-cache-true-unreliable.md",
       "category": "ci-cd",
       "tags": []
     },
     {
-      "name": "pixi-ci-shell-tooling-migration",
-      "description": "Migrate GitHub Actions CI for shell-only repos from ad-hoc curl tool installs to pixi-based tooling. Use when: (1) CI installs yq/shellcheck/bats via curl onto ubuntu-latest, (2) tests fail with yq parse errors on valid v4 expressions, (3) PATH shadowing causes tool version mismatches in bats subshells, (4) adding pixi to a repo that has no Python/Mojo (pure shell GitOps).",
+      "name": "pixi-precommit-hook-binary-resolution",
+      "description": "Pre-commit hooks that invoke 'pixi run <hephaestus-command>' appear to fail with the system-installed binary (newer version with stricter checks) when the project's own pixi env hasn't been populated via 'pixi run dev-install'. Use when: (1) pre-commit check-dep-sync fails locally with 'pyproject.toml contains [project.optional-dependencies] \u2014 remove it' but the same check passes in CI, (2) 'which hephaestus-*' inside 'pixi run' returns the system ~/.local/bin path instead of .pixi/envs/default/bin, (3) a pre-commit hook that invokes a console-script via 'pixi run' is using a newer/older version of that script than the one in the current repo, (4) CI pre-commit job runs 'pixi run dev-install' before running hooks but local dev environment does not.",
       "version": "1.0.0",
-      "source": "./skills/pixi-ci-shell-tooling-migration.md",
+      "source": "./skills/pixi-precommit-hook-binary-resolution.md",
       "category": "ci-cd",
       "tags": [
         "pixi",
-        "yq",
-        "go-yq",
-        "shellcheck",
-        "bats",
-        "github-actions",
-        "shell",
-        "gitops",
-        "path-shadowing"
+        "pre-commit",
+        "dev-install",
+        "binary-resolution",
+        "hephaestus",
+        "console-scripts"
       ]
-    },
-    {
-      "name": "pixi-lock-rebase-regenerate",
-      "description": "Correctly resolve pixi.lock staleness after git rebase or when main advances. Use when: (1) CI fails with 'lock-file not up-to-date with the workspace', (2) multiple PRs all fail identical CI jobs after a version bump on main, (3) git rebase causes pixi.lock conflicts, (4) Dependabot PRs fail CI fast (6-12 seconds) because Dependabot only bumps pyproject.toml not pixi.lock, (5) a second rebase of the same branch produces a pixi.lock commit conflict \u2014 skip the stale commit and re-run pixi install, (6) a second commit in the rebase chain patches code that was migrated to an external package \u2014 accept HEAD's version and use git rebase --skip, (7) pixi.toml pins a dependency version but pixi.lock still references old version (CI shows 'Environment is not consistent with the lockfile'), (8) creating a fix branch \u2014 always base off origin/main not local main which may be stale commits behind, (9) MULTIPLE PR branches all fail CI with 'lock-file not up-to-date' simultaneously after a recent merge to main \u2014 main itself is likely broken; verify with `git checkout main && pixi install --locked` before per-branch fixups, (10) a recently-merged PR that touched `pyproject.toml`'s `[project.dependencies]` (or any field that contributes to the local-package SHA hash) without regenerating `pixi.lock` \u2014 fix on main with a 1-line hotfix PR; then re-rebase all open PRs to inherit the fixed lock, (11) per-branch `pixi install` regeneration produces only a single-line diff (the local-package `sha256:`) and CI keeps failing \u2014 confirms the bug is upstream on main, not on the branch, (12) a comment-only or metadata-only edit to `pyproject.toml`/`pixi.toml` invalidates the local-package SHA256 in `pixi.lock` and CI fails with `pixi install --locked rejected: <package> SHA256 mismatch` \u2014 use `pixi install` NOT `pixi update` (install regenerates only the affected SHA; update re-resolves the entire dep graph and produces a ~50-line diff).",
-      "version": "1.7.0",
-      "source": "./skills/pixi-lock-rebase-regenerate.md",
-      "category": "ci-cd",
-      "tags": [
-        "dependabot",
-        "pixi",
-        "rebase",
-        "pixi-lock",
-        "ci-cd",
-        "pixi-install",
-        "pixi-update"
-      ]
-    },
-    {
-      "name": "pixi-pip-audit-cve-pinning",
-      "description": "Fix pip-audit CVE failures in pixi-managed Python projects by pinning minimum versions. Use when: (1) CI pip-audit step fails with known CVEs, (2) indirect dependencies resolve to vulnerable versions.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-pip-audit-cve-pinning.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pixi-pip-audit-severity-filter",
-      "description": "Configure pip-audit in pixi CI to fail only on HIGH/CRITICAL severity vulnerabilities using pixi task definitions",
-      "version": "1.0.0",
-      "source": "./skills/pixi-pip-audit-severity-filter.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pixi-toml-dep-dedup",
-      "description": "Reconcile duplicate package version specs between [dependencies] and [feature.dev.dependencies] in pixi.toml. Use when a package appears in both sections with conflicting constraints, or when a quality audit flags dependency ambiguity.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-toml-dep-dedup.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "podman-ci-containerization",
-      "description": "Containerize GitHub Actions CI using Podman (rootless, no SU) with a separate CI image, GHCR push, Trivy scanning, local runner script, and security hardening. Use when: adding container isolation to pixi-based Python CI, enabling local CI parity without Docker daemon, replacing pygrep security hooks with bandit/gitleaks.",
-      "version": "1.0.0",
-      "source": "./skills/podman-ci-containerization.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "podman-nextjs-ci-container",
-      "description": "Build Podman/Docker dev containers for Next.js projects with full CI simulation. Use when: creating Containerfiles for Node.js/Next.js, running CI in containers, debugging native module builds.",
-      "version": "1.0.0",
-      "source": "./skills/podman-nextjs-ci-container.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "post-remediation-audit",
@@ -3765,11 +2636,30 @@
     },
     {
       "name": "pr-conflict-rebase-workflow",
-      "description": "Rebase conflicting PRs onto main when a merge commit introduces workflow changes. Use when: (1) multiple open PRs are CONFLICTING after a main branch merge, (2) GitHub Actions workflow files conflict over concurrency/permissions/timeout additions, (3) pixi.lock is in a modify/delete conflict during rebase, (4) two independent CI fix branches both modified the same workflow file with different approaches \u2014 one already merged to main and the other needs rebasing, (5) rebasing a consolidation/merge branch that deleted absorbed files, where those files were subsequently modified on the base branch \u2014 produces modify/delete (UD) conflicts on every absorbed file.",
-      "version": "1.2.0",
+      "description": "Rebase conflicting PRs onto main when a merge commit introduces workflow changes. Use when: (1) multiple open PRs are CONFLICTING after a main branch merge, (2) GitHub Actions workflow files conflict over concurrency/permissions/timeout additions, (3) pixi.lock is in a modify/delete conflict during rebase, (4) two independent CI fix branches both modified the same workflow file with different approaches \u2014 one already merged to main and the other needs rebasing, (5) rebasing a consolidation/merge branch that deleted absorbed files, where those files were subsequently modified on the base branch \u2014 produces modify/delete (UD) conflicts on every absorbed file, (6) a test-coverage PR conflicts because main added nearby tests while the PR added helpers or edge-case tests.",
+      "version": "1.3.0",
       "source": "./skills/pr-conflict-rebase-workflow.md",
       "category": "ci-cd",
       "tags": []
+    },
+    {
+      "name": "pr-merged-state-not-proof-of-remote-sync",
+      "description": "GitHub API state, your local `origin/<branch>` ref, and your working tree are three independent surfaces that diverge until `git fetch` runs \u2014 in BOTH the read direction (`gh pr view` says MERGED but refs are stale) and the write direction (a local branch and `origin/<same-name>` point at different commits because a parallel process pushed). A matching branch NAME does not imply matching CONTENT. Use when: (1) about to report `PR is merged` based on `gh pr view`, (2) auditing whether a file is present/absent in main after a deletion or rename PR, (3) spawning sub-agents that grep or scan the working tree expecting it matches main, (4) running deletion-validation or migration-completeness workflows, (5) reasoning about whether `origin/main` reflects the latest merges, (6) a sub-agent reports `feature X didn't execute / files missing / wave didn't run` immediately after PRs were marked merged, (7) about to push a local `<issue>-impl` / feature branch to update a PR when a parallel automation process may have pushed to the same branch name, (8) merging main into a local branch and pushing it to a PR branch you did not author end-to-end.",
+      "version": "1.1.0",
+      "source": "./skills/pr-merged-state-not-proof-of-remote-sync.md",
+      "category": "ci-cd",
+      "tags": [
+        "gh-cli",
+        "git-fetch",
+        "audit",
+        "sub-agents",
+        "merge-verification",
+        "working-tree",
+        "branch-divergence",
+        "parallel-automation",
+        "fast-forward-gate",
+        "rev-parse"
+      ]
     },
     {
       "name": "pr-preexisting-failure-triage",
@@ -3797,105 +2687,27 @@
     },
     {
       "name": "pr-review-no-action-ci-diagnosis",
-      "description": "Use when: (1) a PR review-fix plan concludes no code changes are required, (2) CI failures appear on a PR but changes are unrelated to the failing jobs, (3) CI flakes need to be distinguished from PR-introduced regressions, (4) a fix commit may be local-only and not yet pushed to remote, (5) a stale branch was force-pushed dropping a fix commit, (6) verifying a PR is ready to merge despite red CI",
-      "version": "2.1.0",
+      "description": "Use when: (1) a PR review-fix plan concludes no code changes are required, (2) CI failures appear on a PR but changes are unrelated to the failing jobs, (3) CI flakes need to be distinguished from PR-introduced regressions, (4) a fix commit may be local-only and not yet pushed to remote, (5) a stale branch was force-pushed dropping a fix commit, (6) verifying a PR is ready to merge despite red CI, (7) a REQUIRED status check (e.g. security/dependency-scan, pip-audit) fails identically across multiple unrelated PRs because of a stale build/dependency cache in CI rather than anything in the PR's diff",
+      "version": "2.2.0",
       "source": "./skills/pr-review-no-action-ci-diagnosis.md",
       "category": "ci-cd",
       "tags": []
     },
     {
-      "name": "pre-commit-hook-configuration",
-      "description": "Use when: (1) ruff or other linter hooks run on hardcoded directories instead of staged files, (2) aligning pre-commit hook versions with pixi-resolved tool versions, (3) updating hook versions with autoupdate, (4) adding a language: pygrep regex hook to catch forbidden patterns, (5) evaluating whether a hook should use pass_filenames: true or false, (6) writing pytest tests to verify pre-commit hook YAML configuration, (7) pre-commit hook uses SCRIPT_DIR/../ to find REPO_ROOT but is installed as .git/hooks/pre-commit in a test repo \u2014 resolves to .git/ not repo root, (8) SKIP_TESTS env var needed to prevent test-suite step from running in temporary test repos, (9) just command finds Justfile in a parent directory instead of the test repo, (10) a Go-based hook (e.g. gitleaks) fails to build from source because the system Go version is too old, (11) detect-private-key hook false-fires on test fixtures, TLS unit tests, or k8s secret manifests containing fake/test PEM headers",
-      "version": "2.3.0",
-      "source": "./skills/pre-commit-hook-configuration.md",
+      "name": "precommit-scope-full-pr-diff-not-current-edit",
+      "description": "Before `git push` for a PR, run pre-commit against the full PR diff (every file changed since the merge-base with the target branch), not just the files of the most recent edit. `pre-commit run --files X Y Z` only checks X, Y, Z; a sub-agent's earlier commit can carry stale-formatter content that no one re-checks locally and that only fails in CI. Use when: (1) handing off work between sub-agents that each ran their own per-file pre-commit, (2) making fixup commits after a delegated change and preparing to push, (3) any time `pre-commit run --all-files` is considered too slow and you reach for `--files`, (4) diagnosing CI mojo-format / ruff-format / formatter failures on files you did not personally edit in this session, (5) writing a pre-push checklist for any repo where formatter hooks rewrite files.",
+      "version": "1.0.0",
+      "source": "./skills/precommit-scope-full-pr-diff-not-current-edit.md",
       "category": "ci-cd",
       "tags": [
         "pre-commit",
-        "hooks",
-        "bats",
-        "shell-testing",
-        "repo-root",
-        "test-isolation",
-        "gitleaks",
-        "golang",
-        "prebuilt-binary",
-        "detect-private-key",
-        "false-positive",
-        "tls",
-        "kubernetes",
-        "test-fixtures"
+        "mojo-format",
+        "sub-agent-handoff",
+        "pr-diff",
+        "ci-parity",
+        "formatter",
+        "pre-push"
       ]
-    },
-    {
-      "name": "precommit-linter-stale-branch-revert",
-      "description": "Pre-commit linter reverts files on branches created before an ecosystem migration. Use when: (1) a branch was created before a Makefile/justfile/config migration was merged to main, (2) CI lint job fails with unexpected file reversions, (3) files that were changed on main appear to regress on an older branch after rebase.",
-      "version": "1.0.0",
-      "source": "./skills/precommit-linter-stale-branch-revert.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "linter",
-        "rebase",
-        "migration",
-        "branch",
-        "stale"
-      ]
-    },
-    {
-      "name": "precommit-schema-validation",
-      "description": "TRIGGER CONDITIONS: Adding a pre-commit hook that validates YAML config files against JSON schemas at commit time. Use when you have schemas/ JSON schemas and config/ YAML files and want to catch schema violations before CI. Also use when extending an existing _SCHEMA_MAP to cover an additional config directory (e.g. adding config/tiers/ alongside config/models/).",
-      "version": "1.1.0",
-      "source": "./skills/precommit-schema-validation.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "jsonschema",
-        "yaml",
-        "validation",
-        "config",
-        "hooks",
-        "schema-map"
-      ]
-    },
-    {
-      "name": "precommit-timing-benchmark",
-      "description": "Add pre-commit hook runtime measurement to CI to catch performance regressions. Use when: (1) regressions in hook speed are suspected, (2) a hook config change may affect performance, (3) you want to document before/after timing improvements.",
-      "version": "1.0.0",
-      "source": "./skills/precommit-timing-benchmark.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "precommit-version-drift-detection",
-      "description": "Automate detection of version drift between .pre-commit-config.yaml revs and pixi.toml/pixi.lock package versions using a validation script and local hook. Use when: auditing external hooks for drift, enforcing version consistency automatically at commit time, or adding new external pre-commit hooks that are also pixi dependencies.",
-      "version": "1.1.0",
-      "source": "./skills/precommit-version-drift-detection.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "preexisting-flaky-crash-rerun",
-      "description": "Diagnose whether CI failures are pre-existing flaky crashes unrelated to PR changes, and re-trigger CI as the sole fix. Use when: (1) CI fails with execution crashes in Mojo tests, (2) the PR diff does not touch failing test files, (3) the same tests passed on a recent main CI run.",
-      "version": "1.0.0",
-      "source": "./skills/preexisting-flaky-crash-rerun.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pygrep-artifact-detection-hook",
-      "description": "Zero-dependency pattern for adding a pygrep pre-commit hook that blocks commits if banned phrases appear in source files. Covers regex design, ruff D301 fix, and test strategy.",
-      "version": "1.0.0",
-      "source": "./skills/pygrep-artifact-detection-hook.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pypi-trusted-publishing-setup",
-      "description": "Configure PyPI trusted publishing (OIDC) with GitHub Actions for namespace packages. Use when: (1) setting up OIDC trusted publishing for a new PyPI project, (2) debugging 403/400 errors during PyPI upload, (3) publishing namespace packages like Org-Project to PyPI.",
-      "version": "1.0.0",
-      "source": "./skills/pypi-trusted-publishing-setup.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "pytest-coverage-threshold-config",
@@ -3914,36 +2726,20 @@
       "tags": []
     },
     {
-      "name": "reenable-precommit-hook",
-      "description": "Skill: reenable-precommit-hook. Use when working with reenable precommit hook.",
+      "name": "renovate-pixi-conda-dependency-automation",
+      "description": "Add Renovate config to automate conda-forge/pixi dependency updates that Dependabot cannot parse. Use when: (1) a repo uses pixi.toml for conda-forge deps but Dependabot only covers pip/github-actions, (2) conda deps are updated manually with no automation signal, (3) setting up Renovate to mirror an existing Dependabot cadence/grouping.",
       "version": "1.0.0",
-      "source": "./skills/reenable-precommit-hook.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "renovate-multi-ecosystem-cpp-repos",
-      "description": "Configure Renovate bot for C++20 repos using Conan, FetchContent, pixi, GitHub Actions, and Dockerfiles. Use when: (1) adding automated dependency updates to a C++ project, (2) need custom regex for CMake FetchContent GIT_TAG, (3) configuring Renovate for a multi-repo org with submodules.",
-      "version": "1.0.0",
-      "source": "./skills/renovate-multi-ecosystem-cpp-repos.md",
+      "source": "./skills/renovate-pixi-conda-dependency-automation.md",
       "category": "ci-cd",
       "tags": [
         "renovate",
-        "conan",
         "pixi",
-        "fetchcontent",
-        "github-actions",
-        "dockerfile",
-        "dependency-management"
+        "conda",
+        "conda-forge",
+        "dependabot",
+        "dependency-automation",
+        "renovate-json"
       ]
-    },
-    {
-      "name": "replace-curl-sh-with-pixi",
-      "description": "Replace unverifiable curl|sh installer patterns in CI with the setup-pixi composite action to eliminate supply-chain risk. Use when: a workflow installs a runtime or CLI tool via curl -s <url> | sh without hash verification.",
-      "version": "1.0.0",
-      "source": "./skills/replace-curl-sh-with-pixi.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "replace-printf-emoji-with-python-script",
@@ -3986,44 +2782,25 @@
       "tags": []
     },
     {
-      "name": "ruff-exclude-vs-per-file-ignores-generated-files",
-      "description": "Explains the difference between [tool.ruff] exclude and [tool.ruff.lint.per-file-ignores] for generated files. Use when: (1) ruff format --check still flags a file after adding it to per-file-ignores, (2) a generated file (hatch-vcs _version.py, protobuf, etc.) causes CI lint failures, (3) you want to completely exclude a file from all ruff processing.",
+      "name": "security-scanning-and-supply-chain-hardening",
+      "description": "Use when: (1) CI security scans only trigger on push to main (not PRs), (2) Semgrep or Gitleaks failures are silently masked with continue-on-error, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) GitHub Actions use mutable version tags instead of pinned commit SHAs, (5) a Dockerfile or workflow installs tools via unverifiable curl|sh, npm, or pixi without pinned versions, (6) a GHA job fails at Set up job with Unable to resolve action for a transitive dependency you do not reference directly.",
       "version": "1.0.0",
-      "source": "./skills/ruff-exclude-vs-per-file-ignores-generated-files.md",
+      "source": "./skills/security-scanning-and-supply-chain-hardening.md",
       "category": "ci-cd",
       "tags": [
-        "ruff",
-        "ruff-format",
-        "ruff-check",
-        "exclude",
-        "per-file-ignores",
-        "generated-files",
-        "lint"
+        "gitleaks",
+        "semgrep",
+        "sarif",
+        "pip-audit",
+        "dependabot",
+        "supply-chain",
+        "sha-pinning",
+        "trivy",
+        "curl-sh",
+        "pixi",
+        "npm",
+        "dockerfile"
       ]
-    },
-    {
-      "name": "ruff-rule-set-expansion",
-      "description": "Workflow for safely expanding ruff lint rule sets (B, SIM, C4, RUF) in an existing Python project",
-      "version": "1.0.0",
-      "source": "./skills/ruff-rule-set-expansion.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "run-precommit",
-      "description": "Run pre-commit hooks locally or in CI to validate code quality before committing. Use when: (1) before committing code, (2) testing if CI will pass, (3) after making code changes, (4) troubleshooting commit failures, (5) setting up CI pre-commit checks.",
-      "version": "2.0.0",
-      "source": "./skills/run-precommit.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "security-review-false-positive-filter",
-      "description": "Perform security code reviews with parallel false-positive filtering agents to produce high-confidence findings only. Use when: reviewing PR diffs for security vulnerabilities, static analysis is noisy, or internal APIs need exploitability validation before reporting.",
-      "version": "1.0.0",
-      "source": "./skills/security-review-false-positive-filter.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "self-cancelling-review-plan",
@@ -4042,6 +2819,25 @@
       "tags": []
     },
     {
+      "name": "signing-remote-host-ssh-noreply-email",
+      "description": "Make GitHub-VALID (verification.verified==true) signed commits from a remote/headless build host (e.g. aeolus in the HomericIntelligence mesh swarm) using an SSH signing key. Covers: (a) generating an ed25519 SSH signing keypair on the host and wiring git's gpg.format=ssh config + allowed_signers file; (b) registering the PUBLIC key as a SIGNING key on GitHub via `gh ssh-key add --type signing`, which REQUIRES the PAT scope admin:ssh_signing_key (granted interactively, not headlessly); (c) the email-privacy push block where a commit authored with the real private email is REJECTED with 'push declined due to email privacy restrictions', fixed by authoring with the <id>+<login>@users.noreply.github.com email; (d) the finding that GitHub does NOT auto-sign PAT-authored commits made via the Contents REST API. Use when: (1) setting up commit signing on a fresh remote/headless/CI host, (2) commits land Unverified despite a key being added (key added auth-only, missing --type signing), (3) `git push` is rejected for email privacy restrictions even though signing is correct, (4) you need the GitHub noreply email derivation, (5) `gh api user/ssh_signing_keys` returns 404 for missing admin:ssh_signing_key scope, (6) API-authored commits report verification.reason=unsigned.",
+      "version": "1.0.0",
+      "source": "./skills/signing-remote-host-ssh-noreply-email.md",
+      "category": "ci-cd",
+      "tags": [
+        "git",
+        "ssh-signing",
+        "commit-signing",
+        "github",
+        "noreply-email",
+        "email-privacy",
+        "headless",
+        "remote-host",
+        "gh-cli",
+        "admin-ssh-signing-key"
+      ]
+    },
+    {
       "name": "skills-to-plugins-migration",
       "description": "Migrate PRs that add skills to the flat skills/ directory into the correct plugins/<category>/<name>/ structure so CI triggers and the validate check passes. Use when a PR branch puts files under skills/ instead of plugins/, or when the validate CI check never appears on a PR.",
       "version": "1.0.0",
@@ -4050,12 +2846,33 @@
       "tags": []
     },
     {
-      "name": "skip-reusable-workflow-jobs-in-checkout-validator",
-      "description": "Extend a checkout-order validator to skip reusable workflow caller jobs. Use when: a steps-based validator fires false positives on reusable workflow jobs, or when extending checkout validation to handle mixed job types.",
-      "version": "1.0.0",
-      "source": "./skills/skip-reusable-workflow-jobs-in-checkout-validator.md",
+      "name": "squash-only-repo-merge-method-docs",
+      "description": "Repo allows squash-only merges (allow_rebase_merge=false); using --rebase silently fails to arm auto-merge (CLI) or fails at runtime (code/API). The wrong merge method hides in docs, code, AND skill/plugin instruction files. The robust fix is settings-aware merge-method selection (query gh api repos/<repo>, pick rebase->squash->merge), not hardcoding a different fixed method. Use when: (1) gh pr merge --auto --rebase returns no error but auto-merge is not armed, (2) project docs or CLAUDE.md instruct --rebase for a repo that has disabled rebase merges, (3) a PyGithub pr.merge(merge_method='rebase') callsite on a squash-only repo fails with 'Rebase merges are not allowed on this repository', (4) verifying which merge method a repo supports before arming auto-merge, (5) updating stale documentation that references the wrong merge flag, (6) auditing a squash-only repo \u2014 grep for BOTH the gh pr merge --rebase CLI form and the merge_method=\"rebase\" code/API form, (7) a skill/plugin instruction file (e.g. /learn, /finish-branch SKILL.md) hardcodes gh pr merge --auto --rebase against a squash-only target repo, (8) deciding the merge method for a cross-repo gh pr merge \u2014 detect allowed methods instead of hardcoding.",
+      "version": "1.2.0",
+      "source": "./skills/squash-only-repo-merge-method-docs.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "auto-merge",
+        "squash",
+        "rebase",
+        "github",
+        "docs"
+      ]
+    },
+    {
+      "name": "stacked-pr-retarget-lint-fix-orphan",
+      "description": "When PR-B is retargeted onto PR-A's branch, only the commits present at retarget time fast-forward in. Later commits on PR-B's branch (CI/lint fixes) stay orphaned from PR-A and must be cherry-picked. Use when: (1) two open PRs are stacked via gh pr edit --base, (2) CI/lint fix lands on the dependent PR's branch after retarget, (3) the same failure later appears on the prerequisite PR.",
+      "version": "1.0.0",
+      "source": "./skills/stacked-pr-retarget-lint-fix-orphan.md",
+      "category": "ci-cd",
+      "tags": [
+        "stacked-pr",
+        "retarget",
+        "cherry-pick",
+        "ci",
+        "lint",
+        "github"
+      ]
     },
     {
       "name": "stale-ci-warnings-in-pr-comment",
@@ -4068,7 +2885,7 @@
     {
       "name": "stale-plan-already-resolved",
       "description": "Detect when an issue's implementation plan is stale because the fix was already applied. Use when: the plan references specific line numbers that don't match current code, or the requested change is already satisfied by a broader fix already in place.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./skills/stale-plan-already-resolved.md",
       "category": "ci-cd",
       "tags": []
@@ -4082,70 +2899,10 @@
       "tags": []
     },
     {
-      "name": "symbolicate-mojo-cores-inside-container",
-      "description": "Post-mortem symbolication of Mojo JIT crash cores must run INSIDE the pixi container via `podman compose exec`, because the host runner doesn't share the pixi env tree where the `mojo` binary lives. Use when: (1) extending a coredump-capture GHA composite action with a symbolication step that dumps backtrace/registers/disasm around $pc, (2) host-side gdb fails with `Could not resolve mojo binary` even though `podman compose exec which mojo` returned a valid path, (3) you need `info all-registers` output to diagnose AVX-512 / ISA-feature-mismatch JIT crashes, (4) symbol bundling steps silently produce an empty `crash-bundle/symbols/` because container paths were used on the host.",
-      "version": "1.0.0",
-      "source": "./skills/symbolicate-mojo-cores-inside-container.md",
-      "category": "ci-cd",
-      "tags": [
-        "coredump",
-        "symbolicate",
-        "gdb",
-        "disasm",
-        "mojo",
-        "libkgen",
-        "podman",
-        "github-actions",
-        "mount-namespace",
-        "avx-512"
-      ]
-    },
-    {
-      "name": "tier-label-consistency-check",
-      "description": "Pattern for adding a testable Python script + CI grep gate + pre-commit hook that prevents tier-number/tier-name mismatches from recurring in documentation. Includes glob-scan mode for covering all project markdown files. Use when a doc field has regressed 3+ times and manual audits have failed to prevent it.",
-      "version": "1.1.0",
-      "source": "./skills/tier-label-consistency-check.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "training-tests-weekly-workflow",
       "description": "Create a weekly GitHub Actions workflow for Mojo training tests excluded from per-PR CI. Use when: test files are in validate_test_coverage.py exclusion list but have no periodic workflow running them.",
       "version": "1.0.0",
       "source": "./skills/training-tests-weekly-workflow.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "ubuntu-gtest-gmock-apt-cmake-targets",
-      "description": "Ubuntu 24.04 splits GTest and GMock into separate apt packages. Use when: (1) CMake error 'GTest::gmock target not found' in Docker/CI builds using apt, (2) Dockerfile installs libgtest-dev but cmake can't find GTest::gmock, (3) mapping apt package names to CMake targets for C++ testing deps.",
-      "version": "1.0.0",
-      "source": "./skills/ubuntu-gtest-gmock-apt-cmake-targets.md",
-      "category": "ci-cd",
-      "tags": [
-        "ubuntu",
-        "apt",
-        "gtest",
-        "gmock",
-        "cmake",
-        "dockerfile",
-        "cpp",
-        "testing"
-      ]
-    },
-    {
-      "name": "validate-workflow",
-      "description": "Validate GitHub Actions workflow files for syntax and correctness",
-      "version": "1.0.0",
-      "source": "./skills/validate-workflow.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "verify-and-commit",
-      "description": "Take a dirty working tree (implementation already complete) through the full verify \u2192 fix \u2192 commit \u2192 PR workflow. Covers running tests, fixing pre-commit failures, and creating a PR.",
-      "version": "1.0.0",
-      "source": "./skills/verify-and-commit.md",
       "category": "ci-cd",
       "tags": []
     },
@@ -4166,19 +2923,21 @@
       "tags": []
     },
     {
-      "name": "versioning-consistency-release-workflow",
-      "description": "Establish single-source-of-truth version management with importlib.metadata, pre-commit consistency checks, and CHANGELOG fixes. Use when: (1) project has version declared in multiple files that can drift, (2) __init__.py hardcodes a version string instead of using importlib.metadata, (3) CHANGELOG references phantom version numbers, (4) skill templates generate aspirational version refs.",
-      "version": "2.0.0",
-      "source": "./skills/versioning-consistency-release-workflow.md",
+      "name": "versioned-releases-changelog-release-workflow",
+      "description": "Implement pinnable versioned releases with keepachangelog CHANGELOG format and tag-triggered GitHub Actions release workflows. Use when: (1) project needs versioned releases with semver tags (v1.0.0+), (2) CHANGELOG entries must be organized by dated release sections with [Unreleased] section, (3) release.yml workflow triggers on semver tags and validates version consistency across manifests, (4) all commits must be signed, (5) pre-commit hooks must validate version fields in manifest files.",
+      "version": "1.0.0",
+      "source": "./skills/versioned-releases-changelog-release-workflow.md",
       "category": "ci-cd",
       "tags": [
         "versioning",
-        "release",
-        "ci",
-        "changelog",
-        "DRY",
-        "importlib-metadata",
-        "pre-commit"
+        "releases",
+        "keepachangelog",
+        "github-actions",
+        "git-tags",
+        "semver",
+        "tag-workflow",
+        "signed-commits",
+        "release-automation"
       ]
     },
     {
@@ -4190,52 +2949,20 @@
       "tags": []
     },
     {
-      "name": "wheel-only-build",
-      "description": "Skill: wheel-only-build",
-      "version": "1.0.0",
-      "source": "./skills/wheel-only-build.md",
+      "name": "workaround-demolition-wave-strategy",
+      "description": "Multi-PR sequencing framework for safely ripping out workarounds after an upstream library/compiler bug is fixed. Use when: (1) an upstream dependency (compiler, runtime, library) just shipped a fix for a bug your repo has accumulated workarounds for, (2) workarounds are spread across CI retry loops, continue-on-error flags, build flags, debug infrastructure, ADRs, dev docs, reproducer files, test-file comments, and agent-facing skills/memory, (3) you need to avoid one giant unreviewable demolition PR and instead want a safe, bisectable, reviewable sequence, (4) you have to decide between scorched-earth deletion vs preservation-with-Superseded-markers for documentation/ADRs, (5) some workaround-removals are risky one-liners not exercised by your validation matrix and need their own CI gate, (6) Wave 2 scorched-earth targets a directory (e.g. `repro/`) where files may correspond to DISTINCT upstream bugs sharing only symptom surface \u2014 partition by bug, not by directory, before deletion.",
+      "version": "1.1.0",
+      "source": "./skills/workaround-demolition-wave-strategy.md",
       "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "workflow-action-version-comment-audit",
-      "description": "Audit SHA-pinned GitHub Actions uses: lines for missing version comments, add them, and add a regression test. Use when: (1) a SHA-pinning pass left bare SHA refs without # vX.Y.Z comments, (2) a follow-up issue flags inconsistent comment coverage, (3) a regression test is needed to prevent future omissions.",
-      "version": "1.0.0",
-      "source": "./skills/workflow-action-version-comment-audit.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "workflow-binary-sha256-verification",
-      "description": "Add SHA256 checksum verification for binary downloads in GitHub Actions workflows to prevent supply chain attacks. Use when: a workflow downloads a binary via wget/curl without integrity verification before execution.",
-      "version": "1.0.0",
-      "source": "./skills/workflow-binary-sha256-verification.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "workflow-deduplication-pixi-composite-action",
-      "description": "Deduplicate repeated Pixi setup blocks across GitHub Actions workflows using a composite action. Use when: consolidating CI workflows, replacing inline prefix-dev/setup-pixi with a shared composite action, or merging security/audit workflows.",
-      "version": "1.0.0",
-      "source": "./skills/workflow-deduplication-pixi-composite-action.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "workflow-inventory-drift",
-      "description": "Detect drift between .github/workflows/*.yml files on disk and the workflow inventory table in README.md. Use when: adding or removing workflow files, setting up enforcement to keep workflow docs in sync, or diagnosing CI failures from inventory mismatch.",
-      "version": "1.0.0",
-      "source": "./skills/workflow-inventory-drift.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "workflow-smoke-tests",
-      "description": "Write pytest smoke tests and pre-commit hooks to prevent GitHub Actions security workflow regressions. Use when: (1) security workflow gaps were fixed and need regression protection, (2) CI properties like triggers/flags need continuous verification, (3) a pygrep pre-commit hook should catch bad patterns in workflow files.",
-      "version": "1.0.0",
-      "source": "./skills/workflow-smoke-tests.md",
-      "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "workaround-removal",
+        "multi-pr-strategy",
+        "upstream-fix",
+        "wave-sequencing",
+        "ci-discipline",
+        "demolition",
+        "rollback-strategy"
+      ]
     },
     {
       "name": "yaml-frontmatter-validation",
@@ -4246,59 +2973,51 @@
       "tags": []
     },
     {
-      "name": "yamllint-trailing-blank-lines",
-      "description": "Use when: (1) yamllint CI fails with 'too many blank lines (1 > 0)' at end of file, (2) conflict resolution leaves trailing blank lines in YAML files, (3) ensuring YAML files have exactly one newline at EOF.",
-      "version": "1.0.0",
-      "source": "./skills/yamllint-trailing-blank-lines.md",
-      "category": "ci-cd",
-      "tags": [
-        "yaml",
-        "yamllint",
-        "lint",
-        "trailing-blank-lines",
-        "eof",
-        "ci",
-        "github-actions"
-      ]
-    },
-    {
-      "name": "always-retry-infra-failures",
-      "description": "Fix retry logic bugs where a flag-gated retry conflates infra crashes with bad-grade results, discarding valid judge results. Use when: removing a retry flag to make behavior unconditional, fixing state machine reset logic that incorrectly resets completed runs, or debugging checkpoint semantics with multiple terminal state meanings.",
-      "version": "1.0.0",
-      "source": "./skills/always-retry-infra-failures.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "audit-composition-root-wiring-check",
-      "description": "Verifies that internal components are actually wired in the composition root (cmd/main, app entry, DI container) \u2014 not just present as packages with tests. Use when: (1) auditing a codebase before declaring it complete or shippable, (2) tests pass but a feature seems 'done but not working' or metrics permanently read zero, (3) before tagging a release, (4) inheriting a codebase and need to know what's actually live in production vs structurally dead.",
-      "version": "1.0.0",
-      "source": "./skills/audit-composition-root-wiring-check.md",
-      "category": "debugging",
-      "tags": [
-        "audit",
-        "dead-code",
-        "composition-root",
-        "wiring",
-        "instrumentation",
-        "go",
-        "verification"
-      ]
-    },
-    {
-      "name": "automation-implementer-dryrun-guard",
-      "description": "Guard against dry-run mode leaking into post-implementation steps (PR creation, learn, follow-up). Use when: (1) adding --dry-run to an automation implementer that has distinct Claude-code and PR-creation phases, (2) debugging 'No commits between main and branch' errors in dry-run mode, (3) designing any multi-phase CLI tool where --dry-run should exit early after the simulated phase.",
-      "version": "1.0.0",
-      "source": "./skills/automation-implementer-dryrun-guard.md",
+      "name": "automation-pipeline-observability-and-dryrun",
+      "description": "Operational reliability of automation pipeline scripts (implement_issues.py, curses UI runners, Claude Code harness, multi-phase shell orchestrators). Use when: (1) dry-run mode leaks into post-implementation phases (PR creation, /learn, follow-up), (2) errors are swallowed or invisible in curses UI automation scripts, (3) execution logs are not persisted after worktree cleanup, (4) debugging implement_issues.py pipeline failures (git parsing, branch reuse, import errors), (5) auditing that runtime components are actually wired in the composition root and not structurally dead code, (6) a shell orchestrator fans out to multiple Python entry points and some phases declare --issues (or similar) as required=True while others auto-discover \u2014 uniform invocation produces silent argparse exit 2 in the required-arg phases, (7) a multi-phase bash orchestrator silently aborts mid-pipeline after phase N completes \u2014 phases N+1..K never log a banner, the outer `wait` reports non-zero, and `bash -x` + ERR/EXIT traps inside the function reveal no continuation past the phase N subshell, (8) an accumulated stack of bash safety layers (`set -euo pipefail` + `set -m` + `set +e` defang + RETURN trap + single-command subshells + mapfile + process substitution) keeps producing new silent-abort triggers despite per-PR fixes for prior triggers \u2014 the structural fix is to rewrite the orchestrator as a Python module.",
+      "version": "1.2.0",
+      "source": "./skills/automation-pipeline-observability-and-dryrun.md",
       "category": "debugging",
       "tags": [
         "dry-run",
-        "implementer",
         "automation",
+        "implementer",
+        "curses-ui",
+        "error-visibility",
+        "log-persistence",
+        "composition-root",
+        "wiring",
         "hephaestus",
         "worktree",
-        "pr-creation",
-        "early-return"
+        "fan-out",
+        "argparse",
+        "orchestrator-contract",
+        "required-args",
+        "bash-to-python-rewrite",
+        "silent-abort",
+        "set-euo-pipefail",
+        "set-m",
+        "subprocess-orchestrator",
+        "phase-isolation"
+      ]
+    },
+    {
+      "name": "automation-prefix-match-plan-detection",
+      "description": "Fix substring-match anti-pattern in plan detection by delegating to canonical helpers or inlining proven prefix-match logic with shared constants. Use when: (1) fixing a substring-match bug in comment detection (like _has_plan), (2) after fixing a prefix-match bug in one automation module, grep sibling modules for the same anti-pattern, (3) implementing plan detection across multiple modules, (4) test regressions show Plan Review comments quoting the plan are miscounted as 'having a plan'.",
+      "version": "1.0.0",
+      "source": "./skills/automation-prefix-match-plan-detection.md",
+      "category": "debugging",
+      "tags": [
+        "automation",
+        "prefix-match",
+        "substring-match",
+        "anti-pattern",
+        "plan-detection",
+        "comment-parsing",
+        "comment-filters",
+        "canonical-helpers",
+        "sibling-modules",
+        "test-regression"
       ]
     },
     {
@@ -4310,208 +3029,108 @@
       "tags": []
     },
     {
-      "name": "bash-exit-127-function-recovery",
-      "description": "Diagnose and recover bash shell functions dropped during a merge when a test harness exits with code 127. Use when: (1) a standalone bash test returns exit 127 and all binaries are installed, (2) a sourced shell library was refactored and an old function name was removed or renamed, (3) CI test output shows exit 127 from a raw bash test script rather than from bats.",
-      "version": "1.0.0",
-      "source": "./skills/bash-exit-127-function-recovery.md",
-      "category": "debugging",
-      "tags": [
-        "bash",
-        "exit-127",
-        "shell-function",
-        "test-harness",
-        "merge-regression",
-        "function-recovery",
-        "api-retry",
-        "jq"
-      ]
-    },
-    {
-      "name": "bash-set-e-pipefail-grep-no-matches-trap",
-      "description": "Under set -euo pipefail, a grep pipe that finds no matches exits with status 1, aborting the whole script via pipefail+set-e before the while-read loop body is entered. Use when: (1) a script silently exits mid-loop when processing files that don't match a pattern, (2) a pre-commit hook fails on files that are expected NOT to contain a string, (3) grep | while read exits zero iterations but kills the script.",
-      "version": "1.0.0",
-      "source": "./skills/bash-set-e-pipefail-grep-no-matches-trap.md",
+      "name": "bash-script-and-jq-failure-modes",
+      "description": "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Claude Code Bash cwd drifts from Read/Edit absolute paths in multi-worktree sessions, (8) a bash function with set -m + set +e silently aborts mid-execution after a single-command (...) subshell finishes with no error log and no continuation past the subshell.",
+      "version": "1.1.0",
+      "source": "./skills/bash-script-and-jq-failure-modes.md",
       "category": "debugging",
       "tags": [
         "bash",
         "pipefail",
         "set-euo",
         "grep",
-        "while-read",
-        "process-substitution",
-        "no-matches",
-        "pre-commit",
-        "pipeline"
+        "array",
+        "exit-127",
+        "shell-function",
+        "jq",
+        "boolean",
+        "falsy",
+        "cwd",
+        "worktree",
+        "tool-divergence",
+        "json",
+        "set-m",
+        "job-control",
+        "subshell",
+        "exec-optimization",
+        "silent-abort",
+        "orchestrator-rewrite"
       ]
     },
     {
-      "name": "bash-unbound-array-pipefail-crash",
-      "description": "Bash arrays not initialized before use crash with 'unbound variable' under set -euo pipefail. Use when: (1) a script dies silently at an array length check (${#ARRAY[@]}), (2) bash -u causes a crash on an array declared but never assigned, (3) a function crashes on first failed-agent tracking despite apparent initialization.",
+      "name": "concurrency-and-process-reliability-patterns",
+      "description": "Debugging and fixing concurrency bugs and process-level reliability failures in Python. Use when: (1) batch/parallel workers hang on exit or ignore Ctrl+C, (2) subprocess stdin blocks because DEVNULL is missing, (3) os.setpgrp() or os.setsid() breaks terminal signal delivery, (4) stty called from a worker thread blocks the main thread, (5) global parallelism control needed across multiple ProcessPoolExecutors, (6) pytest OOM-kills the shell with no traceback, (7) pytest hangs due to unmocked Monte Carlo simulations, (8) nats-py optional import guard fires silently due to an enum import inside the try block, (9) nats-py printing stack traces instead of clean connection state, (10) subprocess git clone fails with transient network errors.",
       "version": "1.0.0",
-      "source": "./skills/bash-unbound-array-pipefail-crash.md",
+      "source": "./skills/concurrency-and-process-reliability-patterns.md",
       "category": "debugging",
       "tags": [
-        "bash",
-        "array",
-        "pipefail",
-        "set-euo",
-        "unbound-variable",
-        "local-a",
-        "initialization"
+        "subprocess",
+        "signal",
+        "process-group",
+        "semaphore",
+        "multiprocessing",
+        "pytest",
+        "oom",
+        "ulimit",
+        "monte-carlo",
+        "mock",
+        "nats",
+        "asyncio",
+        "retry",
+        "transient-errors",
+        "threading"
       ]
     },
     {
-      "name": "batch-subprocess-signal-hang",
-      "description": "Debugging batch mode hangs caused by subprocess stdin blocking, signal group isolation, and worker-thread terminal calls. Use when: (1) batch/parallel workers hang on exit, (2) Ctrl+C stops working after os.setpgrp(), (3) subprocess.run blocks waiting for stdin.",
+      "name": "cpp-build-and-runtime-bug-patterns",
+      "description": "Use when: (1) a C++ PR fails with 'no matching function for call to register_routes' or undefined references after a signature change, (2) std::atomic members cause POSIX socket calls to resolve as std::bind via ADL, (3) a [[deprecated]] struct field causes the struct's own .cpp to fail under -Werror, (4) cpp-httplib route handler lambdas crash due to dangling reference UB after register_routes returns, (5) nlohmann/json .value(key, nullptr).is_null() fails to compile with nullptr_t type error, (6) cmake configure succeeds but ctest reports No tests were found in a scaffold repo.",
       "version": "1.0.0",
-      "source": "./skills/batch-subprocess-signal-hang.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "checkpoint-disk-reconciliation",
-      "description": "Reconcile stale checkpoint states with on-disk artifacts after ProcessPool race conditions or interrupted runs. Use when: checkpoint shows intermediate states but disk has valid results, --retry-errors skips runs that completed on disk, or judge-failed runs need re-running.",
-      "version": "1.0.0",
-      "source": "./skills/checkpoint-disk-reconciliation.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "checkpoint-intermediate-state-resume",
-      "description": "Fixing checkpoint resume when runs are stuck in intermediate states or subtests are orphaned. Use when: experiment marked complete but runs not terminal, subtest_states without run_states, or ProcessPool checkpoint save races.",
-      "version": "1.0.0",
-      "source": "./skills/checkpoint-intermediate-state-resume.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "checkpoint-save-guard-bug",
-      "description": "Fix for --retry-errors not persisting checkpoint when only intermediate-state runs exist",
-      "version": "1.0.0",
-      "source": "./skills/checkpoint-save-guard-bug.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "confusion-matrix-dtype-guard",
-      "description": "Add dtype validation guards to Mojo metric structs that use bitcast to read tensor data, preventing silent corruption when callers pass float tensors. Use when: a metric update() silently accepts float32 labels, a bitcast fallback branch accepts any non-primary dtype, or adding input validation to Mojo structs consuming typed tensors.",
-      "version": "1.0.0",
-      "source": "./skills/confusion-matrix-dtype-guard.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "cpp-agamemnon-register-routes-signature-cascade",
-      "description": "Use when: (1) Agamemnon C++ PR fails with 'error: no matching function for call to register_routes' in test files, (2) PR fails with undefined references to a new feature class after CMakeLists was updated, (3) clang-tidy fails with misc-use-anonymous-namespace on static functions in src/nats_client.cpp, (4) PR's CMakeLists.txt was updated but test/CMakeLists.txt or agamemnon_lib source list was not. Covers the three recurring error classes when a PR adds a new parameter to register_routes() in routes.hpp and only patches server_main.cpp but leaves test call-sites stale.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-agamemnon-register-routes-signature-cascade.md",
+      "source": "./skills/cpp-build-and-runtime-bug-patterns.md",
       "category": "debugging",
       "tags": [
         "cpp",
+        "cpp20",
         "agamemnon",
-        "register_routes",
         "cmake",
-        "test-fixture",
+        "register_routes",
         "signature-mismatch",
         "undefined-reference",
         "clang-tidy",
-        "anonymous-namespace",
-        "agamemnon_lib"
-      ]
-    },
-    {
-      "name": "cpp-atomic-posix-socket-adl-collision",
-      "description": "Fix C++ build failures when std::atomic members break POSIX socket API calls. Use when: (1) adding std::atomic<int> to a class that uses POSIX socket functions causes build errors like 'call to deleted constructor of std::atomic<int>', (2) a bind() call suddenly resolves as std::bind instead of POSIX bind(), (3) socket/file descriptor operations fail with type errors after a member is changed to atomic.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-atomic-posix-socket-adl-collision.md",
-      "category": "debugging",
-      "tags": [
-        "cpp",
         "atomic",
         "posix",
         "adl",
-        "socket"
-      ]
-    },
-    {
-      "name": "cpp-deprecated-field-internal-use-pragma-suppression",
-      "description": "Suppress -Wdeprecated-declarations in the struct/class's own .cpp when a field is marked [[deprecated]]. Use when: (1) adding [[deprecated(\"...\")]] to a C++ struct/class member causes the struct's own implementation file to fail under -Werror,-Wdeprecated-declarations, (2) internal assignments to a deprecated field need to be silenced without removing the deprecation marker, (3) a deprecation-marker PR must not refactor internals.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-deprecated-field-internal-use-pragma-suppression.md",
-      "category": "debugging",
-      "tags": [
-        "cpp",
+        "socket",
         "deprecated",
         "pragma",
         "werror",
-        "wdeprecated-declarations",
-        "diagnostic-suppression",
-        "struct-field"
-      ]
-    },
-    {
-      "name": "cpp-httplib-lambda-capture-ub",
-      "description": "Fix dangling reference UB in cpp-httplib route handler lambdas. Use when: (1) registering cpp-httplib routes that capture shared state by reference, (2) debugging crashes in HTTP handlers after register_routes() returns, (3) reviewing cpp-httplib lambda captures.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-httplib-lambda-capture-ub.md",
-      "category": "debugging",
-      "tags": [
         "cpp-httplib",
         "lambda",
         "undefined-behavior",
         "dangling-reference",
-        "cpp20"
-      ]
-    },
-    {
-      "name": "cpp-nlohmann-json-value-nullptr-type-error",
-      "description": "Fix nlohmann/json value() returning nullptr_t when passed nullptr as default, causing .is_null() compile error. Use when: (1) json.value(key, nullptr).is_null() causes compile error about member reference base type nullptr_t, (2) checking if a json field is null using value() with nullptr default, (3) clang-tidy reports clang-diagnostic-error on a .value() call.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-nlohmann-json-value-nullptr-type-error.md",
-      "category": "debugging",
-      "tags": [
         "nlohmann-json",
-        "cpp",
-        "cpp20",
         "nullptr",
-        "clang-tidy",
-        "type-error"
-      ]
-    },
-    {
-      "name": "cpp-scaffold-cmake-test-path-fix",
-      "description": "Fix CMake test source path bug in C++20 scaffold repos where add_subdirectory(test) causes double-prefix. Use when: (1) cmake configure succeeds but ctest reports 'No tests were found', (2) test/CMakeLists.txt uses 'test/src/test_main.cpp' as the source path, (3) linking succeeds but gtest never discovers tests, (4) building a scaffolded C++ repo (Agamemnon/Nestor/Charybdis template) for the first time.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-scaffold-cmake-test-path-fix.md",
-      "category": "debugging",
-      "tags": [
-        "cmake",
-        "gtest",
-        "add_subdirectory",
-        "test-path",
-        "cpp20",
-        "scaffold",
         "ctest",
-        "odysseus"
+        "scaffold"
       ]
     },
     {
-      "name": "cross-cpu-survey-gha-only-crash",
-      "description": "Fan a GHA-extracted container image out across a tailnet of physical machines spanning multiple CPU generations to narrow a 'GHA-only crash' bug class. Use when: (1) a CI failure reproduces only on GitHub-Actions runners and you suspect CPU-feature mismatch (AVX-512, BMI2, AMX, etc.), (2) you have ssh/Tailscale access to a fleet of personal/lab machines spanning different x86 microarchitectures, (3) you need to falsify a coarse hypothesis like 'any non-AVX-512 CPU triggers it' and narrow to a specific CPU+hypervisor class. Companion to extract-gha-container-image-cache-locally (which produces the image).",
+      "name": "cpp-logger-init-race",
+      "description": "A SIGABRT / 'Subprocess aborted' that appears only under -O0 --coverage (or TSan) builds, with a CI log line like `terminate called after throwing an instance of 'spdlog::spdlog_ex'  what(): logger with name '<name>' already exists`, is a check-then-act data race in a lazy logger singleton \u2014 NOT a flaky assertion. Use when: (1) a unit test intermittently aborts (SIGABRT) only in coverage/TSan CI builds, (2) CI logs show spdlog_ex / 'already exists' / 'terminate called', (3) a prior PR relaxed an assertion tolerance to 'fix flakiness' but the abort persisted, (4) any lazily-initialized C++ singleton (logger, registry) is created from multiple threads without synchronization.",
       "version": "1.0.0",
-      "source": "./skills/cross-cpu-survey-gha-only-crash.md",
+      "source": "./skills/cpp-logger-init-race.md",
       "category": "debugging",
       "tags": [
-        "cpu-feature",
-        "avx-512",
-        "podman",
-        "tailscale",
-        "multi-host",
-        "ci-debugging",
-        "jit",
-        "mojo",
-        "hyper-v",
-        "simd"
+        "cpp",
+        "thread-safety",
+        "data-race",
+        "check-then-act",
+        "spdlog",
+        "lazy-singleton",
+        "sigabrt",
+        "coverage-build",
+        "tsan",
+        "call-once",
+        "flaky-test-fallacy"
       ]
     },
     {
@@ -4521,39 +3140,6 @@
       "source": "./skills/cytoscape-filter-compose.md",
       "category": "debugging",
       "tags": []
-    },
-    {
-      "name": "debugging-argparse-ambiguous-flag-silent-mismatch",
-      "description": "Python argparse silently accepts prefix-matching flag abbreviations by default \u2014 `--require X` may be parsed as `--requirement X` (or any other `--req...` flag) without warning. Combined with `|| true` or `|| echo \"::warning::\"`, the resulting argparse exit-2 is swallowed and the command appears advisory while doing nothing. Use when: (1) a Python CLI in CI has been silently no-op'ing for an unknown duration, (2) you removed a `|| true` wrapper around a `pip-audit` / `pytest` / similar tool and discovered the underlying invocation was broken all along, (3) reviewing CLI invocations after a forbid-suppressions sweep, (4) auditing scripts for ambiguous-flag risk.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-argparse-ambiguous-flag-silent-mismatch.md",
-      "category": "debugging",
-      "tags": [
-        "argparse",
-        "python-cli",
-        "silent-flag-mismatch",
-        "prefix-matching",
-        "allow_abbrev",
-        "pip-audit",
-        "cli-debugging",
-        "silent-noop"
-      ]
-    },
-    {
-      "name": "debugging-auth-mode-case-mismatch-fail-open",
-      "description": "Detect and fix the case-mismatched-enum + fail-open-default-branch pattern that ships dashboards open. Use when: (1) reviewing or auditing auth-mode middleware that compares against typed string constants, (2) you find a switch with a default branch that calls next.ServeHTTP.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-auth-mode-case-mismatch-fail-open.md",
-      "category": "debugging",
-      "tags": [
-        "security",
-        "auth-bypass",
-        "fail-open",
-        "case-mismatch",
-        "enum-normalization",
-        "defense-in-depth",
-        "go"
-      ]
     },
     {
       "name": "debugging-blog-bug-validation-methodology",
@@ -4585,39 +3171,6 @@
       ]
     },
     {
-      "name": "debugging-loggeradapter-process-dict-mutation",
-      "description": "Fix LoggerAdapter.process() mutating caller's extra dict and add thread-safe context reads. Use when: (1) ContextLogger or LoggerAdapter subclass modifies kwargs in-place, (2) shared dicts leak context between log calls.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-loggeradapter-process-dict-mutation.md",
-      "category": "debugging",
-      "tags": [
-        "logging",
-        "thread-safety",
-        "dict-mutation",
-        "LoggerAdapter",
-        "ContextLogger"
-      ]
-    },
-    {
-      "name": "debugging-mojo-jit-crash-capture-gdb-wrapper",
-      "description": "Use when: (1) Mojo 1.0 runtime crashes (modular/modular#6413 family) but kernel `core_pattern` + `ulimit -c unlimited` produce no core because `libKGENCompilerRTShared.so` installs an in-process SIGABRT/SIGILL handler that swallows the signal before the kernel can dump, (2) you need real ELF cores from the JIT-emitted fault site (not Crashpad's 3-frame published trace), (3) you've already tried kernel `core_pattern` and confirmed empty cores directory, (4) you need a wrapper that runs `mojo` under `gdb` from inside `pixi run` so `MODULAR_HOME`/stdlib paths remain activated, (5) you're on gdb 15.1 where `hook-stop` and `--return-child-result` misbehave in `-batch` mode, (6) you want to handle SIGILL (Mojo's `os.abort()` lowers to `llvm.trap` \u2192 SIGILL on Linux, not SIGABRT) in addition to SIGSEGV/SIGABRT/SIGBUS/SIGFPE, and (7) the wrapper must exit `128 + signo` on crash and the inferior's real exit code on clean exit.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-mojo-jit-crash-capture-gdb-wrapper.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "jit",
-        "crash",
-        "gdb",
-        "coredump",
-        "libKGEN",
-        "SIGILL",
-        "signal-handler",
-        "pixi",
-        "modular-6413"
-      ]
-    },
-    {
       "name": "debugging-radiance-graph-load-capture-browser-api-artifacts",
       "description": "Debug Radiance graph-load hangs by correlating the browser console, `/api/v1/radiance/runs*` endpoints, and persisted run artifacts. Use when: (1) the UI spinner hangs after Analyze/Open, (2) a run reaches `succeeded` but the graph does not render, (3) you need to separate backend graph generation failures from frontend Model Explorer rendering failures.",
       "version": "1.0.0",
@@ -4632,177 +3185,84 @@
       ]
     },
     {
-      "name": "debugging-silent-error-suppression-pola",
-      "description": "Fix functions that silently swallow errors and default to fallback behavior instead of propagating exceptions. Use when: (1) a function catches ValueError but falls back instead of re-raising, (2) symmetric functions (load/save) have inconsistent error handling, (3) POLA violations where callers get unexpected output formats.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-silent-error-suppression-pola.md",
+      "name": "debugging-silent-pipeline-stage-via-argparse-required-grep",
+      "description": "Diagnose silent stages in fan-out orchestrators (shell driving N Python CLIs, Makefile driving N tools, CI workflow driving N jobs) via a 3-command source-grep that compares argparse `required=True` flags against the flags the orchestrator actually passes, OR via a 2-command grep that identifies unguarded infrastructure commands in a backgrounded orchestrator function running under `set -euo pipefail`. Use when: (1) a multi-stage pipeline reports success but a downstream stage produced no visible output, (2) only the first phase of run_automation_loop.sh / similar orchestrator runs, (3) orchestrator logs show generic `Warning: ... exited non-zero` with no underlying error detail, (4) you are tempted to re-run with `tee` + banner greps to reproduce a silent-stage bug, (5) the orchestrator uses `|| echo`, `|| true`, `set +e`, or `continue-on-error: true` to swallow exit codes, (6) the symptom returned AFTER a prior fix to a different silent-stage cause in the same orchestrator \u2014 there is often a SECOND silent-stage cause hiding behind the first.",
+      "version": "1.1.0",
+      "source": "./skills/debugging-silent-pipeline-stage-via-argparse-required-grep.md",
       "category": "debugging",
       "tags": [
-        "error-handling",
-        "POLA",
+        "argparse",
+        "orchestrator",
         "silent-failure",
-        "io-utils",
-        "hephaestus"
+        "source-grep",
+        "debugging-methodology",
+        "fan-out",
+        "exit-code-swallowing",
+        "shell",
+        "python",
+        "cli-contract",
+        "set-e",
+        "errexit",
+        "backgrounded",
+        "subshell",
+        "process-repo",
+        "second-cause"
       ]
     },
     {
-      "name": "debugging-slice-view-bad-free-destructor",
-      "description": "Diagnose and fix bad-free crashes from tensor view destructors that call free() on offset pointers. Use when: (1) ASAN reports 'attempting free on address which was not malloc()-ed', (2) the freed address is INSIDE a larger allocation, (3) a slice/view method offsets _data without guarding __del__, (4) CI crashes appear flaky with libKGENCompilerRTShared.so abort after many test functions.",
+      "name": "debugging-symmetric-weight-init-dead-symmetry",
+      "description": "Diagnose and avoid the symmetric-weight-init pathology where uniform-fill weights make multi-layer gradients algebraically zero and produce false 'substrate bug' diagnoses. Use when: (1) a convergence test or training run plateaus at the uniform-distribution loss (e.g., ln(num_classes)), (2) gradients to early layers come back at fp32 cancellation noise magnitude (~1e-8) while later layers have normal-magnitude gradients, (3) writing self-contained test cases for autograd/backward correctness, (4) reviewing test code that initializes weights with a constant fill.",
       "version": "1.0.0",
-      "source": "./skills/debugging-slice-view-bad-free-destructor.md",
+      "source": "./skills/debugging-symmetric-weight-init-dead-symmetry.md",
       "category": "debugging",
       "tags": [
-        "asan",
-        "bad-free",
-        "view",
-        "slice",
-        "destructor",
-        "mojo",
-        "tensor",
-        "heap-corruption",
-        "ci-flakiness"
+        "autograd",
+        "weight-init",
+        "dead-symmetry",
+        "convergence-test",
+        "backward",
+        "gradient-pathology",
+        "mojo"
       ]
     },
     {
-      "name": "dryrun-checkpoint-cleanup",
-      "description": "Clean up dryrun experiment data: workspace dirs, stuck checkpoints, superseded experiments. Use when: dryrun analysis shows NOGO with fixable blockers.",
+      "name": "e2e-experiment-runner-bug-patterns",
+      "description": "Canonical reference for bugs in the E2E evaluation pipeline covering manage_experiment.py / SubTestExecutor state machines, checkpoint/resume, judge logic, rate limits, path resolution, and rerun scripts. Use when: (1) retry logic conflates infra crashes with bad-grade terminal states, (2) checkpoint resume crashes with AssertionError or FileNotFoundError, (3) judge returns empty responses or prose instead of JSON, (4) --until stepping executes one extra transition or Ctrl+C has no effect, (5) T5 baseline inheritance fails despite parent tiers completing, (6) path resolution causes 100% silent agent failures, (7) rate limits hide inside stdout JSON instead of stderr, (8) rerun scripts crash with SubTestExecutor constructor errors or invalid checkpoint status, (9) judge validity checks are inconsistent across live/regeneration paths.",
       "version": "1.0.0",
-      "source": "./skills/dryrun-checkpoint-cleanup.md",
+      "source": "./skills/e2e-experiment-runner-bug-patterns.md",
       "category": "debugging",
-      "tags": []
+      "tags": [
+        "e2e",
+        "state-machine",
+        "checkpoint",
+        "resume",
+        "judge",
+        "rate-limit",
+        "path-resolution",
+        "manage-experiment",
+        "subtest-executor",
+        "tier-manager",
+        "haiku",
+        "threading",
+        "until-stepping",
+        "json-parse",
+        "rerun"
+      ]
     },
     {
-      "name": "dryrun3-runner-failure-fixes",
-      "description": "Fix three E2E experiment runner failure modes discovered in dryrun3",
+      "name": "experiment-checkpoint-resume-state-bugs",
+      "description": "Diagnose and fix experiment checkpoint resume failures. Use when: (1) checkpoint shows intermediate states (e.g. `judge_prompt_built`, `report_written`) but on-disk artifacts confirm completion, (2) `--retry-errors` appears to do nothing or skips runs that need re-running, (3) experiment is marked `complete` but has stuck or orphaned intermediate runs, (4) dryrun NOGO with fixable blockers (stuck checkpoints, missing subtests, leftover workspace dirs), (5) Liza planning handoff is stalled after checkpoint/resume, (6) `.liza/state.yaml` timestamps were rewritten by PyYAML breaking `liza validate`/`liza resume`.",
       "version": "1.0.0",
-      "source": "./skills/dryrun3-runner-failure-fixes.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "e2e-complete-experiment-rerun-early-exit",
-      "description": "Early-exit when re-running an already-complete E2E experiment to avoid expensive rehydrate (rglob scan of hundreds of run_result.json files) that can hang or OOM on low-memory systems",
-      "version": "1.0.0",
-      "source": "./skills/e2e-complete-experiment-rerun-early-exit.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "e2e-evaluation-framework-bug-fixes",
-      "description": "E2E Evaluation Framework Bug Fixes",
-      "version": "1.0.0",
-      "source": "./skills/e2e-evaluation-framework-bug-fixes.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "e2e-framework-crash-recovery-bugs",
-      "description": "Fix E2E framework crash-recovery bugs including checkpoint thread-safety race conditions, resume state machine AssertionError on tier_config=None, LLM judge returning conversational text instead of JSON, _restore_run_context() missing run_result and judgment loading, progressive resume failures (file path mismatches), and --until stepping bugs (TierState naming confusion). Use when: (1) FileNotFoundError on checkpoint.tmp.*.json, (2) AssertionError tier_ctx.tier_config is not None on resume, (3) judge silently produces no score, (4) Phase 3 resume crashes with run_result must be set, (5) experiment works first time but fails on Nth resume, (6) No sub-test results to select from on --until stepping.",
-      "version": "1.4.0",
-      "source": "./skills/e2e-framework-crash-recovery-bugs.md",
+      "source": "./skills/experiment-checkpoint-resume-state-bugs.md",
       "category": "debugging",
       "tags": [
         "checkpoint",
-        "threading",
         "resume",
-        "judge",
-        "haiku",
-        "race-condition",
-        "e2e",
-        "state-machine",
-        "json-parse",
-        "restore-run-context",
-        "file-path-mismatch",
-        "until-stepping",
-        "tier-state",
-        "pytest-fixtures"
-      ]
-    },
-    {
-      "name": "e2e-judge-prompt-reuse",
-      "description": "E2E Judge Prompt Reuse",
-      "version": "1.0.0",
-      "source": "./skills/e2e-judge-prompt-reuse.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "e2e-path-resolution-fix",
-      "description": "E2E Path Resolution Fix",
-      "version": "1.0.0",
-      "source": "./skills/e2e-path-resolution-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "e2e-rate-limit-detection",
-      "description": "Detect Claude/agent CLI 429 rate limits that hide inside stdout JSON (not stderr) and avoid silently breaking the retry path with `or`-chained detectors. Use when: (1) wrapping `claude -p --output-format=json` (or any CLI with structured output) and need rate-limit-aware retry, (2) every invocation dies in seconds with empty stderr but logs show `is_error: true` / 429, (3) widening a stderr-only detector to also scan stdout, (4) parsing reset times like 'resets May 8, 5pm (America/Los_Angeles)' that span multiple days.",
-      "version": "1.1.0",
-      "source": "./skills/e2e-rate-limit-detection.md",
-      "category": "debugging",
-      "tags": [
-        "claude-cli",
-        "rate-limit",
-        "429",
-        "usage-cap",
-        "stdout-json",
-        "is_error",
-        "detector-chaining",
-        "or-vs-is-not-none",
-        "python",
-        "regex",
-        "json-parsing",
-        "error-detection",
-        "e2e-testing",
-        "api-errors",
-        "stderr-vs-stdout",
-        "tdd"
-      ]
-    },
-    {
-      "name": "e2e-rate-limit-diagnosis-reset",
-      "description": "Diagnose experiment data quality issues caused by Anthropic API monthly usage limits (HTTP 429) and reset affected runs for retry. Use when: experiment results show unexplained failures in later tiers, runs have zero tokens/cost with exit_code=1, or checkpoint marks rate-limited runs as successfully completed with F grades.",
-      "version": "1.0.0",
-      "source": "./skills/e2e-rate-limit-diagnosis-reset.md",
-      "category": "debugging",
-      "tags": [
-        "rate-limit",
-        "429",
-        "experiment-diagnosis",
-        "checkpoint-reset",
-        "data-quality",
-        "e2e-testing"
-      ]
-    },
-    {
-      "name": "e2e-runner-hang-signal-fixes",
-      "description": "Fix E2E experiment runner hanging and ignoring Ctrl+C/Ctrl+Z signals during parallel execution. Use when: manage_experiment.py hangs, signals are ignored, or SIGTSTP does graceful shutdown instead of force kill.",
-      "version": "1.0.0",
-      "source": "./skills/e2e-runner-hang-signal-fixes.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "extensor-bfloat16-fix",
-      "description": "Fix pattern for adding bfloat16 dtype support to Mojo ExTensor float I/O methods. Use when: _set_float64/_get_float64 silently write/read zeros for bfloat16 tensors, or a new dtype is missing from _get_dtype_size_static.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-bfloat16-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "extract-gha-container-image-cache-locally",
-      "description": "Extract a GitHub-Actions-cached Podman container image tar (produced by actions/cache + podman save) and re-upload it as a downloadable workflow artifact so a developer can podman load the exact CI image locally for forensic reproduction. Use when: (1) a CI bug is suspected to live in the cached container bytes rather than source code, (2) you need to bisect whether a stale cache is masking or causing a regression, (3) you want bit-identical local repro of a hard-to-reproduce CI failure (e.g. JIT SIGILL, runner-specific glibc/SIMD issues).",
-      "version": "1.0.0",
-      "source": "./skills/extract-gha-container-image-cache-locally.md",
-      "category": "debugging",
-      "tags": [
-        "github-actions",
-        "podman",
-        "container",
-        "cache",
-        "forensics",
-        "ci-debugging"
+        "intermediate-state",
+        "disk-reconciliation",
+        "retry-errors",
+        "liza",
+        "stale-state"
       ]
     },
     {
@@ -4814,26 +3274,10 @@
       "tags": []
     },
     {
-      "name": "fix-e2e-rerun-script-errors",
-      "description": "Fix common errors in E2E rerun script: SubTestExecutor constructor parameters, checkpoint status validation, and T5 inheritance failures",
-      "version": "1.0.0",
-      "source": "./skills/fix-e2e-rerun-script-errors.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
       "name": "fix-flaky-glob-ordering",
       "description": "Fix flaky tests caused by non-deterministic filesystem glob ordering. Use when: test passes sometimes and fails other times with identical code, and the test asserts on the order of files loaded from a directory.",
       "version": "1.0.0",
       "source": "./skills/fix-flaky-glob-ordering.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "fix-implement-issues-script",
-      "description": "Debug and fix automation pipeline failures in implement_issues.py",
-      "version": "1.0.0",
-      "source": "./skills/fix-implement-issues-script.md",
       "category": "debugging",
       "tags": []
     },
@@ -4860,29 +3304,6 @@
       "source": "./skills/fix-mojo-compilation-patterns.md",
       "category": "debugging",
       "tags": []
-    },
-    {
-      "name": "fix-non-contiguous-tensor-stride-access",
-      "description": "Fix tensor operations that silently produce wrong values for non-contiguous views by replacing flat index offset with stride-based multi-dimensional indexing. Use when: element access uses i*dtype_size instead of strides, as_contiguous or copy functions assume stride-1 layout. Also covers the concatenate() axis-0 non-contiguous else-branch flat-index bug and result_elem_offset tracking.",
-      "version": "1.1.0",
-      "source": "./skills/fix-non-contiguous-tensor-stride-access.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "fix-randn-seed-bug",
-      "description": "Fix unused seed parameter in random number generation functions causing non-reproducible tests",
-      "version": "1.0.0",
-      "source": "./skills/fix-randn-seed-bug.md",
-      "category": "debugging",
-      "tags": [
-        "random",
-        "seed",
-        "reproducibility",
-        "testing",
-        "mojo",
-        "prng"
-      ]
     },
     {
       "name": "fix-s101-assert-to-runtimeerror",
@@ -4917,479 +3338,38 @@
       "tags": []
     },
     {
-      "name": "global-semaphore-parallelism",
-      "description": "Implement global parallelism control using shared semaphores. Use when limiting concurrent workers across multiple process pools or fixing per-tier parallelism issues.",
+      "name": "linter-as-root-cause-of-repeated-policy-violations",
+      "description": "When two or more separate documents/skills/configs violate the same stated policy in the same way, the linter/validator that enforces that policy is the FIRST suspect \u2014 fix the linter before fixing the dependent files, or the new fixes will fail CI and downstream files will re-introduce the violation. Use when: (1) an audit flags the same policy violation in multiple files, (2) you are tempted to open N parallel PRs to fix N violating files, (3) a CLAUDE.md/CONTRIBUTING.md rule is repeatedly violated despite contributors knowing the rule, (4) a wrong-direction validator silently rejects the correct fix and accepts the wrong one.",
       "version": "1.0.0",
-      "source": "./skills/global-semaphore-parallelism.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "improve-automation-error-visibility",
-      "description": "Improve error visibility in curses UI automation scripts and add granular status updates",
-      "version": "1.0.0",
-      "source": "./skills/improve-automation-error-visibility.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "jq-alternative-operator-falsy-boolean-trap",
-      "description": "jq's // alternative operator silently drops boolean false values, treating them as falsy (like null). Use when: (1) jq serialization of a boolean field returns empty instead of 'false', (2) a bats/bash test asserting a JSON boolean key is absent in output, (3) .field // empty or .field // 'default' unexpectedly skips false values.",
-      "version": "1.0.0",
-      "source": "./skills/jq-alternative-operator-falsy-boolean-trap.md",
+      "source": "./skills/linter-as-root-cause-of-repeated-policy-violations.md",
       "category": "debugging",
       "tags": [
-        "jq",
-        "bash",
-        "boolean",
-        "serialization",
-        "bats",
-        "json",
-        "falsy",
-        "alternative-operator"
+        "linter",
+        "validator",
+        "policy-enforcement",
+        "wrong-direction-rule",
+        "root-cause",
+        "audit-remediation",
+        "repeated-violations",
+        "ci-policy",
+        "doc-policy",
+        "meta-debugging"
       ]
     },
     {
-      "name": "jq-compatibility-fix",
-      "description": "Fix jq syntax errors caused by array concatenation with conditionals in older jq versions",
+      "name": "logging-subprocess-context-tracking",
+      "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
-      "source": "./skills/jq-compatibility-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "judge-empty-response-file-path-bug",
-      "description": "Fix judge producing empty responses \u2014 variadic --allowedTools flag issue AND Claude CLI v2.1.83 empty result field bug. Use when: (1) all judges return empty responses across all models, (2) stdout_len=1 (single newline) from judge CLI calls, (3) --print mode returns empty result despite model generating tokens.",
-      "version": "3.0.0",
-      "source": "./skills/judge-empty-response-file-path-bug.md",
+      "source": "./skills/logging-subprocess-context-tracking.md",
       "category": "debugging",
       "tags": [
-        "judge",
-        "cli-bug",
-        "stream-json",
-        "empty-response"
-      ]
-    },
-    {
-      "name": "liza-state-yaml-timestamp-normalization",
-      "description": "Repair a broken `.liza/state.yaml` after a YAML serializer rewrites RFC3339 timestamps into space-separated datetimes that the Liza CLI cannot parse. Use when: (1) `liza validate`, `liza status`, or `liza resume` fail with `cannot parse ... as \"T\"`, (2) `.liza/state.yaml` was rewritten by PyYAML or another generic YAML emitter, (3) the workspace is otherwise intact but all Liza commands fail on timestamp parsing.",
-      "version": "1.0.0",
-      "source": "./skills/liza-state-yaml-timestamp-normalization.md",
-      "category": "debugging",
-      "tags": [
-        "liza",
-        "yaml",
-        "timestamp",
-        "state",
-        "recovery",
-        "pyyaml"
-      ]
-    },
-    {
-      "name": "logging-context-deduplication",
-      "description": "Fix duplicated context prefixes in structured logging pipelines. Use when: log lines show the same context twice, or empty context renders as [//].",
-      "version": "1.0.0",
-      "source": "./skills/logging-context-deduplication.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "logging-handler-registry-deduplication",
-      "description": "Fix Python get_logger() adding duplicate handlers on repeated calls. Use when: (1) logger adds multiple StreamHandlers after repeated get_logger() calls, (2) file handler is silently skipped on second call, (3) parent logger propagation causes duplicate output.",
-      "version": "2.0.0",
-      "source": "./skills/logging-handler-registry-deduplication.md",
-      "category": "debugging",
-      "tags": [
-        "python",
         "logging",
-        "deduplication",
-        "handlers"
-      ]
-    },
-    {
-      "name": "mock-expensive-simulations",
-      "description": "Diagnose and fix pytest tests hanging due to expensive Monte Carlo or bootstrap simulation calls, with correct patch target (caller vs origin namespace) identification",
-      "version": "1.0.0",
-      "source": "./skills/mock-expensive-simulations.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-anytensor-copy-pointer-leak",
-      "description": "UnsafePointer.take_pointee() moves the value out of pointed-to memory but does NOT free the pointer allocation. Must call ptr.free() explicitly after take_pointee(). Use when: (1) implementing copy() methods that use mem_alloc + take_pointee(), (2) debugging ASAN pooled_alloc leaks traced to Mojo struct copy methods.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-anytensor-copy-pointer-leak.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-anytensor-uint-set-float-bitcast",
-      "description": "AnyTensor.set(UInt32/UInt64) silently drops writes to float32/float64 tensors because _set_int64 has no float handler. Use when: (1) writing raw IEEE 754 bit patterns (NaN, Inf, denormals) into float tensors via set(UInt32/UInt64), (2) test assertions about NaN bit patterns in float tensors silently fail, (3) any UInt32/UInt64 write to a float-dtype AnyTensor appears to have no effect.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-anytensor-uint-set-float-bitcast.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "anytensor",
-        "bitcast",
-        "nan",
-        "float32",
-        "float64",
-        "silent-bug",
-        "set"
-      ]
-    },
-    {
-      "name": "mojo-atomic-spinlock-double-check-lock",
-      "description": "Implement a correct SpinLock in Mojo using the TTAS (Test-and-Test-and-Set) double-check lock pattern when Atomic[DType.int64] lacks compare_exchange. Use when: (1) implementing a spinlock in Mojo without CAS support, (2) seeing counter underflow/overflow from naive fetch_add/fetch_sub lock, (3) thread-safety tests hang or produce wrong counts, (4) Mojo Atomic API only has fetch_add/fetch_sub/load, (5) unlock uses store(0) instead of fetch_add(-1) \u2014 a silent race that causes permanent deadlock under TTAS contention.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-atomic-spinlock-double-check-lock.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "atomic",
-        "spinlock",
-        "ttas",
-        "thread-safety",
-        "concurrent",
-        "double-check-lock",
-        "fetch_add",
-        "fetch_sub",
-        "store-zero-race",
-        "deadlock",
-        "memory-pool"
-      ]
-    },
-    {
-      "name": "mojo-binary-closed-source-debugging",
-      "description": "Use when: (1) trying to build Mojo from source to debug a libKGEN* crash and looking for the compiler in the modular/modular repo, (2) trying to resolve a Mojo binary version hash (e.g. ed7c8f0a) to a public commit, (3) deciding whether self-building Mojo is a viable debugging path for a runtime crash, (4) writing an upstream issue and need to know what level of source-level investigation is possible, (5) considering forking modular/modular to add instrumentation, (6) confused why grep/git-blame across modular/modular doesn't find KGEN/Async/MSupport runtime code.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-binary-closed-source-debugging.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "upstream",
-        "modular",
-        "closed-source",
-        "debugging",
-        "libKGEN",
-        "escalation"
-      ]
-    },
-    {
-      "name": "mojo-binary-file-read-bytes-not-string",
-      "description": "Use f.read_bytes() instead of f.read() when reading binary files in Mojo 0.26.3. Use when: (1) reading binary file formats like IDX/MNIST that contain non-UTF-8 bytes, (2) getting 'Cannot construct a String from invalid UTF-8 data' crash on file read, (3) trying to use 'rb' open mode which doesn't exist in Mojo 0.26.3.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-binary-file-read-bytes-not-string.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "binary",
-        "file-io",
-        "idx",
-        "mnist",
-        "utf8",
-        "read_bytes"
-      ]
-    },
-    {
-      "name": "mojo-closures-capturing-numerical-forward-trait",
-      "description": "Workaround for Mojo 0.26.3: capturing closures cannot be passed to def(T) raises -> T parameters. Use when: (1) a nested def captures outer variables and must be passed to a higher-order function, (2) compiler gives 'capturing nested functions must be declared unified' or 'cannot pass unified closure to escaping parameter', (3) higher-order function takes BOTH forward AND backward function arguments (e.g., check_gradient(fwd, bwd, ...)), (4) need to migrate a large codebase (10+ files) of capturing closures in parallel.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-closures-capturing-numerical-forward-trait.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-dirpath-trailing-slash-normalization",
-      "description": "Fix double-slash path construction in Mojo when dirpath has a trailing slash. Use when: (1) save_named_tensors/load_named_tensors produces paths like 'checkpoint//file.weights', (2) os.listdir or file open fails due to double slashes, (3) docstring examples show trailing slash but function concatenates '/' + filename unconditionally.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-dirpath-trailing-slash-normalization.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-dtype-partial-support-guard",
-      "description": "Diagnose and guard against partially-supported Mojo DTypes where the type exists but runtime value operations silently fail. Use when: CI shows 'Element 0 = 0.0, expected N.N' after enabling a previously-skipped dtype test, or DType.bfloat16 tensors return zeros despite explicit value assignment.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-dtype-partial-support-guard.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-exotic-dtype-default-param-crash",
-      "description": "Fix Mojo 0.26.1 ASAN abort at module load from exotic dtype (E8M0, FP8) used as default parameter values. Use when: (1) ASAN abort fires before any test body runs, (2) code uses Scalar[E8M0](1.0) or Scalar[FP8](1.0) as a default param, (3) E8M0/FP8 float-conversion path is triggered at module load time.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-exotic-dtype-default-param-crash.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "asan",
-        "dtype",
-        "e8m0",
-        "fp8",
-        "default-param",
-        "module-load"
-      ]
-    },
-    {
-      "name": "mojo-extensor-implementation-patterns",
-      "description": "Use when: (1) implementing or fixing utility methods on ExTensor (dunder methods, type conversions, hash, bool, setitem, getitem), (2) fixing silent dtype failures in bfloat16 I/O paths, (3) adding stride-view methods (transpose, permute) to ExTensor, (4) encountering Mojo type errors (Int64 implicit conversion, missing __getitem__ overload), (5) documenting ExTensor view/owner contract or fixing MD060 markdownlint errors",
-      "version": "2.0.0",
-      "source": "./skills/mojo-extensor-implementation-patterns.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-float-literal-overload-fix",
-      "description": "Fix Mojo type errors where float literals fail to match Float64 overloads by adding a Float32 overload. Use when: CI fails with 'no matching method in call to __setitem__' for float literals, or when Mojo APIs only have Float64 overloads but user code uses bare float literals.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-float-literal-overload-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-jit-crash-retry",
-      "description": "Use when: (1) CI produces 'execution crashed' (libKGENCompilerRTShared.so) before any test output, (2) multiple unrelated test files crash in the same CI run on unchanged code, (3) a Mojo test file crashes deterministically at the Nth sequential call to a complex function, (4) removing retry workarounds from CI test runners to expose root causes, (5) a Copyable struct with UnsafePointer fields and no explicit __copyinit__ is stored in List, (6) tests crash non-deterministically and the code changes don't touch those test files at all, (7) creating minimal crash reproducers to file upstream issues against modular/modular, (8) required CI checks are blocked by JIT flakiness and PRs cannot auto-merge, (9) diagnosing which of THREE distinct crash types a CI failure is: bitcast UAF (resolved), fortify_fail HOME permission (CI-only UID mismatch), or JIT volume overflow (intermittent, targeted imports fix), (10) considering @always_inline to fix bitcast crashes (ANTI-PATTERN: worsens crashes), (11) ASAP destruction crash in finite-difference perturbation loops after test output prints, (12) codebase-wide swarm elimination of bitcast UAF writes across 50+ files, (13) KGEN internal buffer overflow with fixed crash address +0x6d4ab from 4-condition trigger combination, (14) shared library modules carry heavy module-level imports that cause JIT volume overflow for all their importers, (15) splitting oversized Mojo test files per ADR-009 (<=10 functions), (16) fn main deprecation parse errors after file splitting in Mojo 0.26.3+, (17) Mojo 1.0.0b2 non-deterministic JIT crash at libKGENCompilerRTShared.so+0x6ef7b/+0x6c156/+0x6fc27 \u2014 start with the 4-hypothesis disproof checklist (Tuple destructor UAF, memory pressure, import volume, sequential test-group leak) before opening upstream, (18) launching parallel hypothesis-test sub-agents to root-cause an intermittent crash, (19) using AddressSanitizer / ThreadSanitizer / MemorySanitizer / UndefinedBehaviorSanitizer-instrumented Mojo builds to escalate when local repros fail, (20) decoding a stripped libKGENCompilerRTShared.so crash trace via dynsym map + objdump (bucketing offsets against the giant `_ZNSt24uniform_int_distributionImEclISt13random_deviceEEmRT_RKNS0_10param_typeE@@Base` symbol that fronts a 60+KB stripped region), (21) recognizing that the published 3-frame trace is the Crashpad signal-handler chain (NOT the actual fault) and a coredump is required to recover the real frame, (22) cross-version offset comparison across Mojo releases inside the same unsymbolicated region as a STRONG match signal for same-defect-family classification.",
-      "version": "4.1.0",
-      "source": "./skills/mojo-jit-crash-retry.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "jit",
-        "crash",
-        "repro",
-        "ci",
-        "libKGENCompilerRTShared",
-        "upstream",
-        "required-checks",
-        "always-inline",
-        "asap-destruction",
-        "bitcast",
-        "uaf",
-        "copyinit",
-        "double-free",
-        "kgen",
-        "swarm",
-        "test-splitting",
-        "adr-009",
-        "library-imports"
-      ]
-    },
-    {
-      "name": "mojo-jit-emits-avx512-on-non-avx512-cpu",
-      "description": "Root cause of modular/modular#6413: Mojo 1.0.0b2.dev2026050805 emits AVX-512 instructions (zmm registers, opmasks, {1to4} broadcast, vpternlogd, vpbroadcastb r\u2192xmm) on Azure GHA runners whose CPU does NOT advertise AVX-512 \u2014 SIGILL at runtime. The triggering hardware is AMD EPYC Zen 4 under Microsoft Hyper-V (e.g. EPYC 9V74), NOT pre-AVX-512 Intel CPUs \u2014 that earlier hypothesis is falsified by 6/6 clean local runs across Sandy Bridge-E through Lunar Lake. Mechanism (now directly observed in CI): LLVM's getHostCPUName() reads CPU family 0x19 + Genoa model range \u2192 returns 'znver4' \u2192 X86TargetParser.cpp::Processors[] applies a STATIC AVX-512 feature list that is NOT gated on the masked CPUID feature leaves. Hyper-V masks the leaves but not family/model, so fingerprinting wins. v3.0.0: mechanism captured end-to-end on the CI host via `mojo build --print-effective-target` (12 AVX-512 features emitted) alongside C cpuid/xgetbv/__builtin_cpu_supports probe (AVX512F=0 everywhere kernel-visible), plus 20/20 bare-command crash reproduction. Use when: (1) triaging Mojo SIGILL on GHA, (2) `mojo build --print-effective-target` shows znver4 + AVX-512 but /proc/cpuinfo shows no avx512 flag, (3) capturing disassembly evidence from ELF cores, (4) reasoning about Mojo runtime CPU detection (LLVM getHostCPUFeatures path via closed-source CLOptions.h:118).",
-      "version": "3.0.0",
-      "source": "./skills/mojo-jit-emits-avx512-on-non-avx512-cpu.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "jit",
-        "avx-512",
-        "avx512",
-        "sigill",
-        "libKGEN",
-        "modular-6413",
-        "cpu-detection",
-        "azure-runner",
-        "gha",
-        "runtime-codegen",
-        "zen4",
-        "epyc",
-        "hyper-v",
-        "llvm-host-cpu-detection"
-      ]
-    },
-    {
-      "name": "mojo-missing-function-from-test-import",
-      "description": "Debug Mojo test import failures where a function exists in tests but not in the source module. Use when: (1) Mojo test imports a function that causes compilation errors, (2) CI tests are skipped due to package compilation failure, (3) investigating why a Mojo test file was added without the corresponding implementation.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-missing-function-from-test-import.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-moveinit-list-corruption",
-      "description": "Diagnose Mojo 0.26.1 bug where ^ transfer of List in __moveinit__ corrupts in-place-mutated values. Use when: struct move breaks assertions on List-derived data, or considering switching .copy() to ^ in __moveinit__ for performance.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-moveinit-list-corruption.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-nd-slice-copy-semantics",
-      "description": "Fix Mojo multi-dimensional tensor slicing bugs caused by pointer-offset view approach on non-contiguous data. Use when: (1) N-D tensor slice tests are skipped/disabled, (2) __getitem__(*slices) returns wrong values for 2D/3D/ND slices, (3) multi-dim slicing uses self.copy() + data pointer offset which fails for non-contiguous results.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-nd-slice-copy-semantics.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-nested-fn-capture-fix",
-      "description": "Fix Mojo fieldwise init synthesis failure when nested fn captures non-copyable struct. Use when: getting 'cannot synthesize fieldwise init because field has non-copyable and non-movable type' errors.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-nested-fn-capture-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-noncontiguous-reshape-fix",
-      "description": "Fix flat-index bugs in Mojo tensor ops that ignore strides on non-contiguous inputs. Use when: debugging wrong element order after transpose/slice, or implementing copy loops that must respect non-C-order layouts.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-noncontiguous-reshape-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-param-method-collision",
-      "description": "Fix Mojo v0.26.1 struct parameter-method name collision where a parametric struct's type parameter and a trait method share the same name. Use when: (1) CI fails with 'invalid redefinition' on a parametric struct method, (2) a trait requires fn dtype() but the struct has [dtype: DType] parameter, (3) typed overloads create 'no matching function' ambiguity with existing untyped functions.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-param-method-collision.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-print-effective-target-codegen-diagnostic",
-      "description": "First-line no-compile diagnostic for 'wrong instructions emitted on this host' Mojo reports: `mojo build --print-effective-target <some.mojo>` prints the driver-resolved `--target-cpu` and `--target-features` list without actually compiling the program. Run on each suspect host and diff. The Mojo driver populates the `!kgen.target` MLIR attribute from `llvm::sys::getHostCPUFeatures()`; that attribute drives every `target_has_feature[\"...\"]` query in stdlib (e.g. `has_avx512f`). If the driver fingerprints the CPU and applies a static AVX-512 feature list but the kernel/hypervisor doesn't expose AVX-512, codegen will emit AVX-512 ops that SIGILL at runtime. Use when: (1) triaging a Mojo SIGILL where you suspect the JIT picked the wrong ISA, (2) pre-flighting a Mojo binary across a mixed-CPU fleet, (3) differentiating 'wrong CPU name picked' from 'right CPU name, wrong static feature table', (4) gathering evidence before opening a modular/modular CPU-detection bug.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-print-effective-target-codegen-diagnostic.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "target-cpu",
-        "target-features",
-        "print-effective-target",
-        "codegen",
-        "host-fingerprinting",
-        "cpu-detection",
-        "avx-512",
-        "sigill",
-        "modular-6413",
-        "diagnostic"
-      ]
-    },
-    {
-      "name": "mojo-runtime-crash-bisection",
-      "description": "Systematic approach for bisecting Mojo runtime crashes to create minimal reproducers and isolate root causes. Use when: Mojo crashes in runtime libraries, need upstream bug reports.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-runtime-crash-bisection.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-sanitizer-support-matrix",
-      "description": "Use when: (1) running `mojo build --sanitize=thread` and hitting `'DW.ref.__gcc_personality_v0' is already defined` linker error, (2) trying `--sanitize=memory` or `--sanitize=undefined` and getting `invalid sanitizer 'X', expected one of: 'address' or 'thread'`, (3) deciding which sanitizer to use to escalate a non-deterministic Mojo runtime crash, (4) interpreting a clean ASAN run alongside a persistent libKGEN crash, (5) writing an upstream issue and wondering whether to attach TSAN/MSAN/UBSAN evidence (don't \u2014 they don't run in 1.0.0b2), (6) filing or referencing modular/modular#6512 (TSan personality-symbol duplicate definition).",
-      "version": "1.0.0",
-      "source": "./skills/mojo-sanitizer-support-matrix.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "sanitizer",
-        "asan",
-        "tsan",
-        "msan",
-        "ubsan",
-        "debugging",
-        "mojo-1-0",
-        "upstream-issue"
-      ]
-    },
-    {
-      "name": "mojo-serialization-ci-crash",
-      "description": "Debug Mojo serialization CI crashes from dtype string conversion mismatches and Python interop crashes. Use when: (1) mojo test crashes during hex encoding or serialization roundtrip, (2) CI fails with libKGENCompilerRTShared crash in serialization tests, (3) dtype roundtrip produces wrong type after load, (4) load_named_tensors returns wrong ordering.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-serialization-ci-crash.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-set-api-migration-syntax-patterns",
-      "description": "Three syntax error patterns introduced by Mojo bitcast\u2192set() API migration: inline comments inside call parens swallow closing delimiters (Pattern A), empty Float32(()) split across lines (Pattern B), garbled = in call args or orphaned declarations (Pattern C). Use when: (1) mojo compiler reports 'expected ) in call argument list' after a set() migration, (2) 'use of unknown declaration' errors appear after commenting out var declarations, (3) fixing ASAN JIT symbol errors in dtype tests.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-set-api-migration-syntax-patterns.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-setitem-lvalue-semantics",
-      "description": "Documents Mojo subscript assignment semantics and ExTensor __setitem__ implementation: obj[i]=val uses __getitem__ lvalue, not __setitem__; adding __setitem__ overloads to structs lacking them; handling GLIBC mismatch causing mojo format pre-commit failures; and test patterns for Float64/Int64/out-of-bounds coverage. Use when: (1) debugging 'cannot implicitly convert' errors on ExTensor/subscript assignments, (2) designing subscript APIs in Mojo structs, (3) encountering 'cannot call function that may raise' after wrapping subscript assignments, (4) CI fails with 'expression must be mutable in assignment' on tensor subscript lines, (5) mojo format pre-commit hook fails locally with GLIBC_2.32+ not found, (6) adding tests for __setitem__ overloads on Mojo tensor types.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-setitem-lvalue-semantics.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "type-errors",
-        "subscript",
-        "setitem",
-        "getitem",
-        "lvalue",
-        "ExTensor",
-        "Float32",
-        "Float64",
-        "Float16",
-        "glibc",
-        "pre-commit",
-        "testing",
-        "ci-cd"
-      ]
-    },
-    {
-      "name": "mojo-shallow-copy-tensor-hazard",
-      "description": "Fix Mojo tensor mutation caused by shallow copy sharing _data pointer. Use when: a function mutates a tensor copy but silently corrupts the caller's original tensor.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-shallow-copy-tensor-hazard.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-silent-noop-int8-dtype-fix",
-      "description": "Fix silent no-op writes in Mojo dtype dispatch functions missing integer branches. Use when: a _set_float* function silently discards writes for int8, a dtype chain has no integer branch, or a test documents a known no-op instead of asserting correct truncation.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-silent-noop-int8-dtype-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-slice-negative-step",
-      "description": "Fix negative-step slice bugs in Mojo __getitem__(Slice). Use when: reverse slicing returns empty or wrong results, result_size is 0 for t[::-1], or slice defaults are wrong for negative step.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-slice-negative-step.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "mojo-tuple-destructor-clone-pattern",
-      "description": "Mojo 0.26.x Tuple does not call __del__ on non-trivial element types; Dataset.__getitem__ must return .clone() not .slice() to prevent ASAN memory leaks. Use when: (1) implementing __getitem__ in Dataset structs that return Tuple[AnyTensor, AnyTensor], (2) debugging ASAN pooled_alloc leaks where leak count matches dataset count, (3) refcount elevation survives tuple scope exit.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-tuple-destructor-clone-pattern.md",
-      "category": "debugging",
-      "tags": [
-        "asan",
-        "leak",
-        "tuple",
-        "destructor",
-        "clone",
-        "slice",
-        "refcount",
-        "dataset",
-        "mojo",
-        "getitem"
-      ]
-    },
-    {
-      "name": "mojo-upstream-bug-filing-reproducibility-standard",
-      "description": "Use before filing any Mojo bug or feature request upstream against modular/modular. Enforces reproducibility standard: minimal reproducer, 100% deterministic on current pinned version, verified just-in-time. Prevents wasted effort from filing already-fixed or non-reproducible bugs.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-upstream-bug-filing-reproducibility-standard.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "upstream",
-        "bug-filing",
-        "reproducibility",
-        "modular",
-        "determinism",
-        "minimal-reproducer"
+        "subprocess",
+        "working-directory",
+        "pytest",
+        "caplog",
+        "custom-handlers",
+        "context-tracking"
       ]
     },
     {
@@ -5420,77 +3400,10 @@
       ]
     },
     {
-      "name": "multidim-slice-step-validation",
-      "description": "Fix silent incorrect results when a variadic-slice __getitem__ ignores the step field. Use when: multi-dim tensor slicing silently returns wrong data for step != 1, or you need a fail-fast guard for unimplemented strided access.",
-      "version": "1.0.0",
-      "source": "./skills/multidim-slice-step-validation.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "nan-hash-canonicalization",
-      "description": "Canonicalize NaN bit patterns in __hash__ for IEEE 754 float tensors to ensure hash stability. Use when: different NaN representations (sign bit, payload, signaling vs quiet) produce different hashes for semantically identical NaN content.",
-      "version": "1.0.0",
-      "source": "./skills/nan-hash-canonicalization.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "nats-optional-import-guard-deliver-policy",
-      "description": "Debugging pattern for nats-py optional import guard failures caused by enum conversion. Use when: (1) nats subscriber tests show mock_js.subscribe.call_count == 0, (2) adding an enum/type conversion from nats.js.api inside _subscribe_loop, (3) CI shows 'nats-py is not installed' error when nats IS mocked.",
-      "version": "1.0.0",
-      "source": "./skills/nats-optional-import-guard-deliver-policy.md",
-      "category": "debugging",
-      "tags": [
-        "nats",
-        "optional-dependency",
-        "import-guard",
-        "lazy-import",
-        "DeliverPolicy",
-        "nats-py",
-        "python",
-        "asyncio"
-      ]
-    },
-    {
-      "name": "nats-py-connection-resilience-patterns",
-      "description": "Patterns for making nats-py Python clients show clean connection state instead of stack traces. Use when: (1) building a NATS event viewer or console that must handle NATS being unreachable, (2) nats-py is printing full tracebacks on connection failures, (3) implementing retry-with-clean-status for asyncio NATS clients, (4) needing interruptible reconnection loops with graceful shutdown.",
-      "version": "1.0.0",
-      "source": "./skills/nats-py-connection-resilience-patterns.md",
-      "category": "debugging",
-      "tags": [
-        "nats",
-        "nats-py",
-        "asyncio",
-        "connection-handling",
-        "resilience",
-        "python",
-        "odysseus-console",
-        "error-handling",
-        "reconnection"
-      ]
-    },
-    {
-      "name": "null-best-subtest-fallthrough-fix",
-      "description": "Fix pattern for elif\u2192if fallthrough when a primary JSON file exists with a null key, silently preventing fallback to a secondary file. Use when: T5 subtests fail with 'all required tiers failed' despite tiers completing, or any if/elif chain where primary file exists but has empty/null data.",
-      "version": "1.0.0",
-      "source": "./skills/null-best-subtest-fallthrough-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
       "name": "orphan-branch-recovery",
       "description": "Diagnose and fix branches with no common ancestor that cannot be merged",
       "version": "1.0.0",
       "source": "./skills/orphan-branch-recovery.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "persist-automation-logs",
-      "description": "Persist execution logs (Claude Code, retrospective, follow-up) to disk for post-mortem analysis after worktrees are cleaned up. Use when: automation fails silently, curses UI hides subprocess output, non-blocking phases fail without trace, or you need to debug after cleanup.",
-      "version": "1.0.0",
-      "source": "./skills/persist-automation-logs.md",
       "category": "debugging",
       "tags": []
     },
@@ -5507,21 +3420,6 @@
         "linker",
         "conda-forge",
         "sysroot"
-      ]
-    },
-    {
-      "name": "podman-rootless-dns-container-resolution",
-      "description": "Fix podman rootless DNS resolution failures between containers in compose networks. Use when: (1) containers cannot resolve each other by service name, (2) NATS/HTTP connections fail with 'Temporary failure in name resolution', (3) aardvark-dns is running but resolution still fails.",
-      "version": "1.1.0",
-      "source": "./skills/podman-rootless-dns-container-resolution.md",
-      "category": "debugging",
-      "tags": [
-        "podman",
-        "rootless",
-        "dns",
-        "aardvark-dns",
-        "compose",
-        "networking"
       ]
     },
     {
@@ -5551,20 +3449,43 @@
       ]
     },
     {
-      "name": "python-logging-filter-placement",
-      "description": "Diagnose and fix Python logging KeyError from custom format fields. Use when: KeyError on %(custom_field)s, filter fields missing from output, or custom context not appearing in threaded logs.",
+      "name": "python-logging-and-silent-error-patterns",
+      "description": "Diagnose and fix Python logging configuration bugs and silent-error anti-patterns. Use when: (1) log lines show duplicated context prefixes or empty delimiters like [//], (2) get_logger() adds duplicate StreamHandlers on repeated calls, (3) KeyError on custom %(field)s format placeholders, (4) LoggerAdapter.process() mutates the caller's extra dict, (5) a function silently swallows ValueError and falls back to a default instead of raising, (6) a string-typed enum is not normalized in-place so downstream middleware fails-open, (7) a Python CLI flag is silently prefix-matched by argparse causing a silent no-op, (8) __repr__ produces untruncated output inconsistent with __str__.",
       "version": "1.0.0",
-      "source": "./skills/python-logging-filter-placement.md",
+      "source": "./skills/python-logging-and-silent-error-patterns.md",
       "category": "debugging",
-      "tags": []
+      "tags": [
+        "python",
+        "logging",
+        "deduplication",
+        "handlers",
+        "filter-placement",
+        "LoggerAdapter",
+        "silent-failure",
+        "POLA",
+        "fail-open",
+        "argparse",
+        "repr-truncation"
+      ]
     },
     {
-      "name": "python-subprocess-terminal-corruption",
-      "description": "Fix terminal corruption from Python subprocess management and None-safe error handling patterns",
+      "name": "rebase-merge-shadow-var-tdz-ts-error",
+      "description": "Diagnose and fix TypeScript TS7022 + TS2448 errors that appear only after a rebase or merge, when two non-overlapping branch edits independently introduced a function parameter and a local `const` of the same name in the same scope \u2014 producing a shadowing/TDZ bug that auto-merge cannot detect. Use when: (1) CI fails after rebase with TS7022/TS2448 on adjacent lines for the same identifier, (2) the file compiled cleanly on both source branches individually, (3) no conflict markers appeared during the rebase.",
       "version": "1.0.0",
-      "source": "./skills/python-subprocess-terminal-corruption.md",
+      "source": "./skills/rebase-merge-shadow-var-tdz-ts-error.md",
       "category": "debugging",
-      "tags": []
+      "tags": [
+        "typescript",
+        "rebase",
+        "merge",
+        "shadowing",
+        "tdz",
+        "ts7022",
+        "ts2448",
+        "block-scoped",
+        "dagger",
+        "achaeanfleet"
+      ]
     },
     {
       "name": "refactor-context-manager-double-counter-stale-caller",
@@ -5575,60 +3496,45 @@
       "tags": []
     },
     {
-      "name": "repr-truncation-consistency",
-      "description": "Apply NumPy-style truncation to __repr__ for consistency with __str__. Use when: a class has truncated __str__ but untruncated __repr__, or repr() on large objects causes performance issues.",
+      "name": "sata-drive-bus-disconnect-diagnosis",
+      "description": "Diagnose and triage a SATA drive that has dropped off the bus (capacity=0, DID_BAD_TARGET on every command). Use when: (1) dmesg shows 'detected capacity change from N to 0' on a drive that was previously working, (2) smartctl returns 'A mandatory SMART command failed', (3) wipefs/sgdisk hit 'Read error 5/22' on raw device access.",
       "version": "1.0.0",
-      "source": "./skills/repr-truncation-consistency.md",
+      "source": "./skills/sata-drive-bus-disconnect-diagnosis.md",
       "category": "debugging",
-      "tags": []
+      "tags": [
+        "sata",
+        "scsi",
+        "smartctl",
+        "drive-failure",
+        "did-bad-target",
+        "dmesg",
+        "reallocated-sectors",
+        "ahci"
+      ]
     },
     {
-      "name": "retry-transient-errors",
-      "description": "Fix git clone failures caused by transient network errors. Use when experiencing connection reset, curl 56, or timeout errors in subprocess calls.",
-      "version": "1.0.0",
-      "source": "./skills/retry-transient-errors.md",
+      "name": "tensor-numeric-correctness-bugs",
+      "description": "Diagnose and fix silent correctness bugs in tensor/array numeric operations. Use when: (1) tensor ops produce wrong values for non-contiguous (strided/transposed) layouts, (2) a destructor frees an offset view pointer causing ASAN bad-free, (3) dtype mismatches silently corrupt values via bitcast (float bits read as int), (4) a missing dtype case (bfloat16) causes silent zero reads/writes, (5) multi-dim slice ignores step, returning all elements instead of strided subset, (6) IEEE 754 NaN bit patterns produce inconsistent hashes across runs, (7) a seed parameter is declared but never wired to the PRNG causing non-reproducible random tensors, (8) byte-pointer arithmetic on a `UnsafePointer[UInt8]` tensor buffer silently copies one byte per element regardless of dtype, leaving 3/4 of float32 storage uninitialized and quietly corrupting training data.",
+      "version": "1.1.0",
+      "source": "./skills/tensor-numeric-correctness-bugs.md",
       "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "skill-e2e-state-machine-bugs",
-      "description": "Fix --until off-by-one in advance_to_completion() loops and disconnected terminal signal handlers in manage_experiment.py",
-      "version": "1.0.0",
-      "source": "./skills/skill-e2e-state-machine-bugs.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "skill-fix-common-patterns",
-      "description": "Use when: (1) tests pass locally but fail in CI due to absolute symlinks or mocks patching the wrong method, (2) FileNotFoundError from a directory path assigned but never created before write, (3) evaluation framework bugs cause agents to be scored on framework changes they didn't make, (4) checkpoint resume fails with config mismatch or shows empty completed_runs despite result files on disk, (5) judge can't verify file creation tasks because workspace state only shows directory names, (6) unittest.mock.patch targets point to stdlib global namespace instead of the call-site module, (7) Pydantic model fixtures are missing newly required fields after model evolution, (8) rerun scripts don't complete all cases due to missing run_result.json or infinite judge retry loops",
-      "version": "2.0.0",
-      "source": "./skills/skill-fix-common-patterns.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "skill-path-resolution-fix",
-      "description": "Skill: skill-path-resolution-fix. Use when working with skill path resolution fix.",
-      "version": "1.0.0",
-      "source": "./skills/skill-path-resolution-fix.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "skill-resume-checkpoint-bugs",
-      "description": "Fix experiment runner resume bugs: uppercase INTERRUPTED state, max_subtests ephemeral handling, missing-subtest detection, and tier state reset target selection",
-      "version": "1.0.0",
-      "source": "./skills/skill-resume-checkpoint-bugs.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "unify-judge-validity-logic",
-      "description": "Unify judge validity logic",
-      "version": "1.0.0",
-      "source": "./skills/unify-judge-validity-logic.md",
-      "category": "debugging",
-      "tags": []
+      "tags": [
+        "tensor",
+        "mojo",
+        "dtype",
+        "stride",
+        "bitcast",
+        "nan",
+        "hash",
+        "asan",
+        "bad-free",
+        "view",
+        "slice",
+        "bfloat16",
+        "reproducibility",
+        "seed",
+        "numeric-correctness"
+      ]
     },
     {
       "name": "validation-test-fixture-symmetry",
@@ -5653,6 +3559,21 @@
       "source": "./skills/academic-paper-validation.md",
       "category": "documentation",
       "tags": []
+    },
+    {
+      "name": "academic-paper-validation-and-publication",
+      "description": "Canonical workflow for academic paper validation and publication readiness: data accuracy checks, iterative accuracy review, peer-review prep, LaTeX section-adding patterns, paper-readiness epic management. Use when: (1) preparing a manuscript for submission, (2) running an iterative-accuracy review pass, (3) adding architecture/methodology sections to a LaTeX paper, (4) managing a paper-readiness epic with sub-tasks.",
+      "version": "1.0.0",
+      "source": "./skills/academic-paper-validation-and-publication.md",
+      "category": "documentation",
+      "tags": [
+        "merged",
+        "academic",
+        "paper",
+        "latex",
+        "publication",
+        "validation"
+      ]
     },
     {
       "name": "add-ci-badge-to-readme",
@@ -5687,52 +3608,32 @@
       "tags": []
     },
     {
-      "name": "audit-runtime-note-prints",
-      "description": "Audit example scripts for ambiguous runtime NOTE/TODO/FIXME print statements and replace with plain status messages. Use when: following up after a partial fix of NOTE prints, auditing all examples/ scripts for misleading runtime output, or converting Note: prefixes to factual plain text.",
+      "name": "audit-monolith-documentation-resolution-pattern",
+      "description": "Resolve audit nitpicks for monolithic code by documenting verified design rationale. Use when: (1) auditor questions code organization as violation of SRP, (2) splitting vs. documenting trade-off exists, (3) design decision lacks permanent record.",
       "version": "1.0.0",
-      "source": "./skills/audit-runtime-note-prints.md",
+      "source": "./skills/audit-monolith-documentation-resolution-pattern.md",
       "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "audit-shared-links",
-      "description": "Audit shared documentation files for missing link-backs in a root markdown file. Use when: adding shared files that should appear in a Quick Links section, wiring a pre-commit hook to prevent drift, or implementing documentation audits with typed Python and pytest.",
-      "version": "1.0.0",
-      "source": "./skills/audit-shared-links.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "auto-impl-preflight",
-      "description": "Verify auto-impl issue completion and detect already-done work before starting. Use when: (1) prior session committed work and created a PR but implementation plan may have additional items not captured in the commit, (2) starting an auto-impl session and need to check if work was already done in a previous session.",
-      "version": "1.1.0",
-      "source": "./skills/auto-impl-preflight.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "backward-pass-catalog-module-authoring",
-      "description": "Add a new module section to backward-pass-catalog.md documenting backward passes with formulas, shapes, and stability notes. Use when: an issue asks to document formulas/shapes for an untracked backward function, or catalog header stats are stale after new functions are implemented.",
-      "version": "1.0.0",
-      "source": "./skills/backward-pass-catalog-module-authoring.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "batchnorm-epsilon-audit",
-      "description": "Audit backward-pass tester methods for undocumented epsilon/tolerance magic numbers and apply structured NOTE comment pattern. Use when: following up a backward-pass epsilon audit, or when BatchNorm/Pooling backward testers lack gradient-checking constant documentation.",
-      "version": "1.0.0",
-      "source": "./skills/batchnorm-epsilon-audit.md",
-      "category": "documentation",
-      "tags": []
+      "tags": [
+        "audit",
+        "documentation",
+        "architecture-decision",
+        "monolith",
+        "nitpick"
+      ]
     },
     {
       "name": "blog-writer",
-      "description": "Write development blog posts in cycle format. Creates engaging, narrative-driven posts about development work with informal tone while maintaining technical accuracy and markdown compliance. Use after completing milestones or phases.",
-      "version": "1.0.0",
+      "description": "Write development blog posts in episodic story-arc format with day numbering anchored to project start. Produces self-contained, narrative-driven posts where the root cause arrives near the end, every rejected hypothesis gets its own paragraph, and primary-source quotes are mined from Claude session logs. Use after a milestone, bug hunt, or multi-day investigation worth a narrative retrospective.",
+      "version": "2.0.0",
       "source": "./skills/blog-writer.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "blog",
+        "narrative",
+        "documentation",
+        "retrospective",
+        "story-arc"
+      ]
     },
     {
       "name": "citation-verification-arxiv-abstract-fetch",
@@ -5752,22 +3653,6 @@
       ]
     },
     {
-      "name": "claude-md-token-trim",
-      "description": "Reduce CLAUDE.md token consumption by replacing verbose/duplicate sections with concise summaries and links. Use when: (1) CLAUDE.md exceeds a line/token budget, (2) sections duplicate content already in shared docs, (3) pre-commit markdownlint MD060 table errors need fixing alongside trimming.",
-      "version": "2.0.0",
-      "source": "./skills/claude-md-token-trim.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "cleanup-issue-doc-only-change",
-      "description": "Pattern for documentation-only cleanup issues: expand bare NOTE/TODO markers with structured deferred-item format and add README Limitations sections. Use when: a cleanup issue has no code implementation needed, only inline comment expansion and user-facing docs.",
-      "version": "1.0.0",
-      "source": "./skills/cleanup-issue-doc-only-change.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
       "name": "consolidate-duplicate-adr-references",
       "description": "Consolidate duplicate inline comments or docstring Notes into a single ADR, then replace each duplicate with a short cross-reference. Use when: two or more functions have nearly identical limitation comments, or an issue asks to reduce maintenance burden by centralizing a workaround note in an ADR.",
       "version": "1.0.0",
@@ -5776,39 +3661,18 @@
       "tags": []
     },
     {
-      "name": "cross-doc-citation-drift-defenses",
-      "description": "Procedural and audit defenses against two failure modes when authoring inter-citing markdown corpora: (A) section-numbering drift when one document is reorganized but its citers are not updated in the same commit, and (B) arXiv ID-to-title swaps within a single author's multi-paper corpus during initial drafting. Use when: (1) authoring a corpus of inter-citing markdown documents (research scoping docs, design specs, paper drafts) with \u00a7-references between files, (2) citations involve external sources (arXiv IDs, DOIs, model cards, API URLs), (3) multiple documents share section-numbering schemes that may be reorganized during review loops, (4) multi-author corpora where one author has 3+ papers (Millidge, Bengio, Hinton, etc.) \u2014 high ID/title swap risk, (5) you need authoring-time defenses, not just post-hoc verification.",
+      "name": "demo-scripts-dynamic-version-from-package-attr",
+      "description": "Use a package's public __version__ attribute in demo/example scripts rather than hardcoded strings or direct importlib.metadata calls. Use when: (1) demo/example scripts display or reference the package version, (2) you want sample code to stay in sync with releases automatically, (3) replacing a placeholder version string with the actual installed version, (4) teaching users how to consume version the same way their own code should.",
       "version": "1.0.0",
-      "source": "./skills/cross-doc-citation-drift-defenses.md",
+      "source": "./skills/demo-scripts-dynamic-version-from-package-attr.md",
       "category": "documentation",
       "tags": [
-        "citation",
-        "cross-reference",
-        "section-numbering",
-        "stale-reference",
-        "arxiv",
-        "primary-source",
-        "authoring-discipline",
-        "multi-document-corpus",
-        "citation-drift",
-        "reorganization-discipline"
+        "version-management",
+        "demo-scripts",
+        "example-code",
+        "package-public-interface",
+        "idiomatic-python"
       ]
-    },
-    {
-      "name": "deferred-doc-placeholder",
-      "description": "Pattern for adding an HTML comment placeholder to a docs navigation index when an entire section is removed due to stub deletion. Use when: a docs/index.md section disappears after placeholder stubs are deleted and a follow-up issue tracks restoring it.",
-      "version": "1.0.0",
-      "source": "./skills/deferred-doc-placeholder.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "delete-placeholder-docs",
-      "description": "Delete empty placeholder documentation stubs and remove broken links. Use when: stub files contain only placeholder text, YAGNI cleanup is needed, or broken links must be fixed.",
-      "version": "1.0.0",
-      "source": "./skills/delete-placeholder-docs.md",
-      "category": "documentation",
-      "tags": []
     },
     {
       "name": "doc-audit-policy-violations",
@@ -5819,119 +3683,39 @@
       "tags": []
     },
     {
-      "name": "doc-contradiction-resolution",
-      "description": "Skill: Resolve Documentation Contradictions Between Project Files",
+      "name": "docs-contributing-md-case-clash-redirect",
+      "description": "Resolve CONTRIBUTING.md case-clash and circular cross-reference between root CONTRIBUTING.md and docs/contributing.md. Use when: (1) a repo has both CONTRIBUTING.md (root) and docs/contributing.md with a circular 'See also' mutual reference, (2) docs/contributing.md duplicates content from the root canonical file, (3) docs hygiene audit flags CONTRIBUTING case ambiguity on case-insensitive filesystems.",
       "version": "1.0.0",
-      "source": "./skills/doc-contradiction-resolution.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "doc-stale-future-improvements-audit",
-      "description": "Systematically audit design docs for Future Improvements sections that describe features already implemented in source code. Use when an issue asks to audit docs for staleness, when CI flags stale docs, or after a period of active development.",
-      "version": "1.0.0",
-      "source": "./skills/doc-stale-future-improvements-audit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "doc-sync-existing-impl",
-      "description": "Sync documentation when an issue's fix is already implemented but docs lag behind. Use when: (1) issue requests fix but code fix already exists in scripts/, (2) CLAUDE.md describes old behavior instead of current wrapper, (3) pre-commit docs reference direct tool invocation instead of compat wrapper.",
-      "version": "1.0.0",
-      "source": "./skills/doc-sync-existing-impl.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "docs-status-fix",
-      "description": "Skill: docs-status-fix",
-      "version": "1.0.0",
-      "source": "./skills/docs-status-fix.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "docstring-only-change",
-      "description": "Workflow for implementing docstring-only changes to Python scripts: expand module docstrings with routing rules, target structure tables, or auxiliary subdirectory documentation. Use when a GitHub issue requests documenting implicit behaviour in a module docstring with no code or test changes required.",
-      "version": "1.0.0",
-      "source": "./skills/docstring-only-change.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "docstring-update-workflow",
-      "description": "Workflow for updating stale module-level docstring examples after API signature changes. Use when: a function signature changed and the module docstring still shows the old call, or a docstring example omits required arguments.",
-      "version": "1.0.0",
-      "source": "./skills/docstring-update-workflow.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "docstring-view-vs-copy-clarification",
-      "description": "Fix docstring inconsistencies where memory semantics are mislabeled (view vs copy). Use when: a docstring claims 'view' but the implementation allocates new memory, or sibling methods have conflicting return-type documentation.",
-      "version": "1.0.0",
-      "source": "./skills/docstring-view-vs-copy-clarification.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "document-copy-vs-view-semantics",
-      "description": "Document copy vs view semantics for slicing operations, updating docstrings and fixing misleading test names. Use when: NOTE markers exist, test names contradict assertions, or 'Returns: view' contradicts copy implementation.",
-      "version": "1.0.0",
-      "source": "./skills/document-copy-vs-view-semantics.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "document-deferred-future-improvements",
-      "description": "Pattern for documenting deferred Future Improvements in design docs: add Status, Why Deferred, and Acceptance Criteria to each item so future contributors avoid re-investigating implementation status",
-      "version": "1.0.0",
-      "source": "./skills/document-deferred-future-improvements.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "document-hook-glibc-incompatibility",
-      "description": "Document pre-commit hook OS/runtime incompatibilities in CONTRIBUTING.md. Use when: a hook auto-skips due to host OS constraints but lacks a discoverable explanation for contributors.",
-      "version": "1.0.0",
-      "source": "./skills/document-hook-glibc-incompatibility.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "document-magic-number-constants",
-      "description": "Extract inline magic-number NOTE comments into named module-level constants with full rationale. Use when: (1) a value is used with a NOTE comment referencing an issue, (2) the same magic number appears in multiple locations, (3) a cleanup issue asks to convert inline NOTEs to docstrings.",
-      "version": "1.0.0",
-      "source": "./skills/document-magic-number-constants.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "document-normalization-test-gotcha",
-      "description": "Document normalization backward pass test gotchas in project docs. Use when: a normalization layer backward gradient test produced a false mismatch that was a mathematical identity, or adding Known Gotchas sections to testing-strategy.md or backward-pass-catalog.md.",
-      "version": "1.0.0",
-      "source": "./skills/document-normalization-test-gotcha.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "documentation-architecture-research-quality-rubric",
-      "description": "6-dimension weighted rubric for auditing AI architecture research documents, with canonical baseline geometry for LLM-scale proposals. Use when: (1) grading research docs for structural compliance, citations, baseline accuracy, TTFT/TPOT tables, TPOT direction honesty, and novelty verdicts, (2) performing corpus-scale quality audits on AI architecture proposals, (3) checking for the A2 KV@32K error (68 GB vs correct 8.59 GB), (4) enforcing D5 TPOT honesty rules for sequential-pass mechanisms, (5) verifying D6 novelty verdict format.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-architecture-research-quality-rubric.md",
+      "source": "./skills/docs-contributing-md-case-clash-redirect.md",
       "category": "documentation",
       "tags": [
-        "rubric",
-        "grading",
-        "research-docs",
-        "tpot",
-        "novelty-verdict",
-        "baseline-geometry",
-        "kv-cache",
-        "citation",
-        "architecture-research",
-        "audit",
-        "d1-d6"
+        "contributing",
+        "docs",
+        "case-clash",
+        "redirect",
+        "duplication",
+        "hygiene"
+      ]
+    },
+    {
+      "name": "docstring-and-api-documentation-update",
+      "description": "Update, fix, and extend docstrings and API documentation in source files to match current implementation semantics. Use when: (1) a function signature changed and the module docstring still shows the old call, (2) memory semantics (copy vs view) are mislabeled or inconsistent across sibling methods, (3) inline # NOTE comments in __init__ files need promotion to docstring Note: sections, (4) a catalog doc (backward-pass-catalog.md, testing-strategy.md) needs a new module section, formula, or gotcha subsection, (5) placeholder 'requires implementation' language persists after tests are written, (6) module docstrings have orphaned lowercase continuation fragments, (7) a new dunder/trait method is undocumented, (8) a utility function has an undocumented error-handling contract (swallows exceptions silently, returns special error shapes on failure).",
+      "version": "1.1.0",
+      "source": "./skills/docstring-and-api-documentation-update.md",
+      "category": "documentation",
+      "tags": [
+        "docstring",
+        "api-docs",
+        "copy-vs-view",
+        "mojo",
+        "module-docstring",
+        "backward-pass-catalog",
+        "re-export",
+        "float16",
+        "placeholder",
+        "error-handling-contract",
+        "POLA",
+        "silent-error"
       ]
     },
     {
@@ -5949,41 +3733,6 @@
         "citation-gap",
         "paper-discovery",
         "parallel-search"
-      ]
-    },
-    {
-      "name": "documentation-corpus-myrmidon-parallel-remediation",
-      "description": "Myrmidon swarm pattern for remediating a large document corpus in parallel using isolated git worktree agents. Use when: (1) an unpublished research corpus contains change-note prose, correction-history blocks, or backward-compatibility text that must be deleted (not annotated), (2) defects span many files and must be fixed in parallel without file ownership collisions, (3) you need wave-based execution: parallel fixers \u2192 read-only verifier \u2192 merge. Includes citation-verification pass that web-fetches arXiv abstracts to catch fabricated numeric ranges, reversed-polarity claims, and paper-body figures misattributed as abstract-level.",
-      "version": "1.6.0",
-      "source": "./skills/documentation-corpus-myrmidon-parallel-remediation.md",
-      "category": "documentation",
-      "tags": [
-        "myrmidon",
-        "swarm",
-        "parallel",
-        "corpus",
-        "remediation",
-        "worktree",
-        "wave-based",
-        "change-notes",
-        "unpublished",
-        "conflict-partitioning",
-        "citation-verification",
-        "arxiv-abstract-check"
-      ]
-    },
-    {
-      "name": "documentation-ecosystem-role-drift-detection",
-      "description": "Reconcile stale ecosystem role descriptions with actual implementation. Use when: (1) external docs describe a project differently than its code, (2) adding drift-detection tests to prevent doc/implementation divergence.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-ecosystem-role-drift-detection.md",
-      "category": "documentation",
-      "tags": [
-        "documentation",
-        "ecosystem",
-        "drift-detection",
-        "ablation",
-        "reconciliation"
       ]
     },
     {
@@ -6006,77 +3755,28 @@
       ]
     },
     {
-      "name": "documentation-mkdocs-strict-out-of-tree-links",
-      "description": "Fix mkdocs --strict build failures caused by relative links from files under docs/ pointing to repo paths outside docs/ (scripts/, .github/, etc.). Use when: (1) \"Deploy Documentation\" CI job aborts with \"Aborted with N warnings in strict mode\", (2) mkdocs warns \"contains a link 'X', but the target 'Y' is not found among documentation files\", (3) writing/editing docs that need to reference scripts, workflows, or other repo-root files. Fix: replace ../../foo/bar with absolute https://github.com/<org>/<repo>/blob/main/foo/bar.",
+      "name": "documentation-workflow-meta-patterns",
+      "description": "Meta-patterns for documentation-only PR workflows. Use when: (1) starting any documentation task and needing to detect already-done work before beginning, (2) handling a review fix plan that concludes no changes are needed, (3) triaging a security review on a docs-only PR, (4) implementing a small targeted doc edit, (5) merging two overlapping markdown docs into one canonical source, (6) documenting a pre-commit hook incompatibility in CONTRIBUTING.md, or (7) expanding bare NOTE/TODO markers with structured deferred-item format.",
       "version": "1.0.0",
-      "source": "./skills/documentation-mkdocs-strict-out-of-tree-links.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "documentation-multi-file-ecosystem-sync",
-      "description": "Synchronize ecosystem repository listings across multiple documentation files using GitHub API as source of truth. Use when: (1) ecosystem docs list wrong repo count or descriptions, (2) same repo table appears in multiple files and needs consistency, (3) adding new repos to existing ecosystem documentation.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-multi-file-ecosystem-sync.md",
+      "source": "./skills/documentation-workflow-meta-patterns.md",
       "category": "documentation",
       "tags": [
         "documentation",
-        "ecosystem",
-        "multi-file-sync",
-        "github-api"
+        "workflow",
+        "preflight",
+        "no-op",
+        "review",
+        "security",
+        "pre-commit",
+        "deferred-items",
+        "duplicate-detection"
       ]
-    },
-    {
-      "name": "documentation-strict-audit-remediation-workflow",
-      "description": "Workflow for running strict repo audits and fixing documentation findings. Use when: (1) performing comprehensive repository quality audits, (2) remediating documentation issues found in audits.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-strict-audit-remediation-workflow.md",
-      "category": "documentation",
-      "tags": [
-        "audit",
-        "documentation",
-        "quality",
-        "strict-grading",
-        "remediation"
-      ]
-    },
-    {
-      "name": "extend-reexport-audit-to-sibling-packages",
-      "description": "Extend a Mojo re-export limitation audit from one package to sibling packages, promoting inline # NOTE comments to module docstring Note: sections. Use when: (1) a follow-up issue asks to audit packages not covered by a prior re-export audit, (2) inline # NOTE comments in __init__.mojo files need to be promoted to docstring Note: sections, (3) a package re-exports from a sibling package and needs import guidance documented.",
-      "version": "1.0.0",
-      "source": "./skills/extend-reexport-audit-to-sibling-packages.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "extensor-copy-vs-view-docstrings",
-      "description": "Document copy-vs-view memory semantics in tensor class docstrings. Use when: a tensor class exposes both view-returning (slice) and copy-returning (__getitem__) access patterns without a unified contract at the class level.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-copy-vs-view-docstrings.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "extensor-hash-api-docs",
-      "description": "Document trait-implementing special methods in Mojo struct docstrings and package __init__.mojo API listings. Use when: a new dunder method is added to a Mojo struct but not mentioned in docs or the package module listing.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-hash-api-docs.md",
-      "category": "documentation",
-      "tags": []
     },
     {
       "name": "fix-broken-doc-references",
       "description": "Skill: Fix Broken Documentation References",
       "version": "1.0.0",
       "source": "./skills/fix-broken-doc-references.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "fix-doc-metric-discrepancies",
-      "description": "Fix stale or incorrect metric values in documentation (test counts, coverage thresholds, command paths) that drift from actual codebase state. Use when a code audit reveals contradictions between docs and pyproject.toml, README, or CI config.",
-      "version": "1.0.0",
-      "source": "./skills/fix-doc-metric-discrepancies.md",
       "category": "documentation",
       "tags": []
     },
@@ -6105,22 +3805,6 @@
       "tags": []
     },
     {
-      "name": "fp16-accumulation-threshold-math-docs",
-      "description": "Document Float16 convolution skips in dev testing-strategy guides using accumulation threshold math. Use when: adding a Float16 limitations subsection to testing-strategy.md, documenting why convolution gradient-checking skips Float16, or writing per-layer accumulation error tables for a dev guide.",
-      "version": "1.1.0",
-      "source": "./skills/fp16-accumulation-threshold-math-docs.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "generator-template-placeholder-cleanup",
-      "description": "Review TODO comments in code generator scripts and reclassify as TEMPLATE: markers or actual work items. Use when: cleaning up generator scripts, distinguishing template scaffolding from implementation gaps, or working on TODO-review issues.",
-      "version": "1.0.0",
-      "source": "./skills/generator-template-placeholder-cleanup.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
       "name": "getting-started-doc-audit",
       "description": "Audit and rewrite getting-started documentation stubs by sourcing real commands from justfile and versions from pixi.toml, removing fabricated APIs. Use when: stub files contain placeholder text, follow-up audit after installation.md is written, or markdown linting fails on broken fenced code blocks.",
       "version": "1.0.0",
@@ -6129,26 +3813,25 @@
       "tags": []
     },
     {
-      "name": "impl-already-committed-and-pr-open",
-      "description": "Detect and handle auto-impl worktrees where all changes are already committed and a PR is already open. Use when: branch is named <number>-auto-impl, git status is clean, and git log HEAD shows a commit matching the issue title.",
+      "name": "inline-comment-and-note-cleanup",
+      "description": "Systematically audit and clean up inline NOTE/TODO/FIXME/placeholder comments in source code. Use when: (1) a cleanup issue targets NOTE/TODO/FIXME markers for normalization, removal, or tracing, (2) runtime print statements carry NOTE prefixes that confuse users, (3) magic-number comments need extracting into named constants, (4) generator-script TODOs need reclassifying as TEMPLATE markers, (5) shipped-feature placeholders or no-op placeholder tests need removal.",
       "version": "1.0.0",
-      "source": "./skills/impl-already-committed-and-pr-open.md",
+      "source": "./skills/inline-comment-and-note-cleanup.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "note-cleanup",
+        "comment-normalization",
+        "placeholder",
+        "todo",
+        "mojo",
+        "python"
+      ]
     },
     {
       "name": "installation-anchor-validator",
       "description": "Validate anchor fragments in markdown deep-links to an installation guide. Use when: README or other docs link to specific sections of installation.md and you need CI to catch broken anchors when headings are renamed or removed.",
       "version": "1.0.0",
       "source": "./skills/installation-anchor-validator.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "installation-md-ide-setup",
-      "description": "Extend an installation.md with IDE setup section and tighten prerequisites version constraints. Use when: an installation doc lacks editor/IDE guidance, VS Code Mojo extension steps are missing, or prerequisites need explicit version numbers.",
-      "version": "1.0.0",
-      "source": "./skills/installation-md-ide-setup.md",
       "category": "documentation",
       "tags": []
     },
@@ -6184,12 +3867,29 @@
       ]
     },
     {
-      "name": "link-workaround-notes-to-issues",
-      "description": "Link temporary workaround NOTE comments in source code to tracking GitHub issues. Use when: performing NOTE/TODO cleanup sprints, auditing untracked workarounds, or ensuring every temporary hack has a tracking issue.",
-      "version": "1.0.0",
-      "source": "./skills/link-workaround-notes-to-issues.md",
+      "name": "markdown-linting-and-build-fixes",
+      "description": "Use when: (1) markdownlint CI reports MD056/table-column-count errors from pipes inside backtick code spans in table cells, (2) mkdocs --strict build fails with out-of-tree relative links pointing outside docs/, (3) CLAUDE.md exceeds a line/token budget and needs trimming without losing critical rules, (4) shared documentation files are missing link-backs in an index/root markdown file, (5) an entire PR queue is red on the same markdownlint check pointing to the same file:line \u2014 systemic main-branch regression needing fix + bulk queue recovery",
+      "version": "1.2.0",
+      "source": "./skills/markdown-linting-and-build-fixes.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "markdownlint",
+        "MD056",
+        "MD060",
+        "tables",
+        "pipe-escape",
+        "mkdocs",
+        "strict-mode",
+        "claude-md",
+        "token-budget",
+        "ci-unblocking",
+        "queue-unblock",
+        "admin-merge",
+        "MD033",
+        "MD018",
+        "MD059",
+        "false-positives"
+      ]
     },
     {
       "name": "mass-figure-documentation",
@@ -6200,161 +3900,10 @@
       "tags": []
     },
     {
-      "name": "merge-duplicate-docs",
-      "description": "Merge two overlapping markdown docs into one canonical source, preserving unique content and fixing all cross-references. Use when: two files cover the same topic (DRY violation), one has visual/summary content and the other has detailed specs, or you need a single authoritative reference.",
-      "version": "1.0.0",
-      "source": "./skills/merge-duplicate-docs.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "module-docstring-line-wrap-audit",
-      "description": "Module Docstring Line-Wrap Audit",
-      "version": "1.0.0",
-      "source": "./skills/module-docstring-line-wrap-audit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "mojo-adr-supersession-on-version-upgrade",
-      "description": "Mark ADRs as Superseded after a Mojo version upgrade removes the limitation they document. Use when: (1) bumping the pinned Mojo version in pixi.toml, (2) an ADR describes a compiler limitation or missing feature that may now work, (3) code still carries scalar workarounds that vectorized paths could replace.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-adr-supersession-on-version-upgrade.md",
-      "category": "documentation",
-      "tags": [
-        "mojo",
-        "adr",
-        "superseded",
-        "version-upgrade",
-        "workaround",
-        "fp16",
-        "simd"
-      ]
-    },
-    {
-      "name": "mojo-api-name-reconciliation",
-      "description": "Reconcile planned API names in Mojo test placeholders and documentation comments with actual implemented names after an import audit. Use when: placeholder tests use old planned names, __init__.mojo docs are stale, or following up on import audit issues.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-api-name-reconciliation.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "mojo-docstring-format-precommit",
-      "description": "Enrich sparse Mojo test function docstrings to accurately describe what the test validates, pre-formatted to pass mojo format without producing a diff. Use when: (1) a one-liner docstring needs detail after feature support is added, (2) a split file got a minimal docstring, (3) stale placeholder language needs replacing in a test fn.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-docstring-format-precommit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "mojo-module-docstring-limitation",
-      "description": "Document Mojo re-export limitations in module docstrings when submodule symbols cannot be imported via the parent package. Use when: (1) a NOTE comment exists warning about an import limitation, (2) a GitHub issue asks to document a Mojo import workaround, (3) a module docstring is missing guidance for users who cannot import types from the parent package.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-module-docstring-limitation.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "mojo-note-to-docstring",
-      "description": "Convert, condense, and enforce Mojo NOTE comments. Use when: (1) converting inline # NOTE: implementation-constraint comments to proper docstring Note: sections, (2) condensing verbose compiler-limitation NOTEs with version + tracking references on GLIBC-mismatched systems, (3) enforcing # NOTE (Mojo vX.Y.Z): format compliance via pre-commit hook and Python audit script.",
-      "version": "2.1.0",
-      "source": "./skills/mojo-note-to-docstring.md",
-      "category": "documentation",
-      "tags": [
-        "mojo",
-        "notes",
-        "docstrings",
-        "pre-commit",
-        "code-cleanup",
-        "compiler-limitations"
-      ]
-    },
-    {
-      "name": "mojo-promote-constants-to-public-api",
-      "description": "Promote module-scoped Mojo constants to the package public API via __init__.mojo re-exports. Use when: (1) constants are alias/comptime in one module but needed across test files, (2) an issue asks to export constants from the public API, (3) callers must import the entire module just to access one constant.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-promote-constants-to-public-api.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "mojo-public-api-table-update",
-      "description": "Update the public API comment table in a Mojo __init__.mojo to distinguish available-now exports from pending-implementation symbols. Use when: (1) live exports were added but the API table still lists them as pending, (2) a flat pending list needs splitting into available-now vs pending sections, (3) a newly-added symbol is missing from the ASCII table of top-level exports.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-public-api-table-update.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "no-op-review-fix",
-      "description": "Handle review fix plans that require no changes. Use when: a review fix plan explicitly states no fixes are needed, CI failures are pre-existing and unrelated to the PR, or you need to verify clean git state before confirming a PR is ready.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-no-op-review-fix.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "note-comment-cleanup",
-      "description": "Systematically review and clean up NOTE/Note comment inconsistencies: remove stale markers, convert docstring NOTEs to prose, normalize casing. Use when: auditing code comments for a cleanup issue, standardizing NOTE vs Note casing, or removing outdated reference markers.",
-      "version": "1.0.0",
-      "source": "./skills/note-comment-cleanup.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "note-variant-canonical-audit",
-      "description": "Audit Mojo production files for non-canonical # NOTE variants: wrong issue/version order, missing version tag, or TODO-style notes masquerading as limitation notes. Use when: follow-up cleanup after a prior audit, grep shows mixed ordering, or limitation NOTEs lack version tags.",
-      "version": "1.0.0",
-      "source": "./skills/note-variant-canonical-audit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "paper-consolidation-skill",
-      "description": "Consolidate scattered LaTeX paper files into unified directory structure with publication readiness fixes",
-      "version": "1.0.0",
-      "source": "./skills/paper-consolidation-skill.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
       "name": "paper-final-review-publication-readiness-workflow",
       "description": "Paper Final Review - Publication Readiness Workflow",
       "version": "1.0.0",
       "source": "./skills/paper-final-review-publication-readiness-workflow.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "paper-iterative-accuracy-review",
-      "description": "Second-pass review after initial paper fixes: catch internal inconsistencies introduced by edits, verify statistical effect-size labels against defined thresholds, clarify ambiguous table headers, explain counter-intuitive results, and add missing pricing context",
-      "version": "1.0.0",
-      "source": "./skills/paper-iterative-accuracy-review.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "paper-readiness-epic",
-      "description": "Skill: paper-readiness-epic. Use when working with paper readiness epic.",
-      "version": "1.0.0",
-      "source": "./skills/paper-readiness-epic.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "paper-revision-workflow",
-      "description": "Systematic workflow for revising research papers: data validation, structural improvements, and tone unification",
-      "version": "1.0.0",
-      "source": "./skills/paper-revision-workflow.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "paper-validation-workflow",
-      "description": "Paper Validation Workflow",
-      "version": "1.0.0",
-      "source": "./skills/paper-validation-workflow.md",
       "category": "documentation",
       "tags": []
     },
@@ -6403,50 +3952,41 @@
       "tags": []
     },
     {
-      "name": "placeholder-doc-rewrite",
-      "description": "Replace placeholder documentation with accurate, verified content grounded in the actual codebase. Use when: a doc file contains stub text, a getting-started guide needs real commands, or a quickstart links to non-existent paths.",
+      "name": "placeholder-and-stub-doc-lifecycle",
+      "description": "Manage the full lifecycle of placeholder and stub documentation. Use when: (1) stub files contain only placeholder text and should be deleted under YAGNI, (2) a navigation index loses sections after stub deletion and needs a deferred comment placeholder, (3) a design doc Future Improvements list needs structured deferral annotations, (4) a placeholder doc needs rewriting with accurate codebase- grounded content (quickstart, installation, README, or other guides), (5) an existing installation doc needs IDE setup section or version-constraint tightening.",
       "version": "1.0.0",
-      "source": "./skills/placeholder-doc-rewrite.md",
+      "source": "./skills/placeholder-and-stub-doc-lifecycle.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "placeholder",
+        "stub",
+        "documentation",
+        "yagni",
+        "deferred",
+        "installation",
+        "readme",
+        "rewrite"
+      ]
     },
     {
-      "name": "placeholder-note-to-status-tracking",
-      "description": "Clarify ambiguous NOTE: runtime print statements as intentional placeholders by converting them to STATUS: messages with GitHub tracking issue links. Use when: (1) example/demo scripts print confusing NOTE messages during execution, (2) cleanup issues require disambiguating placeholder code from bugs.",
+      "name": "readme-badges-live-sources-verification",
+      "description": "Use live-source badge endpoints (shields.io, GitHub Actions, PyPI JSON API) instead of hardcoded values. Verify package names via PyPI before committing. Use when: adding badges to README, updating badge rows, validating badge accuracy, or implementing cross-project badge standards.",
       "version": "1.0.0",
-      "source": "./skills/placeholder-note-to-status-tracking.md",
+      "source": "./skills/readme-badges-live-sources-verification.md",
       "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "placeholder-test-docstring-update",
-      "description": "Update placeholder test language in __init__.mojo docstrings when real test implementations exist. Use when: (1) docstrings say 'Placeholder tests require implementation' but tests are already written, (2) closing a test-tracking issue after tests are implemented, (3) keeping module documentation accurate.",
-      "version": "1.0.0",
-      "source": "./skills/placeholder-test-docstring-update.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "publication-readiness-review",
-      "description": "Comprehensive 10-category GO/NO-GO assessment framework for academic paper publication readiness",
-      "version": "2.0.0",
-      "source": "./skills/publication-readiness-review.md",
-      "category": "documentation",
-      "tags": []
+      "tags": [
+        "documentation",
+        "badges",
+        "semantic-anchors",
+        "live-sources",
+        "pypi-verification"
+      ]
     },
     {
       "name": "readme-ci-badges",
       "description": "Add GitHub Actions status badges for key CI workflows to a README badge block. Use when: adding missing PR-critical workflow badges, improving CI health visibility at a glance, or following up on a badge audit issue.",
       "version": "1.0.0",
       "source": "./skills/readme-ci-badges.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "readme-from-codebase-exploration",
-      "description": "Replace placeholder README.md with accurate project description by exploring the live codebase. Use when: README has placeholder text, project has outgrown its docs, or a new contributor needs to understand quickly.",
-      "version": "1.0.0",
-      "source": "./skills/readme-from-codebase-exploration.md",
       "category": "documentation",
       "tags": []
     },
@@ -6479,22 +4019,6 @@
       ]
     },
     {
-      "name": "remove-shipped-feature-placeholders",
-      "description": "Remove stale 'feature not yet supported' comments, TODO placeholders, and disabled test stubs from source code once the underlying feature ships natively. Use when: an issue asks to document a dtype/language feature that was aliased or stubbed, code has 'X aliases to Y until Z is supported' comments, or tests are disabled with pass-placeholder and TODO.",
-      "version": "1.0.0",
-      "source": "./skills/remove-shipped-feature-placeholders.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "remove-unimplemented-mojo-placeholder",
-      "description": "Remove no-op placeholder tests and NOTE comments for unimplemented Mojo features. Use when: a test contains only a NOTE comment and pass, or a feature needs stdlib APIs not available in the current Mojo version.",
-      "version": "1.0.0",
-      "source": "./skills/remove-unimplemented-mojo-placeholder.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
       "name": "replace-hardcoded-counts-with-live-commands",
       "description": "Replace hardcoded test/file counts in README badges and prose with a live command users can run. Use when a CI check enforces doc accuracy but counts change frequently, making the docs flaky.",
       "version": "1.0.0",
@@ -6503,12 +4027,44 @@
       "tags": []
     },
     {
-      "name": "review-commented-imports",
-      "description": "Review and resolve commented-out imports in module init files by auditing which are implemented, misnamed, or pending. Use when: cleaning up Mojo/Python __init__ files with placeholder NOTEs, auditing API surface post-implementation, or documenting name mismatches between planned and actual symbols.",
-      "version": "1.0.0",
-      "source": "./skills/review-commented-imports.md",
+      "name": "scifi-mechanism-single-device-design",
+      "description": "Design a single speculative-but-rigorous physics mechanism for a fictional sci-fi device, grounded in real cited science, with a Laws-Broken Ledger, Walls Defeated table, Parsimony/Capability scores, and Failure Modes. Use when: (1) a Myrmidon swarm agent is assigned one mechanism (MNN-name) to design in isolation, (2) the mechanism file must follow the HomericIntelligence/Story M-series template, (3) you need real cited papers (URL+date, \u22654) anchoring speculative extrapolations, (4) the prompt says 'pure science \u2014 no story/plot/character content'.",
+      "version": "1.4.0",
+      "source": "./skills/scifi-mechanism-single-device-design.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "scifi",
+        "worldbuilding",
+        "mechanism-design",
+        "physics",
+        "citations",
+        "hard-walls",
+        "m-series",
+        "homeric-intelligence",
+        "speculative-science",
+        "laws-broken",
+        "parsimony",
+        "capability",
+        "monopole",
+        "topological-soliton",
+        "exotic-particles",
+        "false-vacuum",
+        "higgs",
+        "vacuum-decay",
+        "coleman-bounce",
+        "lloyd",
+        "wheeler",
+        "it-from-bit",
+        "computational-universe",
+        "offload-architecture",
+        "bekenstein",
+        "holevo",
+        "landauer",
+        "reality-computes",
+        "tqc",
+        "anyons",
+        "topological-quantum-computation"
+      ]
     },
     {
       "name": "security-md-version-sync",
@@ -6525,22 +4081,6 @@
       ]
     },
     {
-      "name": "security-review-docs-only-pr",
-      "description": "Efficiently triage and close security reviews for PRs containing only documentation or metadata changes. Use when: a security review is triggered on a PR that adds only markdown files, JSON metadata, or other static documentation with no executable code.",
-      "version": "1.0.0",
-      "source": "./skills/security-review-docs-only-pr.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "skill-adding-architecture-sections-to-latex-academic-papers",
-      "description": "Add architecture sections to academic LaTeX papers with TikZ diagrams, including fixing common TikZ syntax errors and managing arxiv builds",
-      "version": "1.0.0",
-      "source": "./skills/skill-adding-architecture-sections-to-latex-academic-papers.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
       "name": "skill-arxiv-paper-publication-polish",
       "description": "Skill: arXiv Paper Publication Polish",
       "version": "1.0.0",
@@ -6549,28 +4089,19 @@
       "tags": []
     },
     {
-      "name": "small-doc-edit-workflow",
-      "description": "Workflow for implementing small, well-specified documentation edits in a worktree. Use when: (1) issue specifies exact insert location, (2) change is adding a note/clarification to markdown, (3) single targeted Edit with pre-commit verification.",
+      "name": "stale-documentation-audits-and-sync",
+      "description": "Canonical workflow for detecting and remediating stale documentation: doc-drift grep audits, stale-count fixes, metric discrepancy reconciliation, ecosystem-role drift detection, multi-file doc sync, README audit workflows, cross-doc citation drift defenses, doc-contradiction resolution. Use when: (1) running a doc-drift audit across a corpus, (2) reconciling docs to current implementation, (3) fixing stale agent/file/test counts in README, (4) catching cross-doc contradictions before publication, (5) syncing docs after a structural change.",
       "version": "1.0.0",
-      "source": "./skills/small-doc-edit-workflow.md",
+      "source": "./skills/stale-documentation-audits-and-sync.md",
       "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "stale-agent-count-fix",
-      "description": "Fix stale agent count references in documentation after agents are deleted or converted to skills. Use when: agent files are removed/converted and doc counts are out of sync.",
-      "version": "1.0.0",
-      "source": "./skills/stale-agent-count-fix.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "stale-doc-count-audit",
-      "description": "TRIGGER CONDITIONS: Fixing stale numeric counts in documentation (figures, tables, sub-tests, source files). Use when a code registry or pipeline changes size but docs still reference old counts. Covers the pattern of searching all .md files for stale numbers after fixing the primary file.",
-      "version": "1.0.0",
-      "source": "./skills/stale-doc-count-audit.md",
-      "category": "documentation",
-      "tags": []
+      "tags": [
+        "merged",
+        "doc-drift",
+        "stale-doc",
+        "doc-sync",
+        "doc-audit",
+        "citation-drift"
+      ]
     },
     {
       "name": "statistical-claim-verification",
@@ -6581,100 +4112,43 @@
       "tags": []
     },
     {
-      "name": "strip-note-prefix-comments",
-      "description": "Strip NOTE: prefix variants from plain comments in Mojo files without functional changes. Use when: a follow-up cleanup issue targets # NOTE: markers in test/example/script files, files contain # NOTE(#N): or # NOTE (version): variants, or scope must be verified against actual file state before editing.",
+      "name": "valuation-private-securities-platform-data-beats-web-research",
+      "description": "When valuing private securities (Reg-CF crowdfunding, pre-IPO equity, private LLCs) for legal disclosure (divorce FL-142, estate tax, FBAR), the investor platform's own portfolio data beats web research for quantitative facts (share counts, cost basis, current marks) but platform marks lag wipeouts by months-to-years. Use platform data as authoritative for quantities; use parallel web research to catch silent wipeouts. Use when: (1) building FL-142 or estate-tax disclosure for a venture-investment LLC, (2) reconciling agent web research against an investor portfolio snapshot, (3) deciding whether to trust platform mark vs independent valuation.",
       "version": "1.0.0",
-      "source": "./skills/strip-note-prefix-comments.md",
+      "source": "./skills/valuation-private-securities-platform-data-beats-web-research.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "private-securities",
+        "crowdfunding",
+        "reg-cf",
+        "startengine",
+        "valuation",
+        "due-diligence",
+        "fl-142",
+        "divorce-disclosure",
+        "platform-data",
+        "web-research",
+        "investor-platform-primary-source"
+      ]
     },
     {
-      "name": "sync-stale-future-improvements",
-      "description": "Sync stale Future Improvements sections with actual implementation. Use when a TODO or Future Improvements doc section lists a feature that has already been shipped.",
-      "version": "1.0.0",
-      "source": "./skills/sync-stale-future-improvements.md",
+      "name": "verify-audit-findings-before-acting",
+      "description": "Strict-mode repo audits AND PR-reviewer sub-agents routinely hallucinate critical findings (references to nonexistent files, claims of missing CI checks that already exist, REQUEST_CHANGES citing a red CI check that is ALSO red on main) AND miss real ones (linter bugs, root causes). Verify each finding against ground truth (filesystem state or `gh run list --branch main`) BEFORE writing a remediation plan or posting a review verdict, and search for inverse hypotheses (what the audit MISSED) before acting. Use when: (1) consuming output from /repo-analyze-strict or any swarm-audit, (2) about to write a remediation plan from audit output, (3) about to bulk-file remediation issues, (4) deciding which audit majors are real, (5) the audit's CRITICAL/MAJOR count differs from what you can verify on disk, (6) about to post a REQUEST_CHANGES verdict that cites a red CI check as the blocker.",
+      "version": "1.3.0",
+      "source": "./skills/verify-audit-findings-before-acting.md",
       "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "update-blocker-note",
-      "description": "Update blocked feature NOTE comments with issue tracking references and resolution path. Use when: a NOTE comment lacks a tracking issue number, a blocker needs a resolution path, cleanup issues require linking NOTEs to parent tracking issues, or pre-commit mojo-format fails due to GLIBC incompatibility.",
-      "version": "1.1.0",
-      "source": "./skills/update-blocker-note.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "verify-implementation-completeness",
-      "description": "Verify that a GitHub issue's implementation is already complete before re-doing work. Use when: assigned to an existing branch for an issue, suspecting prior session completed the work, or a .claude-prompt file says 'implement issue #N'.",
-      "version": "1.0.0",
-      "source": "./skills/verify-implementation-completeness.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "workflow-readme-audit",
-      "description": "Audit .github/workflows/README.md against actual files on disk, update inventory to match reality, and document remaining duplication. Use when: workflows were added/deleted but README was not updated, a consolidation pass removed workflows still listed, or inline setup steps exist across many workflows needing inventory before extraction. Also covers updating README AFTER a migration is complete to remove stale inline-step references and Remaining Duplication sections.",
-      "version": "1.1.0",
-      "source": "./skills/workflow-readme-audit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "write-installation-docs",
-      "description": "Replace placeholder installation documentation with complete, accurate content. Use when: installation.md contains placeholder text, a README links to an installation guide that needs real content, or a follow-up issue requests writing real installation steps.",
-      "version": "1.0.0",
-      "source": "./skills/write-installation-docs.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "add-analysis-metric",
-      "description": "TRIGGER CONDITIONS: Adding new aggregated metrics to build_subtests_df(), tier_summary(), or model_comparison() in scylla/analysis/dataframes.py. Use when extending the analysis layer with new per-run measurements that need mean/median/std at the subtest, tier, or model-comparison level.",
-      "version": "1.0.0",
-      "source": "./skills/add-analysis-metric.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "add-comparison-table",
-      "description": "TRIGGER CONDITIONS: Adding a new pairwise statistical comparison table to scylla/analysis/tables/comparison.py. Use when a new metric (e.g. CFP, R_Prog, impl_rate) needs tier-by-tier Kruskal-Wallis + Mann-Whitney U + Holm-Bonferroni comparison in both Markdown and LaTeX formats.",
-      "version": "1.0.0",
-      "source": "./skills/add-comparison-table.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "add-process-metric-figure",
-      "description": "TRIGGER CONDITIONS: Adding a new figure function to scylla/analysis/figures/process_metrics.py for a per-run process metric (e.g. strategic_drift, r_prog, cfp, pr_revert_rate). Use when: (1) a new nullable column exists in build_runs_df() output but has no corresponding figure in process_metrics.py, (2) a follow-up issue says 'add a figure for <metric> following the same pattern as fig_r_prog_by_tier', (3) a process metric column was added in a prior issue but the figure was deferred.",
-      "version": "1.0.0",
-      "source": "./skills/add-process-metric-figure.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "adding-json-links-to-markdown-reports",
-      "description": "Add JSON result links to markdown reports for structured data access",
-      "version": "1.0.0",
-      "source": "./skills/adding-json-links-to-markdown-reports.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "analyze-code-structure",
-      "description": "Examine code organization and identify structural patterns. Use when reviewing module design.",
-      "version": "1.0.0",
-      "source": "./skills/analyze-code-structure.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "analyze-equations",
-      "description": "Parse and interpret mathematical equations from research papers. Use when extracting formulas for implementation.",
-      "version": "1.0.0",
-      "source": "./skills/analyze-equations.md",
-      "category": "evaluation",
-      "tags": []
+      "tags": [
+        "audit",
+        "code-review",
+        "fact-checking",
+        "remediation",
+        "phase-1-verification",
+        "inverse-hypothesis-search",
+        "audit-corrections-section",
+        "root-cause-discovery",
+        "remediation-plan-corrections",
+        "pr-reviewer-verdict-verification"
+      ]
     },
     {
       "name": "auto-review-loop-per-artifact",
@@ -6695,149 +4169,62 @@
       ]
     },
     {
-      "name": "benchmark-functions",
-      "description": "Measure function performance and compare implementations. Use when optimizing critical code paths.",
+      "name": "codebase-analysis-generic-tier2-tools",
+      "description": "Use when: (1) analyzing code structure, module hierarchy, or dependency graphs for orientation or documentation; (2) extracting algorithms, equations, or hyperparameters from research papers for implementation planning; (3) measuring function performance via benchmarking or profiling to identify bottlenecks; (4) checking test coverage, detecting code smells, or linting for quality assurance; (5) validating function inputs for correctness and suggesting optimization strategies.",
       "version": "1.0.0",
-      "source": "./skills/benchmark-functions.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "calculate-coverage",
-      "description": "Measure test coverage and identify untested code. Use when assessing test completeness.",
-      "version": "1.0.0",
-      "source": "./skills/calculate-coverage.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "check-dependencies",
-      "description": "Validate and verify dependencies are available and compatible. Use when setting up environments.",
-      "version": "1.0.0",
-      "source": "./skills/check-dependencies.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "complex-agent-eval-task",
-      "description": "Create sophisticated E2E test cases for AI agents using real PRs as reference solutions",
-      "version": "1.0.0",
-      "source": "./skills/complex-agent-eval-task.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "create-swe-bench-tests",
-      "description": "Create SWE-bench style benchmark test cases from repository PR history",
-      "version": "1.0.0",
-      "source": "./skills/create-swe-bench-tests.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "debug-evaluation-logs",
-      "description": "Improving diagnostic clarity of LLM judge warning messages by adding specific failure details",
-      "version": "1.0.0",
-      "source": "./skills/debug-evaluation-logs.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "detect-code-smells",
-      "description": "Identify code quality issues and anti-patterns. Use when reviewing code for maintainability problems.",
-      "version": "1.0.0",
-      "source": "./skills/detect-code-smells.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "dryrun3-analysis-fix",
-      "description": "Fix 1-based subtest ID misclassification in dryrun3 analysis scripts. Use when: analysis script misreports complete/orphan/missing counts due to mixed ID numbering schemes.",
-      "version": "1.0.0",
-      "source": "./skills/dryrun3-analysis-fix.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "dryrun3-completion",
-      "description": "Complete interrupted dryrun experiments: diagnose broken/partial runs, clean stale git worktrees, re-run broken experiments, repair partial experiments, build loader-compatible symlink tree, generate full analysis pipeline output, and produce Go/NoGo assessment with run classification script.",
-      "version": "1.0.0",
-      "source": "./skills/dryrun3-completion.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "e2e-agent-judge-timing",
-      "description": "Add separate agent and judge timing fields to E2E test results for tiebreaker ranking",
-      "version": "1.0.0",
-      "source": "./skills/e2e-agent-judge-timing.md",
+      "source": "./skills/codebase-analysis-generic-tier2-tools.md",
       "category": "evaluation",
       "tags": [
-        "e2e",
-        "timing",
-        "metrics",
-        "tiebreaker",
-        "agent",
-        "judge",
-        "evaluation"
+        "code-analysis",
+        "benchmarking",
+        "profiling",
+        "coverage",
+        "linting",
+        "dependencies",
+        "architecture",
+        "paper-extraction",
+        "optimization",
+        "input-validation"
       ]
     },
     {
-      "name": "e2e-batch-result-analysis",
-      "description": "Analyze E2E batch dry run results: triage failures, write local analysis files, generate GitHub issue filing script",
+      "name": "e2e-experiment-run-triage-completion",
+      "description": "Use when: (1) a batch E2E experiment run has completed and needs result triage (framework bugs vs model failures); (2) experiments are broken/partial and need repair, fresh re-runs, or stale-worktree cleanup; (3) checkpoint states appear inconsistent or misleading and need validation; (4) analysis scripts report wrong counts due to regex, multiplier, or subtest-ID numbering bugs; (5) a FAILED checkpoint causes immediate exit on resume or --retry-errors is silently ignored; (6) new benchmark test cases need to be created from PR history or real-world tasks; (7) A/B sub-tests for experimental features need to be added to existing evaluation tiers.",
       "version": "1.0.0",
-      "source": "./skills/e2e-batch-result-analysis.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "e2e-checkpoint-resume",
-      "description": "Implementing checkpoint/resume with rate limit handling for E2E evaluation frameworks",
-      "version": "1.0.0",
-      "source": "./skills/e2e-checkpoint-resume.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "e2e-directory-flattening",
-      "description": "E2E Directory Flattening",
-      "version": "1.0.0",
-      "source": "./skills/e2e-directory-flattening.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "e2e-judge-rubric-design",
-      "description": "Design LLM-as-Judge evaluation rubrics for E2E agent testing",
-      "version": "1.0.0",
-      "source": "./skills/e2e-judge-rubric-design.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "e2e-staged-experiment-execution",
-      "description": "Run E2E experiments in 3 stages with controlled concurrency: Stage 1 (agent execution, --until agent_complete), Stage 2 (commit+diff+promote, --until promoted_to_completed), Stage 3 (judging+finalization, no --until). Use when: (1) you need to split agent work from judging for cost control, (2) judges must only read from completed/ directory, (3) you want independent concurrency limits per phase.",
-      "version": "1.0.0",
-      "source": "./skills/e2e-staged-experiment-execution.md",
+      "source": "./skills/e2e-experiment-run-triage-completion.md",
       "category": "evaluation",
       "tags": [
         "e2e",
-        "experiment",
-        "staged-execution",
-        "concurrency",
-        "judging",
+        "evaluation",
+        "dryrun",
         "checkpoint",
-        "cli-flags",
-        "off-peak"
+        "triage",
+        "ablation",
+        "swe-bench",
+        "experiment-lifecycle"
       ]
     },
     {
-      "name": "emit-process-metrics-from-runner",
-      "description": "Emitting process_metrics, progress_tracking, and changes blocks to run_result.json from the E2E runner stage pipeline",
+      "name": "evaluation-analysis-pipeline-reporting",
+      "description": "Use when: (1) building or extending an end-to-end analysis pipeline that turns raw experiment results into publication-quality figures, statistical tables, and JSON/markdown reports; (2) adding new Altair/Vega-Lite figures or statistical comparison tables to an existing pipeline; (3) enhancing E2E report structure with token tracking, hierarchical reports, JSON links, or timing data; (4) reviewing or refactoring a large (~4 000-LOC) analysis pipeline for statistical correctness and DRY compliance; (5) fixing critical E2E evaluation report issues (crashes, broken links, workspace detection, judge validation).",
       "version": "1.0.0",
-      "source": "./skills/emit-process-metrics-from-runner.md",
+      "source": "./skills/evaluation-analysis-pipeline-reporting.md",
       "category": "evaluation",
-      "tags": []
+      "tags": [
+        "altair",
+        "vega-lite",
+        "statistical-analysis",
+        "publication-quality",
+        "e2e-reports",
+        "hierarchical-reports",
+        "token-stats",
+        "kruskal-wallis",
+        "mann-whitney",
+        "latex",
+        "figures",
+        "tables",
+        "dry-refactoring"
+      ]
     },
     {
       "name": "evaluation-paper-rewrite-after-data-fix",
@@ -6857,110 +4244,6 @@
       ]
     },
     {
-      "name": "experiment-analysis-script-patterns",
-      "description": "Patterns for fixing experiment analysis scripts: directory regex matching, run multiplier correctness, exit code semantics, and retry shell script error handling. Use when: analysis script discovers 0 experiments, run totals are wrong, or retry scripts abort on first failure.",
-      "version": "1.0.0",
-      "source": "./skills/experiment-analysis-script-patterns.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "experiment-dataset-triage",
-      "description": "Triage experiment datasets for paper readiness by analyzing checkpoint states, detecting inconsistencies, and planning phased resume. Use when: assessing experiment completion, diagnosing stale checkpoints, or planning phased --until execution.",
-      "version": "1.0.0",
-      "source": "./skills/experiment-dataset-triage.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "expose-run-report-process-metrics",
-      "description": "TRIGGER CONDITIONS: Adding new metric fields to per-run report.json or report.md in scylla/e2e/run_report.py. Use when per-run structured data (in run_result.json) needs to be surfaced in both the human-readable markdown report and the machine-readable JSON report generated by stage_write_report.",
-      "version": "1.0.0",
-      "source": "./skills/expose-run-report-process-metrics.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "extend-statistical-tests",
-      "description": "TRIGGER CONDITIONS: Adding a new nullable per-run metric to all four statistical test sections (normality, omnibus, pairwise, effect sizes) in scripts/export_data.py compute_statistical_results(). Use when surfacing process or quality metrics in statistical_results.json.",
-      "version": "1.0.0",
-      "source": "./skills/extend-statistical-tests.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "extract-algorithm",
-      "description": "Parse and document algorithm pseudocode from research papers. Use when preparing for implementation.",
-      "version": "1.0.0",
-      "source": "./skills/extract-algorithm.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "extract-dependencies",
-      "description": "Analyze imports and identify all module dependencies. Use when mapping project structure.",
-      "version": "1.0.0",
-      "source": "./skills/extract-dependencies.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "extract-hyperparameters",
-      "description": "Identify and document model hyperparameters from papers. Use when setting up training configurations.",
-      "version": "1.0.0",
-      "source": "./skills/extract-hyperparameters.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "fair-evaluation-baseline",
-      "description": "Implement baseline pipeline capture and regression detection to distinguish agent-introduced failures from pre-existing issues in E2E evaluations",
-      "version": "1.0.0",
-      "source": "./skills/fair-evaluation-baseline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "fix-validation-accuracy-placeholder",
-      "description": "Fix hardcoded 0.0 accuracy placeholders in validation loop methods by wiring real AccuracyMetric accumulation per batch. Use when: a validation method passes a literal 0.0 for accuracy to a metrics update call instead of computing it.",
-      "version": "1.0.0",
-      "source": "./skills/fix-validation-accuracy-placeholder.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "grading-consolidation",
-      "description": "Eliminate duplicate grading definitions and consolidate to single source of truth",
-      "version": "1.0.0",
-      "source": "./skills/grading-consolidation.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "identify-architecture",
-      "description": "Analyze ML model architecture from papers and code. Use when understanding model structure for implementation.",
-      "version": "1.0.0",
-      "source": "./skills/identify-architecture.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "industry-grading-scale",
-      "description": "Industry-Aligned Grading Scale",
-      "version": "1.0.0",
-      "source": "./skills/industry-grading-scale.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "investigate-test-failures",
-      "description": "Systematic workflow for investigating test failures to differentiate framework bugs from model hallucinations",
-      "version": "1.0.0",
-      "source": "./skills/investigate-test-failures.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
       "name": "issue-validation-workflow",
       "description": "Validate GitHub issue state against codebase reality before implementation. Use when starting work on multiple issues to prevent wasted effort on already-resolved issues.",
       "version": "1.0.0",
@@ -6969,28 +4252,23 @@
       "tags": []
     },
     {
-      "name": "judge-criteria-enhancement",
-      "description": "Add new evaluation criteria to LLM judge systems. Use when penalizing over-engineering, fixing result validation, or adding proportionality scoring.",
+      "name": "llm-judge-rubric-design-patterns",
+      "description": "Use when: (1) designing or extending LLM-as-Judge rubrics for agent evaluation, (2) reducing judge score variance beyond 10%, (3) implementing multi-judge consensus or hybrid scoring, (4) adding fair-baseline regression detection, (5) consolidating grading-scale definitions, (6) hardening judge worker pools against API rate limits, (7) improving diagnostic clarity of judge pipeline logs",
       "version": "1.0.0",
-      "source": "./skills/judge-criteria-enhancement.md",
+      "source": "./skills/llm-judge-rubric-design-patterns.md",
       "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "judge-system-extension",
-      "description": "Patterns for extending AI evaluation/judge systems with new capabilities",
-      "version": "1.0.0",
-      "source": "./skills/judge-system-extension.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "lint-code",
-      "description": "Check code for style and quality issues. Use when validating code before commits.",
-      "version": "1.0.0",
-      "source": "./skills/lint-code.md",
-      "category": "evaluation",
-      "tags": []
+      "tags": [
+        "llm-judge",
+        "rubric",
+        "evaluation",
+        "grading",
+        "consensus",
+        "rate-limit",
+        "baseline",
+        "variance",
+        "hybrid-scoring",
+        "processpool"
+      ]
     },
     {
       "name": "merged-project-specialized-reviewer",
@@ -7008,38 +4286,6 @@
         "read-only",
         "agent-extension"
       ]
-    },
-    {
-      "name": "multi-experiment-figure-pipeline",
-      "description": "Patterns for adding conditional figure generation to multi-experiment analysis pipelines. Use when: adding new Altair figures with data-dependent guards, creating task-level analysis, or scaling figure pipelines to large experiment counts.",
-      "version": "1.0.0",
-      "source": "./skills/multi-experiment-figure-pipeline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "multi-judge-consensus",
-      "description": "Implement multiple LLM judges with consensus voting in evaluation systems",
-      "version": "1.0.0",
-      "source": "./skills/multi-judge-consensus.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "parallel-metrics-integration-into-statistical-pipelines",
-      "description": "Skill for integrating multiple metrics into statistical analysis pipelines in parallel",
-      "version": "1.0.0",
-      "source": "./skills/parallel-metrics-integration-into-statistical-pipelines.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "persist-process-metrics-resume",
-      "description": "TRIGGER CONDITIONS: Persisting process_metrics (progress_steps, change_results) through a resume scenario when a run crashes between DIFF_CAPTURED and RUN_FINALIZED in ProjectScylla's 16-stage pipeline. Use when a stage needs to reload previously-computed data from a JSON artifact when ctx fields are None on resume.",
-      "version": "1.0.0",
-      "source": "./skills/persist-process-metrics-resume.md",
-      "category": "evaluation",
-      "tags": []
     },
     {
       "name": "plan-review-interview",
@@ -7066,386 +4312,81 @@
       ]
     },
     {
-      "name": "processpoolexecutor-rate-limit-recovery",
-      "description": "Robust ProcessPoolExecutor rate limit recovery for E2E evaluation frameworks",
+      "name": "process-metrics-pipeline-integration",
+      "description": "Use when: (1) emitting R_Prog, CFP, strategic_drift, or pr_revert_rate from a stage-based E2E runner into run_result.json; (2) loading process_metrics from run_result.json into the ProjectScylla loader \u2192 dataframes \u2192 figures stack; (3) persisting progress_steps/change_results through crash-resume cycles; (4) surfacing process metrics in per-run report.md and report.json; (5) exporting mean_r_prog / mean_cfp / mean_pr_revert_rate to summary.json; (6) adding metric aggregations to build_subtests_df() or model_comparison(); (7) adding figure functions to process_metrics.py and wiring them into generate_figures.py; (8) extending compute_statistical_results() with new per-run process metrics; (9) renaming figure functions to the fig{NN}_description convention.",
       "version": "1.0.0",
-      "source": "./skills/processpoolexecutor-rate-limit-recovery.md",
+      "source": "./skills/process-metrics-pipeline-integration.md",
       "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "profile-code",
-      "description": "Measure execution time and memory usage of code. Use when analyzing performance characteristics.",
-      "version": "1.0.0",
-      "source": "./skills/profile-code.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "publication-pipeline-enhancement",
-      "description": "Publication Pipeline Enhancement",
-      "version": "1.0.0",
-      "source": "./skills/publication-pipeline-enhancement.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "rename-figure-convention",
-      "description": "TRIGGER CONDITIONS: Renaming figure functions to match the fig{NN}_{description} sequential naming convention in ProjectScylla. Use when: (1) figure functions use ad-hoc names instead of sequential numbers (e.g. fig_r_prog_by_tier instead of fig28_r_prog_by_tier), (2) --list-figures output is out of alphabetical/sequential order, (3) a follow-up issue asks to standardize figure naming after figures were wired with unsequenced names.",
-      "version": "1.0.0",
-      "source": "./skills/rename-figure-convention.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "resume-from-failed-experiment",
-      "description": "Fix resume-from-FAILED experiment in E2E state machine framework \u2014 three compounding bugs where terminal states cause immediate exit, --retry-errors is silently ignored in single mode, and saved tiers_to_run overrides CLI tiers on resume",
-      "version": "1.0.0",
-      "source": "./skills/resume-from-failed-experiment.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-add-analysis-metric-to-pipeline",
-      "description": "Workflow for adding new metrics to ProjectScylla analysis pipeline",
-      "version": "1.0.0",
-      "source": "./skills/skill-add-analysis-metric-to-pipeline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-analysis-pipeline-code-review",
-      "description": "Skill: Analysis Pipeline Code Review",
-      "version": "1.0.0",
-      "source": "./skills/skill-analysis-pipeline-code-review.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-containerize-e2e-experiments",
-      "description": "Skill: Containerize E2E Experiments",
-      "version": "1.0.0",
-      "source": "./skills/skill-containerize-e2e-experiments.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-dryrun-validation-workflow",
-      "description": "Complete workflow for re-running dryrun experiments, generating analysis outputs, and validating results against baseline",
-      "version": "1.0.0",
-      "source": "./skills/skill-dryrun-validation-workflow.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-e2e-evaluation-report-fixes",
-      "description": "Fix critical E2E evaluation report issues including timing persistence, workspace detection, judge validation, and broken links",
-      "version": "1.0.0",
-      "source": "./skills/skill-e2e-evaluation-report-fixes.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-experimental-feature-sub-tests",
-      "description": "Add A/B testing for experimental features in evaluation tiers using parallel sub-tests with environment variable feature flags",
-      "version": "1.0.0",
-      "source": "./skills/skill-experimental-feature-sub-tests.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-export-process-metrics-to-summary-json",
-      "description": "Workflow for wiring pre-existing dataframe columns into the export_data.py summary JSON output",
-      "version": "1.0.0",
-      "source": "./skills/skill-export-process-metrics-to-summary-json.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-hybrid-llm-judge-with-granular-scoring",
-      "description": "Hybrid LLM judge evaluation system combining objective checklists (80%) with subjective engineering judgment (20%) to achieve low-variance (<10%) granular scoring",
-      "version": "1.0.0",
-      "source": "./skills/skill-hybrid-llm-judge-with-granular-scoring.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-integrate-process-metrics-into-analysis-pipeline",
-      "description": "Workflow for wiring pre-implemented process metrics (R_Prog, CFP, PR Revert Rate, Strategic Drift) into the ProjectScylla loader \u2192 dataframes \u2192 figures stack",
-      "version": "1.0.0",
-      "source": "./skills/skill-integrate-process-metrics-into-analysis-pipeline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-preserve-workspaces-on-e2e-experiment-re-runs",
-      "description": "Preserving git worktrees and test results when re-running E2E experiments with checkpoint resume",
-      "version": "1.0.0",
-      "source": "./skills/skill-preserve-workspaces-on-e2e-experiment-re-runs.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "skill-vega-lite-analysis-pipeline",
-      "description": "Build comprehensive analysis pipelines with text-based Vega-Lite figures and statistical tables for research papers",
-      "version": "1.0.0",
-      "source": "./skills/skill-vega-lite-analysis-pipeline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "suggest-optimizations",
-      "description": "Identify performance optimization opportunities. Use when improving code efficiency.",
-      "version": "1.0.0",
-      "source": "./skills/suggest-optimizations.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "tier-ablation-testing",
-      "description": "Run comprehensive tier ablation studies across AI agent architectures (T0-T6) with ~114 sub-tests",
-      "version": "1.0.0",
-      "source": "./skills/tier-ablation-testing.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "token-stats-aggregation",
-      "description": "Pattern for tracking detailed token statistics with cache tokens across hierarchical E2E report levels",
-      "version": "1.0.0",
-      "source": "./skills/token-stats-aggregation.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "validate-inputs",
-      "description": "Check function inputs for correctness and safety. Use when implementing defensive programming.",
-      "version": "1.0.0",
-      "source": "./skills/validate-inputs.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "verify-e2e-experiment-completion",
-      "description": "Verify E2E Experiment Completion",
-      "version": "1.0.0",
-      "source": "./skills/verify-e2e-experiment-completion.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "wire-figure-pipeline",
-      "description": "TRIGGER CONDITIONS: Adding new figure functions to the generate_figures.py pipeline in ProjectScylla. Use when: (1) a new figure function exists in scylla/analysis/figures/ but is not called from scripts/generate_figures.py, (2) registering batch-generated figures so they run automatically with all other figures, (3) wiring process-metric or other optional figures into the report pipeline.",
-      "version": "1.0.0",
-      "source": "./skills/wire-figure-pipeline.md",
-      "category": "evaluation",
-      "tags": []
-    },
-    {
-      "name": "analyze-simd-usage",
-      "description": "Analyze SIMD usage opportunities in Mojo code. Use to find performance optimization opportunities.",
-      "version": "1.0.0",
-      "source": "./skills/analyze-simd-usage.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "check-memory-safety",
-      "description": "Check Mojo code for memory safety issues (ownership violations, use-after-free, etc.). Use to catch memory bugs.",
-      "version": "1.0.0",
-      "source": "./skills/check-memory-safety.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "checkpoint-result-validation",
-      "description": "Validate checkpoint results before resuming expensive operations to prevent wasted API calls",
-      "version": "1.0.0",
-      "source": "./skills/checkpoint-result-validation.md",
-      "category": "optimization",
       "tags": [
-        "checkpoint",
-        "resume",
-        "validation",
-        "cost-optimization",
-        "idempotency"
+        "process-metrics",
+        "r-prog",
+        "cfp",
+        "strategic-drift",
+        "pr-revert-rate",
+        "run-result",
+        "analysis-pipeline",
+        "figures",
+        "statistical-tests",
+        "ProjectScylla"
       ]
     },
     {
-      "name": "e2e-artifact-deduplication",
-      "description": "Consolidate duplicate artifacts in E2E evaluation output by sharing prompts, commands, and configuration files across judges and runs",
+      "name": "automation-graphql-batch-comment-fetch",
+      "description": "Fetch GitHub issue comments for N issues in one aliased GraphQL call instead of N sequential round-trips (N+1 anti-pattern). Use when: (1) a pipeline checks comment state per issue before or after a worker pool starts, (2) the per-issue comment check uses `gh issue view --comments` or single-issue GraphQL, (3) you already batch-fetch issue states with `prefetch_issue_states()` and want to apply the same pattern to comments, (4) profiling shows comment fetches dominate pipeline wall-clock time, (5) adding a cache layer to `has_existing_plan()` or similar per-issue gates.",
       "version": "1.0.0",
-      "source": "./skills/e2e-artifact-deduplication.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "e2e-claude-cli-pipeline-oom-fixes",
-      "description": "Fix OOM crashes in multi-stage Claude CLI pipelines orchestrated via NATS JetStream. Use when: (1) claude-myrmidon or similar NATS pipeline OOM-kills a WSL2/Linux host, (2) spawning multiple `claude -p` processes exhausts memory, (3) NATS JetStream messages grow unbounded across pipeline stages, (4) adding dry-run validation mode to a Claude CLI pipeline.",
-      "version": "1.0.0",
-      "source": "./skills/e2e-claude-cli-pipeline-oom-fixes.md",
+      "source": "./skills/automation-graphql-batch-comment-fetch.md",
       "category": "optimization",
       "tags": [
-        "oom",
-        "nats",
-        "jetstream",
-        "claude-cli",
-        "myrmidon",
-        "pipeline",
-        "memory",
-        "dry-run",
-        "wsl2",
-        "docker-compose"
+        "graphql",
+        "batch-fetch",
+        "github-api",
+        "aliased-query",
+        "n-plus-one",
+        "comment-fetch",
+        "automation-pipeline",
+        "planner-state",
+        "round-trip-reduction"
       ]
     },
     {
-      "name": "e2e-resource-exhaustion",
-      "description": "Diagnose and fix machine crashes from memory/disk exhaustion during parallel E2E experiment runs. Use when: experiment runner hangs, WSL2 VM crashes, or disk fills with uncleaned workspaces.",
+      "name": "github-graphql-batch-query-optimization",
+      "description": "Replace N serial `gh api search/issues` REST calls with a single GraphQL query using aliased fields to fetch multiple issue counts (total/merged/open) in one round-trip. Use when: (1) a pipeline needs multiple GitHub issue statistics (count, merged count, open count), (2) currently implemented via N sequential REST search calls, (3) profiling shows API round-trips dominate wall-clock time, (4) need to reduce rate-limit consumption and latency.",
       "version": "1.0.0",
-      "source": "./skills/e2e-resource-exhaustion.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "module-level-schema-cache",
-      "description": "TRIGGER CONDITIONS: A _validate_schema() helper reads a JSON schema file from disk on every call, and it is invoked N times for N config files (e.g. in load_all_tiers() or load_all_models()). Use when adding a module-level dict cache to eliminate redundant file I/O for repeated schema validation calls.",
-      "version": "1.0.0",
-      "source": "./skills/module-level-schema-cache.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-build-package",
-      "description": "Build Mojo packages (.mojopkg files) for distribution. Use when creating distributable libraries or during packaging phase.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-build-package.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-gpu-fundamentals-programming-guide",
-      "description": "GPU programming patterns in Mojo using MAX GPU API. Use when: (1) writing GPU kernels in Mojo, (2) managing GPU memory and data transfer, (3) optimizing compute-bound workloads with GPU parallelism, (4) translating CUDA mental models to Mojo GPU API.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-gpu-fundamentals-programming-guide.md",
+      "source": "./skills/github-graphql-batch-query-optimization.md",
       "category": "optimization",
       "tags": [
-        "mojo",
-        "gpu",
-        "max-gpu",
-        "kernel",
-        "parallel",
-        "optimization",
-        "modular-upstream",
-        "cuda",
-        "tiletensor",
-        "shared-memory"
+        "graphql",
+        "batch-fetch",
+        "github-api",
+        "aliased-query",
+        "performance",
+        "rest-migration",
+        "api-optimization",
+        "round-trip-reduction"
       ]
     },
     {
-      "name": "mojo-lint-syntax",
-      "description": "Validate Mojo syntax against current v0.26.1+ standards. Use to catch syntax errors before compilation.",
-      "version": "1.2.0",
-      "source": "./skills/mojo-lint-syntax.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-memory-check",
-      "description": "Verify memory safety in Mojo code including ownership, borrowing, and lifetime management. Use when reviewing code or debugging memory issues.",
+      "name": "runtime-resource-optimization-mojo-python",
+      "description": "Runtime performance and resource management across Mojo SIMD/vectorisation and Python infrastructure. Use when: (1) SIMD-vectorizing element-wise tensor operations (NaN/Inf detection, gradient clipping, norm accumulation) in Mojo for 4-16x throughput; (2) validating Mojo language patterns (out self, mut, List, trait conformances, ownership transfer); (3) identifying SIMD optimization opportunities or checking memory safety in Mojo code; (4) fixing OOM crashes in multi-stage Claude CLI/NATS pipelines via session reuse and payload pruning; (5) preventing machine crashes from unbounded workspace accumulation or concurrent process limits in E2E runs; (6) adding module-level caching to eliminate redundant JSON schema file reads; (7) parallelizing I/O-bound subprocess loops with ThreadPoolExecutor; (8) validating checkpoint results before re-running expensive API calls; (9) deduplicating shared artifacts across E2E judge/run directories.",
       "version": "1.0.0",
-      "source": "./skills/mojo-memory-check.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-nd-slice-fast-path",
-      "description": "Add a contiguous-memcpy fast-path for N-D tensor slices where only the first axis is non-trivially sliced. Use when optimizing batch-extraction in training loops.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-nd-slice-fast-path.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-simd-optimize",
-      "description": "Apply SIMD optimizations to Mojo code for parallel computation. Use when optimizing performance-critical tensor and array operations.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-simd-optimize.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "mojo-type-safety",
-      "description": "Validate type safety in Mojo code including parametric types and trait constraints. Use during code review or when type errors occur.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-type-safety.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "optimization-mojo-simd-nan-inf-vectorization",
-      "description": "SIMD-vectorize NaN/Inf detection and gradient clipping functions in Mojo for hot-path performance. Use when: (1) optimizing element-wise tensor scanning functions, (2) implementing SIMD early-exit patterns in Mojo, (3) using vectorize[] with lane reduction for counting, (4) replacing scalar _get_float64/_set_float64 loops with SIMD, (5) implementing vectorized L2 norm accumulation with Float64 accumulator, (6) SIMD in-place tensor scaling or clamping.",
-      "version": "1.1.0",
-      "source": "./skills/optimization-mojo-simd-nan-inf-vectorization.md",
+      "source": "./skills/runtime-resource-optimization-mojo-python.md",
       "category": "optimization",
       "tags": [
         "mojo",
         "simd",
         "vectorization",
-        "numerical-safety",
+        "memory-safety",
+        "oom",
+        "nats",
+        "claude-cli",
+        "threadpoolexecutor",
+        "checkpoint",
+        "schema-cache",
+        "artifact-dedup",
         "performance",
-        "nan-detection",
-        "gradient-clipping",
-        "training",
-        "norm-computation"
+        "python",
+        "wsl2"
       ]
-    },
-    {
-      "name": "parallel-i-o-bound-execution-with-threadpoolexecutor",
-      "description": "Pattern for implementing ThreadPoolExecutor-based parallelization of I/O-bound tasks in Python CLI tools",
-      "version": "1.0.0",
-      "source": "./skills/parallel-io-bound-execution-with-threadpoolexecutor.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "validate-mojo-patterns",
-      "description": "Validate Mojo code patterns (out self, mut, List, etc.) against best practices. Use to ensure code follows project standards.",
-      "version": "1.0.0",
-      "source": "./skills/validate-mojo-patterns.md",
-      "category": "optimization",
-      "tags": []
-    },
-    {
-      "name": "activate-mojo-str-repr-tests",
-      "description": "Implement Stringable/Representable traits on a Mojo struct and activate commented-out __str__/__repr__ placeholder tests. Use when: a test file has TODO-guarded __str__/__repr__ stubs, you need String()/repr() support on a Mojo struct, or tests are commented out pending string method implementation.",
-      "version": "1.0.0",
-      "source": "./skills/activate-mojo-str-repr-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "add-uint-bitwise-not-tests",
-      "description": "Add Mojo UInt bitwise NOT (~) operator tests. Use when: extending bitwise coverage for unsigned integer types, or adding complement operator tests to an existing Mojo test suite.",
-      "version": "1.0.0",
-      "source": "./skills/add-uint-bitwise-not-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "add-unit-tests-for-existing-script",
-      "description": "Add comprehensive pytest unit tests for an existing Python script with no coverage. Use when: a script has no tests, bugs were found during implementation, or a follow-up issue requests test coverage.",
-      "version": "1.0.0",
-      "source": "./skills/add-unit-tests-for-existing-script.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "additive-resume-integration-tests",
-      "description": "Integration test patterns for stateful additive resume behavior in ProjectScylla \u2014 validates that sequential invocations with expanding --tiers/--max-subtests never reset existing checkpoint state, including TierStateMachine-level tier_states verification.",
-      "version": "1.1.0",
-      "source": "./skills/additive-resume-integration-tests.md",
-      "category": "testing",
-      "tags": []
     },
     {
       "name": "assert-to-runtime-error-migration",
@@ -7460,49 +4401,6 @@
       "description": "TRIGGER CONDITIONS: A pytest.mark.parametrize list hardcodes fixture filenames that must be manually updated when new fixtures are added. Use when replacing a hardcoded list with glob-based auto-discovery so new fixtures are picked up automatically.",
       "version": "1.0.0",
       "source": "./skills/auto-discover-parametrize-fixtures.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "bash-globstar-test-discovery-pitfall",
-      "description": "Test runners that use `for f in dir/**/*.ext` silently skip files at depth >=3 without `shopt -s globstar`. Use when: (1) writing a bash loop over recursive globs, (2) test count is suspiciously low, (3) coverage metrics drop after refactor.",
-      "version": "1.0.0",
-      "source": "./skills/bash-globstar-test-discovery-pitfall.md",
-      "category": "testing",
-      "tags": [
-        "bash",
-        "globstar",
-        "test-discovery",
-        "find",
-        "mapfile",
-        "justfile",
-        "recursive-glob",
-        "silent-failure"
-      ]
-    },
-    {
-      "name": "bash-test-helper-captured-rc-pattern",
-      "description": "Replace `cmd || true` in bash test helpers with `_rc=0; cmd || _rc=$?; : $((_rc))`. Use when: (1) a test helper invokes a command whose exit code should NOT abort the test but SHOULD remain observable for debugging, (2) the `|| true` suppresses an exit code that the test transcript should still surface (`echo \"DEBUG: cmd rc=$_rc\"`), (3) a codebase enforces a forbid-`|| true` lint guard but the test-helper case was previously labeled 'intentional', (4) a test framework helper like `run_test`, `apply_agent`, `handle_unmanaged` is called with an expected-failure path and downstream assertions don't depend on $?, (5) needing to preserve 'don't assert on rc' semantics while complying with a no-silent-failures policy.",
-      "version": "1.0.0",
-      "source": "./skills/bash-test-helper-captured-rc-pattern.md",
-      "category": "testing",
-      "tags": [
-        "bash",
-        "test-helpers",
-        "captured-rc",
-        "silent-failures",
-        "exit-code",
-        "bats",
-        "myrmidons",
-        "set-e",
-        "debugging-observability"
-      ]
-    },
-    {
-      "name": "batch-norm-gradient-testing",
-      "description": "Use when: (1) batch_norm backward gradient check fails with analytical ~0 vs numerical non-zero mismatch, (2) a gradient check test uses ones_like(output) as upstream gradient for a normalization layer, (3) upgrading ad-hoc non-uniform grad_output to a principled loss-based approach, (4) adding inference-mode (training=False) gradient checks for batch_norm2d_backward covering grad_gamma and grad_beta",
-      "version": "2.0.0",
-      "source": "./skills/batch-norm-gradient-testing.md",
       "category": "testing",
       "tags": []
     },
@@ -7522,36 +4420,24 @@
       ]
     },
     {
-      "name": "batchnorm-backward-gradient-checking",
-      "description": "Implements gradient checking for BatchNorm backward pass using finite differences with non-uniform grad_output to avoid pathological cancellation. Use when: adding gradient checking to normalization layer testers, validating batch norm backward correctness, or debugging zero-gradient false failures in gradient checks.",
+      "name": "bats-shell-test-patterns",
+      "description": "Use when: (1) adding BATS test coverage to any shell script (preflight check, Docker entrypoint, CLI wrapper), (2) stubbing external CLI binaries (gh, kubectl, aws, curl, git) under BATS with per-test configurable responses via fake-binary shims, (3) a recursive glob in a bash test runner silently skips files at depth >=3, (4) replacing `|| true` in bash test helpers with an observable captured-rc pattern that satisfies a no-silent-failures lint guard.",
       "version": "1.0.0",
-      "source": "./skills/batchnorm-backward-gradient-checking.md",
+      "source": "./skills/bats-shell-test-patterns.md",
       "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "bats-shell-testing",
-      "description": "Skill: bats-shell-testing. Use when working with bats shell testing.",
-      "version": "1.0.0",
-      "source": "./skills/bats-shell-testing.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "bf16-nan-canonicalization-test",
-      "description": "Test and fix BFloat16 NaN canonicalization in Mojo tensor types. Use when: implementing __hash__ for float tensors, BF16 NaN hashing produces inconsistent results, or debugging NaN bit pattern preservation through dtype conversions.",
-      "version": "1.0.0",
-      "source": "./skills/bf16-nan-canonicalization-test.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "bfloat16-regression-test-pattern",
-      "description": "Pattern for writing bfloat16 regression tests in Mojo that catch silent-failure bugs (missing dtype branches). Use when: (1) adding bfloat16 support to dtype-dispatched functions, (2) auditing existing dtype handlers, (3) writing regression tests after fixing a silent-write or silent-read bug.",
-      "version": "1.0.0",
-      "source": "./skills/bfloat16-regression-test-pattern.md",
-      "category": "testing",
-      "tags": []
+      "tags": [
+        "bats",
+        "bash",
+        "shell-testing",
+        "fake-binary",
+        "shim",
+        "mocking",
+        "globstar",
+        "captured-rc",
+        "docker-entrypoint",
+        "pixi",
+        "ci"
+      ]
     },
     {
       "name": "bulk-test-type-annotation",
@@ -7562,28 +4448,46 @@
       "tags": []
     },
     {
-      "name": "checkpoint-reconcile-state-order",
-      "description": "Fix stale checkpoint run states by reconciling with on-disk artifacts. Use when: adding RunState enum values, testing checkpoint reconcile edge cases, or debugging silent rank-comparison failures.",
+      "name": "checkpoint-state-machine-test-fixtures",
+      "description": "Use when: (1) writing integration or unit tests for ProjectScylla checkpoint-based state machines (StateMachine / SubtestStateMachine / TierStateMachine / ExperimentStateMachine), (2) debugging tests where checkpoint states are unexpectedly reset to pending, (3) adding orphan/integrity detectors to resume pipelines, (4) verifying additive/non-destructive resume behavior across sequential invocations, (5) testing zombie detection with real disk I/O, (6) verifying DataLoader reset behavior in Mojo training/validation loops, or (7) extracting shared pytest fixtures to eliminate per-test boilerplate.",
       "version": "1.0.0",
-      "source": "./skills/checkpoint-reconcile-state-order.md",
+      "source": "./skills/checkpoint-state-machine-test-fixtures.md",
       "category": "testing",
-      "tags": []
+      "tags": [
+        "checkpoint",
+        "state-machine",
+        "test-fixtures",
+        "pytest",
+        "integration-tests",
+        "orphan-detection",
+        "resume",
+        "zombie-detection",
+        "dataloader",
+        "mojo"
+      ]
     },
     {
-      "name": "checkpoint-test-fixture-patterns",
-      "description": "Patterns for building consistent checkpoint test fixtures with hierarchical state. Use when: writing tests for resume/retry logic, debugging orphan detector resets, or setting up checkpoint state for state machine tests.",
+      "name": "ci-tests-agent-subprocess-claude-absent",
+      "description": "Automation/agent-orchestration unit tests pass locally but fail in CI because the dev machine has the `claude` CLI on PATH and CI does not \u2014 an unpatched agent call (invoke_claude_with_session / _run_advise / _run_learn) spawns a REAL claude subprocess. Use when: (1) you add an agent-invoking method to code under test, (2) a unit test reaches an invoke_claude_with_session / _run_advise / _run_learn call, (3) automation/orchestration tests are green locally but red in CI, (4) you are auditing fixtures that do not disable agent gates. Fix: default agent gates OFF in shared fixtures + reproduce CI locally by hiding ~/.local/bin (where claude lives) from PATH while keeping pixi + gh.",
       "version": "1.0.0",
-      "source": "./skills/checkpoint-test-fixture-patterns.md",
+      "source": "./skills/ci-tests-agent-subprocess-claude-absent.md",
       "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "close-script-test-gap-cmd-run-repair",
-      "description": "Pattern for extending existing CLI test files to cover command-handler argument flow and repair edge cases using mocks only",
-      "version": "1.0.0",
-      "source": "./skills/close-script-test-gap-cmd-run-repair.md",
-      "category": "testing",
-      "tags": []
+      "tags": [
+        "testing",
+        "ci-cd",
+        "test-isolation",
+        "claude-cli",
+        "agent-orchestration",
+        "automation",
+        "subprocess",
+        "mock",
+        "fixtures",
+        "path",
+        "pixi",
+        "invoke-claude-with-session",
+        "flaky-ci",
+        "local-green-ci-red"
+      ]
     },
     {
       "name": "cmd-visualize-filter-format-coverage",
@@ -7594,44 +4498,34 @@
       "tags": []
     },
     {
-      "name": "config-filename-model-id-audit",
-      "description": "Audit and fix YAML config files where filename stems mismatch model_id fields",
+      "name": "coverage-module-floors-integration-backstop",
+      "description": "Enforce per-module coverage floors and integration tests for omitted modules. Use when: (1) aggregate coverage gates hide under-tested critical modules, (2) some modules are omitted from measurement (live orchestration, TTY), (3) need end-to-end backstop without false negatives.",
       "version": "1.0.0",
-      "source": "./skills/config-filename-model-id-audit.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "conv2d-backward-analytical-value-tests",
-      "description": "Use when: (1) writing conv2d_backward tests that verify exact gradient values (not just shapes), (2) using all-ones configs for analytically tractable batch accumulation or multi-channel verification, (3) verifying grad_bias=batch*out_H*out_W, grad_weights=batch*1.0, grad_input=out_channels, (4) testing padding>0 border pixel gradient reduction analytically",
-      "version": "1.0.0",
-      "source": "./skills/conv2d-backward-analytical-value-tests.md",
+      "source": "./skills/coverage-module-floors-integration-backstop.md",
       "category": "testing",
       "tags": [
-        "conv2d",
-        "backward-pass",
-        "analytical-values",
-        "mojo",
-        "batch-accumulation",
-        "multi-channel",
-        "padding",
-        "border-pixels"
+        "coverage",
+        "testing",
+        "module-floors",
+        "integration-tests",
+        "cobertura"
       ]
     },
     {
-      "name": "conv2d-gradient-checking-finite-differences",
-      "description": "Use when: (1) conv2d_backward tests only validate shapes but not grad_input/grad_weights values numerically, (2) adding finite-difference gradient checks for standard conv2d across padding=0, padding>0, stride, and multi-channel configurations, (3) verifying transposed convolution correctness, (4) extending gradient checking coverage to all three backward outputs (grad_input, grad_weights, grad_bias), (5) keeping per-file test count under 10",
+      "name": "cpp-rate-limiter-test-fixture-burst-capacity-trap",
+      "description": "Token-bucket RateLimiter constructor takes (tokens_per_sec, burst_capacity) not (max_requests, window). Tests that pass burst_capacity=1e9 will never see 429. Use when: (1) writing a test that exercises rate-limit exceedance, (2) a RateLimit test passes locally but the production limiter mysteriously never fires, (3) inheriting a token-bucket library and not sure what the second constructor arg means.",
       "version": "1.0.0",
-      "source": "./skills/conv2d-gradient-checking-finite-differences.md",
+      "source": "./skills/cpp-rate-limiter-test-fixture-burst-capacity-trap.md",
       "category": "testing",
       "tags": [
-        "conv2d",
-        "gradient-checking",
-        "finite-differences",
-        "mojo",
-        "backward-pass",
-        "numerical-gradients",
-        "padding"
+        "rate-limiter",
+        "token-bucket",
+        "test-fixture",
+        "burst-capacity",
+        "cpp",
+        "agamemnon",
+        "httplib",
+        "route-test"
       ]
     },
     {
@@ -7639,14 +4533,6 @@
       "description": "Generate customized review checklists based on type of change",
       "version": "1.0.0",
       "source": "./skills/create-review-checklist.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "dataloader-reset-verification",
-      "description": "Test pattern to verify DataLoader reset behavior in training/validation loops. Use when: confirming an iterator's reset() is called before iteration, or verifying a loop does not silently skip batches on a partially-consumed loader.",
-      "version": "1.0.0",
-      "source": "./skills/dataloader-reset-verification.md",
       "category": "testing",
       "tags": []
     },
@@ -7675,104 +4561,10 @@
       "tags": []
     },
     {
-      "name": "depthwise-conv2d-gradient-checking-tests",
-      "description": "Use when: (1) depthwise_conv2d_backward exists but lacks gradient-correctness tests, (2) adding per-channel finite-difference gradient checking for grad_input, grad_weights, and grad_bias, (3) the kernel shape is (channels,1,kH,kW) not (out_ch,in_ch,kH,kW), (4) keeping per-file test count \u22648",
-      "version": "1.0.0",
-      "source": "./skills/depthwise-conv2d-gradient-checking-tests.md",
-      "category": "testing",
-      "tags": [
-        "depthwise-conv2d",
-        "gradient-checking",
-        "finite-differences",
-        "mojo",
-        "backward-pass"
-      ]
-    },
-    {
-      "name": "docker-entrypoint-bats",
-      "description": "Skill: docker-entrypoint-bats. Use when adding BATS tests for Docker entrypoint scripts that handle credential chains, environment validation, and command dispatch.",
-      "version": "1.0.0",
-      "source": "./skills/docker-entrypoint-bats.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-absent-pkg-helper",
-      "description": "Extract a shared assert_pkg_absent helper into conftest.py to DRY up Dockerfile absence regression tests. Use when: (1) multiple test methods repeat apt-get/install regex checks, (2) adding a new removed-dependency regression test, (3) refactoring Dockerfile test suites.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-absent-pkg-helper.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-cache-arg-ordering",
-      "description": "Assert Dockerfile ARG declarations appear before RUN commands that consume them, ensuring Docker build-cache is correctly invalidated when build-args change.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-cache-arg-ordering.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "dockerfile-cargo-free-regression",
-      "description": "Add static regression tests and pre-commit hooks to assert a forbidden shell pattern is absent from Dockerfiles. Use when: a dep was removed from Dockerfiles and you want to prevent re-introduction, or when adding absent-pattern guards.",
-      "version": "1.0.0",
-      "source": "./skills/dockerfile-cargo-free-regression.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "enable-disabled-mojo-tests",
-      "description": "Re-enable disabled, skipped, or TODO-stubbed Mojo test files by identifying the root cause and replacing stubs with real tests. Use when: (1) a .mojo test file has a NOTE saying tests are disabled or prints SKIPPED with no test functions, (2) a test file has TODO markers citing an issue number with commented-out test code, (3) backward pass tests are commented out with stale ownership/borrowing notes, (4) a cleanup issue asks to re-enable tests, (5) blocking components are now implemented, or (6) pytest.skip() guards exist for resolved configuration issues.",
-      "version": "2.0.0",
-      "source": "./skills/enable-disabled-mojo-tests.md",
-      "category": "testing",
-      "tags": [
-        "mojo",
-        "tests",
-        "skip",
-        "todo",
-        "disabled",
-        "re-enable",
-        "cleanup"
-      ]
-    },
-    {
-      "name": "expand-ruff-rule-set",
-      "description": "Skill: expand-ruff-rule-set. Use when working with expand ruff rule set.",
-      "version": "1.0.0",
-      "source": "./skills/expand-ruff-rule-set.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "expand-tier-fixture-coverage",
       "description": "Expand YAML fixture files and test parametrize lists when adding new tiers to the testing tier registry. Use when tier count assertions or schema parametrize lists are out of sync with fixture files.",
       "version": "1.0.0",
       "source": "./skills/expand-tier-fixture-coverage.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "extend-script-test-coverage",
-      "description": "Pattern for systematically adding mock-only unit tests to previously untested Python scripts \u2014 prioritizing by testability \u00d7 impact to reach a coverage threshold",
-      "version": "1.0.0",
-      "source": "./skills/extend-script-test-coverage.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "extend-structural-test-with-value-assertions",
-      "description": "Pattern for closing the value-correctness gap in Mojo tensor tests that only assert structure (strides, contiguity) but not element values. Use when: existing test verifies is_contiguous() or strides but skips element value checks after as_contiguous().",
-      "version": "1.0.0",
-      "source": "./skills/extend-structural-test-with-value-assertions.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "extensor-dtype-str-repr",
-      "description": "Pattern for dtype-aware __str__/__repr__ in Mojo ExTensor and testing integer/bool formatting. Use when: adding string formatting to tensor structs, testing integer types render without decimals, testing bool renders as True/False.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-dtype-str-repr.md",
       "category": "testing",
       "tags": []
     },
@@ -7785,14 +4577,6 @@
       "tags": []
     },
     {
-      "name": "fastapi-pydantic-settings-test-isolation",
-      "description": "Fix FastAPI test isolation failures caused by Depends() capturing function references at import time and pydantic-settings reading .env at instantiation. Use when: (1) patching get_settings returns mock but tests still use real settings, (2) tests pass in CI but fail locally due to .env, (3) rate limiting returns 202 instead of 429, (4) AsyncMock triggers unawaited coroutine warnings.",
-      "version": "1.0.0",
-      "source": "./skills/fastapi-pydantic-settings-test-isolation.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "fix-default-value-test-mismatch",
       "description": "Fix test failures when default values change in source code but tests aren't updated",
       "version": "1.0.0",
@@ -7801,66 +4585,10 @@
       "tags": []
     },
     {
-      "name": "fix-flaky-sleep-mock",
-      "description": "Fix timing-sensitive tests by replacing wall-clock assertions with deterministic time.sleep mocks",
-      "version": "1.0.0",
-      "source": "./skills/fix-flaky-sleep-mock.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "fix-placeholder-code-ci",
-      "description": "Fix CI failures caused by partially commented placeholder code and dtype migration assertion mismatches",
-      "version": "1.0.0",
-      "source": "./skills/fix-placeholder-code-ci.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "fix-review-feedback-missing-assertion",
-      "description": "Pattern for fixing a misleading test that names/documents both setup and baseline assertions but only asserts one \u2014 add the missing mock capture and assertion",
-      "version": "1.0.0",
-      "source": "./skills/fix-review-feedback-missing-assertion.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "fix-review-feedback-runner-path-untested",
-      "description": "Pattern for fixing a test that calls an internal delegate directly instead of through the runner entry point, when the issue requirement specifies the entry point must be exercised",
-      "version": "1.0.0",
-      "source": "./skills/fix-review-feedback-runner-path-untested.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "fix-tests-after-config-refactor",
       "description": "Fix Tests After Config Refactor",
       "version": "1.0.0",
       "source": "./skills/fix-tests-after-config-refactor.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "fixture-timeout-calibration",
-      "description": "Skill: fixture-timeout-calibration",
-      "version": "1.0.0",
-      "source": "./skills/fixture-timeout-calibration.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "flaky-test-patch-isolation",
-      "description": "Fix flaky tests caused by class-level mock state leakage via patch.object(__class__, ...). Adds autouse teardown fixture with patch.stopall() to isolate test classes.",
-      "version": "1.0.0",
-      "source": "./skills/flaky-test-patch-isolation.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "forbid-e2e-remote-ops",
-      "description": "Prevent remote Git operations in e2e tests and optimize worktree creation",
-      "version": "1.0.0",
-      "source": "./skills/forbid-e2e-remote-ops.md",
       "category": "testing",
       "tags": []
     },
@@ -7889,53 +4617,37 @@
       "tags": []
     },
     {
-      "name": "gradient-checking-test-setup-fixes",
-      "description": "Fix gradient checking test failures caused by pathological test setup. Use when: (1) gradient checks fail with analytical~0 vs numerical~nonzero for normalization layers, (2) any gradient check exceeds tolerance due to large-magnitude gradients, (3) migrating check_gradients() to check_gradient(). Migration is COMPLETE as of v3.0.0.",
-      "version": "3.0.0",
-      "source": "./skills/gradient-checking-test-setup-fixes.md",
+      "name": "gradient-checking-and-backward-pass-testing",
+      "description": "Use when: (1) writing numerical gradient checks for conv2d, depthwise conv2d, batch norm, layer norm, or pooling backward passes in Mojo, (2) a gradient check reports analytical\u22480 vs numerical\u2248nonzero for a normalization layer, (3) migrating from check_gradients() to check_gradient() or choosing tolerances for float32 backward tests, (4) extending backward coverage to inference mode, 4D inputs, multi-channel configs, or all three gradient fields (grad_input, grad_weights, grad_bias), (5) implementing analytically tractable exact-value tests for conv2d backward with all-ones configs, (6) adding end-to-end convergence tests as a complementary class to per-op finite-difference checks for validating the full forward\u2192backward\u2192optimizer\u2192writeback loop",
+      "version": "1.1.0",
+      "source": "./skills/gradient-checking-and-backward-pass-testing.md",
       "category": "testing",
       "tags": [
         "gradient-checking",
+        "backward-pass",
         "batch-norm",
+        "layer-norm",
         "conv2d",
         "depthwise-conv2d",
+        "pooling",
+        "finite-differences",
         "float32-precision",
-        "test-setup",
-        "tolerance",
-        "migration-complete"
+        "mojo"
       ]
     },
     {
-      "name": "hook-grep-chain-unit-tests",
-      "description": "Write pure-Python pytest tests that replicate a pre-commit hook's bash grep chain as a Python predicate. Use when: a pre-commit hook uses grep with exclusion patterns and has no unit tests, you need fast regression coverage without invoking pre-commit, or you want to document known hook limitations.",
+      "name": "liza-go-tests-embedded-cache",
+      "description": "Run and debug Liza Go tests in local/sandboxed environments. Use when Go tests fail on missing embedded contracts or skills, cannot write the default Go cache, or show flaky internal/gitenv timeout behavior during Liza validation.",
       "version": "1.0.0",
-      "source": "./skills/hook-grep-chain-unit-tests.md",
+      "source": "./skills/liza-go-tests-embedded-cache.md",
       "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "json-schema-validation-wiring",
-      "description": "Wire JSON schema validation into config loader methods (load_test, load_rubric). Use when adding schema validation to new config file types in ProjectScylla's ConfigLoader.",
-      "version": "1.0.0",
-      "source": "./skills/json-schema-validation-wiring.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "layer-norm-4d-gradient-test",
-      "description": "Pattern for writing numerical gradient tests for layer_norm_backward on 4D inputs in Mojo. Use when: extending 2D gradient validation to 4D (batch, channels, H, W), validating backward pass correctness when indexing/reduction logic differs by rank, or adding follow-up tests after a 2D gradient test.",
-      "version": "1.0.0",
-      "source": "./skills/layer-norm-4d-gradient-test.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "layer-norm-param-gradient-checks",
-      "description": "Add numerical gradient checks for layer_norm_backward grad_gamma and grad_beta using central finite differences. Use when: layer norm backward pass lacks parameter gradient validation, extending batch_norm gradient check pattern to layer norm, or validating result[1] and result[2] of layer_norm_backward.",
-      "version": "1.0.0",
-      "source": "./skills/layer-norm-param-gradient-checks.md",
-      "category": "testing",
-      "tags": []
+      "tags": [
+        "liza",
+        "go",
+        "tests",
+        "embedded",
+        "gocache"
+      ]
     },
     {
       "name": "manager-proxy-type-hints",
@@ -7954,292 +4666,67 @@
       "tags": []
     },
     {
-      "name": "mojo-api-signature-test-fix",
-      "description": "Fix Mojo test files when API signatures change (missing required positional args, positional/keyword conflicts). Use when: tests fail with 'missing required positional arguments' or 'argument passed both as positional and keyword operand'.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-api-signature-test-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-as-contiguous-stride-verification",
-      "description": "TDD pattern for verifying stride-aware memory remapping in Mojo tensor as_contiguous(). Use when: writing regression tests for non-contiguous tensor copy operations, verifying stride-based indexing before or after a bug fix.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-as-contiguous-stride-verification.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-assert-close-float-tests",
-      "description": "Documents patterns for comprehensive assert_close_float tests in Mojo. Use when: adding float tolerance tests, covering NaN/infinity edge cases, verifying atol/rtol boundary behavior.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-assert-close-float-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-batch-norm-gradient-parametrize",
-      "description": "Parametrize Mojo batch norm backward gradient checks across batch sizes [1, 2, 4] using loop-based helpers, handling batch_size=1 degenerate case (variance=0) with finiteness-only assertions. Use when: adding gradient check coverage for batch norm backward edge cases, implementing parametrized tests in Mojo without a native parametrize decorator, or handling the variance=0 degenerate case for batch_size=1.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-batch-norm-gradient-parametrize.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-bfloat16-factory-dtype-guards",
-      "description": "Add bfloat16 dtype guard tests to Mojo tensor factory functions. Use when: a factory function routes float16/float32/float64 to a float path but is missing bfloat16, causing silent int-truncation of bfloat16 values.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-bfloat16-factory-dtype-guards.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-boolable-raises-fix",
-      "description": "Fix Mojo test compile errors from Bool(t) on structs whose __bool__ has raises, preventing Boolable trait conformance. Use when: CI fails with 'does not conform to trait Boolable', __bool__ is defined with raises, or you need to test raising __bool__ without Boolable.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-boolable-raises-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-bounds-test-pattern",
-      "description": "Pattern for adding symmetric boundary condition tests in Mojo by mirroring existing analogous tests. Use when: (1) adding a missing bounds check test, (2) implementing follow-up coverage for __setitem__/__getitem__ boundary conditions.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-bounds-test-pattern.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-broadcast-edge-case-fix",
-      "description": "Fix and test broadcast_to edge cases in Mojo tensor libraries. Use when: broadcast_to incorrectly accepts incompatible target shapes, adding 0-d scalar/identity/multi-axis tests, or validating ndim-reduction rejection.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-broadcast-edge-case-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-confusion-matrix-integration-tests",
-      "description": "Pattern for adding ConfusionMatrix integration tests to a Mojo ValidationLoop test file. Use when: a ValidationLoop accepts compute_confusion=True but has no test covering that path, or you need to verify exact ConfusionMatrix cell counts with known binary fixtures.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-confusion-matrix-integration-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-depthwise-conv-backward-shapes",
-      "description": "Pattern for adding shape-verification tests for depthwise conv backward passes in Mojo. Use when: adding backward tests for depthwise conv variants, verifying DepthwiseConv2dNoBiasGradient shapes, mirroring existing conv_no_bias_backward shape tests.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-depthwise-conv-backward-shapes.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-exception-message-assertion",
-      "description": "Pattern for asserting exact error message text in Mojo exception tests using 'except e:'. Use when: (1) upgrading bare except: clauses to assert specific error message text, (2) adding message verification to out-of-bounds or error-path tests.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-exception-message-assertion.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-expose-internal-state-testability",
-      "description": "Refactor Mojo structs to expose internally-constructed state as fields for integration testing. Use when: (1) a struct creates metric/state objects internally in a method but never exposes them, (2) you need to verify internal state after calling a method, (3) adding raises to __init__ cascades to callers.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-expose-internal-state-testability.md",
+      "name": "mock-and-test-isolation-patterns",
+      "description": "Use when: (1) writing chaos/fault injection tests where a mock service must simulate latency, kill, or queue-starvation side effects \u2014 not just record the fault command, (2) a FastAPI/Pydantic endpoint test expects a specific HTTP status code (e.g. 503) but receives 500 because MagicMock attributes fail Pydantic response serialization, (3) tests pass individually but fail together due to mock pollution across test files and real file I/O with tmp_path is a cleaner alternative, (4) a test name says 'and' but only one side is asserted \u2014 a patch.object is missing 'as mock_X' and assert_called_once(), (5) a test bypasses the runner entry point and calls an internal delegate directly, leaving the full path untested, (6) adding unit tests for a class that constructs collaborators internally \u2014 patch the instance attribute after construction, (7) testing RuntimeError precondition guards (if-None, subprocess returncode, or _is_setup state) with parametrize or side_effect lists, (8) testing closure guards inside action-builder methods without a full state machine, (9) tests pass in isolation but fail when run after a test that calls importlib.reload() \u2014 patch.object on a module-imported object becomes stale after reload; use patch() string form instead.",
+      "version": "1.1.0",
+      "source": "./skills/mock-and-test-isolation-patterns.md",
       "category": "testing",
       "tags": [
-        "mojo",
-        "refactoring-for-testability",
-        "integration-testing",
-        "cascading-raises"
+        "mock",
+        "test-isolation",
+        "pydantic",
+        "magicmock",
+        "fastapi",
+        "chaos-testing",
+        "fault-injection",
+        "tmp-path",
+        "patch-object",
+        "runtime-error",
+        "guard-tests",
+        "instance-attribute-patching",
+        "subprocess",
+        "importlib-reload",
+        "stale-reference",
+        "string-patch"
       ]
     },
     {
-      "name": "mojo-hash-testing-patterns",
-      "description": "Use when: (1) implementing or fixing __hash__ on a Mojo tensor/struct with float fields, (2) adding hash collision tests for shape/dtype/value sensitivity, (3) verifying hash stability for edge-case tensors (empty, large values, small values), (4) guarding against dtype regression in __hash__ when numel=0, (5) testing integer-dtype coverage through _get_float64 dispatch path",
-      "version": "2.1.0",
-      "source": "./skills/mojo-hash-testing-patterns.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-if-true-scope-fix",
-      "description": "Replace Mojo 'if True:' constant condition anti-patterns with named helper functions. Use when: Mojo --Werror reports constant condition warnings on if True: blocks used for scope-based destructor testing.",
+      "name": "mojo-dtype-shape-and-package-edges",
+      "description": "Canonical edge-case patterns for Mojo dtype handling, shape inference, and package builds: bfloat16/NaN canonicalization, exotic dtype defaults, shape-bound inference, parametric vs runtime dtype, package re-export rules, package-build edges, test patterns for dtype matrices, dtype string serialization. Use when: (1) implementing dtype-aware kernels and dealing with bfloat16/fp16 edge cases, (2) writing shape-bound inference for parametric tensors, (3) building/publishing a Mojo package and dealing with re-exports, (4) constructing dtype/shape test matrices.",
       "version": "1.0.0",
-      "source": "./skills/mojo-if-true-scope-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-logical-xor-test-coverage",
-      "description": "Add logical_xor test coverage for Mojo elementwise operations. Use when: (1) a logical op is imported but untested, (2) the file is at the per-file test limit and a new file is needed, (3) binary logical truth-table coverage is missing.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-logical-xor-test-coverage.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-multidim-setitem-tests",
-      "description": "Implement variadic-Int __setitem__ on ExTensor and corresponding multi-dim tests. Use when: adding stride-aware multi-dim assignment (t[i,j]=v) to a Mojo tensor, writing 2D/3D __setitem__ tests verifying flat index = sum(idx*stride).",
-      "version": "1.0.0",
-      "source": "./skills/mojo-multidim-setitem-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-narrowing-cast-tests",
-      "description": "Documents how to add narrowing conversion tests in Mojo following the if/raise pattern. Use when: (1) adding UInt narrowing tests for a new target type, (2) extending test_unsigned.mojo with new cast coverage.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-narrowing-cast-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-numerical-gradient-test",
-      "description": "Add numerical gradient validation for Mojo ML backward passes using central finite differences. Use when: adding backward pass gradient tests, avoiding grad_output=ones cancellation, verifying analytical vs numerical gradient agreement, or testing gradients w.r.t. learnable parameters (gamma, beta) not just input tensors.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-numerical-gradient-test.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-reexport-import-tests",
-      "description": "Mojo re-export: add import tests for package re-exports, wire structs through multi-level __init__.mojo chains with canonical aliases, and audit submodule __init__.mojo files for re-export limitations. Use when: (1) adding exports to __init__.mojo and verifying package public API, (2) a struct exists in a leaf module but is missing from parent package imports, (3) a follow-up issue asks to check if re-export limitations affect sibling submodules, (4) a docstring audit reveals undocumented submodules.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-reexport-import-tests.md",
+      "source": "./skills/mojo-dtype-shape-and-package-edges.md",
       "category": "testing",
       "tags": [
+        "merged",
         "mojo",
-        "reexport",
-        "imports",
-        "__init__.mojo",
-        "package-api",
-        "alias",
-        "docstring",
-        "audit"
+        "dtype",
+        "shape",
+        "package",
+        "bfloat16",
+        "parametric"
       ]
     },
     {
-      "name": "mojo-run-epoch-with-batches",
-      "description": "Test run_epoch_with_batches() in Mojo training scripts using a real DataLoader and a named step_fn. Use when: a training utility that accepts a DataLoader and step_fn has no tests, need to verify avg_loss > 0 and loader.reset() semantics, or step_fn must match the fn pointer signature fn(ExTensor, ExTensor) raises -> ExTensor.",
+      "name": "mojo-tensor-unit-test-patterns",
+      "description": "Test patterns specific to Mojo tensor and operator implementations. Use when: (1) activating TODO-guarded __str__/__repr__ placeholder tests in Mojo, (2) adding dtype-aware string/repr formatting for integer or bool types, (3) writing BFloat16 NaN canonicalization or regression tests, (4) adding UInt bitwise NOT or overflow/wrap-around boundary tests, (5) closing value-correctness gaps in structural tensor tests, (6) fixing view vs copy semantics mismatches in slice tests, (7) replacing hardcoded /tmp paths with unique per-run paths, (8) re-enabling NOTE-disabled or TODO-stubbed Mojo test files, (9) annotating pass-only placeholder tests against staleness, (10) resolving TODO(#N) markers after a blocking issue closes.",
       "version": "1.0.0",
-      "source": "./skills/mojo-run-epoch-with-batches.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-sanitizer-build-scope-and-tcmalloc-incompat",
-      "description": "Scope Mojo ASAN/TSAN builds to shared-library-only + per-test compile, not full binary AOT. Document the known TSAN/tcmalloc startup abort. Use when: (1) adding --sanitize modes to a Mojo build, (2) sanitizer sweeps OOM partway through, (3) TSAN binaries abort with `FATAL: ThreadSanitizer: unexpected memory mapping`.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-sanitizer-build-scope-and-tcmalloc-incompat.md",
+      "source": "./skills/mojo-tensor-unit-test-patterns.md",
       "category": "testing",
       "tags": [
         "mojo",
-        "sanitizer",
-        "asan",
-        "tsan",
-        "tcmalloc",
-        "build-scope",
-        "oom",
-        "justfile",
-        "mojo-1-0"
+        "tensor",
+        "extensor",
+        "dtype",
+        "bfloat16",
+        "uint",
+        "view",
+        "copy",
+        "str",
+        "repr",
+        "placeholder",
+        "todo",
+        "re-enable"
       ]
-    },
-    {
-      "name": "mojo-shape-noncontiguous-value-tests",
-      "description": "TDD regression pattern for verifying element-value correctness of shape ops on Mojo tensors. Use when: (1) adding value-correctness tests for shape ops (reshape, flatten, permute, concatenate, tile, repeat, broadcast_to) on non-contiguous inputs, surfacing flat-index bugs where _get_float64(i) ignores _strides; (2) shape tests use assert_numel/assert_dim only and need actual value assertions added; (3) code review flags tests that pass even if operations produce wrong output.",
-      "version": "2.0.0",
-      "source": "./skills/mojo-shape-noncontiguous-value-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-shared-test-helper-extraction",
-      "description": "Move duplicated Mojo test helper functions from local test files into shared testing libraries. Use when: a parametric helper fn is copy-pasted across test files, a test file split requires the same utility, or conftest re-export pattern is needed.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-shared-test-helper-extraction.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-signed-int-bitwise-not",
-      "description": "Pattern for adding bitwise NOT (~) tests for Mojo signed integer types using two's complement semantics. Use when: adding ~ operator tests for Int8/Int16/Int32/Int64, extending unsigned NOT tests to signed types, or splitting test files when the per-file test limit is reached.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-signed-int-bitwise-not.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-stride-manipulation-for-noncontiguous-tests",
-      "description": "Technique for testing non-contiguous tensor behavior in Mojo by directly manipulating _strides fields. Use when: testing is_contiguous()/as_contiguous() without transpose(), simulating column-major layout, or unblocking placeholder tests that depend on unimplemented higher-level ops.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-stride-manipulation-for-noncontiguous-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-subpackage-import-tests",
-      "description": "Add tests verifying Mojo sub-package import paths work (e.g. from shared.training.callbacks import EarlyStopping). Use when: an issue requests confirming a direct sub-module import works, or when only parent-package re-export imports are tested but not the canonical sub-package path.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-subpackage-import-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-trait-conformance-for-sequential-integration",
-      "description": "Add Module trait conformance to Mojo layers for Sequential container use, and fix missing trait declarations causing compile-time 'does not conform to trait' errors. Use when: (1) existing layers lack train()/inference() methods, (2) forward() uses self instead of mut self, (3) layers need to be composed inside Sequential2/Sequential3, (4) a struct implements trait methods (e.g. __hash__) but is missing the trait in its declaration list.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-trait-conformance-for-sequential-integration.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-transpose-view-contiguity",
-      "description": "Add stride-based transpose_view() to Mojo ExTensor for testing contiguity contracts. Use when: tests use direct _strides mutation, needing realistic non-contiguous tensors for is_contiguous()/as_contiguous() tests.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-transpose-view-contiguity.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-unsigned-wrapping-tests",
-      "description": "Document and verify wrapping arithmetic semantics for Mojo unsigned integer types at type boundaries. Use when: adding overflow/underflow wrap tests to Mojo unsigned type test files.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-unsigned-wrapping-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-val-accuracy-behavioral-test",
-      "description": "Add a behavioral test asserting metrics.val_accuracy is updated after ValidationLoop.run() with compute_accuracy=True. Use when: a GH issue flags that only default values are tested but not behavioral effects, or when closing a test gap between init-defaults tests and run-effects tests.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-val-accuracy-behavioral-test.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-validation-loop-accuracy-tracking",
-      "description": "Fix a Mojo ValidationLoop that hardcodes accuracy=0.0 in metrics updates and add tests verifying metrics.val_accuracy is updated. Use when: a ValidationLoop.run() passes placeholder 0.0 for accuracy, a GitHub issue asks for a test verifying val_accuracy is non-zero after run(), you need to avoid Mojo tuple-return syntax, or the implementation is already fixed and only the test is missing.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-validation-loop-accuracy-tracking.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-value-verification-tests",
-      "description": "Add value-correctness assertions to Mojo shape operation tests that only verify element counts. Use when: shape tests pass with assert_numel/assert_dim but do not check actual output data values.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-value-verification-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mojo-view-semantics-test",
-      "description": "Add Mojo tests asserting view/shared-memory semantics for tensor slicing. Use when: a slice() method claims view semantics but lacks a mutation test, or adding regression coverage for copy-vs-view bugs.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-view-semantics-test.md",
-      "category": "testing",
-      "tags": []
     },
     {
       "name": "move-loose-test-files",
@@ -8289,82 +4776,10 @@
       ]
     },
     {
-      "name": "mypy-annotate-test-functions",
-      "description": "Skill: mypy-annotate-test-functions. Use when annotating test functions and helper classes in pytest test files for mypy compliance.",
-      "version": "1.0.0",
-      "source": "./skills/mypy-annotate-test-functions.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mypy-per-directory-baseline",
-      "description": "Use when: (1) tracking mypy error counts per-directory with a living baseline (scripts/, tests/, scylla/); (2) removing ignore_errors = true overrides from pyproject.toml; (3) fixing quick-win single-violation mypy error codes (override, no-redef, exit-return, return-value, call-overload); (4) extending mypy coverage from a blanket-suppressed directory to full enforcement; (5) adding or updating a pre-commit validation script for mypy count enforcement.",
-      "version": "2.0.0",
-      "source": "./skills/mypy-per-directory-baseline.md",
-      "category": "testing",
-      "tags": [
-        "mypy",
-        "type-checking",
-        "baseline",
-        "pre-commit",
-        "per-directory",
-        "quick-wins",
-        "scripts-coverage"
-      ]
-    },
-    {
-      "name": "narrow-mypy-override-subset",
-      "description": "Narrow a broad mypy module glob override to an explicit list when a subset of subdirs is fully annotated. Use when annotating tests/unit/<subdir>/ and removing it from a blanket suppressor.",
-      "version": "1.0.0",
-      "source": "./skills/narrow-mypy-override-subset.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "nd-tensor-dataloader-fix",
       "description": "Fix DataLoader.next() to support N-D tensors by replacing hardcoded 2D shape assumption with ExTensor.slice(). Use when: DataLoader produces wrong batch shapes for 3D/4D data, or adding N-D batch slicing tests in Mojo.",
       "version": "1.0.0",
       "source": "./skills/nd-tensor-dataloader-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "noncontiguous-tensor-guard",
-      "description": "Add as_contiguous() guards to Mojo flat-buffer kernels so non-contiguous tensor views don't silently produce wrong results. Use when: a kernel uses _data.bitcast[T]()[i] flat indexing, adding support for transposed/sliced tensor inputs, or auditing kernels after a new non-contiguous tensor API is introduced.",
-      "version": "1.0.0",
-      "source": "./skills/noncontiguous-tensor-guard.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "normalization-backward-grad-output-warning",
-      "description": "Document the grad_output=ones cancellation hazard in normalization backward tests as a shared testing guide warning. Use when: a normalization backward test produced a false failure due to sum(x_norm)=0 cancellation and you want to prevent recurrence via shared documentation.",
-      "version": "1.0.0",
-      "source": "./skills/normalization-backward-grad-output-warning.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "orphan-aware-test-fixtures",
-      "description": "Patterns for fixing test fixtures that break when checkpoint integrity detectors are added. Use when: adding orphan detection to resume pipelines, or when aggregated states get unexpectedly reset.",
-      "version": "1.0.0",
-      "source": "./skills/orphan-aware-test-fixtures.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "placeholder-test-staleness-annotations",
-      "description": "Upgrade pass-only placeholder tests with TODO annotations, cross-issue references, and concrete test specs. Use when: placeholder tests contain only `pass`, are blocked on an unimplemented dependency, or need to be made grep-discoverable.",
-      "version": "1.0.0",
-      "source": "./skills/placeholder-test-staleness-annotations.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "pool-layer-backward-tester",
-      "description": "Implement a pooling backward pass tester following the three-tier gradient checking pattern (shape, analytical, numerical). Use when: adding test_pool_layer_backward to a Mojo layer_testers utility, validating MaxPool/AvgPool backward pass gradients, or filling a gap where conv/batchnorm backward testers exist but pooling backward is absent.",
-      "version": "1.0.0",
-      "source": "./skills/pool-layer-backward-tester.md",
       "category": "testing",
       "tags": []
     },
@@ -8377,42 +4792,103 @@
       "tags": []
     },
     {
-      "name": "pytest-coverage-fail-under-partial-run-trap",
-      "description": "[tool.coverage.report] fail_under = X in pyproject.toml fires for EVERY pytest invocation, not just full-suite runs. Partial test runs (e.g., `pytest -m integration`, single test class, single file) measure coverage of only what they execute, naturally producing lower numbers and tripping the global gate even when the full suite is well above threshold. Use when: (1) integration-only CI job fails with 'Required test coverage of X.0% not reached' but full-suite coverage is fine, (2) running a single pytest file or class trips coverage gate, (3) you suspect coverage failure caused by recently-added gate and partial test selection rather than real coverage regression, (4) deciding whether to put coverage gate in pyproject.toml's [tool.coverage.report] vs in CI workflow's --cov-fail-under flag.",
+      "name": "pydantic-frozen-models-testing-pattern",
+      "description": "Testing patterns for frozen Pydantic models. Use when: (1) converting mutable config to frozen=True, (2) rewriting mode='after' validators as mode='before', (3) fixing test override patterns with LRU-cached singletons.",
       "version": "1.0.0",
-      "source": "./skills/pytest-coverage-fail-under-partial-run-trap.md",
+      "source": "./skills/pydantic-frozen-models-testing-pattern.md",
       "category": "testing",
       "tags": [
-        "pytest",
-        "coverage",
-        "fail-under",
-        "ci",
-        "integration-tests",
-        "partial-runs",
-        "coverage-gate"
+        "pydantic",
+        "testing",
+        "frozen-models",
+        "validators",
+        "config",
+        "lru-cache"
       ]
     },
     {
-      "name": "pytest-pythonpath-scripts-fix",
-      "description": "TRIGGER CONDITIONS: When analysis/scripts tests fail to collect due to ImportError on a scripts/ module, or when test count is suspiciously low (~1691 vs expected ~3199+), or when a pre-push hook runs fewer tests than a direct pytest invocation.",
-      "version": "1.0.0",
-      "source": "./skills/pytest-pythonpath-scripts-fix.md",
+      "name": "pytest-asyncio-hang-and-mock-hazards",
+      "description": "Diagnosing and fixing pytest tests that hang or produce false results due to asyncio event loops, sleep mocks, and coroutine patching. Use when: (1) pytest CI step times out without reporting a test failure \u2014 hang signature, (2) async daemon tests block in epoll.poll(-1) and pytest-timeout does not interrupt them, (3) a coroutine internally reassigns a global asyncio.Event making pre-set fixtures ineffective, (4) patch('module.time.sleep') causes OOM via runaway retry loops, (5) FastAPI Depends() ignores a patched get_settings because the function reference was captured at import time, (6) a code-quality bot flags `await <asyncio.Task>` as a no-effect statement.",
+      "version": "1.1.0",
+      "source": "./skills/pytest-asyncio-hang-and-mock-hazards.md",
       "category": "testing",
-      "tags": []
+      "tags": [
+        "asyncio",
+        "pytest",
+        "hang",
+        "timeout",
+        "epoll",
+        "AsyncMock",
+        "coroutine",
+        "patch",
+        "time-sleep",
+        "oom",
+        "fastapi",
+        "pydantic-settings",
+        "event-loop",
+        "python",
+        "pytest-timeout",
+        "false-positive",
+        "unmocked-blocking-call",
+        "subprocess-hang",
+        "baseline-duration-diagnosis",
+        "faulthandler"
+      ]
+    },
+    {
+      "name": "pytest-configuration-and-isolation-pitfalls",
+      "description": "Use when: (1) CI Python test job hangs until timeout with no explicit failure, (2) pytest warns 'ignoring pytest config in pyproject.toml!' or a pytest.ini coexists with pyproject.toml, (3) test collection count is suspiciously low or ImportError on a scripts/ module, (4) coverage gate fires for a partial test run (e.g., pytest -m integration) but full-suite coverage is fine, (5) a test is flaky only in the full suite and uses class-level patch.object, (6) YAML fixture timeouts are far too conservative and inflate CI job duration, (7) a test suddenly fails in CI with no code changes and references hardcoded calendar dates or Unix timestamps.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-configuration-and-isolation-pitfalls.md",
+      "category": "testing",
+      "tags": [
+        "pytest",
+        "configuration",
+        "isolation",
+        "coverage",
+        "mock",
+        "fixture",
+        "timeout",
+        "date-bomb",
+        "pythonpath",
+        "fail-under"
+      ]
+    },
+    {
+      "name": "pytest-testpaths-integration-discovery",
+      "description": "Use when: (1) developers run bare `pytest` and only unit tests are discovered, (2) integrating a new `tests/integration/` suite but default test invocation skips it, (3) you want to enable marker-based test selection (`-m unit`, `-m integration`) without fragmenting test discovery, (4) CI test counts differ from local collection counts, (5) you need consistent test discovery behavior across all invocation patterns.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-testpaths-integration-discovery.md",
+      "category": "testing",
+      "tags": [
+        "pytest",
+        "testpaths",
+        "test-discovery",
+        "integration-tests",
+        "markers",
+        "pytest-markers"
+      ]
+    },
+    {
+      "name": "python-script-unit-test-coverage-expansion",
+      "description": "Use when: (1) a Python script in scripts/ has zero test coverage and needs tests added; (2) a coverage threshold audit reveals that scripts/ is under-tested vs. the threshold; (3) a follow-up issue requests tests for specific untested modules; (4) you need to close CLI command-handler test gaps (cmd_run/cmd_repair style); (5) you need to audit existing tests before writing new ones to avoid duplication; (6) you are running a coverage swarm with one PR per source file or test shard; (7) new tests must be documented and added to CI workflows that enumerate files manually.",
+      "version": "1.1.0",
+      "source": "./skills/python-script-unit-test-coverage-expansion.md",
+      "category": "testing",
+      "tags": [
+        "python",
+        "pytest",
+        "unit-tests",
+        "coverage",
+        "mocking",
+        "scripts"
+      ]
     },
     {
       "name": "regression-test-from-issue-plan",
       "description": "Add missing regression tests by reading the issue's implementation plan. Use when: (1) an issue references a test by name that should exist as a harness, (2) a bug fix landed but the named test was never added, (3) issue comments contain hand-computed expected values.",
       "version": "1.0.0",
       "source": "./skills/regression-test-from-issue-plan.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "resolve-blocked-todos",
-      "description": "Resolve TODO markers blocked by a now-closed issue. Use when: (1) a tracking issue has TODO(#N) markers and issue #N is now closed, (2) disabled tests have TODO comments waiting on a dependency, (3) cleanup issues need to be resolved after a blocking PR merges.",
-      "version": "1.0.0",
-      "source": "./skills/resolve-blocked-todos.md",
       "category": "testing",
       "tags": []
     },
@@ -8433,42 +4909,10 @@
       "tags": []
     },
     {
-      "name": "runtime-error-guard-tests",
-      "description": "Patterns for testing if-None RuntimeError precondition guards in Python \u2014 covers unit test structure, parametrized fixtures, closure guards via action builders, inline run() guards with side-effect patching, and the local-import patch target rule.",
-      "version": "1.1.0",
-      "source": "./skills/runtime-error-guard-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "script-test-coverage-pattern",
-      "description": "Patterns for adding mock-only unit tests to Python utility scripts \u2014 covering subprocess-heavy, filesystem-heavy, and pure-function scripts in ProjectScylla. Raises scripts/ test coverage from 29% to 65% (10/34 \u2192 22/34 scripts tested).",
-      "version": "1.0.0",
-      "source": "./skills/script-test-coverage-pattern.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "script-unit-test-coverage",
-      "description": "TRIGGER CONDITIONS: Use when adding unit tests for scripts/ that lack test files, following the ProjectScylla pattern of mocked I/O with pytest class-based tests.",
-      "version": "1.0.0",
-      "source": "./skills/script-unit-test-coverage.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "skill-cli-deep-audit-and-fix",
       "description": "Deep-audit CLI scripts across 8 dimensions (bugs, dead code, duplication, validation placement, error messaging, exception safety, test coverage gaps, argparse resolution) then fix in dependency order with complementary tests.",
       "version": "1.0.0",
       "source": "./skills/skill-cli-deep-audit-and-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "skill-replace-pytest-mocks-with-real-file-i-o",
-      "description": "Pattern for replacing pytest mocks with real file I/O to fix test isolation issues",
-      "version": "1.0.0",
-      "source": "./skills/skill-replace-pytest-mocks-with-real-file-io.md",
       "category": "testing",
       "tags": []
     },
@@ -8485,14 +4929,6 @@
       "description": "Split a monolithic test file exceeding the Edit tool's ~25K token limit into focused sub-modules, preserving test count and git history",
       "version": "1.0.0",
       "source": "./skills/split-large-test-file.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "test-coverage-audit",
-      "description": "Audit existing test files before adding new tests to avoid duplicating coverage. Use when: an issue requests adding tests for a method, investigating whether a test coverage gap is real, or consolidating test suites.",
-      "version": "1.0.0",
-      "source": "./skills/test-coverage-audit.md",
       "category": "testing",
       "tags": []
     },
@@ -8529,12 +4965,19 @@
       "tags": []
     },
     {
-      "name": "test-internal-method-with-mocks",
-      "description": "Skill: Test Internal Methods with Mocks in E2ERunner",
+      "name": "test-matrix-and-e2e-infrastructure",
+      "description": "Canonical patterns for test matrix management and E2E test infrastructure: group splitting by filesystem structure, glob pattern evolution, zero-discovery guards, matrix status checks, workspace lifecycle, checkpoint/resume mechanics, parallel test generation, staged execution. Use when: (1) adding or splitting test groups in a CI matrix, (2) preventing silent test drops from glob refactors, (3) building E2E workspace lifecycle code, (4) staging parallel E2E generation.",
       "version": "1.0.0",
-      "source": "./skills/test-internal-method-with-mocks.md",
+      "source": "./skills/test-matrix-and-e2e-infrastructure.md",
       "category": "testing",
-      "tags": []
+      "tags": [
+        "merged",
+        "test-matrix",
+        "e2e",
+        "fixture",
+        "parallel-test",
+        "workspace-lifecycle"
+      ]
     },
     {
       "name": "testing-ast-import-layer-enforcement",
@@ -8553,25 +4996,27 @@
       ]
     },
     {
-      "name": "testing-asyncio-await-task-bot-false-positive",
-      "description": "Identifies and dismisses the GitHub code-quality bot false positive where `await <task>` in asyncio test code is flagged as 'Statement has no effect'. Use when: (1) github-code-quality[bot] flags `await <task>` as a no-effect statement, (2) an asyncio.Task stored in a local variable is awaited as cleanup after test assertions, (3) a PR review contains bot comments about awaiting a Task variable.",
+      "name": "testing-asyncio-fixture-state-reset",
+      "description": "Reset asyncio objects (Lock, Event) in autouse fixtures with lazy imports for test isolation. Use when: (1) tests depend on fresh asyncio state per test, (2) manual per-test initialization is fragile and error-prone, (3) asyncio.Lock or asyncio.Event instance must be reset both before (setup) and after (teardown) each test, (4) import-order coupling or circular dependencies complicate fixture setup.",
       "version": "1.0.0",
-      "source": "./skills/testing-asyncio-await-task-bot-false-positive.md",
+      "source": "./skills/testing-asyncio-fixture-state-reset.md",
       "category": "testing",
       "tags": [
         "asyncio",
-        "python",
-        "false-positive",
-        "github-code-quality-bot",
-        "await-task",
-        "pytest-asyncio",
-        "static-analysis"
+        "pytest-fixture",
+        "autouse-fixture",
+        "test-isolation",
+        "asyncio-lock",
+        "asyncio-event",
+        "lazy-import",
+        "conftest",
+        "state-reset"
       ]
     },
     {
       "name": "testing-cli-entrypoint-help-smoke",
       "description": "Smoke-test Python CLI entry points with --help subprocess calls and import verification. Use when: (1) a package declares [project.scripts] entry points, (2) entry points need regression protection, (3) an issue asks for CLI importability tests.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./skills/testing-cli-entrypoint-help-smoke.md",
       "category": "testing",
       "tags": [
@@ -8583,20 +5028,61 @@
       ]
     },
     {
-      "name": "testing-date-bomb-hardcoded-timestamp-future-failure",
-      "description": "Identifies and fixes 'date bomb' tests \u2014 time-dependent assertions using hardcoded epochs or calendar dates that pass when written but fail after a fixed window elapses. Use when: (1) a test suddenly fails in CI with no code changes, (2) reviewing tests that reference specific calendar dates or hardcoded Unix timestamps, (3) a test asserts a parsed time value is within N seconds of a literal constant.",
+      "name": "testing-coverage-per-module-floor-enforcement",
+      "description": "Enforce minimum coverage thresholds at per-file granularity using parse_module_coverage() + coverage.toml + CI step. Use when: (1) aggregate coverage gate masks under-tested modules, (2) need per-file coverage floors, (3) want to prevent skipped test modules from regressing.",
       "version": "1.0.0",
-      "source": "./skills/testing-date-bomb-hardcoded-timestamp-future-failure.md",
+      "source": "./skills/testing-coverage-per-module-floor-enforcement.md",
       "category": "testing",
-      "tags": []
+      "tags": [
+        "coverage",
+        "per-module",
+        "cobertura",
+        "ci-gate"
+      ]
     },
     {
-      "name": "testing-mock-fault-injection-must-simulate-side-effects-not-just-record",
-      "description": "Mock services for chaos/fault injection tests must simulate the actual side effects of each fault (slow responses, degraded health, stalled queues) \u2014 not just record or acknowledge the fault command. Use when: (1) writing or debugging chaos integration tests, (2) mock has a /inject_fault or /v1/chaos/* endpoint, (3) tests pass at 'fault was recorded' level but fail at 'system observed faulty behavior'.",
+      "name": "testing-coverage-raise-targeted-branches-plus-optional-deps",
+      "description": "Unlock skipped tests by installing optional dependency in test environment + write targeted unit tests for remaining uncovered branches. Use when: (1) coverage is lower than expected, (2) pytest.importorskip() guards hide easy wins, (3) optional deps are skipped in test config but could be installed.",
       "version": "1.0.0",
-      "source": "./skills/testing-mock-fault-injection-must-simulate-side-effects-not-just-record.md",
+      "source": "./skills/testing-coverage-raise-targeted-branches-plus-optional-deps.md",
       "category": "testing",
-      "tags": []
+      "tags": [
+        "coverage",
+        "optional-deps",
+        "pytest-importorskip",
+        "branch-coverage",
+        "skipped-tests"
+      ]
+    },
+    {
+      "name": "testing-integration-backstop-omitted-modules",
+      "description": "Prevent silent growth of coverage omit list by enforcing that omitted modules remain importable + console scripts work. Use when: (1) modules are intentionally omitted from coverage (live CLI/TTY), (2) want to catch import-time regressions, (3) need proof that entry points are functional.",
+      "version": "1.0.0",
+      "source": "./skills/testing-integration-backstop-omitted-modules.md",
+      "category": "testing",
+      "tags": [
+        "testing",
+        "integration",
+        "omit-list",
+        "backstop",
+        "smoke-test",
+        "console-scripts"
+      ]
+    },
+    {
+      "name": "testing-integration-fake-binary-on-path",
+      "description": "Pattern for integration tests that verify subprocess environment variable propagation: create fake executable in temporary directory, prepend to PATH with monkeypatch, subprocess finds fake first. Use when: testing that subprocesses receive expected env vars (GH_TRACE_ID, custom config, etc.) and must verify behavior without mocking subprocess.run().",
+      "version": "1.0.0",
+      "source": "./skills/testing-integration-fake-binary-on-path.md",
+      "category": "testing",
+      "tags": [
+        "integration-testing",
+        "subprocess",
+        "environment-variables",
+        "monkeypatch",
+        "fake-binaries",
+        "test-fixtures"
+      ]
     },
     {
       "name": "testing-package-module-mock-coverage",
@@ -8610,88 +5096,6 @@
         "coverage",
         "hephaestus",
         "package-module"
-      ]
-    },
-    {
-      "name": "testing-pydantic-mock-field-type-mismatch",
-      "description": "Fix HTTP 500 errors in tests caused by Pydantic response model rejecting MagicMock attributes during response serialization. Use when: (1) an endpoint test expects 4xx/5xx but gets 500 unexpectedly, (2) a FastAPI/Starlette endpoint uses a Pydantic response model, (3) mock objects populate response model fields, (4) Pydantic ValidationError appears in server logs during testing.",
-      "version": "1.0.0",
-      "source": "./skills/testing-pydantic-mock-field-type-mismatch.md",
-      "category": "testing",
-      "tags": [
-        "pydantic",
-        "magicmock",
-        "fastapi",
-        "validation",
-        "http-status",
-        "response-model",
-        "serialization"
-      ]
-    },
-    {
-      "name": "testing-pytest-asyncio-daemon-coroutine-patch",
-      "description": "Fix pytest tests that hang indefinitely (CI timeout) when testing an async daemon by patching the coroutine function itself with AsyncMock instead of patching internal functions the coroutine calls. Use when: (1) pytest CI step times out (10-min limit) but individual tests do not fail, (2) daemon tests call main() which internally calls asyncio.run(coroutine()) that waits on a never-set Event, (3) patching run_routing_loop or other internal helpers is a no-op because main() does not call them directly.",
-      "version": "1.0.0",
-      "source": "./skills/testing-pytest-asyncio-daemon-coroutine-patch.md",
-      "category": "testing",
-      "tags": [
-        "asyncio",
-        "pytest",
-        "daemon",
-        "AsyncMock",
-        "coroutine",
-        "patch",
-        "hang",
-        "timeout",
-        "event-loop",
-        "python"
-      ]
-    },
-    {
-      "name": "testing-pytest-asyncio-event-mock-hang",
-      "description": "Fix pytest tests that hang when a coroutine internally reassigns a global asyncio.Event and then awaits it \u2014 pre-setting the module variable is ineffective because the coroutine overwrites it. Fix by patching the asyncio.Event constructor in the module's namespace so the coroutine receives a pre-set event. Use when: (1) coroutine does global _shutdown_event = asyncio.Event() internally, (2) pre-setting the module-level event before calling run() has no effect, (3) test hangs at _shutdown_event.wait() even though you set it beforehand.",
-      "version": "1.0.0",
-      "source": "./skills/testing-pytest-asyncio-event-mock-hang.md",
-      "category": "testing",
-      "tags": [
-        "asyncio",
-        "pytest",
-        "asyncio.Event",
-        "hang",
-        "mock",
-        "patch",
-        "global",
-        "shutdown-event",
-        "coroutine",
-        "python"
-      ]
-    },
-    {
-      "name": "testing-pytest-ini-shadows-pyproject",
-      "description": "TRIGGER CONDITIONS: (1) CI Python test job hangs until timeout with no visible failure, (2) pytest warns 'ignoring pytest config in pyproject.toml!', (3) tests fail with ModuleNotFoundError even though pythonpath is set in pyproject.toml, (4) asyncio tests hang indefinitely after import failure.",
-      "version": "1.0.0",
-      "source": "./skills/testing-pytest-ini-shadows-pyproject.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "testing-pytest-timeout-thread-method-asyncio",
-      "description": "Fix pytest tests that hang indefinitely (CI job timeout) when using pytest-timeout with asyncio tests blocked in epoll.poll(-1). Use when: (1) async tests hang for exactly the CI job timeout with no output, (2) pytest-timeout fires but fails to interrupt the test, (3) asyncio event loop is blocked in _SelectorEventLoop._run_once \u2192 epoll.poll(-1) with no events ready.",
-      "version": "1.0.0",
-      "source": "./skills/testing-pytest-timeout-thread-method-asyncio.md",
-      "category": "testing",
-      "tags": [
-        "pytest",
-        "pytest-timeout",
-        "asyncio",
-        "epoll",
-        "signal",
-        "thread",
-        "timeout-method",
-        "event-loop",
-        "hang",
-        "ci",
-        "python"
       ]
     },
     {
@@ -8710,37 +5114,53 @@
       ]
     },
     {
-      "name": "testing-regression-guard-syntax-vs-property-assertion",
-      "description": "Refactor regression-guard tests that assert on the exact literal text of a suppression mechanism (`continue-on-error: true`, `|| true`, etc.) to instead assert the underlying property. Use when: (1) running an ecosystem sweep that changes the syntax of a known idiom while preserving its semantics, (2) CI tests fail with `assert \"continue-on-error: true\" in step_text` even though the property the test guards is preserved, (3) meta-tests / smoke tests / workflow-property tests pin to literal strings instead of behavioral predicates, (4) preparing a codebase for a forbid-suppressions or forbid-deprecated-API sweep \u2014 fix these meta-tests BEFORE the sweep, not after.",
+      "name": "testing-respx-async-mock-fixtures-with-stateful-faults",
+      "description": "Use when: (1) writing integration tests for asyncio code that calls httpx.AsyncClient (REST API clients, etc.), (2) testing error scenarios (500, 409, 503, timeouts) via HTTP mocking without nested contexts or async/sync boundary issues, (3) needing stateful fault injection (permanent status override, task status queue, exception flags) without redefining the mock for each test, (4) validating HTTP request payloads with assertions that survive schema evolution, (5) using respx 0.21+ with route names for call inspection, (6) pytest-asyncio with auto mode where fixture and test both run in same event loop.",
       "version": "1.0.0",
-      "source": "./skills/testing-regression-guard-syntax-vs-property-assertion.md",
+      "source": "./skills/testing-respx-async-mock-fixtures-with-stateful-faults.md",
       "category": "testing",
       "tags": [
-        "meta-tests",
-        "regression-guard",
-        "syntax-pinning",
-        "property-assertion",
-        "ecosystem-sweep",
-        "smoke-tests",
-        "workflow-tests",
-        "test-broadening"
+        "respx",
+        "httpx",
+        "async",
+        "asyncio",
+        "pytest-asyncio",
+        "fixture",
+        "mock",
+        "http",
+        "fault-injection",
+        "integration-test",
+        "state-machine",
+        "payload-validation",
+        "rest-api",
+        "python"
       ]
     },
     {
-      "name": "testing-view-copy-semantics-mismatch",
-      "description": "Fix CI failures caused by tests assuming __getitem__(Slice) returns a view when it actually returns a copy. Use when: (1) test asserts _is_view but gets False, (2) __setitem__ write-through test fails because the 'view' is actually a copy, (3) slice() vs __getitem__(Slice) semantics diverge, (4) CI fix introduces new failures from implicit type conversion.",
-      "version": "1.0.0",
-      "source": "./skills/testing-view-copy-semantics-mismatch.md",
+      "name": "testing-singleton-isolation-circuit-breaker-reset",
+      "description": "Test isolation for module-level singleton instances (e.g., circuit breaker, cache, registry) requires calling .reset() on the held reference directly \u2014 in a pytest autouse fixture in conftest.py at the broadest scope, OR at the top of any new test that trips the singleton \u2014 not via a registry-clearing reset helper that orphans the import-time-bound instance. Use when: (1) adding tests that intentionally trigger failures/exceptions to a class whose code path goes through a module-level circuit breaker / rate limiter / retry primitive, (2) new tests pass in isolation but make UNRELATED sibling tests fail with a 'circuit breaker is open'/unavailable error when the whole class runs, (3) a reset helper clears a registry (`_registry.clear()`) rather than resetting the import-time-bound instance, (4) testing code with module-level singleton instances (breakers, caches, registries, contextvar defaults) that maintain internal state across test runs, (5) a test passes locally in isolation but fails in CI with cross-test contamination, (6) the same test fails identically on multiple Python versions in CI (3.10/3.11/3.12/3.13) \u2014 a fingerprint of order-dependent shared state, (7) deciding where to put a pytest autouse fixture: single test file vs package conftest.py, (8) extending a non-transient/fail-fast error classifier and verifying it, (9) deciding whether HTTP 422 or GraphQL schema errors should be retried (they should NOT \u2014 they are deterministic).",
+      "version": "1.2.0",
+      "source": "./skills/testing-singleton-isolation-circuit-breaker-reset.md",
       "category": "testing",
       "tags": [
-        "view",
-        "copy",
-        "slice",
-        "semantics",
-        "mojo",
-        "tensor",
-        "ci-fix",
-        "type-conversion"
+        "test-isolation",
+        "singleton",
+        "circuit-breaker",
+        "module-singleton",
+        "test-pollution",
+        "shared-state",
+        "pytest-fixture",
+        "autouse-fixture",
+        "conftest-scope",
+        "cross-test-contamination",
+        "ci-only-failure",
+        "stateful-objects",
+        "fail-fast",
+        "non-transient-retry",
+        "registry-reset",
+        "github-api",
+        "422",
+        "graphql-schema-error"
       ]
     },
     {
@@ -8760,38 +5180,6 @@
       "tags": []
     },
     {
-      "name": "uint-overflow-wrap-tests",
-      "description": "Skill: uint-overflow-wrap-tests. Use when adding overflow/wrap-around tests for Mojo built-in unsigned integer types (UInt8, UInt16, UInt32, UInt64) to verify modular arithmetic at boundary values.",
-      "version": "1.0.0",
-      "source": "./skills/uint-overflow-wrap-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "unique-tmp-path-per-test-run",
-      "description": "Replace hardcoded /tmp test file paths with unique per-run paths to prevent stale state. Use when: a test writes a fixed temp path that can persist across aborted runs, or parallel runs may collide.",
-      "version": "1.0.0",
-      "source": "./skills/unique-tmp-path-per-test-run.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "unit-test-instance-attr-patching",
-      "description": "Skill: Unit Testing with Instance Attribute Patching",
-      "version": "1.0.0",
-      "source": "./skills/unit-test-instance-attr-patching.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "unit-tests-untested-modules",
-      "description": "Workflow for adding unit tests to previously untested source modules. Use when a quality audit identifies modules with no test file, coverage threshold is at risk, or an issue requests tests for specific untested modules.",
-      "version": "1.0.0",
-      "source": "./skills/unit-tests-untested-modules.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "validate-tier-id-filename-consistency",
       "description": "Validate that config field values match their source filename at the aggregation layer to prevent silent key/value disagreement",
       "version": "1.0.0",
@@ -8800,60 +5188,29 @@
       "tags": []
     },
     {
-      "name": "validation-loop-reset-test",
-      "description": "Pattern for testing that training/validation loops reset DataLoaders before iterating, using a pre-exhaustion strategy. Use when: adding tests for loop reset behavior, verifying run() or run_subset() semantics, or writing parallel tests across loop methods.",
-      "version": "1.0.0",
-      "source": "./skills/validation-loop-reset-test.md",
+      "name": "validate-upstream-mojo-fix-hostile-home-matrix",
+      "description": "Validate that an upstream Mojo fix (runtime crash, codegen flag resolution, compiler-driver bug, JIT mis-emission, etc.) actually landed in your newly-bumped nightly BEFORE removing downstream workarounds or starting a demolition wave. Uses a 4-gate progression: (Gate 1) cheapest local signal \u2014 either a hostile-`$HOME` matrix for filesystem-error class bugs, or `mojo build --print-effective-target` codegen check for compiler-driver / target-resolution bugs, or any analogous bug-class-specific micro-repro; (Gate 2) \u226510\u00d7 consecutive dispatches of the project's existing `repro-<issue#>` workflow on the bump branch; (Gate 3) full-iteration soak workflow if one exists; (Gate 4) \u22658 consecutive green required-check runs on the bump branch. Includes the load-bearing caveat that pre-fix infrastructure (coredump capture, gdb wrappers) often breaks for reasons unrelated to the fix \u2014 read the actual Mojo invocation logs, not the workflow's pass/fail summary. Use when: (1) you bumped the pinned Mojo version past an upstream fix-shipped date and want to confirm the fix landed in your build, (2) you are about to peel back a downstream workaround (Dockerfile chmod, entrypoint mkdir, BUILD_FLAGS pin to specific `--target-cpu`, sudoers `_ensure_writable`) and need deterministic confirmation, (3) an upstream Modular issue closed with 'fix in next nightly' and you want to verify before commenting or opening a workaround-removal / demolition PR, (4) you need to position a validation branch as a durable canary spanning the demolition wave.",
+      "version": "2.0.0",
+      "source": "./skills/validate-upstream-mojo-fix-hostile-home-matrix.md",
       "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "verify-mypy-compliance-test-annotations",
-      "description": "Pattern for verifying and adding -> None return types and parameter type hints to test functions for mypy compliance",
-      "version": "1.0.0",
-      "source": "./skills/verify-mypy-compliance-test-annotations.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "wire-schema-validation",
-      "description": "TRIGGER CONDITIONS: Wiring JSON schema validation into a config loader that already parses YAML into dataclass/Pydantic models. Use when load_defaults(), load_model_config(), or load_tier_config() should validate raw YAML data against a corresponding JSON schema and raise a typed ConfigurationError on failure.",
-      "version": "1.0.0",
-      "source": "./skills/wire-schema-validation.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "wired-runner-fixture",
-      "description": "Skill: wired-runner-fixture",
-      "version": "1.0.0",
-      "source": "./skills/wired-runner-fixture.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "workspace-manager-guard-tests",
-      "description": "Patterns for testing RuntimeError guards in subprocess-wrapping classes \u2014 covers state guards (no mock needed), sequential subprocess side_effect lists, and bypassing earlier guards to test later ones. Used in ProjectScylla WorkspaceManager.",
-      "version": "1.0.0",
-      "source": "./skills/workspace-manager-guard-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "zombie-detection-integration-tests",
-      "description": "Integration test patterns for zombie experiment detection and reset in ProjectScylla \u2014 validates the full path from dead PID + stale heartbeat through ResumeManager.handle_zombie() to checkpoint.status='interrupted' with real disk I/O.",
-      "version": "1.0.0",
-      "source": "./skills/zombie-detection-integration-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "add-shell-log-level",
-      "description": "Skill: add-shell-log-level",
-      "version": "1.0.0",
-      "source": "./skills/add-shell-log-level.md",
-      "category": "tooling",
-      "tags": []
+      "tags": [
+        "mojo",
+        "modular",
+        "upstream-validation",
+        "container",
+        "permissions",
+        "filesystem-error",
+        "getAcceleratorArchOrEmpty",
+        "hostile-home",
+        "workaround-removal",
+        "rootless-podman",
+        "codegen-flags",
+        "avx512",
+        "target-cpu",
+        "four-gate-protocol",
+        "ci-canary",
+        "print-effective-target"
+      ]
     },
     {
       "name": "advise-before-planning",
@@ -8879,14 +5236,6 @@
       ]
     },
     {
-      "name": "agent-hooks-pattern",
-      "description": "Pattern for agent-scoped lifecycle hooks in Claude Code v2.1.0. Use when implementing custom agents with safety controls or tool restrictions.",
-      "version": "1.0.0",
-      "source": "./skills/agent-hooks-pattern.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "ai-blog-generator",
       "description": "Generate AI-authored blog posts from git commit history to fill documentation gaps",
       "version": "1.0.0",
@@ -8895,23 +5244,15 @@
       "tags": []
     },
     {
-      "name": "already-done-issue-detection",
-      "description": "Detect GitHub issues that are already fixed (or partially fixed) before starting implementation. Use when: (1) starting a batch triage of 10+ open issues, (2) assigned an issue in a repo with active prior automation, (3) audit issues filed weeks/months ago, (4) issue title contains 'missing', 'add', 'fix' for a file or config value, (5) BEFORE dispatching multi-agent implementation on any open issue \u2014 check if recent merged PRs have invalidated the plan (stale-plan / scope-drift detection).",
-      "version": "2.1.0",
-      "source": "./skills/already-done-issue-detection.md",
+      "name": "argparse-tristate-optional-flag",
+      "description": "Python argparse pattern for tri-state CLI flags (absent / present-with-no-arg / present-with-value) using nargs='?' + const=<sentinel>. Use when: (1) designing CLI flags like --org that need three behaviors, (2) want argparse to do parsing rather than custom post-processing.",
+      "version": "1.0.0",
+      "source": "./skills/argparse-tristate-optional-flag.md",
       "category": "tooling",
       "tags": [
-        "triage",
-        "already-done",
-        "issue-classification",
-        "batch",
-        "audit",
-        "stale-plan",
-        "preflight",
-        "scope-drift",
-        "multi-agent-dispatch",
-        "2-pass-classification",
-        "classifier-under-detection"
+        "python",
+        "argparse",
+        "cli"
       ]
     },
     {
@@ -8923,45 +5264,27 @@
       "tags": []
     },
     {
-      "name": "audit-implementation",
-      "description": "Implements repository audit findings as concrete fixes via PRs. Use when: audit report needs actionable implementation, triage of findings into fix vs defer.",
-      "version": "1.0.0",
-      "source": "./skills/audit-implementation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "audit-skip-cwd-resolution",
-      "description": "Documents the pattern for resolving --audit-skip file paths relative to CWD in migration audit scripts. Use when: (1) audit skip-list path semantics are unclear, (2) adding CWD-relative path resolution tests, (3) updating argparse help text.",
-      "version": "1.0.0",
-      "source": "./skills/audit-skip-cwd-resolution.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "audit-stale-scripts",
-      "description": "Audit scripts/ for stale one-time tools and safely remove confirmed candidates. Use when: follow-up cleanup after a bulk script removal PR, scripts/ has grown with historical one-off files, or you need a caller-check pattern before deleting.",
-      "version": "1.0.0",
-      "source": "./skills/audit-stale-scripts.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "audit-strict-full-swarm-coverage",
-      "description": "Methodology for running a strict, full-coverage repository audit by dispatching one swarm agent per audit section in waves of 5. Use when: (1) running /hephaestus:repo-analyze-strict-full or equivalent full-coverage audit on a repo with >500 files, (2) bug-finding completeness matters and sampling is unsafe, (3) you need pre-release readiness review with strict grading (default F, evidence required), (4) single-agent audits are overflowing context or producing shallow results.",
-      "version": "1.0.0",
-      "source": "./skills/audit-strict-full-swarm-coverage.md",
+      "name": "audit-driven-remediation-workflow",
+      "description": "Canonical end-to-end audit-driven remediation workflow: audit pass \u2192 severity classification \u2192 batch fix planning \u2192 PR generation \u2192 verification. Use when: (1) running a strict audit across a repo or ecosystem, (2) reconciling audit-finding issue counts against open issues, (3) generating remediation PRs from audit findings, (4) coordinating audit + fix + verification across multiple repos, (5) deciding fix vs accept/suppress for findings, (6) you added a new producer-side signal and must verify every downstream consumer reads it, (7) after landing a bug-pattern fix, grep sibling modules for the same pattern, (8) before declaring an epic complete, run a strict-audit by an independent reviewer agent.",
+      "version": "1.2.0",
+      "source": "./skills/audit-driven-remediation-workflow.md",
       "category": "tooling",
       "tags": [
+        "merged",
         "audit",
-        "repo-analyze",
-        "swarm",
-        "myrmidon",
-        "strict-grading",
-        "full-coverage",
-        "wave-dispatch",
-        "bucketing",
-        "go-no-go"
+        "remediation",
+        "ecosystem-audit",
+        "strict-audit",
+        "repo-hygiene",
+        "downstream-consumer-drift",
+        "strict-audit-self-review",
+        "producer-consumer-pattern",
+        "cross-module-duplication",
+        "copy-paste-bugs",
+        "test-mask",
+        "fixture-contract-violation",
+        "post-completion-audit",
+        "strict-mode-review-discovers-bug"
       ]
     },
     {
@@ -8980,22 +5303,130 @@
       ]
     },
     {
-      "name": "automation-resilience-label-discovery-dirty",
-      "description": "Three resilience patterns for hephaestus.automation implement/plan pipelines: (1) auto-create missing GitHub labels and retry on label-not-found error, (2) auto-discover open issues when no --issues/--epic CLI arg is given via gh_list_open_issues(), (3) WorktreeDirtyError preserve-and-report pattern that blocks forced removal of dirty worktrees and prints a rerun command. Use when: (1) gh issue create fails with 'could not add label: X not found', (2) implementer/planner needs to process all open issues by default, (3) cleanup_all() should not silently discard in-progress agent worktrees.",
+      "name": "automation-duplicate-pr-prevention-idempotency-guards",
+      "description": "Use when: (1) an automation pipeline creates duplicate PRs for one issue, (2) two PRs land on the same branch, (3) a worktree manager rebuilds a branch from base and discards remote history, (4) gh pr create runs unconditionally without checking for an existing PR, (5) making issue->branch->PR creation idempotent",
       "version": "1.0.0",
-      "source": "./skills/automation-resilience-label-discovery-dirty.md",
+      "source": "./skills/automation-duplicate-pr-prevention-idempotency-guards.md",
       "category": "tooling",
       "tags": [
         "automation",
-        "implement-issues",
-        "plan-issues",
-        "github-labels",
-        "gh_list_open_issues",
-        "WorktreeDirtyError",
-        "worktree",
-        "dirty-worktree",
-        "resilience",
-        "hephaestus"
+        "duplicate-pr",
+        "idempotency",
+        "git-worktree",
+        "gh-pr-create",
+        "ls-remote",
+        "pr-creation"
+      ]
+    },
+    {
+      "name": "automation-github-graphql-field-validation-live-schema",
+      "description": "A GitHub GraphQL mutation/query that selects a non-existent output field \u2014 OR names a mutation whose Input type lacks the argument you pass \u2014 fails on EVERY call (`Field 'X' doesn't exist on type 'Y'` for a bad output selection; `InputObject '<Input>' doesn't accept argument '<arg>'` + `Variable $X is declared by <Mutation> but not used` for a wrong mutation name), and a code path with no direct unit test can ship such a broken query indefinitely. Validate every field selection AND every input argument against the LIVE schema via introspection before shipping. Use when: (1) writing or editing a raw `gh api graphql` query/mutation string (especially `addPullRequestReview`, `addPullRequestReviewThreadReply`, `reviewThreads`, or any PR-review traversal), (2) a runtime log shows `gh: Field '<field>' doesn't exist on type '<Type>'`, `gh: InputObject '<Input>' doesn't accept argument '<arg>'`, `Variable $X is declared by <Mutation> but not used`, or repeated identical mutation failures, (3) you need to read a parent object off a child node (e.g. a comment's thread or review) and are assuming a reverse edge exists, (4) a function that builds a GraphQL query has no direct unit test and is only mocked out by higher-level callers, (5) an automation loop treats a PR as NOGO/re-runs forever because an in-loop review/comment/reply never posts.",
+      "version": "1.1.0",
+      "source": "./skills/automation-github-graphql-field-validation-live-schema.md",
+      "category": "tooling",
+      "tags": [
+        "graphql",
+        "github-api",
+        "schema-introspection",
+        "field-validation",
+        "input-argument-validation",
+        "wrong-mutation-name",
+        "addPullRequestReview",
+        "addPullRequestReviewThreadReply",
+        "resolveReviewThread",
+        "reviewThreads",
+        "pull-request-review",
+        "silent-broken-query",
+        "missing-unit-test",
+        "child-to-parent-edge",
+        "gh-api-graphql",
+        "automation-pipeline"
+      ]
+    },
+    {
+      "name": "automation-graphql-parameterisation-prevent-injection",
+      "description": "Pattern for parameterising GraphQL queries to prevent injection attacks. Use when: (1) building dynamic GraphQL queries with user/caller-supplied data (issue numbers, PR numbers, owner/repo names), (2) eliminating f-string interpolation in raw GraphQL queries, (3) handling batch queries with aliases (one scalar variable per batch element since GraphQL has no list indexing for aliases), (4) need to bind multiple scalar values to a single query safely.",
+      "version": "1.0.0",
+      "source": "./skills/automation-graphql-parameterisation-prevent-injection.md",
+      "category": "tooling",
+      "tags": [
+        "graphql",
+        "parameterisation",
+        "injection-prevention",
+        "gh-api-graphql",
+        "variable-binding",
+        "security",
+        "batch-queries",
+        "aliased-queries",
+        "-f-query-flag",
+        "-F-variable-flag",
+        "automation-pipeline",
+        "github-api"
+      ]
+    },
+    {
+      "name": "automation-loop-early-exit-zero-work-convergence",
+      "description": "How to wire and test early-exit in hephaestus-automation-loop when a full pass produces zero new work. Use when: (1) implementing loop convergence detection in run_loop, (2) adding tests for early-exit stub placeholders, (3) diagnosing whether early-exit scaffold already exists before implementing.",
+      "version": "1.0.0",
+      "source": "./skills/automation-loop-early-exit-zero-work-convergence.md",
+      "category": "tooling",
+      "tags": [
+        "automation",
+        "loop-runner",
+        "early-exit",
+        "convergence",
+        "testing"
+      ]
+    },
+    {
+      "name": "automation-loop-gating-removal",
+      "description": "Patterns for removing defensive gating when upstream bug is fixed. Use when: (1) removing a gate function that guards against an upstream issue, (2) making previously-gated CLI flags optional, (3) cleaning up environment variable injections that are no longer needed, (4) synchronizing shell script invocations with CLI changes.",
+      "version": "1.0.0",
+      "source": "./skills/automation-loop-gating-removal.md",
+      "category": "tooling",
+      "tags": [
+        "automation",
+        "loop-runner",
+        "argparse",
+        "gating",
+        "refactoring",
+        "cli"
+      ]
+    },
+    {
+      "name": "automation-pr-review-inline-comment-diff-hunk-validation",
+      "description": "Validate LLM/agent-generated inline PR-review comments against the PR diff hunks before POSTing the review, so GitHub does not reject the entire review with HTTP 422. Use when: (1) writing/editing code that POSTs a PR review with inline comments via `gh api -X POST .../pulls/{n}/reviews`, (2) a runtime log shows `gh: Unprocessable Entity (HTTP 422)` on a review POST, (3) an LLM/agent generates inline review comments (path/line/side) that may not lie on a changed line, (4) an automation loop records a spurious NOGO/Grade=F because the in-loop review POST failed, (5) the diff shown to a review model is truncated so it can cite real-but-out-of-hunk lines.",
+      "version": "1.0.0",
+      "source": "./skills/automation-pr-review-inline-comment-diff-hunk-validation.md",
+      "category": "tooling",
+      "tags": [
+        "github-api",
+        "pull-request-review",
+        "422",
+        "unprocessable-entity",
+        "diff-hunk",
+        "inline-comments",
+        "llm-generated-comments",
+        "fail-open",
+        "automation-pipeline"
+      ]
+    },
+    {
+      "name": "automation-reuse-repo-clone-with-worktree-per-pr",
+      "description": "Use when: (1) code clones the SAME repo once per PR/branch/item inside a loop, (2) a fleet/batch tool re-clones a repo for every item causing redundant network+disk I/O that scales with item count, (3) refactoring a per-item-clone hot loop to a single clone + git worktree per item, (4) a per-item working dir is created in a temp subdir via full `git clone`, (5) you need isolated per-item checkouts of one repo for rebase/conflict/agent work.",
+      "version": "1.0.0",
+      "source": "./skills/automation-reuse-repo-clone-with-worktree-per-pr.md",
+      "category": "tooling",
+      "tags": [
+        "git-worktree",
+        "clone-reuse",
+        "fleet-sync",
+        "batch-automation",
+        "performance",
+        "per-pr-checkout",
+        "idempotent-clone",
+        "dry-run-real-step",
+        "github-automation"
       ]
     },
     {
@@ -9048,60 +5479,10 @@
       "tags": []
     },
     {
-      "name": "batch-low-difficulty-issue-impl",
-      "description": "Classify, deduplicate, and batch-implement GitHub issues in a large swarm session (24+ waves, 200+ issues). Use when: (1) a large backlog of open issues needs triage, (2) many issues are pure doc/text or infra-only changes, (3) duplicate issues need closing before implementation. Includes worktree-safe grep pattern for ALREADY-DONE verification, correct pre-filter order, ci.yml conflict avoidance, EASY queue exhaustion detection, Docker inline comment parse error pattern, parallel-agent add/add rebase conflict resolution when multiple agents create the same package independently, pre-launch repo-capability checks (autoMergeAllowed, lockfile, pre-commit config), hot-file serialization for shared scripts (apply.sh/reconcile.sh), pre-swarm existing-PR audit, close-before-delegate pattern, and C++20/Conan/pixi-specific guards (libssl-dev, TSan+concurrentqueue blocker, enable_shared_from_this diamond inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check).",
-      "version": "1.11.0",
-      "source": "./skills/batch-low-difficulty-issue-impl.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "bf16-precision-recommendation",
       "description": "Add hardware-guarded BF16 support to dtype recommendation functions. Use when: enabling BF16 for large Mojo ML models, adding Apple Silicon hardware guard for BF16, or extending precision recommendation with hardware capability parameters.",
       "version": "1.0.0",
       "source": "./skills/bf16-precision-recommendation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "bulk-fix-orphan-quick-reference",
-      "description": "Bulk-fix SKILL.md files with orphaned top-level ## Quick Reference sections alongside ## Verified Workflow. Use when: validate_plugins.py reports Quick Reference warnings across many files.",
-      "version": "1.0.0",
-      "source": "./skills/bulk-fix-orphan-quick-reference.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "bulk-issue-terminology-migration",
-      "description": "Update all GitHub issues across a multi-repo org to remove deprecated terminology references, bulk-create issues from code markers (TODO/FIXME/DEPRECATED/NOTE), and deduplicate noisy issue trackers. Use when: (1) an ADR or architectural decision deprecates a component name that appears in many open issues, (2) doing a mass rename (e.g., ai-maestro \u2192 Agamemnon) across 5+ repos with 50+ issues, (3) need to purge all traces of deprecated terminology from issue tracker, (4) systematically filing GitHub issues from code markers (357+ markers in a codebase), (5) issue count has grown 3x+ with duplicate clusters and sprint planning is blocked.",
-      "version": "2.0.0",
-      "source": "./skills/bulk-issue-terminology-migration.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "issues",
-        "bulk-update",
-        "terminology",
-        "migration",
-        "myrmidon-swarm",
-        "dedup",
-        "bulk-filing",
-        "code-markers"
-      ]
-    },
-    {
-      "name": "bulk-skill-migration-script",
-      "description": "Write an idempotent Python script to bulk-migrate skills from a source Claude project to a ProjectMnemosyne marketplace. Handles discovery, SKILL.md transformation, category mapping, and skips already-migrated skills.",
-      "version": "1.0.0",
-      "source": "./skills/bulk-skill-migration-script.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "centralize-repo-clones",
-      "description": "Skill: centralize-repo-clones. Use when working with centralize repo clones.",
-      "version": "1.0.0",
-      "source": "./skills/centralize-repo-clones.md",
       "category": "tooling",
       "tags": []
     },
@@ -9114,12 +5495,19 @@
       "tags": []
     },
     {
-      "name": "ci-validate-workflow",
-      "description": "Validate GitHub Actions workflow files for syntax, best practices, and correctness. Use before committing workflow changes or when workflows fail.",
+      "name": "checkpoint-state-machine-resume",
+      "description": "Canonical patterns for checkpoint-based resume and recovery across long-running workflows: state-machine guards, intermediate-state recovery, until-resume past-state fixes, experiment-recovery tools, housekeeping verification, completion verification. Use when: (1) building a workflow that must resume mid-run after failure, (2) diagnosing a resume that loads a stale or non-terminal checkpoint, (3) adding completion-verification gates to issue/experiment workflows, (4) integrating retrospective hooks after a recovery operation.",
       "version": "1.0.0",
-      "source": "./skills/ci-validate-workflow.md",
+      "source": "./skills/checkpoint-state-machine-resume.md",
       "category": "tooling",
-      "tags": []
+      "tags": [
+        "merged",
+        "checkpoint",
+        "resume",
+        "state-machine",
+        "recovery",
+        "workflow-gate"
+      ]
     },
     {
       "name": "claude-code-slash-command-discovery",
@@ -9154,20 +5542,23 @@
       "tags": []
     },
     {
-      "name": "clean-branches",
-      "description": "Clean up stale git worktrees and merged/closed remote branches. Use after a wave of PRs merges or periodically to prune remote refs.",
-      "version": "1.1.0",
-      "source": "./skills/clean-branches.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "cleanup-issue-detection",
-      "description": "Detect when a cleanup issue has already been implemented before starting work. Use when: implementing a cleanup/removal issue, checking if a branch already has the fix, or verifying prior auto-implementation state.",
+      "name": "clear-open-issue-backlog-myrmidon-swarm",
+      "description": "End-to-end orchestrator recipe for clearing an entire open GitHub issue backlog with a single myrmidon-swarm session: preflight the whole backlog, re-grade each issue against current code, map file ownership, dispatch wave-based parallel agents, trust-but-verify each PR, and close out. Use when: (1) an open-issue backlog has 5+ issues to triage and implement in one session, (2) planning a myrmidon swarm to close out accumulated issues, (3) managing file-ownership collisions across parallel agents, (4) deciding which issues to flag to the user vs dispatch to agents.",
       "version": "1.0.0",
-      "source": "./skills/cleanup-issue-detection.md",
+      "source": "./skills/clear-open-issue-backlog-myrmidon-swarm.md",
       "category": "tooling",
-      "tags": []
+      "tags": [
+        "myrmidon",
+        "swarm",
+        "issue-backlog",
+        "orchestration",
+        "file-ownership",
+        "wave-dispatch",
+        "trust-but-verify",
+        "issue-triage",
+        "re-grade",
+        "squash-merge"
+      ]
     },
     {
       "name": "cli-adapter-implementation",
@@ -9176,6 +5567,38 @@
       "source": "./skills/cli-adapter-implementation.md",
       "category": "tooling",
       "tags": []
+    },
+    {
+      "name": "cli-dry-run-help-standardization",
+      "description": "Standardize --dry-run help text across multiple CLIs using a shared constant and helper function. Use when: (1) Multiple CLIs need identical --dry-run semantics, (2) Token-cost caveats must be user-visible at --help time, (3) Refactoring CLI parsers to extract testable _build_parser() entrypoints, (4) Adding parametrized help-text tests across CLI modules.",
+      "version": "1.0.0",
+      "source": "./skills/cli-dry-run-help-standardization.md",
+      "category": "tooling",
+      "tags": [
+        "argparse",
+        "cli",
+        "help-text",
+        "dry-run",
+        "testing",
+        "parametrized-tests",
+        "DRY-principle",
+        "refactoring"
+      ]
+    },
+    {
+      "name": "cli-flag-validation-prevent-silent-noop",
+      "description": "CLI flag validation at parse time to prevent silent no-ops. When a flag value is incompatible with the selected backend (e.g., --approval with --agent=claude), reject it at parse time with a clear error message describing the constraint from the backend's perspective. Use when: (1) designing CLI tools that support multiple backends with different feature sets, (2) discovering that a flag value silently no-ops for one backend but not another, (3) operators pass incompatible flag combinations without realizing they're being ignored.",
+      "version": "1.0.0",
+      "source": "./skills/cli-flag-validation-prevent-silent-noop.md",
+      "category": "tooling",
+      "tags": [
+        "argparse",
+        "cli",
+        "flag-validation",
+        "silent-no-op",
+        "agent",
+        "backend-compatibility"
+      ]
     },
     {
       "name": "cli-json-report-format-implementation",
@@ -9209,47 +5632,17 @@
       "tags": []
     },
     {
-      "name": "codebase-quality-plan-execution",
-      "description": "Execute a pre-analyzed codebase improvement plan. Applies categorized fixes (type safety, dead code, error handling, performance, frontend bugs) across multiple files with continuous test verification.",
-      "version": "1.0.0",
-      "source": "./skills/codebase-quality-plan-execution.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "conan-hybrid-cpp20-turnkey-packaging",
-      "description": "Hybrid Conan 2.x + FetchContent packaging for C++20 CMake repos with E2E install validation. Use when: (1) migrating a FetchContent-only project to Conan, (2) some deps aren't on ConanCenter so you need both, (3) integrating Conan with CMakePresets.json, (4) validating installed packages work end-to-end across a multi-repo ecosystem.",
-      "version": "1.2.0",
-      "source": "./skills/conan-hybrid-cpp20-turnkey-packaging.md",
-      "category": "tooling",
-      "tags": [
-        "conan",
-        "cmake",
-        "fetchcontent",
-        "cpp20",
-        "packaging",
-        "e2e",
-        "pip",
-        "docker"
-      ]
-    },
-    {
-      "name": "conan-validate-script-cmake-version-mismatch",
-      "description": "Fix validate-conan-install.sh failing on hosts with CMake < 3.20, and fix IPC test runner T4 port override bug. Use when: (1) conan package export succeeds but consumer CMake configure fails with 'CMake 3.20 or higher required', (2) validate-conan-install.sh works on CI but fails on Debian 11 or Ubuntu 20.04 hosts, (3) adding conan validation to older distros where system CMake is 3.16-3.19, (4) IPC test runner ignores --port override and binds to wrong port.",
+      "name": "code-quality-bot-ignores-noqa",
+      "description": "GitHub's `github-code-quality[bot]` static analyzer flags imports as 'unused' even when they have explicit `# noqa: F401` markers, blocking PR merge under org rulesets with `required_review_thread_resolution`. The fix isn't to fight the bot or rewrite the imports \u2014 it's to resolve the threads via `gh api graphql resolveReviewThread` with one explanatory PR comment. Use when: (1) bot review comments flag deliberate test-patch-seam re-exports as 'unused imports', (2) PR shows `MERGEABLE / BLOCKED` with all CI checks green, (3) `required_review_thread_resolution` is in the org ruleset.",
       "version": "1.1.0",
-      "source": "./skills/conan-validate-script-cmake-version-mismatch.md",
+      "source": "./skills/code-quality-bot-ignores-noqa.md",
       "category": "tooling",
       "tags": [
-        "conan",
-        "cmake",
-        "validation",
-        "e2e",
-        "debian",
-        "pixi",
-        "ipc",
-        "test-runner",
-        "port",
-        "homeric-intelligence"
+        "github",
+        "pull-request",
+        "code-quality",
+        "review-threads",
+        "noqa"
       ]
     },
     {
@@ -9261,51 +5654,18 @@
       "tags": []
     },
     {
-      "name": "config-filename-validation",
-      "description": "Skill: Config Filename/ID Validation Pattern",
-      "version": "2.0.0",
-      "source": "./skills/config-filename-validation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "config-linter-yaml-false-positive-fix",
-      "description": "Fix line-level YAML linter false positives by replacing a narrow key regex with an allowlist of valid YAML constructs and block scalar state tracking. Use when: (1) a regex-based YAML linter flags valid colons as malformed keys, (2) block scalar contents trigger line-level warnings.",
+      "name": "config-validation-and-schema-alignment",
+      "description": "Canonical patterns for config validation and schema alignment: JSON-Schema generation from Pydantic, schema-wiring tests, config-filename and model-id validation, YAML linter false-positives, env-var double-underscore nesting, plugin-cache staleness, pixi container env isolation. Use when: (1) adding a new config validator, (2) wiring schema checks to CI, (3) diagnosing config-loader schema mismatches, (4) plugin/cache reports stale skill metadata, (5) reconciling config-filename conventions across model configs.",
       "version": "1.0.0",
-      "source": "./skills/config-linter-yaml-false-positive-fix.md",
+      "source": "./skills/config-validation-and-schema-alignment.md",
       "category": "tooling",
       "tags": [
-        "yaml",
-        "linter",
-        "false-positive",
-        "regex",
-        "config-validation"
+        "merged",
+        "config-validation",
+        "json-schema",
+        "pydantic",
+        "config-loader"
       ]
-    },
-    {
-      "name": "console-inline-status-carriage-return",
-      "description": "Pattern for using carriage return (\\r) to overwrite transient terminal status lines instead of printing new lines. Use when: (1) a console tool prints repeated status updates that spam the terminal, (2) you need inline status for transient states (disconnected, reconnecting, retrying) while preserving permanent events on their own lines, (3) implementing a NATS event viewer or similar long-running console that cycles through connection states.",
-      "version": "1.0.0",
-      "source": "./skills/console-inline-status-carriage-return.md",
-      "category": "tooling",
-      "tags": [
-        "console",
-        "terminal",
-        "carriage-return",
-        "inline",
-        "nats",
-        "status",
-        "ansi",
-        "tui"
-      ]
-    },
-    {
-      "name": "consolidate-skills-directory",
-      "description": "Consolidate a dual plugins/+skills/ structure into a single skills/<category>/<name>/ directory. Use when: (1) ProjectMnemosyne has both plugins/ and skills/ directories causing confusion, (2) migrating flat legacy skills to plugin format, (3) updating all tooling and CI to reference the new canonical location.",
-      "version": "1.0.0",
-      "source": "./skills/consolidate-skills-directory.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "contributing-md-structure-sync",
@@ -9324,19 +5684,38 @@
       "tags": []
     },
     {
-      "name": "cross-repo-python-utility-port",
-      "description": "Use when porting a Python utility (class, module, tests) from one repo to another that already has a related implementation. Covers: (1) diff analysis between source and destination implementations, (2) identifying which features to cherry-pick vs skip, (3) merging test suites without duplication, (4) finding and fixing bugs exposed during porting, (5) creating a re-export shim in the source repo and filing a cleanup issue.",
+      "name": "cpp-conflict-resolution-clang-format-cmake-and-local-build",
+      "description": "Avoid breaking the build during a C++ rebase/merge conflict resolution: NEVER run clang-format on non-C++ files (it silently mangles CMakeLists.txt into a CMake parse error), and build the resolved merge LOCALLY before pushing to catch sibling-PR signature changes. Use when: (1) resolving a rebase/merge conflict that touches both C++ and CMakeLists/*.cmake/*.yaml; (2) clang-format ran on a build/config file and CI now fails with a CMake `Parse error`/`Expected a newline`; (3) `include(cmake / X.cmake)` with stray spaces around `/` appears after formatting; (4) you hand-resolved a conflict in compiled code and want to verify it before a slow CI round; (5) a sibling PR changed a function signature and your call sites (including tests) fail with 'too few/many arguments' after rebase.",
       "version": "1.0.0",
-      "source": "./skills/cross-repo-python-utility-port.md",
+      "source": "./skills/cpp-conflict-resolution-clang-format-cmake-and-local-build.md",
+      "category": "tooling",
+      "tags": [
+        "clang-format",
+        "cmake",
+        "rebase",
+        "conflict",
+        "local-build"
+      ]
+    },
+    {
+      "name": "cross-repo-script-and-library-porting",
+      "description": "Systematic patterns for porting scripts, utilities, and libraries between repositories. Use when: (1) migrating utility scripts or full libraries from one project to another with dependency elimination and CI validation, (2) diff-analyzing two repos' diverged implementations to cherry-pick missing features without downgrading the destination, (3) porting skills from upstream OSS repos (Modular Apache 2.0, third-party MIT, or Agent Skills Standard format) with attribution, (4) installing and adapting external skills into a local Codex environment, or (5) creating re-export shims in the source repo after a successful port.",
+      "version": "1.0.0",
+      "source": "./skills/cross-repo-script-and-library-porting.md",
       "category": "tooling",
       "tags": [
         "porting",
         "cross-repo",
         "python",
-        "circuit-breaker",
         "re-export",
-        "test-merge",
-        "shim"
+        "shim",
+        "apache-2.0",
+        "mit-license",
+        "modular-upstream",
+        "agent-skills-standard",
+        "codex",
+        "sequential-prs",
+        "dependency-elimination"
       ]
     },
     {
@@ -9344,14 +5723,6 @@
       "description": "Cytoscape.js DAG visualization bug fixes and performance patterns. Covers edge-at-baseline-hidden pattern, read-only graph config, day-filter phase boundary visibility, and role-complete trajectory highlighting.",
       "version": "1.0.0",
       "source": "./skills/cytoscape-edge-visibility-optimization.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "deprecated-file-stub-cleanup",
-      "description": "Safely delete deprecated files and stubs. Use when: (1) removing deprecated .mojo stub files, (2) cleaning up dead code after refactor, (3) deleting deprecated skills from the registry.",
-      "version": "1.0.0",
-      "source": "./skills/deprecated-file-stub-cleanup.md",
       "category": "tooling",
       "tags": []
     },
@@ -9372,84 +5743,12 @@
       "tags": []
     },
     {
-      "name": "docker-compose-v5-healthcheck-array-split",
-      "description": "Docker Compose v5 (v2.39+) splits healthcheck test: arrays on spaces, breaking all pipe-based shell healthchecks. Use when: (1) healthchecks fail with CMD array format on Docker Compose v5, (2) containers become unhealthy despite service being responsive, (3) migrating compose files to Docker Compose v5, (4) diagnosing 'sh -c wget' help text in healthcheck logs.",
-      "version": "1.1.0",
-      "source": "./skills/docker-compose-v5-healthcheck-array-split.md",
-      "category": "tooling",
-      "tags": [
-        "docker-compose",
-        "docker-compose-v5",
-        "healthcheck",
-        "busybox",
-        "wget",
-        "podman",
-        "wsl2",
-        "regression"
-      ]
-    },
-    {
-      "name": "docker-optional-dep-layer-caching",
-      "description": "TRIGGER CONDITIONS: When a Dockerfile uses tomllib to extract pyproject.toml runtime deps for layer caching but omits optional-dependency groups, causing them to be reinstalled on every source change when installed as extras",
-      "version": "1.0.0",
-      "source": "./skills/docker-optional-dep-layer-caching.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "docker-precommit-entrypoint-install",
-      "description": "Pre-commit git hooks must be installed in entrypoint.sh (container startup), not Dockerfile RUN (image build), because .git/ is only accessible after bind-mount volumes are active. Use when: (1) setting up pre-commit in Docker/Podman with a bind-mounted workspace, (2) debugging why git hooks are not running inside containers, (3) pre-commit install appears to succeed during Docker build but hooks don't fire at runtime, (4) `core.hooksPath` git config blocks hook installation with a 'Cowardly refusing' error.",
-      "version": "1.0.0",
-      "source": "./skills/docker-precommit-entrypoint-install.md",
-      "category": "tooling",
-      "tags": [
-        "docker",
-        "podman",
-        "pre-commit",
-        "git-hooks",
-        "bind-mount",
-        "entrypoint",
-        "container"
-      ]
-    },
-    {
-      "name": "documentation-bulk-audit-issue-filing",
-      "description": "Convert a structured repo audit's findings into a coherent set of GitHub issues with a parent tracker. Stage every issue body as a local file first, file the tracker first to capture its number, then file children sequentially with `sleep 1` and a `Tracking: #NNNN` footer, then back-patch the tracker body with concrete child references. Use when: (1) you have just finished a multi-section audit and need to file 10\u201340 issues, (2) you want a single parent issue showing audit progress at a glance, (3) you want every issue body reviewable as a local directory before any API call.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-bulk-audit-issue-filing.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "issues",
-        "audit",
-        "bulk-filing",
-        "tracker",
-        "parent-issue",
-        "governance",
-        "sleep-rate-limit"
-      ]
-    },
-    {
       "name": "dryrun-process-metrics-assertions",
       "description": "Skill: Dryrun process_metrics Assertions in Integration Tests",
       "version": "1.0.0",
       "source": "./skills/dryrun-process-metrics-assertions.md",
       "category": "tooling",
       "tags": []
-    },
-    {
-      "name": "dynamic-rglob-replaces-hardcoded-lists",
-      "description": "Replace hardcoded file lists with Path.rglob() dynamic discovery for self-maintaining scripts. Use when: (1) a script iterates a manually maintained list of files, (2) new files are silently skipped unless someone updates the list, (3) porting fix scripts across repos with different directory conventions.",
-      "version": "1.0.0",
-      "source": "./skills/dynamic-rglob-replaces-hardcoded-lists.md",
-      "category": "tooling",
-      "tags": [
-        "rglob",
-        "dynamic-discovery",
-        "hardcoded-lists",
-        "pathlib",
-        "cross-repo-porting"
-      ]
     },
     {
       "name": "e2e-crosshost-doctor-prerequisite-checker",
@@ -9482,10 +5781,10 @@
       ]
     },
     {
-      "name": "ecosystem-wide-easy-sweep-2026-05-12",
-      "description": "Retrospective and reusable flowchart for a 5-repo, 3-wave ecosystem-wide easy-sweep using parallel classifier agents + multi-wave myrmidon swarm. Use when: (1) executing a sweep across 3+ HomericIntelligence repos simultaneously, (2) classifying 500+ open issues with parallel Phase-0 classifier agents, (3) coordinating 50+ wave agents across multiple repos with per-repo capability quirks, (4) needing the verified phase ordering (classify \u2192 close-batch \u2192 3 waves \u2192 CVE-fix-unblock \u2192 rebase-cascade \u2192 CI triage \u2192 knowledge capture).",
+      "name": "ecosystem-wide-multi-repo-sweep-orchestration",
+      "description": "Orchestrating ecosystem-wide sweeps across 3+ HomericIntelligence repos using parallel classifier agents, wave/bundle execution, and phase ordering. Use when: (1) executing a sweep across 3+ HomericIntelligence repos simultaneously, (2) classifying 500+ open issues with parallel Phase-A classifier agents, (3) choosing between PR-per-issue (v1) and bundle-PR-per-repo (v2) sweep variants, (4) dispatching 50+ wave agents with sequential within-repo merge ordering, (5) clearing a stuck PR queue with a sequential rebase loop after a systemic fix lands on main, (6) bulk-merging N PRs against the same base branch without hitting the GraphQL base-branch race, (7) batch-rebasing local branches whose commits were parallel-merged or squash-absorbed upstream.",
       "version": "1.0.0",
-      "source": "./skills/ecosystem-wide-easy-sweep-2026-05-12.md",
+      "source": "./skills/ecosystem-wide-multi-repo-sweep-orchestration.md",
       "category": "tooling",
       "tags": [
         "ecosystem-wide",
@@ -9493,10 +5792,14 @@
         "easy-sweep",
         "classifier-swarm",
         "wave-execution",
-        "2-pass-classification",
-        "cve-unblock",
-        "rebase-cascade",
-        "retrospective"
+        "bundle-per-repo",
+        "rebase-loop",
+        "sequential-merge",
+        "pr-queue",
+        "gh-tidy",
+        "parallel-merge",
+        "squash-absorb",
+        "rate-limit-event"
       ]
     },
     {
@@ -9522,20 +5825,6 @@
       "tags": []
     },
     {
-      "name": "execution-stage-logging",
-      "description": "Add structured stage logging with timing to track worker thread progress through multi-stage pipelines",
-      "version": "1.0.0",
-      "source": "./skills/execution-stage-logging.md",
-      "category": "tooling",
-      "tags": [
-        "logging",
-        "observability",
-        "debugging",
-        "worker-threads",
-        "pipeline"
-      ]
-    },
-    {
       "name": "explicit-false-schema-fixture-tests",
       "description": "Skill: Explicit-False Schema Fixture Tests",
       "version": "1.0.0",
@@ -9552,69 +5841,33 @@
       "tags": []
     },
     {
-      "name": "extract-logging-helper",
-      "description": "Skill: extract-logging-helper. Use when working with extract logging helper.",
+      "name": "feature-dev-code-reviewer-cannot-execute-shell-commands",
+      "description": "The `feature-dev:code-reviewer` agent type has only read-only tools \u2014 it can analyze a PR but cannot post `gh pr review`. Use this skill to (1) choose the right agent type for tasks that need to write back, (2) structure prompts so analysis-only agents return parseable bodies the orchestrator can post, (3) avoid wasting agent tokens composing `gh` commands the agent cannot execute, (4) detect the failure signature (`I cannot run shell commands` / `Available tools: Read, WebFetch, ...`) when sub-agents report blockers, (5) decide between `general-purpose` (full toolset, can post) and `feature-dev:code-reviewer` (read-only, analysis only) for PR-review delegation.",
       "version": "1.0.0",
-      "source": "./skills/extract-logging-helper.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "file-upstream-feature-request",
-      "description": "Use when filing a feature request or bug against a third-party OSS repo. Covers: duplicate check, label discovery, local patch proposal via secret gist, smoke testing, and clean cross-repo issue creation with gh CLI. Use when: (1) proposing a new flag/behavior to an upstream tool you don't maintain, (2) attaching a proposed patch as a gist to an external issue, (3) needing to verify no duplicate exists before filing.",
-      "version": "1.0.0",
-      "source": "./skills/file-upstream-feature-request.md",
+      "source": "./skills/feature-dev-code-reviewer-cannot-execute-shell-commands.md",
       "category": "tooling",
       "tags": [
-        "gh",
-        "github",
-        "upstream",
-        "feature-request",
-        "gist",
-        "patch",
-        "oss",
-        "third-party",
-        "issue-filing",
-        "gh-extension"
+        "agent-types",
+        "code-review",
+        "sub-agents",
+        "shell-access",
+        "gh-cli",
+        "tool-availability",
+        "read-only-agent",
+        "prompt-design",
+        "delegation",
+        "orchestrator-pattern",
+        "write-back",
+        "feature-dev",
+        "general-purpose",
+        "analysis-only"
       ]
-    },
-    {
-      "name": "fix-docker-image-case",
-      "description": "Fix Docker SBOM and workflow failures caused by mixed-case image names in GitHub Actions",
-      "version": "1.0.0",
-      "source": "./skills/fix-docker-image-case.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "fix-hardcoded-target-path",
       "description": "Fix hardcoded output/target directory paths in migration and tooling scripts by adding CLI flag, env var fallback, and safe default. Use when: a script has a hardcoded absolute path that fails on other machines.",
       "version": "1.0.0",
       "source": "./skills/fix-hardcoded-target-path.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "fix-incomplete-pydantic-migration",
-      "description": "Fix CI test failures from incomplete Pydantic v2 migrations with bandaid approach",
-      "version": "1.0.0",
-      "source": "./skills/fix-incomplete-pydantic-migration.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "fix-stale-prs-and-branches",
-      "description": "Rebase open PRs with no CI / failing CI, delete stale remote branches, commit orphaned local work as a new PR. Use when: open PRs show no checks, CI fails due to merge conflicts, stale remote branches need cleanup.",
-      "version": "1.0.0",
-      "source": "./skills/fix-stale-prs-and-branches.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "flesh-out-scaffolded-repo",
-      "description": "Fill gaps in scaffolded repos to make them production-ready: add justfile + pixi.toml, build scripts, READMEs, and fix bash syntax bugs, hardcoded values, and suppressed failures. Use when: a repo was scaffolded and pushed but is missing task runner files, compose/Nomad files have hardcoded paths, or shell scripts have syntax errors.",
-      "version": "1.0.0",
-      "source": "./skills/flesh-out-scaffolded-repo.md",
       "category": "tooling",
       "tags": []
     },
@@ -9656,164 +5909,95 @@
       "tags": []
     },
     {
-      "name": "gh-batch-merge-by-labels",
-      "description": "Batch merge multiple PRs by label matching",
+      "name": "gh-issue-author-or-assignee-union",
+      "description": "Combine `gh issue list` filters with OR semantics via two calls + Python set union. Use when: (1) you want issues authored-by OR assigned-to a user (not both), (2) automation that should only touch the operator's own issues.",
       "version": "1.0.0",
-      "source": "./skills/gh-batch-merge-by-labels.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-cli-proactive-per-thread-throttle",
-      "description": "Add proactive per-thread token-bucket throttling at the single `gh` CLI invocation chokepoint to prevent GitHub secondary rate limits before they trigger. Use when: (1) a Python codebase wraps `gh` and bursts requests during fan-out (e.g. one `gh issue view` per discovered issue), (2) reactive rate-limit handling exists but secondary limits still fire, (3) a `ThreadPoolExecutor` fans out work and per-worker pacing is needed without global coordination, (4) deciding the architectural layer for a throttle (answer: at the per-call chokepoint, not the per-phase orchestrator).",
-      "version": "1.0.0",
-      "source": "./skills/gh-cli-proactive-per-thread-throttle.md",
+      "source": "./skills/gh-issue-author-or-assignee-union.md",
       "category": "tooling",
       "tags": [
+        "github",
         "gh-cli",
-        "github-api",
-        "rate-limit",
-        "secondary-limit",
-        "throttle",
-        "token-bucket",
-        "threadpoolexecutor",
-        "per-thread",
-        "proactive",
-        "python",
-        "subprocess"
+        "issues",
+        "automation"
       ]
     },
     {
-      "name": "gh-get-review-comments",
-      "description": "Retrieve all review comments from a pull request using the GitHub API. Use when you need to see what feedback has been provided on a PR.",
+      "name": "gh-token-env-shadows-keyring",
+      "description": "Diagnose and fix a read-only-session gotcha where an ambient GH_TOKEN / GITHUB_TOKEN environment PAT (github_pat_... fine-grained/restricted) shadows the full-scope keyring gho_... OAuth token for BOTH gh and git, causing every write op (git push, gh pr merge, gh pr merge --admin, gh run rerun) to fail with HTTP 403 'Permission denied' or 'Resource not accessible by personal access token' \u2014 even though gh auth status shows a second keyring account with repo+workflow scopes. Fix: prefix every write command with 'unset GH_TOKEN GITHUB_TOKEN;'. Use when: (1) git push returns 403 'Permission denied to <user>' in an agent/CI shell but works interactively, (2) gh pr merge / gh run rerun says 'Resource not accessible by personal access token', (3) gh pr merge --admin is rejected, (4) gh auth status lists two accounts (an active GITHUB_TOKEN PAT and a keyring gho_ token), (5) you are tempted to hand-inject a token via git -c http.extraheader.",
       "version": "1.0.0",
-      "source": "./skills/gh-get-review-comments.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-implement-issue",
-      "description": "End-to-end implementation workflow for a GitHub issue from planning through PR creation. Use when starting work on an issue from scratch.",
-      "version": "1.0.0",
-      "source": "./skills/gh-implement-issue.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-post-issue-update",
-      "description": "Post structured updates to GitHub issues for progress tracking",
-      "version": "1.0.0",
-      "source": "./skills/gh-post-issue-update.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-pr-review-workflow",
-      "description": "GitHub PR review workflow",
-      "version": "1.0.0",
-      "source": "./skills/gh-pr-review-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-read-issue-context",
-      "description": "Read context from GitHub issue including body and comments",
-      "version": "1.0.0",
-      "source": "./skills/gh-read-issue-context.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-reply-review-comment",
-      "description": "Reply to PR review comments using the correct GitHub API endpoint. Use when responding to inline code review feedback (not gh pr comment).",
-      "version": "1.0.0",
-      "source": "./skills/gh-reply-review-comment.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "gh-review-pr",
-      "description": "Comprehensively review a pull request including code changes, CI status, and adherence to project standards. Use when asked to review a PR.",
-      "version": "1.0.0",
-      "source": "./skills/gh-review-pr.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "git-commits-on-local-main-recovery",
-      "description": "Recover when commits accidentally land on local main instead of a feature branch. Use when: (1) git branch --show-current shows 'main' but work was done there, (2) git log shows commits on local main ahead of origin/main, (3) main is protected and pushing directly will be rejected, (4) you need to salvage multiple commits without losing any work.",
-      "version": "1.0.0",
-      "source": "./skills/git-commits-on-local-main-recovery.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "git-rebase-stacked-prs-worktree-isolation",
-      "description": "Use git worktrees to rebase a stack of sibling PRs in parallel without cross-iteration corruption. Use when: (1) batch-rebasing many sibling branches onto main after their shared base advanced, (2) a naive in-place rebase loop fails with 'src refspec does not match any' or 'you need to resolve your current index first', (3) parallelizing conflict resolution across sub-agents (one worktree per agent), (4) a force-push pushed a half-rebased branch because exit-code check was masked by a piped tail/grep.",
-      "version": "1.0.0",
-      "source": "./skills/git-rebase-stacked-prs-worktree-isolation.md",
+      "source": "./skills/gh-token-env-shadows-keyring.md",
       "category": "tooling",
       "tags": [
+        "gh-cli",
+        "github-token",
+        "keyring",
+        "auth",
+        "403",
+        "git-push",
+        "pr-merge",
+        "agent-shell"
+      ]
+    },
+    {
+      "name": "git-workflow-rebase-worktree-signing",
+      "description": "Canonical git-workflow guide covering rebase conflict resolution, worktree lifecycle, GPG signing pitfalls, submodule coordination, and branch-state recovery. Use when: (1) rebasing a feature branch with non-trivial conflicts, (2) creating/cleaning git worktrees, (3) a commit is rejected because GPG signing produced an unknown key, (4) reconciling submodule state across branches, (5) recovering a branch that's in a detached/dirty state, (6) batch-rebasing many sibling branches in parallel, (7) salvaging commits from a rejected PR via cherry-pick, (8) recovering commits accidentally made on local main, (9) resolving stash-pop conflicts blocked by Safety Net, (10) cleaning up stale worktrees/branches/stashes with a preservation bias, (11) dispatching agents into submodule worktrees that hit transient permission errors, (12) finding stale staged or unstaged changes in a worktree that has already been rebased onto main.",
+      "version": "1.1.0",
+      "source": "./skills/git-workflow-rebase-worktree-signing.md",
+      "category": "tooling",
+      "tags": [
+        "merged",
         "git",
         "rebase",
         "worktree",
-        "pr-stack",
-        "parallelism",
-        "conflict-resolution"
-      ]
-    },
-    {
-      "name": "git-stash-pop-conflict-semantic-merge",
-      "description": "Use when: (1) git stash pop produces merge conflicts and Safety Net blocks git checkout -- (discard) or git stash drop (delete), (2) a stash from an old branch conflicts with heavily refactored HEAD, (3) you need to evaluate which side of each conflict hunk is semantically correct rather than blindly choosing ours or theirs.",
-      "version": "1.0.0",
-      "source": "./skills/git-stash-pop-conflict-semantic-merge.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "git-submodule-gh-cli-explicit-repo-flag",
-      "description": "Always pass --repo <owner/submodule-repo> to every gh invocation when working on a git submodule from inside a parent meta-repo, and use git -C <submodule-path> for git operations. The gh CLI auto-detects repos from CWD/origin (which resolves to the parent meta-repo, not the submodule), and Bash tool calls do not preserve CWD between invocations so `cd submodule && gh pr create` silently targets the parent. Use when: (1) working on a git submodule from inside its parent meta-repo, (2) gh pr create fails with 'No commits between' or 'Base ref must be a branch', (3) gh pr view returns 'no pull requests found' for a PR you just opened, (4) git status from the parent shows a submodule as modified after submodule branch ops, (5) stacked PR workflows in submodule repos, (6) Bash-tool environments where CWD does not persist between calls (Claude Code, Cursor, etc.).",
-      "version": "1.0.0",
-      "source": "./skills/git-submodule-gh-cli-explicit-repo-flag.md",
-      "category": "tooling",
-      "tags": [
+        "gpg-signing",
         "submodule",
-        "meta-repo",
-        "gh-cli",
-        "github-cli",
-        "bash-cwd",
-        "explicit-repo-flag",
-        "stacked-prs",
-        "claude-code",
-        "cursor"
+        "branch-state",
+        "cherry-pick",
+        "stash",
+        "cleanup"
       ]
     },
     {
-      "name": "git-worktree-cleanup-preservation-audit",
-      "description": "Systematic 3-method audit for cleaning up stale git worktrees, branches, and stashes with a strong preservation bias. Use when: (1) asked to clean up stale branches/worktrees/stashes and told to 'err on the side of keeping', (2) git cherry shows '+' for commits on a PR that was MERGED (squash-merge false positive), (3) a branch is far behind main but unclear if work is truly on main, (4) a stash exists but unclear if its content is already committed, (5) cleanup request comes with no explicit 'it is safe to destroy' confirmation.",
-      "version": "1.0.0",
-      "source": "./skills/git-worktree-cleanup-preservation-audit.md",
+      "name": "git-worktree-parallel-execution-lifecycle",
+      "description": "Use when: (1) creating isolated git worktrees for parallel agent execution on 3+ independent issues, (2) splitting a single multi-part issue into N independent sub-tasks with hot-file ownership coordination, (3) switching or syncing feature branches without stashing, (4) cleaning up worktrees under no-branch-deletion / reviewable-script constraints, (5) mass-removing 20+ mixed stale worktrees using myrmidon wave parallelization, (6) detecting and recovering from branch-namespace contamination when parallel agents commit to the wrong branch, (7) avoiding the no-worktree-at-all anti-pattern where N agents share the same main workdir, (8) handling locked worktrees from dead agent PIDs, (9) staged-file two-step cleanup (status A lines), (10) cherry=1 rebase-merge artifact classification, (11) inline worktree cleanup inside a per-branch rebase loop, (12) fixing stale origin/HEAD or missing origin/main for worktree creation, (13) branch-name collision check before remote push, (14) a single-PR fix agent finds the shared main repo checked out to its target branch and starts editing there, but a sibling agent stashes + switches the branch out mid-session, silently discarding the unstaged edits \u2014 recover by locating the WIP stash and re-applying into a fresh /tmp worktree, (15) deciding whether a CLOSED-PR branch with `git cherry` +1 is keepable unreleased work or merely superseded (content reached main via another PR, or the branch edits since-deleted/renamed files) \u2014 investigate before keeping, don't assume cherry=+1 means keep.",
+      "version": "1.2.0",
+      "source": "./skills/git-worktree-parallel-execution-lifecycle.md",
       "category": "tooling",
       "tags": [
-        "git",
         "worktree",
+        "git",
+        "parallel-agents",
+        "wave-execution",
         "cleanup",
-        "stash",
-        "branch",
-        "preservation",
-        "audit",
-        "squash-merge",
-        "cherry",
-        "patch-id"
+        "branch-collision",
+        "contamination",
+        "locked-worktree",
+        "staged-files",
+        "rebase-merge",
+        "myrmidon",
+        "safety-net",
+        "lifecycle"
       ]
     },
     {
-      "name": "git-worktree-management-patterns",
-      "description": "Use when: (1) creating isolated git worktrees for parallel development on multiple issues, (2) switching between worktrees without stashing, (3) syncing feature branches with main, (4) cleaning up single or multiple stale worktrees after PRs merge, (5) removing all worktrees in bulk after parallel development sessions, (6) fixing file edits that landed in the wrong worktree, (7) parsing git worktree list --porcelain output programmatically, (8) fixing worktree creation failures due to stale origin/HEAD or missing origin/main, (9) fixing branch name collisions in parallel E2E test runs, (10) enforcing branch deletion policy \u2014 always defer branch deletion to user, (11) avoiding repeated permission prompts in sandboxed harnesses by running git from inside the worktree instead of driving every command through `git -C <path>`, (12) cleaning stale /tmp/mnemosyne-skill-* worktree directories before parallel /learn sub-agents, (13) cleaning 20+ mixed worktrees using myrmidon swarm wave parallelization, (14) batch-fixing end-of-file newline violations across multiple branches, (15) worktrees with uncommitted skill documentation requiring a 2-commit markdownlint pattern, (16) removing locked worktrees whose lock holder PID is dead (stale agent lock cleanup), (17) worktree has modified pyc/__pycache__ or pixi.lock files (build artifacts) blocking rebase \u2014 Safety Net blocks git checkout -- and git restore; use git stash + git stash drop as the only agent-safe path, (18) writing dispatch prompts for sub-agents that call Read/Edit on a repo where the user has a dirty main checkout \u2014 explicit worktree path discipline must be in the prompt.",
-      "version": "2.7.0",
-      "source": "./skills/git-worktree-management-patterns.md",
+      "name": "git-worktree-sys-path-precedence-issue",
+      "description": "Document the sys.path ordering issue in workspace-based git worktrees where the main project directory comes before the worktree in Python's module search path, causing subprocess-spawned entry points (console scripts) to import modules from the main repo instead of the worktree, even though the editable install (.pth file) correctly points to the worktree. Code changes work in direct Python imports but fail in subprocess invocations. Use when: (1) running console scripts via subprocess that load stale code from the main repo, (2) debugging entry points that work in direct Python imports but fail via pixi run or subprocess.run(), (3) code changes in a git worktree work when imported directly but fail when invoked as a console script, (4) sys.path shows main project directory before worktree path.",
+      "version": "1.0.0",
+      "source": "./skills/git-worktree-sys-path-precedence-issue.md",
       "category": "tooling",
-      "tags": []
+      "tags": [
+        "git-worktree",
+        "sys-path",
+        "PYTHONPATH",
+        "editable-install",
+        "console-scripts",
+        "entry-points",
+        "subprocess",
+        "pixi",
+        "python-environment",
+        "monorepo",
+        "module-resolution"
+      ]
     },
     {
       "name": "gitattributes-setup",
@@ -9824,239 +6008,61 @@
       "tags": []
     },
     {
-      "name": "github-bulk-issue-filing-rate-limit-recovery",
-      "description": "Patterns for filing 40+ GitHub issues reliably across multiple repos: handling secondary rate limits (403 BCE2), org monthly API usage limits, duplicate detection/cleanup, and pagination truncation in verification. Use when: (1) filing 200+ issues across 10+ repos in a single session, (2) hitting GitHub 403 errors mid-batch, (3) verifying issue counts after multi-wave filing with retry runs.",
+      "name": "github-bulk-issue-and-pr-operations",
+      "description": "Canonical guide to bulk GitHub issue and PR operations via gh CLI / gh api / GraphQL: rate-limit recovery, batch-create/close/comment, parallel PR remediation waves, mass label edits, idempotent filing with duplicate detection. Use when: (1) creating or closing 20+ issues/PRs in one operation, (2) recovering from primary or secondary rate limits, (3) coordinating parallel-fix swarms via gh CLI, (4) GraphQL bulk operations that span multiple repos, (5) auto-merge / admin-merge mechanics for batches.",
       "version": "1.0.0",
-      "source": "./skills/github-bulk-issue-filing-rate-limit-recovery.md",
+      "source": "./skills/github-bulk-issue-and-pr-operations.md",
       "category": "tooling",
       "tags": [
-        "github",
-        "issues",
-        "rate-limit",
-        "bulk-filing",
-        "epic",
-        "deduplication",
-        "pagination"
-      ]
-    },
-    {
-      "name": "github-comment-dedup-across-restarts",
-      "description": "Prevent duplicate GitHub issue comments when a pipeline worker restarts by lazily loading existing comment IDs from the GitHub API. Use when: (1) a long-running pipeline posts stage-progress comments to GitHub issues, (2) an in-memory comment-ID cache is lost on process restart causing duplicate comments, (3) you need idempotent PATCH-or-POST logic for issue comments keyed by stage name and iteration number, (4) using gh CLI to paginate issue comments efficiently.",
-      "version": "1.0.0",
-      "source": "./skills/github-comment-dedup-across-restarts.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "api",
-        "comment",
-        "deduplication",
-        "nats",
-        "pipeline",
-        "myrmidon",
+        "merged",
         "gh-cli",
-        "idempotent"
-      ]
-    },
-    {
-      "name": "github-email-privacy-noreply-push-fix",
-      "description": "Fix GitHub push rejections caused by email-privacy settings when an agent commits with the user's real email. Use when: (1) a push is rejected with 'push declined due to email privacy restrictions', (2) dispatching sub-agents that will commit and push on the user's behalf, (3) configuring orchestrator/swarm prompts that need to override git author email.",
-      "version": "1.0.0",
-      "source": "./skills/github-email-privacy-noreply-push-fix.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "push",
-        "email-privacy",
-        "noreply",
-        "agent-dispatch",
-        "swarm",
-        "commit"
-      ]
-    },
-    {
-      "name": "github-issues-semantic-branch-rename-gh-edit-graphql-verify",
-      "description": "Semantically rename default-branch references across GitHub issue titles, bodies, and authored comments using gh. Use when: (1) a repository default branch changed and existing issues still mention the old branch, (2) search results include ambiguous English uses that must not be blindly replaced, (3) you need to edit an existing issue comment you authored.",
-      "version": "1.0.1",
-      "source": "./skills/github-issues-semantic-branch-rename-gh-edit-graphql-verify.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "gh",
-        "issues",
+        "github-api",
+        "bulk",
         "graphql",
-        "branch-rename"
+        "rate-limit",
+        "parallel-pr"
       ]
     },
     {
-      "name": "github-ssh-commit-signing-fix-unknown-key-verification",
-      "description": "Resolve GitHub SSH commit signing failures and unknown_key verification errors. Use when: (1) a PR is blocked by required signed commits, (2) GitHub reports commit.verification.reason as unknown_key, (3) you need a dedicated SSH signing key and a re-sign workflow for an existing branch.",
-      "version": "1.0.0",
-      "source": "./skills/github-ssh-commit-signing-fix-unknown-key-verification.md",
+      "name": "github-issue-workflow-and-preflight-gates",
+      "description": "Use when: (1) starting work on any GitHub issue \u2014 run preflight checks to avoid duplicate implementation, (2) building or maintaining automated preflight safety gates in issue-implementation workflows, (3) filing 10\u201340 audit findings as a tracked GitHub issue queue with a parent tracker, (4) filing issues that cite repo-internal markdown docs \u2014 push docs to origin/main first so URLs resolve on first render, (5) posting structured progress updates or completion summaries to GitHub issues, (6) filing a feature request against a third-party OSS repo with a proposed patch and duplicate check, (7) verifying an already-resolved issue and closing it with grep evidence",
+      "version": "1.1.0",
+      "source": "./skills/github-issue-workflow-and-preflight-gates.md",
       "category": "tooling",
       "tags": [
         "github",
-        "git",
-        "ssh",
-        "commit-signing",
-        "pull-requests"
-      ]
-    },
-    {
-      "name": "graceful-signal-handling",
-      "description": "Implement graceful shutdown for SIGINT/SIGTERM with checkpoint save and partial results",
-      "version": "1.0.0",
-      "source": "./skills/graceful-signal-handling.md",
-      "category": "tooling",
-      "tags": [
-        "signals",
-        "shutdown",
-        "checkpoint",
-        "ctrl-c",
-        "graceful-exit"
-      ]
-    },
-    {
-      "name": "haiku-not-for-analysis",
-      "description": "Never dispatch Haiku for analysis, triage, classification, or any judgment-required work \u2014 Haiku silently produces high-confidence false positives that look correct on the surface. Use when: (1) about to choose `model: haiku` for a sub-agent, (2) Sonnet/Opus quota is exhausted and you are tempted to substitute Haiku, (3) writing prompts for issue triage / ALREADY-DONE detection / scope classification / repo audits, (4) routing phases of an automation pipeline to model tiers.",
-      "version": "1.0.0",
-      "source": "./skills/haiku-not-for-analysis.md",
-      "category": "tooling",
-      "tags": [
-        "agent-dispatch",
-        "model-tier",
-        "haiku",
-        "sonnet",
-        "opus",
-        "triage",
-        "classification",
-        "analysis",
-        "false-positive",
-        "already-done",
-        "quota-exhaustion"
-      ]
-    },
-    {
-      "name": "hephaestus-learn-sub-agent-must-execute",
-      "description": "Dispatching /hephaestus:learn sub-agents reliably: prompts must say EXECUTE not plan, and the caller must check `gh pr list --head skill/<name>` before re-dispatching to avoid duplicate work. Use when: (1) launching parallel skill-creation agents, (2) a sub-agent returned 'Plan written to /tmp/plans/...' instead of a PR URL, (3) re-dispatching an agent for a task that may have already partially executed.",
-      "version": "1.0.0",
-      "source": "./skills/hephaestus-learn-sub-agent-must-execute.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "hephaestus-plugin-migration",
-      "description": "Migrate Claude Code plugin from ProjectMnemosyne to ProjectHephaestus. Use when: (1) switching enabled plugins between marketplaces, (2) updating ~/.claude/settings.json enabledPlugins or extraKnownMarketplaces, (3) separating command plugins from data-store marketplaces",
-      "version": "1.0.0",
-      "source": "./skills/hephaestus-plugin-migration.md",
-      "category": "tooling",
-      "tags": [
-        "claude-code",
-        "plugin",
-        "marketplace",
-        "migration",
-        "hephaestus",
-        "mnemosyne",
-        "settings"
-      ]
-    },
-    {
-      "name": "homeric-intelligence-ecosystem-installer",
-      "description": "Add a portable ecosystem installer script (scripts/shell/install.sh) to ProjectHephaestus that installs all HomericIntelligence dependencies on any Tailnet host; deploy it remotely via parallel SSH fan-out. Use when: (1) onboarding a new host to the HomericIntelligence mesh, (2) diagnosing missing dependencies (Go, nats-py, cmake, templ) on worker/control/apollo hosts, (3) extending the shared installer with new dependency sections, (4) troubleshooting nats-server install, Go version, or pip system-packages restrictions on Debian 12, (5) running a parallel SSH fan-out across all Tailnet hosts to install the ecosystem.",
-      "version": "1.1.0",
-      "source": "./skills/homeric-intelligence-ecosystem-installer.md",
-      "category": "tooling",
-      "tags": [
-        "ecosystem",
-        "installer",
-        "homeric-intelligence",
-        "nats-server",
-        "go",
-        "python",
-        "cmake",
-        "tailscale",
-        "podman",
-        "hephaestus",
-        "debian",
-        "mesh-bringup",
-        "dependencies",
-        "ssh-fanout",
-        "parallel-deploy",
-        "tailnet"
-      ]
-    },
-    {
-      "name": "housekeeping-all-done-verification",
-      "description": "Verify external state for pure housekeeping issues where all cleanup may already be complete. Use when: issue describes git branch/worktree/GitHub closure tasks, all target artifacts may already be cleaned up, and an empty verification PR is needed to close the issue.",
-      "version": "1.0.0",
-      "source": "./skills/housekeeping-all-done-verification.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "install-odysseus-ecosystem-container-testing",
-      "description": "Build and test the Odysseus root-level ecosystem installer (install.sh) against clean Debian/Ubuntu containers. Use when: (1) adding or modifying install.sh in the Odysseus meta-repo, (2) verifying ecosystem installer works on a fresh OS before shipping, (3) debugging phase ordering, PATH propagation, or submodule-depth issues in the installer, (4) testing idempotency (run twice, expect identical 0-failure result), (5) hitting Dockerfile COPY failures with git submodule .git symlinks.",
-      "version": "1.0.0",
-      "source": "./skills/install-odysseus-ecosystem-container-testing.md",
-      "category": "tooling",
-      "tags": [
-        "odysseus",
-        "installer",
-        "ecosystem",
-        "container-testing",
-        "podman",
-        "debian",
-        "ubuntu",
-        "submodule",
-        "pixi",
-        "hephaestus",
-        "phase-ordering",
-        "idempotency",
-        "git-clone-dockerfile",
-        "shallow-submodule"
-      ]
-    },
-    {
-      "name": "issue-cleanup-already-resolved-detection",
-      "description": "Use when: (1) assigned a cleanup, deletion, or quality-audit issue and the target file/artifact no longer exists or the problem is already resolved, (2) a branch is at the same commit as main with no commits ahead (git log main..HEAD returns nothing), (3) a prior merged PR is referenced in the issue description as having already made the fix, (4) an auto-impl worktree branch already has commits ahead of main referencing the issue \u2014 prior session may have completed the work.",
-      "version": "1.1.0",
-      "source": "./skills/issue-cleanup-already-resolved-detection.md",
-      "category": "tooling",
-      "tags": [
-        "cleanup",
-        "deletion",
-        "quality-audit",
-        "already-done",
-        "file-existence",
-        "git-log",
-        "pr-check",
+        "issues",
         "preflight",
-        "duplicate-work",
-        "already-implemented"
+        "duplicate-prevention",
+        "workflow",
+        "bulk-filing",
+        "tracker",
+        "audit",
+        "progress-update",
+        "upstream",
+        "feature-request",
+        "safety-gates",
+        "automation"
       ]
     },
     {
-      "name": "issue-completion-verification",
-      "description": "Verify and properly close GitHub issues when PR automation fails to auto-close",
+      "name": "hephaestus-implement-issues-bulk-implementer",
+      "description": "How to use ProjectHephaestus's canonical bulk issue-implementer (hephaestus-implement-issues) to implement many GitHub issues per repo instead of hand-rolling agent prompts \u2014 flags, worker-cap math, and the three failure modes that actually bite (signal-not-main-thread, 429 session-quota, blocking-inside-a-schema'd-Workflow-subagent). Use when: (1) you need to implement N GitHub issues across one or more repos and are tempted to write your own agent loop, (2) you hit 'ValueError: signal only works in main thread', (3) you hit HTTP 429 'session limit' mid-batch, (4) a Workflow subagent wrapping the implementer fails with 'subagent completed without calling StructuredOutput', (5) you need to size --max-workers to a per-CPU-core cap, (6) cleaning up orphaned .worktrees/issue-N after an interrupted run.",
       "version": "1.0.0",
-      "source": "./skills/issue-completion-verification.md",
+      "source": "./skills/hephaestus-implement-issues-bulk-implementer.md",
       "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "issue-triage-workflow",
-      "description": "Use when: (1) large backlog of GitHub issues (10+) needs triage and resolution, (2) many independent low-complexity fixes can be parallelized across worktree-isolated agents, (3) issues may be stale or already implemented and need verification before coding, (4) bulk issue closure with wave-based parallel execution is needed",
-      "version": "2.0.0",
-      "source": "./skills/issue-triage-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "json-schema-from-pydantic-models",
-      "description": "Skill: json-schema-from-pydantic-models",
-      "version": "1.0.0",
-      "source": "./skills/json-schema-from-pydantic-models.md",
-      "category": "tooling",
-      "tags": []
+      "tags": [
+        "hephaestus",
+        "implementer",
+        "bulk-issues",
+        "max-workers",
+        "worktree",
+        "claude-session-quota",
+        "signal-main-thread",
+        "workflow-subagent",
+        "automation",
+        "pixi"
+      ]
     },
     {
       "name": "lazy-clone-dependency",
@@ -10077,76 +6083,52 @@
       ]
     },
     {
-      "name": "liza-agent-pool-reset-explicit-ids",
-      "description": "Reset a dirty Liza workspace and relaunch a clean agent pool with explicit agent IDs so ghost assignments do not reappear. Use when: (1) tasks retain stale `assigned_to` or `worktree` fields after agent failure, (2) `liza` reports invalid state because one agent is assigned to multiple active tasks, (3) leftover task worktrees and local agent processes keep the queue in a bad state, (4) you want to relaunch planners, reviewers, coders, and the orchestrator deterministically.",
+      "name": "legacy-code-deletion-safe-removal-pattern",
+      "description": "Safe removal of legacy dead code files marked as fallback/reference-only. Use when a code file claims \"kept for reference/fallback only\" but has zero real callers across the codebase, leading to stale back-references in production code that create cognitive load during maintenance.",
       "version": "1.0.0",
-      "source": "./skills/liza-agent-pool-reset-explicit-ids.md",
+      "source": "./skills/legacy-code-deletion-safe-removal-pattern.md",
       "category": "tooling",
       "tags": [
-        "liza",
-        "agents",
-        "worktree",
-        "recovery",
-        "orchestration",
-        "queue"
+        "legacy-code",
+        "code-deletion",
+        "refactoring",
+        "yagni",
+        "dead-code"
       ]
     },
     {
-      "name": "logging-stdlib-json-formatter",
-      "description": "Build a zero-dependency JSON log formatter using stdlib logging.Formatter. Use when: (1) adding structured JSON logging to a shared library, (2) integrating Python logs with Loki/Promtail/ELK without adding dependencies.",
-      "version": "1.1.0",
-      "source": "./skills/logging-stdlib-json-formatter.md",
+      "name": "luks-encrypted-drive-readonly-recovery",
+      "description": "Read-only recovery of files from a hotplugged LUKS-encrypted drive, prioritizing data safety over speed. Use when: (1) a SATA/USB drive with LUKS partitions needs file extraction, (2) drive health is unknown or suspect and you must not write to it, (3) imaging-first vs mount-directly tradeoff needs to be decided.",
+      "version": "1.0.0",
+      "source": "./skills/luks-encrypted-drive-readonly-recovery.md",
       "category": "tooling",
       "tags": [
-        "logging",
-        "json",
-        "observability",
-        "stdlib"
+        "luks",
+        "cryptsetup",
+        "ddrescue",
+        "data-recovery",
+        "btrfs",
+        "ext4",
+        "blockdev",
+        "readonly"
       ]
     },
     {
-      "name": "manage-experiment-audit",
-      "description": "Audit and fix manage_experiment.py CLI",
+      "name": "markdownlint-md012-trailing-blank-eof",
+      "description": "Diagnose markdownlint MD012/no-multiple-blanks errors that are actually caused by a trailing double newline at end-of-file, not by visible double blanks at the reported line. Use when: (1) markdownlint CI reports MD012 at a line number close to the file's last content line, (2) the same MD012 error appears across multiple PRs touching different markdown files, (3) you almost stripped blank lines inside a fenced code block trying to fix MD012 (MD012 ignores blanks inside code fences by default), (4) you want a one-line POSIX fix that strips trailing whitespace and re-adds a single newline terminator.",
       "version": "1.0.0",
-      "source": "./skills/manage-experiment-audit.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mechanical-ast-refactor-traps",
-      "description": "Three independently-replicable traps in mechanical batch refactors driven by Python AST + shell automation: (1) Claude Code Bash tool resets cwd between calls, so `git rebase --abort` issued in a follow-up call lands in the wrong directory and silently no-ops; (2) Python AST's `end_col_offset` overcounts past multi-byte UTF-8 characters (em-dash, Unicode arrows, etc.) so source-slicing-by-offset corrupts the next line; (3) ruff `--select G004 --fix --unsafe-fixes` detects f-string-logging anti-patterns but provides NO actual autofix despite the `help` message. Use when: (a) writing AST-based batch refactor scripts for large packages, (b) converting `logger.X(f\"...\")` to `%`-style logging across many files, (c) running multi-step git rebase operations from a Claude Code session where cwd is sandbox-reset between Bash calls, (d) AST-based source-rewriting unexpectedly corrupts adjacent lines.",
-      "version": "1.0.0",
-      "source": "./skills/mechanical-ast-refactor-traps.md",
+      "source": "./skills/markdownlint-md012-trailing-blank-eof.md",
       "category": "tooling",
       "tags": [
-        "ast",
-        "refactor",
-        "fstring",
-        "g004",
-        "ruff",
-        "git-rebase",
-        "sandbox",
-        "cwd",
-        "end_col_offset",
-        "utf8",
-        "balanced-paren-scanner"
+        "markdownlint",
+        "MD012",
+        "no-multiple-blanks",
+        "eof-newline",
+        "end-of-file-fixer",
+        "ci-unblocking",
+        "pre-commit",
+        "diagnostics"
       ]
-    },
-    {
-      "name": "merged-pr-noop-detection",
-      "description": "Detect when a fix-PR workflow targets an already-merged PR and safely short-circuit. Use when: fix plans say 'no fixes needed', PR state is MERGED, or automated scripts generate tasks for closed PRs.",
-      "version": "1.0.0",
-      "source": "./skills/merged-pr-noop-detection.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "migrate-skill-aux-dirs",
-      "description": "Copy auxiliary subdirectories (scripts/, templates/, hooks/) when migrating skills. Use when: fixing a migration script that silently drops subdirs, or porting skills with non-SKILL.md content.",
-      "version": "1.0.0",
-      "source": "./skills/migrate-skill-aux-dirs.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "model-config-explicit-model-id",
@@ -10157,93 +6139,43 @@
       "tags": []
     },
     {
-      "name": "model-config-naming-validation",
-      "description": "Skill: model-config-naming-validation",
+      "name": "monorepo-subproject-gitignore-and-github-template-gotchas",
+      "description": "Two related gotchas when adding per-subproject config to a project that lives in a SUBDIRECTORY of a monorepo. (1) A monorepo-root .gitignore rule silently blocks committing files in a subproject \u2014 `git add` does nothing, `git status` shows nothing \u2014 and un-ignoring requires re-including the parent directory FIRST before any file negation takes effect. (2) GitHub issue/PR templates are NOT auto-wired from a monorepo subdirectory; GitHub reads templates only from the repository-root .github/, root, or docs/. Use when: (1) adding a .claude/, .vscode/, or other tool-config directory to a monorepo subproject and `git add` appears to do nothing; (2) `git status` does not show new files you just created inside a monorepo subproject; (3) adding GitHub issue or PR templates to one subproject of a monorepo; (4) writing a CONTRIBUTING.md for a monorepo subproject.",
       "version": "1.0.0",
-      "source": "./skills/model-config-naming-validation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mojo-026-breaking-changes",
-      "description": "Catalog of Mojo 0.26.3 breaking changes, fixes, and authoritative current syntax reference. Use when: (1) migrating a Mojo codebase from 0.26.1 to 0.26.3, (2) encountering unfamiliar compile errors after a Mojo version bump, (3) auditing code for deprecated APIs, (4) writing new Mojo code and need current syntax corrections.",
-      "version": "3.0.0",
-      "source": "./skills/mojo-026-breaking-changes.md",
+      "source": "./skills/monorepo-subproject-gitignore-and-github-template-gotchas.md",
       "category": "tooling",
       "tags": [
-        "mojo",
-        "breaking-changes",
-        "migration",
-        "0.26.3",
-        "deprecation",
-        "capturing",
-        "ImplicitlyDestructible",
-        "substr",
-        "syntax",
-        "modular-upstream"
+        "monorepo",
+        "gitignore",
+        "git-check-ignore",
+        "github-templates",
+        "issue-template",
+        "subproject",
+        "claude-config"
       ]
     },
     {
-      "name": "mojo-glibc-env-awareness",
-      "description": "Handle Mojo projects that require newer GLIBC than the host OS provides. Use when: mojo fails with GLIBC version errors, pre-commit mojo-format hook fails due to GLIBC mismatch, or running Mojo toolchain on older Linux distributions.",
+      "name": "multi-repo-governance-and-ecosystem-setup",
+      "description": "Provision and govern multiple HomericIntelligence repositories at scale. Use when: (1) rolling out governance files (LICENSE/CODE_OF_CONDUCT/SECURITY/CONTRIBUTING) to 10+ repos in an org, (2) onboarding a new Tailnet host with the full HomericIntelligence dependency stack, (3) fleshing out scaffolded repos with justfile/pixi.toml/READMEs and fixing bash bugs, (4) centralizing external repo clones to save disk and avoid scattered dependencies, (5) configuring the Claude Code plugin marketplace for auto-update via cron, (6) migrating enabled plugins between marketplaces, or (7) setting up SessionEnd hooks or pipeline integration for automatic /learn retrospectives.",
       "version": "1.0.0",
-      "source": "./skills/mojo-glibc-env-awareness.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mojo-hyphenated-dir-rename-for-imports",
-      "description": "Rename hyphenated directories to underscores so Mojo can import from them. Use when: (1) Mojo import fails from a hyphenated directory, (2) test files cannot import from examples/ with hyphens, (3) renaming directories with many cross-codebase references.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-hyphenated-dir-rename-for-imports.md",
+      "source": "./skills/multi-repo-governance-and-ecosystem-setup.md",
       "category": "tooling",
       "tags": [
-        "mojo",
-        "imports",
-        "directory-rename",
-        "hyphenated",
-        "examples"
+        "multi-repo",
+        "governance",
+        "ecosystem",
+        "installer",
+        "scaffold",
+        "plugin-marketplace",
+        "cron",
+        "retrospective",
+        "hooks",
+        "ssh-fanout",
+        "gh-cli",
+        "git-worktree",
+        "tailnet",
+        "debian"
       ]
-    },
-    {
-      "name": "mojo-init-export-uncomment",
-      "description": "Activate commented-out exports in Mojo __init__.mojo by verifying leaf-module implementations and using absolute import paths + comptime aliases to work around the v0.26.1 re-export chain limitation. Use when: (1) __init__.mojo has pending commented-out imports, (2) layer structs are confirmed implemented, (3) API name mismatches need bridging.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-init-export-uncomment.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mojo-runtime-output-pattern-audit",
-      "description": "Audit Mojo source files for misleading runtime print() patterns and wire CI enforcement. Use when: extending an existing audit series to cover WARNING:, HACK:, XXX:, or Not implemented in print() calls; adding a grep-style checker script modeled on an existing one; or enforcing runtime output cleanliness in a Mojo project.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-runtime-output-pattern-audit.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "multi-branch-rebase-workflow",
-      "description": "Parallel multi-branch rebase with semantic conflict resolution and batch PR creation. Includes prevention: ALWAYS branch from origin/main to avoid stale bases. Use when: (1) creating feature branches (always from origin/main), (2) multiple branches need rebasing, (3) semantic conflict resolution needed, (4) batch PR creation after rebase, (5) rebase conflicts are purely markdown table separator style differences.",
-      "version": "2.2.0",
-      "source": "./skills/multi-branch-rebase-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mypy-full-compliance-workflow",
-      "description": "9-phase workflow to achieve full mypy compliance by fixing all suppressed error codes incrementally, decoupling tests/ overrides, and removing disable_error_code entirely",
-      "version": "1.0.0",
-      "source": "./skills/mypy-full-compliance-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "mypy-roadmap-closure",
-      "description": "Close a phased mypy strictness roadmap by removing dead tracking infrastructure, shipping free-win strict settings, triaging remaining work into individual issues, and closing the roadmap issue.",
-      "version": "1.0.0",
-      "source": "./skills/mypy-roadmap-closure.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "natsc-fetchcontent-cpp20-integration",
@@ -10263,6 +6195,31 @@
       ]
     },
     {
+      "name": "observability-logging-and-process-monitoring",
+      "description": "Add structured observability to Python/shell pipelines. Use when: (1) adding JSON log formatting to a shared library for Loki/Promtail/ELK integration, (2) adding stage logging with timing to multi-stage pipeline workers, (3) implementing SIGINT/SIGTERM graceful shutdown with checkpoint save, (4) adding real-time progress indicators to parallel tier execution, (5) suppressing noisy ERROR logs for subprocess failures that callers intentionally catch, (6) adding a log level function to a shared bash logging library, (7) overwriting transient terminal status lines with carriage return, (8) extracting duplicate logger.info/warning blocks into a shared helper method.",
+      "version": "1.0.0",
+      "source": "./skills/observability-logging-and-process-monitoring.md",
+      "category": "tooling",
+      "tags": [
+        "logging",
+        "observability",
+        "json",
+        "stdlib",
+        "stage-logging",
+        "signals",
+        "shutdown",
+        "checkpoint",
+        "progress",
+        "subprocess",
+        "log-suppress",
+        "shell",
+        "terminal",
+        "carriage-return",
+        "refactoring",
+        "dry"
+      ]
+    },
+    {
       "name": "odyssey-audit-migration-coverage",
       "description": "Add --audit flag to a migration script to cross-reference source skills against a target repo and report coverage gaps. Use when: CI needs to detect porting gaps, migration script lacks coverage observability.",
       "version": "1.0.0",
@@ -10277,29 +6234,6 @@
       "source": "./skills/orphan-config-detection.md",
       "category": "tooling",
       "tags": []
-    },
-    {
-      "name": "oss-contribution-issue-filing-pattern",
-      "description": "Strict OSS contribution workflow: audit an upstream repo, triage findings into critical bugs vs. quality improvements, check for duplicate issues, then file individual issues with embedded patches for each critical bug and a single omnibus issue for non-critical improvements. Use when: (1) performing a full repo audit before contributing to a project you don't maintain, (2) deciding which findings warrant individual issues vs. a bundled backlog issue, (3) filing bug reports with complete patches so the maintainer can accept without back-and-forth, (4) asking the maintainer which non-critical improvements they want before opening PRs.",
-      "version": "1.0.0",
-      "source": "./skills/oss-contribution-issue-filing-pattern.md",
-      "category": "tooling",
-      "tags": [
-        "oss",
-        "github",
-        "upstream",
-        "issue-filing",
-        "audit",
-        "deduplication",
-        "patch",
-        "bug-report",
-        "omnibus",
-        "triage",
-        "gh-tidy",
-        "shellcheck",
-        "bats",
-        "ci"
-      ]
     },
     {
       "name": "packaging-pep561-py-typed-marker",
@@ -10317,19 +6251,85 @@
       ]
     },
     {
-      "name": "parallel-issue-wave-execution",
-      "description": "Pattern for implementing 20-35 GitHub issues in parallel waves using isolated git worktrees. Use when: (1) backlog of 20+ issues classified as LOW/MEDIUM, (2) issues are independent and touch different files per wave, (3) need 8-10x speedup via myrmidon swarm Agent(isolation:'worktree') calls, (4) CI must be green on main before launching waves.",
-      "version": "2.8.0",
-      "source": "./skills/parallel-issue-wave-execution.md",
+      "name": "parallel-agent-myrmidon-swarm-orchestration",
+      "description": "Canonical guide to parallel-agent and Myrmidon swarm orchestration: wave-based dispatch, hierarchical tier assignment (Opus L0 \u2192 Sonnet L1/L2 \u2192 Haiku L4), agent prompt patterns, dispatcher discipline, multi-repo coordination. Use when: (1) dispatching 5+ parallel agents on independent tasks, (2) coordinating a multi-repo swarm operation, (3) designing tier assignments (Opus vs Sonnet vs Haiku), (4) ensuring deterministic dispatch without orchestrator hand-holding.",
+      "version": "1.0.0",
+      "source": "./skills/parallel-agent-myrmidon-swarm-orchestration.md",
+      "category": "tooling",
+      "tags": [
+        "merged",
+        "myrmidon",
+        "swarm",
+        "parallel-agent",
+        "l0-orchestrator",
+        "wave-execution"
+      ]
+    },
+    {
+      "name": "parallel-agent-swarm-dispatch-patterns",
+      "description": "Patterns for dispatching, prompting, and verifying parallel sub-agents in Myrmidon swarms. Use when: (1) preparing to dispatch 5+ agents in parallel via Task isolation=worktree, (2) a prior swarm round had high stall rate or sub-agents produced incorrect or missing artifacts, (3) writing dispatch prompts for issue implementation, skill-creation, or report generation, (4) routing tasks to model tiers (Opus / Sonnet / Haiku), (5) N wave issues share the same hot file and fan-out would cause rebase contention, (6) a plan has a bulk-transformation phase followed by an implementation phase that must be gated, (7) verifying sub-agent PR reports or artifacts after dispatch, (8) re-grading a batch of GitHub issues against CURRENT repo state before dispatching any agent (issue text reflects filing time, not now), (9) you need to remediate many audit findings in parallel by dispatching background swarm agents for multiple PRs, (10) orchestrating concurrent agents without file collisions across thematic PRs, (11) agents quitting early or fabricating issue numbers to satisfy a Closes-#N policy, (12) a wave plan has a strict dependency chain (PR D depends on all of wave C) and you must choose between N concurrent agents each polling on the gate vs ONE sequential state-machine agent that handles the chain end-to-end, (13) you are about to write a polling/until/dependency-gate loop as the FIRST instruction in a sub-agent prompt and need the gate-loop early-exit hardening pattern (hard-capped `for` loop + `**DO NOT STOP HERE**` directive + ABSOLUTE RULE block).",
+      "version": "1.4.0",
+      "source": "./skills/parallel-agent-swarm-dispatch-patterns.md",
       "category": "tooling",
       "tags": [
         "myrmidon",
         "swarm",
-        "parallel-agents",
-        "issue-triage",
-        "wave-execution",
-        "worktree",
-        "bulk-pr"
+        "prompt-design",
+        "scope-guardrails",
+        "stall-prevention",
+        "precommit-stall",
+        "sub-agent",
+        "parallel-dispatch",
+        "file-ownership",
+        "collision-avoidance",
+        "trust-but-verify",
+        "verification",
+        "subagent-type",
+        "tool-availability",
+        "hallucinated-success",
+        "artifact-verification",
+        "shared-brief",
+        "fan-out",
+        "model-tier",
+        "haiku",
+        "sonnet",
+        "bundle-pr",
+        "hot-file",
+        "stop-gate",
+        "re-grade",
+        "survivor-queue",
+        "phase-boundary",
+        "agent-dispatch",
+        "pre-dispatch-regrade",
+        "delegation-shim-ratio",
+        "already-done-classification",
+        "moot-churn",
+        "god-class-decomposition",
+        "orchestrator-gate",
+        "audit-remediation",
+        "thematic-pr",
+        "one-issue-per-pr",
+        "issue-first",
+        "fabricated-issue-number",
+        "anti-early-exit",
+        "foreground-test",
+        "dependent-pr-sequencing",
+        "worktree-dev-install",
+        "stale-index",
+        "ci-matrix-consistency",
+        "sequential-vs-concurrent",
+        "dependency-chain",
+        "state-machine-agent",
+        "gate-loop",
+        "polling-agent",
+        "chain-bundling",
+        "dependency-gate",
+        "polling-loop",
+        "until-loop",
+        "sequential-single-agent",
+        "hard-cap-iteration",
+        "do-not-stop-here",
+        "absolute-rule-block"
       ]
     },
     {
@@ -10389,6 +6389,42 @@
       "tags": []
     },
     {
+      "name": "pixi-env-resolve-drops-editable-install",
+      "description": "Pixi silently re-solves the shared `.pixi/envs/default` and wipes the `pip install -e .` editable install whenever a worktree edit to `pyproject.toml` (especially `[project.scripts]`, `[project.dependencies]`, or `[project.optional-dependencies]`) is followed by a `pixi run` invocation. Long-running automation that imports the package then fails with `ModuleNotFoundError: No module named '<pkg>'` starting at the exact env-resolve timestamp. Use when: (1) `ModuleNotFoundError: No module named 'hephaestus'` (or your package) starts mid-run, (2) every repo started AFTER a specific UTC timestamp fails identically while every repo started BEFORE it succeeded, (3) a swarm/parallel agent run touched `pyproject.toml` in any worktree sharing `.pixi/envs/default`, (4) `stat -c '%Y' .pixi/envs/default/conda-meta` is newer than the last `pixi run dev-install`.",
+      "version": "1.0.0",
+      "source": "./skills/pixi-env-resolve-drops-editable-install.md",
+      "category": "tooling",
+      "tags": [
+        "pixi",
+        "editable-install",
+        "pip-install-e",
+        "dev-install",
+        "site-packages",
+        "env-resolve",
+        "module-not-found",
+        "pyproject",
+        "project-scripts",
+        "swarm-worktree",
+        "long-running-driver",
+        "shared-pixi-env"
+      ]
+    },
+    {
+      "name": "pixi-feature-composition-deduplicate-tools",
+      "description": "Eliminate DRY violations when the same dev tools are declared in multiple pixi feature blocks by using feature composition (environments = {features = [shared, dev]}) to merge dependencies. Use when: (1) six or more conda/PyPI tools appear in multiple [feature.*] blocks, (2) version floors need to be synchronized across environments, (3) solving each environment independently while sharing tool definitions.",
+      "version": "1.0.0",
+      "source": "./skills/pixi-feature-composition-deduplicate-tools.md",
+      "category": "tooling",
+      "tags": [
+        "pixi",
+        "dependencies",
+        "feature-composition",
+        "deduplication",
+        "dry-principle",
+        "solve-groups"
+      ]
+    },
+    {
       "name": "pixi-pypi-upper-bounds",
       "description": "Add explicit upper version bounds to pixi.toml [pypi-dependencies]. Use when auditing or hardening dependency version constraints to prevent silent breakage on major releases.",
       "version": "1.0.0",
@@ -10397,20 +6433,16 @@
       "tags": []
     },
     {
-      "name": "pixi-tectonic-latex-build",
-      "description": "Configure tectonic as a LaTeX build engine in pixi environments with platform-specific dependencies and engine-agnostic preambles",
+      "name": "plan-mode-blocks-subagent-writes",
+      "description": "Sub-agents launched while the parent conversation is in plan mode inherit plan-mode and silently stop at planning, refusing to write/commit/push. Use when: (1) launching Agent() sub-agents that must perform write actions, (2) seeing sub-agents return plan files instead of executing, (3) building skills that delegate /learn, /implement, or any write workflow.",
       "version": "1.0.0",
-      "source": "./skills/pixi-tectonic-latex-build.md",
+      "source": "./skills/plan-mode-blocks-subagent-writes.md",
       "category": "tooling",
       "tags": [
-        "pixi",
-        "tectonic",
-        "latex",
-        "pdflatex",
-        "texlive",
-        "conda-forge",
-        "iftex",
-        "cross-platform"
+        "claude-code",
+        "sub-agents",
+        "plan-mode",
+        "isolation"
       ]
     },
     {
@@ -10418,14 +6450,6 @@
       "description": "Skill: planning-implementation-from-issue. Use when working with planning implementation from issue.",
       "version": "1.0.0",
       "source": "./skills/planning-implementation-from-issue.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "plugin-generalization",
-      "description": "Generalize skills/plugins for cross-repository compatibility",
-      "version": "1.0.0",
-      "source": "./skills/plugin-generalization.md",
       "category": "tooling",
       "tags": []
     },
@@ -10438,14 +6462,6 @@
       "tags": []
     },
     {
-      "name": "podman-compose-mount-clone-aware",
-      "description": "Make `podman compose up` clone-aware so it recreates the dev container when bind-mounted to a stale clone. Use when: (1) you maintain multiple checkouts of the same repo, (2) `restart` doesn't pick up host edits, (3) container shows correct status but stale code.",
-      "version": "1.0.0",
-      "source": "./skills/podman-compose-mount-clone-aware.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "podman-from-source-install",
       "description": "Build and install full Podman 4.0+ from source on Debian/PureOS. Use when: apt repos only ship 3.x, GitHub static binary is podman-remote not full podman, or host GLIBC < 2.32 requires a container engine.",
       "version": "1.0.0",
@@ -10454,85 +6470,33 @@
       "tags": []
     },
     {
-      "name": "podman-scratch-image-healthcheck-workaround",
-      "description": "Distroless / scratch / minimal-base container images cannot run shell-based HEALTHCHECK directives \u2014 no shell, no wget, no curl, no busybox. Use when: (1) switching a service to distroless / scratch / minimal base, (2) adding a HEALTHCHECK to a Dockerfile, (3) writing a docker-compose or podman-compose healthcheck: block, (4) a container reports unhealthy forever but the process is clearly running, (5) `docker exec <c> sh` returns 'exec format error' or 'no such file', (6) k8s exec-style livenessProbe/readinessProbe silently fails.",
-      "version": "1.1.0",
-      "source": "./skills/podman-scratch-image-healthcheck-workaround.md",
-      "category": "tooling",
-      "tags": [
-        "distroless",
-        "scratch",
-        "healthcheck",
-        "dockerfile",
-        "docker-compose",
-        "podman",
-        "kubernetes",
-        "liveness",
-        "readiness",
-        "nats"
-      ]
-    },
-    {
-      "name": "port-reusable-scripts",
-      "description": "Port and generalize reusable scripts or full libraries between repositories with proper adaptations, dependency elimination, and Python path setup. Covers both script-level migrations and full installable package ports. Use when migrating utility scripts or libraries from one project to another, deprecating source-repo code after a successful port, or resolving CI failures during cross-repo library migration.",
-      "version": "1.3.0",
-      "source": "./skills/port-reusable-scripts.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "pr-cleanup",
-      "description": "Handle PR cleanup operations including commit squashing, rebasing, conflict resolution, and pre-merge verification. Ensures PR is merge-ready with clean history and passing CI. Use for PR finalization and cleanup.",
-      "version": "1.0.0",
-      "source": "./skills/pr-cleanup.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "pr-merge-conflict-resolution",
-      "description": "Systematic workflow for rebasing PRs and resolving merge conflicts. Use when PR branch is behind main with conflicts.",
-      "version": "1.0.0",
+      "description": "Systematic workflow for rebasing PRs and resolving merge conflicts. Use when: (1) a PR branch is behind main with conflicts, (2) bulk-fixing similar conflicts across many files (e.g., YAML frontmatter), (3) a stacked-PR cascade-rebase produces identical trivial conflicts on the same files across many branches (typically caused by `pre-commit end-of-file-fixer` touching trailing-blank-line drift in workflow YAMLs or single-line drift in pixi.toml/CHANGELOG-style files), (4) you need a sed-based auto-resolver loop that strips the entire conflict block keeping HEAD's side and continues the rebase \u2014 only safe when conflicts are whitespace-only and HEAD is proven correct.",
+      "version": "1.1.0",
       "source": "./skills/pr-merge-conflict-resolution.md",
       "category": "tooling",
       "tags": []
     },
     {
-      "name": "pr-review-automation-workflow",
-      "description": "Use when: (1) building a PRReviewer class on top of implement_issues.py patterns, (2) implementing a two-phase Claude workflow (read-only analysis then full-tools fix) for automated PR remediation, (3) adding new Enum/State/Options models to an automation models.py, (4) running --review mode end-to-end in a live environment, (5) debugging nested Claude Code session failures caused by CLAUDECODE env var",
-      "version": "2.0.0",
-      "source": "./skills/pr-review-automation-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "preflight-script-integration-patterns",
-      "description": "Use when: (1) adding automated preflight safety gates to issue-implementation or worktree-creation workflows, (2) a preflight script produces false positives from PR title/body text search, (3) propagating a safety check from one entry-point skill to a sibling skill",
-      "version": "1.0.0",
-      "source": "./skills/preflight-script-integration-patterns.md",
+      "name": "pre-commit-hooks-and-linting-config",
+      "description": "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes \u2014 system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed \u2014 the hook checks ALL .py files on disk including untracked ones.",
+      "version": "1.6.0",
+      "source": "./skills/pre-commit-hooks-and-linting-config.md",
       "category": "tooling",
       "tags": [
-        "preflight",
-        "bash",
-        "automation",
-        "closingIssuesReferences",
-        "script",
-        "gh-implement-issue",
-        "false-positive"
-      ]
-    },
-    {
-      "name": "preflight-verify-before-implementing",
-      "description": "Use when: (1) starting work on any GitHub issue or prompt file, (2) resuming interrupted work on a pre-existing branch, (3) verifying PR/commit state before creating duplicates, (4) issue references prior sub-issues or codebase may have evolved since filing",
-      "version": "1.0.0",
-      "source": "./skills/preflight-verify-before-implementing.md",
-      "category": "tooling",
-      "tags": [
-        "preflight",
-        "verification",
-        "github",
-        "duplicate-prevention",
-        "issue-management",
-        "workflow"
+        "merged",
+        "pre-commit",
+        "linting",
+        "ruff",
+        "mypy",
+        "clang-format",
+        "yamllint",
+        "actionlint",
+        "hooks",
+        "pixi-environment",
+        "bandit",
+        "markdownlint",
+        "sast"
       ]
     },
     {
@@ -10552,32 +6516,77 @@
       "tags": []
     },
     {
-      "name": "push-docs-before-filing-issues",
-      "description": "Reorder workflow phases so repo-internal markdown docs are pushed to origin/main BEFORE filing GitHub issues that cite them, so issue bodies can use absolute https://github.com/<org>/<repo>/blob/main/... URLs that resolve as clickable links on first render. Adds one PR cycle but eliminates a backfill pass for relative-path placeholders. Use when: (1) filing a backlog of N>5 GitHub issues that cite repo-internal markdown docs, (2) the docs are not yet on origin/main, (3) issue bodies cite each other by GitHub number (cross-references between issues), (4) you want a clean first-render of all issue bodies with no broken links to fix later.",
-      "version": "1.0.0",
-      "source": "./skills/push-docs-before-filing-issues.md",
-      "category": "tooling",
-      "tags": [
-        "github",
-        "issues",
-        "epic",
-        "cross-reference",
-        "absolute-url",
-        "doc-push-first",
-        "phase-ordering",
-        "backlog",
-        "gh-cli",
-        "blocked-by",
-        "dependency-order"
-      ]
-    },
-    {
       "name": "pydantic-json-schema-dual-validation",
       "description": "TRIGGER CONDITIONS: Enforcing a cross-field semantic constraint (e.g., field A=true requires field B=true) in a config model loaded from YAML. Use when: (1) a domain invariant exists between two boolean capability flags, (2) the codebase uses both Pydantic models AND JSON Schema for config validation, (3) you need to catch the violation at both schema validation and model instantiation time.",
       "version": "1.0.0",
       "source": "./skills/pydantic-json-schema-dual-validation.md",
       "category": "tooling",
       "tags": []
+    },
+    {
+      "name": "pyproject-scripts-not-def-main",
+      "description": "When sweeping a change across every console_script, enumerate `[project.scripts]` in pyproject.toml \u2014 NOT `grep '^def main'`. The grep misses *_main-suffixed callables (e.g. check_version_consistency_main). Use when: (1) adding a flag to every CLI, (2) refactoring shared CLI infrastructure, (3) writing a parametrized integration test that must cover every binary.",
+      "version": "1.0.0",
+      "source": "./skills/pyproject-scripts-not-def-main.md",
+      "category": "tooling",
+      "tags": [
+        "python",
+        "packaging",
+        "cli",
+        "console-scripts",
+        "pyproject"
+      ]
+    },
+    {
+      "name": "pytest-watch-to-watcher-dependency-replacement",
+      "description": "Replace the unmaintained pytest-watch (last release 2018) with pytest-watcher, a modern actively maintained fork. Removes deprecated docopt 0.6.2 transitive dependency while preserving ptw CLI compatibility. Use when: (1) pytest-watch is declared in pixi.toml, (2) docopt deprecation warnings appear, (3) pytest 9.x compatibility testing flags legacy dependencies.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-watch-to-watcher-dependency-replacement.md",
+      "category": "tooling",
+      "tags": [
+        "pytest",
+        "pytest-watcher",
+        "dependency",
+        "pixi",
+        "docopt",
+        "deprecation"
+      ]
+    },
+    {
+      "name": "python-cli-cwd-github-repo-detect",
+      "description": "Package a pip-installable Python CLI that auto-detects (org, repo) from cwd via git rev-parse + git remote get-url origin (handles both SSH and HTTPS URLs). Use when: (1) shipping a CLI that should default to acting on the current GitHub repo (POLA), (2) want a $PATH binary without `pixi run` / `python -m` wrappers.",
+      "version": "1.0.0",
+      "source": "./skills/python-cli-cwd-github-repo-detect.md",
+      "category": "tooling",
+      "tags": [
+        "python",
+        "packaging",
+        "cli",
+        "github",
+        "console-scripts"
+      ]
+    },
+    {
+      "name": "python-packaging-and-distribution",
+      "description": "Canonical guide to Python packaging and distribution: wheel/sdist builds, hatchling/setuptools/hatch-vcs/conan integration, pixi.lock management, PyPI trusted-publishing, pip-audit CVE pinning and allowlists, cross-repo dependency hotfixes, pydantic-migration packaging, wheel-only builds. Use when: (1) shipping a Python package to PyPI, (2) regenerating or rebasing pixi.lock after a dep change, (3) handling a pip-audit CVE finding (override hard-pin / allowlist / migration), (4) configuring hatchling force-include for sdist/wheel parity, (5) packaging Conan-based C++ tooling for PyPI distribution, (6) CI fails with 'lock-file not up-to-date with the workspace', (7) pip-audit step flipped from advisory to fail-fast surfacing CVEs, (8) cross-repo shared lib not yet published to PyPI blocks consumer PRs, (9) hatch-vcs editable install makes pixi.lock perpetually stale, (10) migrating from FetchContent-only to hybrid Conan+CMake packaging.",
+      "version": "1.0.0",
+      "source": "./skills/python-packaging-and-distribution.md",
+      "category": "tooling",
+      "tags": [
+        "merged",
+        "python-packaging",
+        "pypi",
+        "pixi",
+        "hatchling",
+        "conan",
+        "pip-audit",
+        "wheel",
+        "hatch-vcs",
+        "sdist",
+        "trusted-publishing",
+        "cve",
+        "pixi-lock"
+      ]
     },
     {
       "name": "python-repo-modernization",
@@ -10588,52 +6597,23 @@
       "tags": []
     },
     {
-      "name": "python-version-alignment",
-      "description": "Align Python version across pyproject.toml, pixi.toml, Dockerfile, and CI test matrix. Use when: (1) classifiers don't match CI matrix, (2) Dockerfile uses wrong Python, (3) pixi ignores setup-python in multi-version CI.",
-      "version": "3.0.0",
-      "source": "./skills/python-version-alignment.md",
+      "name": "python-version-gated-stdlib-import-guard",
+      "description": "Guard stdlib modules that were added in a later Python version so that code remains importable on older versions in the test matrix. Use when: (1) CI matrix includes Python 3.10 and code does a bare import of a 3.11+ stdlib module (tomllib, ExceptionGroup, etc.), (2) test file collection fails with ModuleNotFoundError for a stdlib module on the lowest Python in the matrix, (3) adding tomllib usage and the repo supports Python <3.11, (4) any bare stdlib import causes collection errors on the minimum supported Python version.",
+      "version": "1.0.0",
+      "source": "./skills/python-version-gated-stdlib-import-guard.md",
       "category": "tooling",
       "tags": [
         "python",
-        "ci-cd",
-        "test-matrix",
-        "pixi",
-        "setup-python",
-        "version-drift",
-        "github-actions"
+        "stdlib",
+        "tomllib",
+        "tomli",
+        "version-guard",
+        "ci",
+        "import",
+        "3.10",
+        "3.11",
+        "compatibility"
       ]
-    },
-    {
-      "name": "quality-audit-workflow",
-      "description": "Use when: (1) implementing findings from a comprehensive code quality audit by creating tracking issues and fixing HIGH priority items, (2) converting audit findings into tracked GitHub issues with epics, (3) a quality audit flags a module docstring as a sentence fragment but the docstring is grammatically complete",
-      "version": "2.0.0",
-      "source": "./skills/quality-audit-workflow.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "quality-coverage-report",
-      "description": "Generate test coverage reports showing which code paths are tested. Use to identify untested code and improve test coverage.",
-      "version": "1.0.0",
-      "source": "./skills/quality-coverage-report.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "quality-fix-formatting",
-      "description": "Automatically fix code formatting issues using mojo format, markdownlint, and pre-commit hooks. Use when formatting checks fail or before committing code.",
-      "version": "1.0.0",
-      "source": "./skills/quality-fix-formatting.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "quality-run-linters",
-      "description": "Run all configured linters including mojo format, markdownlint, and pre-commit hooks. Use before committing code to ensure quality standards are met.",
-      "version": "1.0.0",
-      "source": "./skills/quality-run-linters.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "radiance-headless-graph-existing-pipeline-json-validation",
@@ -10650,58 +6630,9 @@
       ]
     },
     {
-      "name": "rebase-conflict-resolution-and-hook-exclusions",
-      "description": "Skill: Rebase Conflict Resolution and Pre-commit Hook Exclusions",
-      "version": "1.0.0",
-      "source": "./skills/rebase-conflict-resolution-and-hook-exclusions.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "rebasing-stale-agent-worktree-branches",
-      "description": "Use when: (1) multiple locked `.claude/worktrees/agent-*` worktrees from sub-agent runs need reconciling against main, (2) agent-generated `worktree-agent-*` branches have commits whose work has already been re-done on main with polished wording, (3) `git cherry main <branch>` reports commits as missing even though content is semantically equivalent, (4) plain `git rebase main` produces hundreds of semantic-reword conflict hunks across many branches, (5) you need to determine which agent branches still carry unique content vs. which are redundant duplicates, (6) many agent branches share identical residual diffs and can be collapsed, (7) rebase artifacts (duplicated paragraphs, misplaced sections) need to be distinguished from legitimate unique content, (8) user says 'rebase all branches' but `gh pr list --state open` returns 0 results \u2014 full batch is actually cleanup not rebase, (9) `git branch -vv` shows many branches 'ahead 1, behind N' after a myrmidon swarm session \u2014 squash-merge artifact pattern not stale branches needing rebase, (10) all branches with open PRs show the same MERGED PR ID in `gh pr list --head <branch> --state all` \u2014 squash-merge wave completed, nothing to rebase, (11) `hephaestus-tidy` or `gh tidy` identifies orphaned `worktree-agent-*` branches with rebase conflicts after `git pull` advanced main, (12) need to decide whether to delete or rebase a cherry=1 no-PR branch \u2014 check whether target file still exists on main first",
-      "version": "1.2.0",
-      "source": "./skills/rebasing-stale-agent-worktree-branches.md",
-      "category": "tooling",
-      "tags": [
-        "git",
-        "rebase",
-        "worktree",
-        "agent",
-        "stale",
-        "cleanup",
-        "-X-ours",
-        "residual-diff",
-        "sub-agent",
-        "squash-merge",
-        "cherry",
-        "pre-flight",
-        "orphan",
-        "conflict-markers",
-        "union-merge",
-        "history-file"
-      ]
-    },
-    {
-      "name": "refactor-code",
-      "description": "Restructure code for improved clarity and maintainability. Use when addressing code smells or technical debt.",
-      "version": "1.0.0",
-      "source": "./skills/refactor-code.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "repo-audit-count-reconciliation",
-      "description": "Reconcile count mismatches across documentation files after a repository audit. Use when: counts in CLAUDE.md/README/hierarchy docs differ, audit reveals stale agent or skill counts, or on-disk file counts don't match any documented number.",
-      "version": "1.0.0",
-      "source": "./skills/repo-audit-count-reconciliation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "repo-audit-triage-fix-and-issue-workflow",
-      "description": "Full workflow for strict repo audit triage: run audit, classify findings by complexity, batch-fix simple items in one PR, file GitHub issues for complex work. Use when: (1) running a comprehensive repository quality audit and acting on all findings, (2) needing to triage audit results into immediate fixes vs tracked issues, (3) remediating dead code, stale docs, broken CI, or missing requirements files.",
-      "version": "1.1.0",
+      "description": "Full workflow for strict repo audit triage: run audit, verify each finding is true before acting on it, classify findings by complexity, batch-fix simple items in one PR, file GitHub issues for complex work. Use when: (1) running a comprehensive repository quality audit and acting on all findings, (2) needing to triage audit results into immediate fixes vs tracked issues, (3) remediating dead code, stale docs, broken CI, or missing requirements files, (4) acting on a multi-agent swarm audit (`/repo-analyze-strict-full`) whose section reports may contain false positives that must be verified before triage.",
+      "version": "1.2.0",
       "source": "./skills/repo-audit-triage-fix-and-issue-workflow.md",
       "category": "tooling",
       "tags": [
@@ -10712,48 +6643,28 @@
         "dead-code",
         "ci",
         "requirements",
-        "parallel-execution"
+        "parallel-execution",
+        "swarm-audit",
+        "false-positive",
+        "trust-but-verify"
       ]
     },
     {
-      "name": "retrospective-hook-integration",
-      "description": "Setup SessionEnd hooks for automatic retrospective prompts in Claude Code. Use when integrating ProjectMnemosyne marketplace.",
+      "name": "review-rubric-exempt-toolchain-forced-churn",
+      "description": "Use when: (1) an automated PR-review agent flags lint/formatter/pre-commit-driven incidental changes as scope creep or YAGNI, (2) designing or fixing a code-review rubric's scope/YAGNI dimension, (3) a reviewer demands removal of whitespace/import-sort/mypy-annotation churn that the toolchain forced, (4) distinguishing toolchain-forced churn from author-chosen opportunistic work in review prompts",
       "version": "1.0.0",
-      "source": "./skills/retrospective-hook-integration.md",
+      "source": "./skills/review-rubric-exempt-toolchain-forced-churn.md",
       "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "retrospective-integration",
-      "description": "Integrate /learn skill into automation pipelines to automatically capture session learnings",
-      "version": "1.0.0",
-      "source": "./skills/retrospective-integration.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "review-pr-changes",
-      "description": "Review PR changes with structured checklist for quality and standards compliance. Use for comprehensive PR code review.",
-      "version": "1.0.0",
-      "source": "./skills/review-pr-changes.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "review-task-orchestration",
-      "description": "Review Task Orchestration",
-      "version": "1.0.0",
-      "source": "./skills/review-task-orchestration.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "ruff-c901-mccabe-complexity",
-      "description": "Skill: ruff-c901-mccabe-complexity",
-      "version": "1.0.0",
-      "source": "./skills/ruff-c901-mccabe-complexity.md",
-      "category": "tooling",
-      "tags": []
+      "tags": [
+        "pr-review",
+        "rubric",
+        "yagni",
+        "scope-creep",
+        "pre-commit",
+        "lint",
+        "automation",
+        "review-agent"
+      ]
     },
     {
       "name": "safety-net-rebase-conflict-python-workaround",
@@ -10788,36 +6699,50 @@
       "tags": []
     },
     {
-      "name": "shellcheck-scope-templates",
-      "description": "Skill: Scope ShellCheck Suppressions to Template Subdirectory",
+      "name": "skill-corpus-count-excludes-notes-and-history-files",
+      "description": "Use when: (1) counting the number of skills in the marketplace corpus, (2) auditing per-category skill counts, (3) any script or agent step that measures corpus size with ls/find/git ls-tree on the skills/ directory. Naive *.md globs silently include .notes.md companion files and inflate counts by ~57%.",
       "version": "1.0.0",
-      "source": "./skills/shellcheck-scope-templates.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "skill-audit-and-merge",
-      "description": "Use when: (1) skills marketplace has 500+ files with visible duplication noise hurting /advise quality, (2) auditing for near-exact duplicates or high-overlap pairs to delete or merge, (3) consolidating topic clusters spanning 3+ files into a single authoritative skill, (4) running a structured deduplication session that must leave all CI tests green",
-      "version": "2.3.0",
-      "source": "./skills/skill-audit-and-merge.md",
+      "source": "./skills/skill-corpus-count-excludes-notes-and-history-files.md",
       "category": "tooling",
       "tags": [
-        "audit",
-        "deduplication",
-        "merge",
-        "consolidation",
+        "skill-corpus",
         "marketplace",
-        "skills",
-        "cleanup"
+        "counting"
       ]
     },
     {
-      "name": "skill-experiment-recovery-tools",
-      "description": "Skill: Experiment Recovery Tools",
+      "name": "skill-corpus-merge-consolidation-workflow",
+      "description": "Workflows for maintaining a skills corpus: deduplicating overlapping skills, merging clusters into canonicals, preserving history snapshots, enumerating cluster members from examples, migrating formats (hierarchical\u2192flat, dual-dir\u2192single), and generalizing skills for cross-repo compatibility. Use when: (1) multiple skills share a common prefix and cover redundant content, (2) a merge epic lists only example members and a full member list is needed, (3) a merge PR deletes originals and their content must remain searchable, (4) legacy skills/<category>/<name>/SKILL.md files need migration to flat skills/<name>.md format, (5) skills have hardcoded repo paths that must be generalized, (6) a dual plugins/+skills/ directory must be consolidated, (7) bulk-migrating skills from one project to another, (8) a skill topic is now OBSOLETE and needs a prominent notice.",
       "version": "1.0.0",
-      "source": "./skills/skill-experiment-recovery-tools.md",
+      "source": "./skills/skill-corpus-merge-consolidation-workflow.md",
       "category": "tooling",
-      "tags": []
+      "tags": [
+        "skill-merge",
+        "deduplication",
+        "semver",
+        "consolidation",
+        "history",
+        "manifest",
+        "enumeration",
+        "flat-format",
+        "migration",
+        "plugin-generalization",
+        "corpus-maintenance"
+      ]
+    },
+    {
+      "name": "skill-teaching-stale-practices-contradicting-canonical-docs",
+      "description": "When a skill or guide teaches practices contradicting CLAUDE.md or other canonical docs, wholesale rewrite (not patching) is required to prevent contradiction persistence. Use when: (1) a skill teaches deprecated tools (flake8, black, requirements.txt, setup.py) contradicting CLAUDE.md Language Preference, (2) a skill references stale Python versions (3.8\u20133.9) contradicting current baseline (3.10+), (3) supporting files (session logs, references) contain the same stale practices as the main skill file, (4) patching individual sections would leave dangerous contradictions elsewhere, (5) stale guidance could mislead downstream consumers before they discover the newer canonical docs.",
+      "version": "1.0.0",
+      "source": "./skills/skill-teaching-stale-practices-contradicting-canonical-docs.md",
+      "category": "tooling",
+      "tags": [
+        "skill-quality",
+        "contradiction-resolution",
+        "canonical-docs",
+        "wholesale-rewrite",
+        "skill-maintenance"
+      ]
     },
     {
       "name": "skills-agent-field",
@@ -10836,56 +6761,40 @@
       "tags": []
     },
     {
-      "name": "stale-script-cleanup",
-      "description": "Remove stale one-time fix/migration scripts safely. Use when: scripts/ directory has accumulated one-time scripts no longer needed, cleaning up before releases, or reducing contributor confusion.",
+      "name": "stale-background-bash-tasks-audit",
+      "description": "Background Bash tasks (via run_in_background) have no built-in completion timeout. If their command hangs (tmpdir cleanup, missing dependency, polling loop with no deadline), they stay 'running' indefinitely with no parent notification. Use when: (1) a parent agent realizes it dispatched a background bash task hours ago and never heard back, (2) the user reports 'X is still running' from their UI panel, (3) writing a polling loop that needs to wait on an external condition, (4) writing a repro harness that depends on transient tmpdirs.",
       "version": "1.0.0",
-      "source": "./skills/stale-script-cleanup.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "submodule-worktree-permission-retry-pattern",
-      "description": "Sub-agents dispatched with `Task isolation=worktree` against a git submodule (e.g. Odysseus -> Myrmidons) hit transient 'permission denied' errors on git commands even when pwd is correctly inside the worktree. Use when: (1) dispatching Haiku/Opus agents into a submodule worktree from a meta-repo orchestrator, (2) first git fetch/push fails with 'Permission for this action has been denied' inside .claude/worktrees/agent-*, (3) the orchestrator needs --force-with-lease=ref:expected-sha recovery after a swarm agent advanced the remote branch, (4) writing dispatch prompts that must include retry-5x guidance to survive lazy git-dir cache resolution.",
-      "version": "1.0.0",
-      "source": "./skills/submodule-worktree-permission-retry-pattern.md",
+      "source": "./skills/stale-background-bash-tasks-audit.md",
       "category": "tooling",
       "tags": [
-        "myrmidon",
+        "bash",
+        "run_in_background",
+        "background-task",
+        "stale-task",
+        "timeout",
+        "polling-loop",
+        "tmpdir-cleanup",
+        "task-audit"
+      ]
+    },
+    {
+      "name": "swarm-agent-status-misread-as-premature-exit",
+      "description": "Distinguish in-progress status updates from premature-exit signals when dispatching parallel swarm sub-agents. Use when: (1) a parallel agent's notification arrives with short duration_ms (<60s) and 'waiting'/'polling' result text, (2) deciding whether to re-dispatch an apparently-stuck swarm agent, (3) auditing a multi-agent swarm for duplicate dispatches that caused PR/branch collisions, (4) the parent agent feels tempted to dispatch a retry within the first minute of a parallel agent's life.",
+      "version": "1.0.0",
+      "source": "./skills/swarm-agent-status-misread-as-premature-exit.md",
+      "category": "tooling",
+      "tags": [
         "swarm",
-        "worktree",
-        "submodule",
-        "permission",
-        "retry",
-        "git",
-        "force-with-lease",
-        "agent-dispatch"
+        "sub-agent",
+        "parallel-agents",
+        "run_in_background",
+        "duration_ms",
+        "status-misread",
+        "premature-retry",
+        "duplicate-pr",
+        "branch-collision",
+        "myrmidon"
       ]
-    },
-    {
-      "name": "subprocess-expected-failure-log-suppress",
-      "description": "Suppress logger.error() for expected CalledProcessError in run_subprocess() and git_utils.run() using log_on_error/log_errors=False. Use when: (1) a subprocess call probes for an optional resource (git ref, remote branch) and failure is expected, (2) a first-try cleanup attempt is expected to fail on clean state, (3) callers catch and handle CalledProcessError themselves so ERROR log entries are noise.",
-      "version": "1.0.0",
-      "source": "./skills/subprocess-expected-failure-log-suppress.md",
-      "category": "tooling",
-      "tags": [
-        "subprocess",
-        "logging",
-        "run_subprocess",
-        "log_on_error",
-        "log_errors",
-        "CalledProcessError",
-        "expected-failure",
-        "git-utils",
-        "hephaestus"
-      ]
-    },
-    {
-      "name": "t5-inherit-missing-manifest-fallback",
-      "description": "Skill: T5 Inheritance Fallback for Missing config_manifest.json",
-      "version": "1.0.0",
-      "source": "./skills/t5-inherit-missing-manifest-fallback.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "tailscale-maestro-setup",
@@ -10896,12 +6805,21 @@
       "tags": []
     },
     {
-      "name": "technical-debt-tracker",
-      "description": "Track and resolve FIXME/TODO comments via GitHub issues",
+      "name": "targeted-port-audit-parallel-reviewers",
+      "description": "Targeted code-port audit using 3-5 parallel review agents instead of a full repo audit. Use when: (1) a script/module was rewritten from one language to another (bash\u2192Python, Python\u2192Rust, etc.), (2) you need feature parity verification vs. a previous implementation, (3) the change is narrowly scoped and the full /repo-analyze-strict-full skill would drown actionable findings in 14 irrelevant sections, (4) auditing a refactor against a deleted-or-archived prior version, (5) you have line-by-line side-by-side comparison material available.",
       "version": "1.0.0",
-      "source": "./skills/technical-debt-tracker.md",
+      "source": "./skills/targeted-port-audit-parallel-reviewers.md",
       "category": "tooling",
-      "tags": []
+      "tags": [
+        "port-audit",
+        "parallel-review",
+        "feature-parity",
+        "code-port",
+        "rewrite-audit",
+        "focused-review",
+        "bash-to-python",
+        "narrow-scope-audit"
+      ]
     },
     {
       "name": "template-migration",
@@ -10912,20 +6830,6 @@
       "tags": []
     },
     {
-      "name": "tier-progress-indicators",
-      "description": "Add real-time progress tracking for parallel tier execution to prevent 'appears hung' issues",
-      "version": "1.0.0",
-      "source": "./skills/tier-progress-indicators.md",
-      "category": "tooling",
-      "tags": [
-        "progress",
-        "observability",
-        "parallel-execution",
-        "logging",
-        "user-experience"
-      ]
-    },
-    {
       "name": "tone-matched-documentation",
       "description": "Fill placeholder sections in documents while matching the author's existing writing style and tone",
       "version": "1.0.0",
@@ -10934,34 +6838,58 @@
       "tags": []
     },
     {
-      "name": "tooling-bulk-resolved-issue-closure",
-      "description": "Efficiently close multiple GitHub issues that are already resolved. Use when: (1) auditing open issues reveals items already addressed, (2) batch-closing stale issues after a cleanup sprint, (3) verifying file existence before closing file-related issues.",
+      "name": "tooling-automation-verify-report-vs-live-state",
+      "description": "Automation tools' headline summaries are observation reports, not ground truth: a `Driven: 8 / Failed: 4` banner can be technically true (the driver was invoked) AND operationally misleading (the driver was architecturally blind to the work that actually needed doing). NEVER conclude a run succeeded just because the script's `_summary.json` says so. Always cross-check live GitHub state per repo (`gh pr list --state open ...`, `gh pr view <pr> --json state,mergedAt,commits`) BEFORE reporting success. The script reports what it observed; what it observed may have been gated by a `Closes #<open-issue>` filter, an `@me` author scope, a `--limit` cap, or a done-gate that fires on noise. Use when: (1) consuming output from `drive-prs-green-ecosystem.sh` / any ecosystem-wide driver / loop runner, (2) about to tell a user 'all repos are green', (3) the run summary disagrees with what you can see in the GitHub UI, (4) a 'Failed' classification feels suspicious (the most-successful repo can be marked failed because of a done-gate firing on Dependabot noise), (5) building or reviewing the verification protocol for any automation that reports per-repo rc codes.",
       "version": "1.0.0",
-      "source": "./skills/tooling-bulk-resolved-issue-closure.md",
+      "source": "./skills/tooling-automation-verify-report-vs-live-state.md",
       "category": "tooling",
       "tags": [
-        "github",
-        "issues",
-        "cleanup",
-        "batch-operations",
-        "gh-cli"
+        "automation-honesty",
+        "trust-but-verify",
+        "cross-check-live-state",
+        "drive-prs-green",
+        "audit-automation-report",
+        "ground-truth-check",
+        "architecturally-blind",
+        "dependabot-flood",
+        "done-gate",
+        "reality-vs-claim",
+        "headline-summary"
       ]
     },
     {
-      "name": "tooling-claude-plugin-third-party-skill-porting",
-      "description": "Port skills from third-party Claude Code plugins into an existing plugin without license violations. Use when: (1) integrating an open-source skill repo like obra/superpowers, (2) deciding which skills to port vs skip vs avoid, (3) adapting external skills to your project's conventions.",
+      "name": "tooling-bulk-pr-sync-statuscheck-504-stale-classify",
+      "description": "Three compounding bugs that stop a bulk PR-sync tool (e.g. hephaestus.github.fleet_sync) from rebasing a large PR queue after a fix lands on main. (1) statusCheckRollup 504: `gh pr list --json ...,statusCheckRollup --limit 100` returns HTTP 504 Gateway Timeout at ~50+ open PRs because the rollup aggregates every check on every PR; drop statusCheckRollup from the bulk list and fetch CI per-PR via `gh pr view <n> --json statusCheckRollup` (one PR per call does not 504), downgrading a flaky per-PR fetch to CI=UNKNOWN instead of aborting. (2) Silent no-op on list failure: code that catches the gh error and `return []` logs 'No open PRs' and exits SUCCESS while skipping the whole queue; distinguish 'no PRs' from 'list failed' and RAISE on a genuine list failure so the run's exit status reflects the unprocessed queue. (3) Stale-failing misclassification: marking ANY CI=FAILURE PR as FAILING (skip) strands the queue, because after a fix lands on main every BEHIND PR shows its OLD failing run; require mergeStateStatus==CLEAN for the FAILING classification \u2014 a BEHIND/BLOCKED+MERGEABLE red PR must classify as OUTDATED so it gets rebased (re-running CI fresh); CONFLICTING stays CONFLICTED. Use when: (1) building or debugging any tool that bulk-lists PRs via gh, (2) a gh pr list with statusCheckRollup times out / 504s at scale, (3) a fix landed on main and the whole PR queue needs rebasing, (4) a sync tool reports 'no PRs' or success but did nothing, (5) PRs show stale failing CI after a main fix and the tool skips them all, (6) a classifier needs to tell genuine PR-specific failures from stale red CI on behind branches.",
       "version": "1.0.0",
-      "source": "./skills/tooling-claude-plugin-third-party-skill-porting.md",
+      "source": "./skills/tooling-bulk-pr-sync-statuscheck-504-stale-classify.md",
       "category": "tooling",
       "tags": [
-        "claude-code",
-        "plugin",
-        "skills",
-        "porting",
-        "third-party",
-        "mit-license",
-        "superpowers",
-        "hephaestus"
+        "fleet-sync",
+        "gh-pr-list",
+        "statusCheckRollup",
+        "504-gateway-timeout",
+        "mergeStateStatus",
+        "stale-ci",
+        "silent-noop",
+        "bulk-pr-sync",
+        "pr-classification",
+        "rebase-queue",
+        "per-pr-ci-fetch"
+      ]
+    },
+    {
+      "name": "tooling-bulk-rename-relative-path-trap",
+      "description": "Bulk path renames (sed/perl across a repo) silently break relative-pattern argument lists like `just test-group \"tests\" \"shared/fuzz/test_*.mojo\"` because the relative arg already has an implicit base path. Use when: (1) planning a `shared/`->`src/<pkg>/` rename, (2) refactoring any directory name that appears in wrapper-script invocations (just, xargs, find -path, Makefile includes, Dockerfile COPY), (3) debugging a CI coverage validator that fails after an otherwise-green bulk refactor, (4) writing perl/sed sweeps with path-boundary lookbehinds and want to audit the false-negative cases.",
+      "version": "1.0.0",
+      "source": "./skills/tooling-bulk-rename-relative-path-trap.md",
+      "category": "tooling",
+      "tags": [
+        "bulk-rename",
+        "perl",
+        "sed",
+        "refactoring",
+        "ci-validation",
+        "test-coverage"
       ]
     },
     {
@@ -10978,23 +6906,6 @@
         "semver",
         "cmake-minimum-required",
         "regex"
-      ]
-    },
-    {
-      "name": "tooling-codex-external-skill-installation",
-      "description": "Install and adapt third-party skills into Codex from a GitHub repository. Use when: (1) importing open-source skills into ~/.codex/skills, (2) external skills lack agents/openai.yaml metadata, (3) imported skills assume Claude-specific slash-command behavior, (4) you want repo-local AGENTS.md instructions to advertise newly installed skills.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-codex-external-skill-installation.md",
-      "category": "tooling",
-      "tags": [
-        "codex",
-        "skills",
-        "projecthephaestus",
-        "install",
-        "openai-yaml",
-        "agents-md",
-        "advise",
-        "learn"
       ]
     },
     {
@@ -11031,20 +6942,12 @@
       ]
     },
     {
-      "name": "tooling-direct-agent-fanout-with-shared-brief",
-      "description": "Dispatch N parallel Agent calls for repetitive multi-repo work by writing a single shared classification/instruction brief to ~/.tmp/<topic>.md, then giving each agent a short pointer-prompt with only the per-repo details (path, occurrence count, special handling). Use when: (1) you've already done the planning yourself and want to skip the orchestrator skill's Phase-1 re-plan, (2) the same procedure applies across many repos with minor per-repo variations, (3) you want each agent's context window to stay small so they don't blow through it reading the brief inline, (4) you want post-dispatch feedback from agents to refine the shared brief without re-issuing prompts, (5) deciding between invoking the formal `/hephaestus:myrmidon-swarm` skill vs. direct Agent fan-out.",
+      "name": "tooling-dry-run-smoke-full-profile-dispatcher",
+      "description": "Ship long-running training/inference/experiment scripts behind a single-file bash dispatcher exposing three named execution profiles (dry-run, smoke, full). Use when: (1) a script has a wall-clock budget ranging from seconds (verify pipeline) to hours (real experiment), (2) users need an unambiguous CI-friendly verification command separate from the real run, (3) per-user improvised flag bundles are drifting apart and need to be co-located.",
       "version": "1.0.0",
-      "source": "./skills/tooling-direct-agent-fanout-with-shared-brief.md",
+      "source": "./skills/tooling-dry-run-smoke-full-profile-dispatcher.md",
       "category": "tooling",
-      "tags": [
-        "agent-orchestration",
-        "parallel-dispatch",
-        "shared-brief",
-        "multi-repo",
-        "myrmidon-alternative",
-        "context-management",
-        "fan-out"
-      ]
+      "tags": []
     },
     {
       "name": "tooling-editorconfig-cross-editor-consistency",
@@ -11060,88 +6963,87 @@
       ]
     },
     {
-      "name": "tooling-gh-pr-auto-merge-rebase-squash-fallback",
-      "description": "EVERY HomericIntelligence repo (verified org-wide as of 2026-05-11) rejects `gh pr merge --auto --rebase` with the GraphQL error 'rebase merging is not allowed on this repository (enablePullRequestAutoMerge)'. Default to `--auto --squash` for any HomericIntelligence repo. Use when: (1) opening PRs on any HomericIntelligence repo and arming auto-merge, (2) writing skills/agents/hooks that call `gh pr merge --auto`, (3) you observe a repo's UI lets you manually rebase-merge but auto-merge with rebase fails, (4) you want a single command pattern that works across all HomericIntelligence repos without per-repo branching, (5) updating stale skills (e.g. multi-repo-pr-orchestration-swarm-pattern v2.2.0) that still scope rebase rejection to specific repos like Myrmidons.",
+      "name": "tooling-force-push-blocked-reopen-as-fresh-branch",
+      "description": "When the Claude Code harness sandbox denies `git push --force` and `git push --force-with-lease`, you cannot complete the canonical post-rebase workflow. The `--force` token in the argv is what the sandbox is matching on; `--force-with-lease` and shell redirection (`2>&1`) do not bypass the denial. PREFERRED fix (keep the same PR/branch instead of close-and-reopen): convert the rewritten history to a fast-forward via merge \u2014 reset to the remote tip, then merge the base, then resolve every conflict to the already-rebased tree (`git checkout <rebased-sha> -- <file>`), then plain-push (no `--force` token, so the sandbox does not block it). The merge commit's TREE is made byte-identical to the rebase result while its HISTORY stays a fast-forward descendant of the old remote tip; squash-merge flattens the merge commit at merge time. Fallback (when a fresh branch is acceptable): push the rebased branch under a NEW remote ref name, close the original PR, open a fresh PR with the same title and `Closes #<N>` body. Use when: (1) `git push --force` is denied by the sandbox without a permission prompt, (2) `git push --force-with-lease` is denied by the same pattern, (3) a PR hit a merge conflict and needs a rebase but force-push is unavailable, (4) the standard rebase workflow's last step (`git push --force-with-lease origin <branch>`) is blocked by harness restrictions, (5) you need to ship a rebased PR under harness sandbox constraints and cannot wait for the restriction to be lifted, (6) you want to keep the same PR/branch instead of close-and-reopen (review history or a PR stack to preserve), (7) you need to convert rewritten history to a fast-forward via merge so a plain push avoids the `--force` token the sandbox blocks, (8) you reset to the remote tip then merge the base then resolve to the rebased tree then plain-push, (9) a PR went DIRTY after a stacked dependency merged into main and retargeted it, (10) PR #843 hit a conflict after PR #842 merged and the rebased branch must reach origin under a new name, (11) PR #1079 went DIRTY after stacked dependency PR #1073 merged and retargeted it to main.",
       "version": "2.0.0",
-      "source": "./skills/tooling-gh-pr-auto-merge-rebase-squash-fallback.md",
+      "source": "./skills/tooling-force-push-blocked-reopen-as-fresh-branch.md",
+      "category": "tooling",
+      "tags": [
+        "git",
+        "git-push",
+        "force-push",
+        "force-with-lease",
+        "rebase",
+        "merge-conflict",
+        "sandbox",
+        "harness",
+        "claude-code",
+        "pr-reopen",
+        "auto-merge"
+      ]
+    },
+    {
+      "name": "tooling-gh-label-list-default-limit-truncation",
+      "description": "`gh label list --json name` silently truncates to 30 rows by default. When the labels you're validating sort late alphabetically (e.g. `state:*`, `tier:*` in a repo with a rich audit/severity taxonomy), validation queries report 0 matches even when the labels exist \u2014 no error, no warning, no exit-code signal, just truncated JSON. The same default-30 pagination bites `gh issue list`, `gh pr list`, `gh release list`, and other `gh <noun> list` subcommands when used in scripts. Fix: always pass `--limit 200` (or higher) when reading list output in scripts. Use when: (1) `gh label list` returns 0 but labels exist when checked interactively, (2) a labels-provisioning script reports success but validation script says labels missing, (3) any `gh <noun> list --json` scripted usage that filters by name/state, (4) batching org-wide repo audits that read labels/issues/PRs across many repos, (5) `gh CLI default pagination 30` is suspected as a root cause, (6) validation script silently missing labels despite create commands succeeding, (7) scripting `gh issue/pr/label` inventory with `jq` filters, (8) writing a CI step that reads `gh` list output and gates on counts.",
+      "version": "1.0.0",
+      "source": "./skills/tooling-gh-label-list-default-limit-truncation.md",
       "category": "tooling",
       "tags": [
         "gh-cli",
-        "auto-merge",
-        "rebase",
-        "squash",
-        "github",
-        "pr-automation",
-        "fallback-pattern",
-        "homericintelligence-org-policy"
+        "gh-label-list",
+        "gh-issue-list",
+        "gh-pr-list",
+        "pagination",
+        "silent-truncation",
+        "default-limit",
+        "validation-script",
+        "scripting",
+        "jq",
+        "org-wide-automation"
       ]
     },
     {
-      "name": "tooling-gh-tidy-myrmidon-rebase-swarm",
-      "description": "Use when wrapping the gh-tidy CLI extension to add Myrmidon swarm rebase-conflict resolution. Triggers: (1) developer wants single-repo branch tidy with interactive delete prompts preserved, (2) gh-tidy aborts rebases due to conflicts and you want agents to fix them autonomously, (3) you need a branch-tidying CLI that dispatches per-branch swarm agents without ever deleting branches, (4) hephaestus-tidy swarm crashes immediately with 'Unknown message type: rate_limit_event' and all branches remain failing.",
-      "version": "1.1.0",
-      "source": "./skills/tooling-gh-tidy-myrmidon-rebase-swarm.md",
+      "name": "tooling-gh-pr-list-limit-cap-use-api-paginate",
+      "description": "`gh pr list --limit N` (and `gh issue list`, `gh repo list`, etc.) is a hard cap, not a page size: pass `--limit 100` and you get at most 100 rows, period. A repo with 200 dependabot PRs silently passes a `gh pr list --limit 100 --json number | jq length == 0` 'no remaining PRs' check after looking at only the first 100. There is no `--no-limit` form, and `gh pr list` does NOT accept `--paginate` \u2014 only `gh api` does. The fix is to call the REST endpoint directly: `gh api --paginate /repos/<owner>/<name>/pulls?state=open&per_page=100`, which walks the `Link: rel=\"next\"` header and emits a single concatenated JSON array with NO upper bound. Same pattern works for issues, branches, releases, runs, etc. Note: REST responses use snake_case nested shapes (`head.ref`, `auto_merge`) while `gh pr list --json` returns camelCase flat fields (`headRefName`, `autoMergeRequest`) \u2014 normalise at the boundary so downstream consumers don't need to know which path produced the data. Use when: (1) building a 'repo is done / clean / quiescent' check that lists ALL remaining open PRs or issues, (2) a repo has hundreds of dependabot PRs and a `--limit 100` check would silently truncate, (3) you tried `--paginate` on `gh pr list` and got 'unknown flag', (4) you want a true 'enumerate every open PR' query for org-wide automation, (5) migrating from `gh pr list --json` to `gh api` and need the field-name mapping.",
+      "version": "1.0.0",
+      "source": "./skills/tooling-gh-pr-list-limit-cap-use-api-paginate.md",
       "category": "tooling",
       "tags": [
-        "gh-tidy",
-        "myrmidon",
-        "rebase",
-        "swarm",
-        "git",
-        "worktree",
-        "branch",
-        "asyncio",
-        "claude-code-sdk",
-        "rate-limit-event"
+        "gh-cli",
+        "gh-pr-list",
+        "gh-api",
+        "paginate",
+        "pagination",
+        "hard-cap",
+        "silent-truncation",
+        "rest-api",
+        "dependabot-flood",
+        "repo-done-check",
+        "field-name-mapping",
+        "snake-case",
+        "camel-case"
       ]
     },
     {
-      "name": "tooling-git-rebase-parallel-merged-branches",
-      "description": "Use when: (1) git rebase shows multiple 'dropping <sha> ... patch contents already upstream' messages interleaved with add/add conflicts, (2) a feature branch has been parallel-merged via a separate squash/rewrite PR causing nearly-identical files on both sides, (3) need to batch-rebase many local branches and reconcile with squash-merged history on origin/main, (4) local main is N ahead and M behind origin/main where the N local commits were independently merged upstream via PR, (5) add/add conflicts appear on files that differ only in trivial ways (file mode 100644 vs 100755, slight refinements upstream), (6) `git checkout --ours` is blocked by safety hooks during rebase and you need stage-index extraction (`git show :2:file`) instead, (7) confused about which side of a rebase conflict is 'ours' vs 'theirs' \u2014 during rebase ours = HEAD = upstream/rebase-base, theirs = the commit being replayed = your branch's commit (inverted vs merge).",
-      "version": "1.0.0",
-      "source": "./skills/tooling-git-rebase-parallel-merged-branches.md",
+      "name": "tooling-hephaestus-automation-loop-drive-green-broken-design",
+      "description": "Two complementary deadlocks keep the hephaestus automation loop from driving PRs to green. (A) `--phases drive-green` skips every loop or every repo ('SKIP not final loop' / 'SKIP no open issues') and leaves failing PRs untouched -- FOUR layered loop-runner design bugs (issues #818-#821, NOT shipped); use the documented bypass. (B) SHIPPED FIX: an existing open PR never gets the `state:implementation-go` label because the implementer hard-returned early on PRs that already exist (the 'skip existing PRs' shortcut) before the in-loop review loop that adds the label -- so a green PR but auto-merge never arms, forever. Use when: (1) `--phases drive-green --loops N` SKIPs every iteration for N>1, (2) `--phases drive-green --loops 1` prints SKIP no open issues even though failing PRs exist, (3) an existing PR never gets state:implementation-go / green PR but auto-merge never arms, (4) implementer skips open PRs / drive-green refuses to merge unlabeled PR, (5) calling `drive_prs_green.py` directly errors on the `--issues required` argument or the HEPH_LOOP_INDEX gate, (6) ci_driver state-{n}.json vs issue-{n}.json session-path mismatch, (7) scoping audits for the loop-runner's phase model, PR-vs-issue discovery, or the implementer per-issue lifecycle.",
+      "version": "2.0.0",
+      "source": "./skills/tooling-hephaestus-automation-loop-drive-green-broken-design.md",
       "category": "tooling",
       "tags": [
-        "git",
-        "rebase",
-        "parallel-merge",
-        "upstream",
-        "drop",
-        "supersede",
-        "conflicts",
-        "add-add",
-        "automation",
-        "batch"
-      ]
-    },
-    {
-      "name": "tooling-github-gist-binary-upload-via-git-push",
-      "description": "Upload large binary files (up to 100 MB each) to a GitHub Gist by treating the gist as a git repo and pushing blobs directly. Use when: you need a permanent URL for a binary artifact (core dumps, compressed datasets, CI outputs) and `gh gist create` fails because it only accepts text content, and GitHub Actions artifacts have expired or will expire.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-github-gist-binary-upload-via-git-push.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "tooling-golangci-lint-v2-fix-not-exclude",
-      "description": "Bumping golangci-lint v1 to v2 (and adding errorlint/bodyclose) surfaces real bugs the v1 config missed \u2014 fix every finding, do not add to exclude-rules. Use when: (1) migrating a Go project's .golangci.yml from v1 to v2 schema, (2) enabling errorlint or bodyclose on an existing Go codebase, (3) inheriting a Go service with minimal lint config, (4) tempted to suppress a new linter finding via exclude-rules, (5) before tagging a Go service release, (6) investigating subtle production bugs that 'shouldn't be possible' (e.g., govet copylocks).",
-      "version": "1.0.0",
-      "source": "./skills/tooling-golangci-lint-v2-fix-not-exclude.md",
-      "category": "tooling",
-      "tags": [
-        "golangci-lint",
-        "go",
-        "linting",
-        "errorlint",
-        "bodyclose",
-        "copylocks",
-        "govet",
-        "gosec",
-        "staticcheck",
-        "errcheck",
-        "ci",
-        "atlas",
-        "argus"
+        "hephaestus-automation-loop",
+        "drive-prs-green",
+        "ci-driver",
+        "homericintelligence",
+        "design-bug",
+        "loop-runner",
+        "phase-model",
+        "pr-discovery",
+        "implementation-go-label",
+        "existing-pr-deadlock",
+        "implementer-phase-runner",
+        "review-loop",
+        "session-resume-uuid5"
       ]
     },
     {
@@ -11163,36 +7065,6 @@
       ]
     },
     {
-      "name": "tooling-legacy-hierarchical-flat-migration",
-      "description": "Migrate remaining legacy hierarchical skills (nested directories with SKILL.md + plugin.json) to flat format (skills/<name>.md). Use when: (1) find skills/ -type d -mindepth 1 returns results, (2) skills have .claude-plugin/plugin.json files, (3) skills use SKILL.md filename instead of <name>.md.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-legacy-hierarchical-flat-migration.md",
-      "category": "tooling",
-      "tags": [
-        "migration",
-        "flat-format",
-        "hierarchical",
-        "legacy",
-        "skill-format",
-        "plugin-json"
-      ]
-    },
-    {
-      "name": "tooling-meta-repo-submodule-cleanup-swarm",
-      "description": "Clean up dirty submodule state across a meta-repo using a myrmidon swarm of parallel agents in multiple waves. Use when: (1) many submodules have untracked generated files, stale checkouts, or WIP changes, (2) cleanup requires per-submodule branches/commits/PRs, (3) dependent work (pin updates) must wait for independent work (gitignore, commits) to complete.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-meta-repo-submodule-cleanup-swarm.md",
-      "category": "tooling",
-      "tags": [
-        "meta-repo",
-        "submodules",
-        "myrmidon-swarm",
-        "git-worktrees",
-        "multi-wave",
-        "cleanup"
-      ]
-    },
-    {
       "name": "tooling-modular-project-setup-wizard",
       "description": "Set up a new Modular/Mojo/MAX project with correct structure. Use when: (1) creating a new Mojo or MAX project from scratch, (2) initializing pixi or uv environment for Mojo/MAX, (3) choosing between nightly and stable channels.",
       "version": "1.0.0",
@@ -11209,106 +7081,26 @@
       ]
     },
     {
-      "name": "tooling-modular-upstream-skill-selective-porting",
-      "description": "Port skills from Modular's official skills repo (Agent Skills Standard format) into ProjectMnemosyne with Apache 2.0 attribution. Use when: (1) integrating skills from modular/skills or similar Agent Skills Standard repos, (2) adapting directory-per-skill format to Mnemosyne flat-file format, (3) merging upstream content with existing overlapping skills, (4) handling Apache 2.0 attribution requirements for ported skills.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-modular-upstream-skill-selective-porting.md",
-      "category": "tooling",
-      "tags": [
-        "modular",
-        "mojo",
-        "skills",
-        "porting",
-        "apache-2.0",
-        "agent-skills-standard",
-        "modular-upstream",
-        "selective-port"
-      ]
-    },
-    {
-      "name": "tooling-multi-repo-governance-file-rollout",
-      "description": "Roll out governance files (LICENSE, CODE_OF_CONDUCT.md, SECURITY.md, CONTRIBUTING.md) across multiple GitHub repos in an organization. Use when: (1) onboarding an org's repos to open-source governance standards, (2) adding missing policy files to 10+ repos at once, (3) creating per-repo-customized CONTRIBUTING.md or SECURITY.md at scale.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-multi-repo-governance-file-rollout.md",
-      "category": "tooling",
-      "tags": [
-        "multi-repo",
-        "governance",
-        "github-api",
-        "batch-operations",
-        "gh-cli"
-      ]
-    },
-    {
-      "name": "tooling-myrmidon-swarm-prompt-guardrails-reduce-stall-rate",
-      "description": "Prompt-design guardrails that reduce Myrmidon swarm agent stall rate from 80% to 0% on multi-agent dispatches. Use when: (1) preparing to dispatch 5+ Opus agents in parallel via Task isolation=worktree, (2) prior swarm round had high stall rate (stream-idle / no-progress watchdog), (3) tasks touch architectural / cross-cutting / multi-file work, (4) deciding between full-fix and partial-fix scope for a single PR.",
+      "name": "tooling-pixi-lockfile-churn-self-reference",
+      "description": "Stop perpetual `pixi.lock` regeneration in Python projects that combine a self-referential `[pypi-dependencies]` editable path entry with `hatch-vcs` dynamic versioning. Use when: (1) every `pixi install` / `pixi run` rewrites `pixi.lock` even on a clean tree with no manifest edits, (2) pre-commit hooks fail because `pixi.lock` is perpetually dirty, (3) `pixi.toml` declares the package itself under `[pypi-dependencies]` with `path = \".\"` and `editable = true`, and (4) `pyproject.toml` uses `dynamic = [\"version\"]` with `[tool.hatch.version] source = \"vcs\"` (hatch-vcs). The combination makes pixi treat the source-of-truth version as changed on every invocation.",
       "version": "1.1.0",
-      "source": "./skills/tooling-myrmidon-swarm-prompt-guardrails-reduce-stall-rate.md",
-      "category": "tooling",
-      "tags": [
-        "myrmidon",
-        "swarm",
-        "prompt-design",
-        "scope-guardrails",
-        "partial-fix",
-        "refs-not-closes",
-        "agent-dispatch",
-        "stall-prevention",
-        "precommit-stall",
-        "dont-run-precommit-locally"
-      ]
-    },
-    {
-      "name": "tooling-myrmidon-swarm-stall-recovery-from-worktree",
-      "description": "Recover Myrmidon swarm agents that fail with 'stream idle timeout' or 'no progress for 600s (stream watchdog did not recover)' by inspecting their worktree state, finishing partial work manually, and pushing. Use when: (1) a background agent task-notification reports status=failed with watchdog wording (different from API connection errors), (2) the worktree shows partial diffs/staged files but no commits, (3) restarting the agent would re-burn tokens for partial work that's salvageable, (4) deciding whether to recover-and-finish vs restart-from-scratch.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-myrmidon-swarm-stall-recovery-from-worktree.md",
-      "category": "tooling",
-      "tags": [
-        "myrmidon",
-        "swarm",
-        "stall",
-        "watchdog",
-        "stream-timeout",
-        "recovery",
-        "worktree",
-        "partial-state",
-        "manual-finish"
-      ]
-    },
-    {
-      "name": "tooling-pixi-container-env-isolation",
-      "description": "Fix host/container pixi environment collision and pixi binary shadowing in Docker/Podman. Use when: (1) just build fails with Permission denied reading .pixi/envs/default inside a Podman container, (2) rootless Podman UID mapping (host UID 1000 -> container UID 0) corrupts pixi env ownership, (3) a named Docker volume was used to isolate .pixi/ but ownership still breaks after restarts, (4) container fails with 'pixi: command not found' after moving pixi-cache volume mountpoint to ~/.pixi/ (which shadows the pixi binary installed during image build).",
-      "version": "2.0.0",
-      "source": "./skills/tooling-pixi-container-env-isolation.md",
+      "source": "./skills/tooling-pixi-lockfile-churn-self-reference.md",
       "category": "tooling",
       "tags": [
         "pixi",
-        "podman",
-        "docker",
-        "container",
-        "env-isolation",
-        "uid-mapping",
-        "workspace-collision",
-        "detached-environments",
-        "volume-shadowing"
-      ]
-    },
-    {
-      "name": "tooling-plugin-cache-stale-skill-sync",
-      "description": "Use when a plugin skill is not loading updated content after a merge: (1) /reload-plugins loads old skill content even after origin/main has the new version, (2) a plugin added skills without bumping its semver version string, (3) the plugin cache directory is pinned to an old git SHA. Fix by manually syncing files into the version-keyed cache directory.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-plugin-cache-stale-skill-sync.md",
-      "category": "tooling",
-      "tags": [
-        "plugin",
-        "cache",
-        "stale",
-        "reload-plugins",
-        "skill-sync",
-        "semver",
-        "gitCommitSha",
-        "installed_plugins"
+        "pixi-lock",
+        "lockfile-churn",
+        "hatch-vcs",
+        "dynamic-version",
+        "editable-install",
+        "pypi-dependencies",
+        "self-reference",
+        "pre-commit",
+        "no-build-isolation",
+        "lockfile-v7",
+        "ci-pin-completeness",
+        "composite-action",
+        "requires-pixi"
       ]
     },
     {
@@ -11327,41 +7119,22 @@
       ]
     },
     {
-      "name": "tooling-plugin-marketplace-hourly-cron",
-      "description": "Set up a cron job to auto-update Claude Code plugin marketplaces hourly. Use when: (1) a custom marketplace (e.g., ProjectMnemosyne) needs to stay current without manual /plugin update, (2) ensuring new skills are available on next Claude Code session start.",
+      "name": "tooling-pyproject-scripts-dev-install-after-merge",
+      "description": "After git pull/merge that touches [project.scripts] in pyproject.toml, re-run editable install (pixi run dev-install / pip install -e .) \u2014 the source tree updates but console-script entry points stay stale until re-install. Use when: (1) command not found after git pull/merge, (2) new hephaestus-* CLI not on PATH after merge, (3) [project.scripts] entry not visible after pull, (4) editable install stale entry points, (5) python -m module works but the registered console-script binary does not.",
       "version": "1.0.0",
-      "source": "./skills/tooling-plugin-marketplace-hourly-cron.md",
+      "source": "./skills/tooling-pyproject-scripts-dev-install-after-merge.md",
       "category": "tooling",
       "tags": [
-        "cron",
-        "plugin",
-        "marketplace",
-        "auto-update",
-        "claude-code"
-      ]
-    },
-    {
-      "name": "tooling-pre-commit-formatter-restages-loop",
-      "description": "Detect and fix the silent-formatter-restage bug where a pre-commit formatter (mojo-format, ruff format, black, prettier, custom shell hooks) rewrites staged files during the hook but does not re-stage them. The commit succeeds with pre-formatter content while the formatter's output sits unstaged in the working tree. Use when: git status shows an unstaged whitespace/blank-line diff immediately after a successful commit, CI fails on a pre-commit check the second push around, or a custom shell-script hook calls a formatter without an explicit `git add` at the end.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-pre-commit-formatter-restages-loop.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "tooling-python-codebase-symbol-rename",
-      "description": "Rename Python symbols (functions, classes, constants, CLI flags, enum variants, filenames) across an entire Python codebase. Use when: (1) renaming a concept across src/, tests/, and scripts/ Python files, (2) renaming a CLI flag with dashes to match a new convention, (3) renaming enum variants to match a renamed operation phase.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-python-codebase-symbol-rename.md",
-      "category": "tooling",
-      "tags": [
-        "rename",
         "python",
-        "refactor",
-        "symbol-rename",
-        "file-rename",
-        "enum",
-        "cli"
+        "pyproject",
+        "console-scripts",
+        "editable-install",
+        "pip-install-e",
+        "dev-install",
+        "entry-points",
+        "pixi",
+        "command-not-found",
+        "post-merge"
       ]
     },
     {
@@ -11379,40 +7152,24 @@
       ]
     },
     {
-      "name": "tooling-safety-net-git-blocked-operations",
-      "description": "Use when: (1) a git or filesystem operation is blocked by the Safety Net hook (cc-safety-net.js) and you need to identify the correct fallback, (2) you need to know which git operations Safety Net blocks vs. allows, (3) a compound bash command fails mid-way due to a Safety Net block, (4) cleaning up locked worktrees in Safety Net-constrained environments, (5) rm -rf $VAR where $VAR is a shell variable pointing to a /tmp/ path is blocked \u2014 Safety Net cannot verify the variable's value at hook time; always use mktemp -d to get a fresh temp dir.",
+      "name": "tooling-ruff-format-precommit-check-trap",
+      "description": "Running `pixi run ruff check` (or `ruff check`) locally does NOT exercise `ruff format --check` \u2014 they are SEPARATE tools sharing a binary. `check` is the linter (errors/warnings); `format` is the formatter (line-wrap/style). A worktree-driven edit that passes `ruff check`, `mypy`, and `pytest` locally can still fail the CI pre-commit gate because the project's pre-commit config runs `ruff-format` (which uses `--diff`/`--check` mode) and finds reflowable multi-line signatures. Use when: (1) CI pre-commit ruff-format hook failed but local `ruff check` passed, (2) deciding what to run before pushing a worktree edit, (3) `ruff check` vs `ruff format` difference unclear, (4) pre-commit hooks running locally before push, (5) ProjectHephaestus pre-push `pytest -q` passed but CI lint/pre-commit failed formatter checks, (6) editor format-on-save bypassed because edits came from tooling/Edit calls instead of editor save, (7) muscle-memory says 'I ran ruff' but the format step was skipped, (8) lint and tests pass yet CI rejects with multi-line function signatures or compact comprehensions that should fit on one line under the 100-col limit.",
       "version": "1.1.0",
-      "source": "./skills/tooling-safety-net-git-blocked-operations.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "tooling-shared-scripts-pypi-centralization",
-      "description": "Workflow for auditing cross-repo script duplication and centralizing shared Python validation scripts into a PyPI package with CLI entry points. Use when: (1) multiple repos have duplicated scripts/check_*.py or scripts/validate_*.py files, (2) planning to consolidate shared tooling into a library package, (3) porting standalone scripts to library modules with testable APIs.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-shared-scripts-pypi-centralization.md",
+      "source": "./skills/tooling-ruff-format-precommit-check-trap.md",
       "category": "tooling",
       "tags": [
-        "pypi",
-        "deduplication",
-        "validation-scripts",
-        "cli-entry-points",
-        "cross-repo"
-      ]
-    },
-    {
-      "name": "tooling-skill-deduplication-semver-versioning",
-      "description": "Deduplicate overlapping skills by merging clusters into consolidated skills, and implement semantic versioning for skill amendments. Use when: (1) multiple skills cover the same topic with redundant content, (2) skill registry has 1000+ entries with obvious duplicates, (3) version bump rules need to distinguish major/minor/patch changes, (4) need algorithmic duplicate detection via marketplace.json without reading all files, (5) running at-scale deduplication across 900+ skills with parallel agents.",
-      "version": "1.6.0",
-      "source": "./skills/tooling-skill-deduplication-semver-versioning.md",
-      "category": "tooling",
-      "tags": [
-        "deduplication",
-        "merge",
-        "semver",
-        "versioning",
-        "skills-registry",
-        "consolidation"
+        "ruff",
+        "ruff-format",
+        "ruff-check",
+        "pre-commit",
+        "formatter",
+        "linter",
+        "worktree",
+        "pre-push",
+        "ci-parity",
+        "pixi",
+        "projecthephaestus",
+        "ci-lint"
       ]
     },
     {
@@ -11431,19 +7188,29 @@
       ]
     },
     {
-      "name": "tooling-sub-agent-pr-trust-but-verify",
-      "description": "Verify sub-agent PR reports against the GitHub API before assuming success. Use when: (1) a sub-agent reports a PR was opened/merged/auto-armed, (2) you need to confirm scope and merge state of an opaque-to-you sub-agent run, (3) a sub-agent reports 'rebased and pushed' but you suspect content corruption \u2014 verify with `git diff origin/main..origin/<branch> --stat` that the changed files match the PR's stated intent (e.g., a 'config refactor' PR should not show Dockerfile changes).",
+      "name": "tooling-wave-b-pr-fix-mesh-playbook",
+      "description": "Wave-B autonomous fix-mesh playbook: green 20+ failing PRs across multiple HomericIntelligence repos by applying mechanical autofixes (markdownlint, clang-format, pixi lock, pre-commit autofixes) with signed/verified commits, AND reliably verifying/finishing a Wave-B auto-fix run whose own log over-reports success. Use when: (1) running an autonomous PR-sweep where many fully-auto PRs are red on the same mechanical checks, (2) a Myrmidon swarm Wave-B auto-fix executor exited claiming PRs pass but you need to confirm/finish them, (3) re-signing previously unsigned commits to satisfy branch-protection signature policies, (4) applying a single shared-doc fix across N PRs that all inherit the same defect from main.",
       "version": "1.1.0",
-      "source": "./skills/tooling-sub-agent-pr-trust-but-verify.md",
+      "source": "./skills/tooling-wave-b-pr-fix-mesh-playbook.md",
+      "category": "tooling",
+      "tags": []
+    },
+    {
+      "name": "tooling-windows-ci-posix-only-stdlib-guards",
+      "description": "Keep Python packages importable on Windows when they reference POSIX-only stdlib modules (curses, fcntl) and timezone data (tzdata). Use when: (1) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError, (2) authoring a subpackage that imports curses/fcntl/termios/grp/pwd, (3) using zoneinfo.ZoneInfo and seeing 'No time zone found' on Windows.",
+      "version": "1.0.0",
+      "source": "./skills/tooling-windows-ci-posix-only-stdlib-guards.md",
       "category": "tooling",
       "tags": [
-        "sub-agent",
-        "pr-merge",
-        "gh-cli",
-        "verification",
-        "mergeable",
-        "trust-but-verify",
-        "orchestration"
+        "windows",
+        "cross-platform",
+        "ci",
+        "python",
+        "stdlib",
+        "curses",
+        "fcntl",
+        "tzdata",
+        "zoneinfo"
       ]
     },
     {
@@ -11463,59 +7230,6 @@
       "tags": []
     },
     {
-      "name": "until-resume-past-state-fix",
-      "description": "Skill: Fix `--until` Resume Bug \u2014 Runs Past Target State Not Skipped",
-      "version": "1.0.0",
-      "source": "./skills/until-resume-past-state-fix.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "validate-agent-tools-content",
-      "description": "Skill: validate-agent-tools-content",
-      "version": "1.0.0",
-      "source": "./skills/validate-agent-tools-content.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "validate-config-name-family",
-      "description": "Skill: validate-config-name-family",
-      "version": "1.0.0",
-      "source": "./skills/validate-config-name-family.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "validate-model-configs-fix-mode",
-      "description": "Use when: (1) adding --fix mode to a validation script that renames YAML files to match their model_id field; (2) centralizing hardcoded model-ID string literals into a shared constants.py module across executor/judge/e2e/config layers; (3) promoting a runtime validation warning to a hard pre-commit gate by reusing existing validation.py logic.",
-      "version": "2.0.0",
-      "source": "./skills/validate-model-configs-fix-mode.md",
-      "category": "tooling",
-      "tags": [
-        "model-id",
-        "constants",
-        "validation",
-        "pre-commit",
-        "fix-mode",
-        "consistency"
-      ]
-    },
-    {
-      "name": "validator-python-env-pyyaml-mismatch",
-      "description": "Run a Python validation script when `python3` fails with `ModuleNotFoundError: No module named 'yaml'` because `python3` and `python` point at different environments. Use when: (1) `python3` lacks PyYAML, (2) `pip show pyyaml` appears installed anyway, (3) validation works only under a different interpreter such as conda-backed `python`.",
-      "version": "1.0.1",
-      "source": "./skills/validator-python-env-pyyaml-mismatch.md",
-      "category": "tooling",
-      "tags": [
-        "validator",
-        "validation",
-        "python",
-        "pyyaml",
-        "environment"
-      ]
-    },
-    {
       "name": "warn-on-existing-dest-subdir",
       "description": "Defensive copytree pattern: emit stderr warning before shutil.copytree(dirs_exist_ok=True) when destination already exists. Use when: adding observability to re-runnable migration scripts, preventing silent overwrites.",
       "version": "1.0.0",
@@ -11524,97 +7238,22 @@
       "tags": []
     },
     {
-      "name": "worktree-agent-plan-mode-avoidance",
-      "description": "Prevent worktree-isolated agents from stopping to plan instead of executing. Use when: (1) Agent(isolation='worktree') returns a plan but no PR URL, (2) launching mechanical tasks like import migrations or config file edits, (3) agents ignore 'complete all steps' instructions and stop after planning.",
+      "name": "workflow-github-issues-individual-per-fix-for-automation-loop",
+      "description": "When filing GitHub issues that the HomericIntelligence automation loop (`hephaestus-automation-loop`) will fix, file ONE issue per independently-shippable PR \u2014 not one combined issue listing several fixes. Use when: (1) filing a multi-bug audit finding, (2) filing a multi-component refactor, (3) the automation loop will pick up these issues, (4) the Closes #N rule (`pr-policy` CI gate enforces exactly-one closing reference) constrains you to one issue per PR.",
       "version": "1.0.0",
-      "source": "./skills/worktree-agent-plan-mode-avoidance.md",
+      "source": "./skills/workflow-github-issues-individual-per-fix-for-automation-loop.md",
       "category": "tooling",
       "tags": [
-        "worktree",
-        "agent",
-        "plan-mode",
-        "execution",
-        "myrmidon",
-        "haiku"
+        "github-issues",
+        "automation-loop",
+        "pr-policy",
+        "homericintelligence",
+        "issue-scoping",
+        "workflow",
+        "closes-n",
+        "multi-fix",
+        "audit-finding"
       ]
-    },
-    {
-      "name": "worktree-cleanup-user-constraints",
-      "description": "Use when cleaning up worktrees under user-specified constraints: (1) no branch deletion allowed, (2) all destructive ops must go into a reviewable script, (3) uncommitted work in merged-branch worktrees must be analyzed and committed if useful. Covers classification of dirty worktrees (artifact noise vs real work), generating a section-annotated cleanup script, handling files left orphaned in merged-branch working trees, the staged-file two-step (reset HEAD then checkout --) required when worktrees contain staged-only new files (status A), all-clean direct execution, cherry=1 rebase-merge artifact handling, the remove-worktree-keep-branch pattern for closed-not-merged PRs, and locked-but-clean worktrees from dead myrmidon agent sessions (unlock+remove without --force).",
-      "version": "1.6.0",
-      "source": "./skills/worktree-cleanup-user-constraints.md",
-      "category": "tooling",
-      "tags": [
-        "worktree",
-        "cleanup",
-        "script",
-        "branches",
-        "artifacts",
-        "safety",
-        "merged-branch",
-        "circuit-breaker",
-        "staged-files",
-        "rebase-merge",
-        "closed-pr",
-        "gitignore",
-        "locked-worktree",
-        "dead-agent"
-      ]
-    },
-    {
-      "name": "worktree-lifecycle-create-switch-sync",
-      "description": "Use when: (1) creating isolated git worktrees for parallel development, (2) switching between worktrees without stashing context, (3) syncing feature branches with remote/main, (4) editing files in a worktree and getting 'nothing to commit', (5) detecting when a worktree prompt's work is already done.",
-      "version": "1.0.0",
-      "source": "./skills/worktree-lifecycle-create-switch-sync.md",
-      "category": "tooling",
-      "tags": [
-        "worktree",
-        "git",
-        "parallel",
-        "path-awareness",
-        "stale-detection"
-      ]
-    },
-    {
-      "name": "worktree-migration-testing-patterns",
-      "description": "Use when: (1) migrating command workflows from clone/rm-rf pattern to git worktree isolation, (2) batch auto-merging and rebasing open PRs, (3) writing integration tests that assert on real SKILL.md files in a worktree, (4) verifying transformation scripts are idempotent on production files.",
-      "version": "1.0.0",
-      "source": "./skills/worktree-migration-testing-patterns.md",
-      "category": "tooling",
-      "tags": [
-        "worktree",
-        "migration",
-        "clone-to-worktree",
-        "integration-tests",
-        "idempotency",
-        "auto-merge"
-      ]
-    },
-    {
-      "name": "worktree-parallel-agent-execution",
-      "description": "Use when: (1) resolving 3+ independent GitHub issues simultaneously with sub-agents, (2) mass-rebasing many PR branches in parallel without collision, (3) triaging issues by complexity then executing LOW items in a single parallel wave, (4) avoiding merge conflicts when multiple agents work on the same repo, (5) splitting ONE multi-part GitHub issue into N independent parallel sub-tasks with hot-file ownership coordination, (6) `Task isolation=worktree` agents reporting they see stat-cache differences from sibling agents (`please run git restore CLAUDE.md`), (7) parallel haiku/sonnet swarm dispatch on EASY-tier batches where agents commit to the parent repo's checked-out branch instead of their own worktree branch, (8) writing Mnemosyne `/learn` skill amendments in parallel (serialize instead \u2014 branch contamination is possible).",
-      "version": "1.2.0",
-      "source": "./skills/worktree-parallel-agent-execution.md",
-      "category": "tooling",
-      "tags": [
-        "parallel-agents",
-        "worktree",
-        "wave-execution",
-        "batch",
-        "rebase",
-        "issue-triage",
-        "automation",
-        "split-issue",
-        "hot-file-coordination"
-      ]
-    },
-    {
-      "name": "yaml-frontmatter-colon-fix",
-      "description": "Fix silent data-loss when parsing YAML frontmatter containing colons in values by replacing line.partition(':') with yaml.safe_load(). Use when: a frontmatter parser truncates values at the first colon.",
-      "version": "1.0.0",
-      "source": "./skills/yaml-frontmatter-colon-fix.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "zero-count-division-guard",
@@ -11655,28 +7294,83 @@
       "tags": []
     },
     {
-      "name": "mojo-dataloader-deferral-resolution",
-      "description": "Resolve PythonObject interop deferral placeholders in Mojo training loops by replacing them with real DataLoader iteration. Use when: a Mojo training function accepts PythonObject as a loader but a native DataLoader struct already exists, or run_epoch() silently returns 0.0 due to a deferred placeholder.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-dataloader-deferral-resolution.md",
-      "category": "training",
-      "tags": []
-    },
-    {
-      "name": "mojo-overload-disambiguation-with-is-defined",
-      "description": "Pattern for adding auto-detecting 1-arg overloads in Mojo 0.26.1 without ambiguity. Use when: (1) adding a convenience overload that auto-detects a parameter via compile-time is_defined[], (2) hitting 'ambiguous call' errors with two overloads sharing leading parameters with defaults, (3) detecting Apple Silicon or platform traits at compile time.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-overload-disambiguation-with-is-defined.md",
-      "category": "training",
-      "tags": []
-    },
-    {
       "name": "spec-driven-experimentation",
       "description": "TECHSPEC.md pattern for structured ML experiments",
       "version": "1.0.0",
       "source": "./skills/spec-driven-experimentation.md",
       "category": "training",
       "tags": []
+    },
+    {
+      "name": "training-diagnosis-loss-accuracy-decoupling-overfitting",
+      "description": "Diagnose late-stage supervised-classification runs where training loss keeps falling but test accuracy plateaus and slowly regresses. Use when: (1) user reports loss-down-accuracy-flat from a long epoch log, (2) user hoped for grokking but is seeing slow test regression instead, (3) auditing a fixed-epoch training run with no validation split.",
+      "version": "1.0.0",
+      "source": "./skills/training-diagnosis-loss-accuracy-decoupling-overfitting.md",
+      "category": "training",
+      "tags": [
+        "overfitting",
+        "early-stopping",
+        "cross-entropy",
+        "diagnostics",
+        "lenet",
+        "emnist",
+        "grokking"
+      ]
+    },
+    {
+      "name": "training-grokking-preconditions-and-vision-recipe",
+      "description": "Catalog the necessary conditions for grokking (delayed generalization) and provide a proposed recipe to attempt it on small vision tasks (MNIST/EMNIST with MLP or LeNet). Use when: (1) a user reports overfitting after long training and asks why they don't see grokking, (2) planning a grokking experiment on supervised vision data, (3) tuning weight decay / AdamW / epochs / dataset-size for delayed-generalization studies, (4) deciding whether a task is structurally capable of grokking, (5) distinguishing grokking from ordinary overfitting or ordinary late convergence, (6) reviewing claims that 'training longer' alone will produce grokking.",
+      "version": "1.0.0",
+      "source": "./skills/training-grokking-preconditions-and-vision-recipe.md",
+      "category": "training",
+      "tags": [
+        "grokking",
+        "delayed-generalization",
+        "weight-decay",
+        "adamw",
+        "omnigrok",
+        "phase-transition",
+        "lenet",
+        "mnist",
+        "emnist",
+        "memorization-plateau"
+      ]
+    },
+    {
+      "name": "training-multi-metric-best-checkpoint-min-after-max",
+      "description": "Capture *transitions* (regime changes) in long-running training runs, not just absolute extrema, by tracking multiple metrics with per-metric modes (max / min / both / min_after_max / max_after_min). Use when: (1) designing checkpointing for a grokking or phase-transition study where the interesting test loss is the one *after* it has spiked and come back down, (2) the naive `if test_loss < best_test_loss` tracker is trivially won at epoch 1 because loss starts highest and falls monotonically, (3) you want to diagnose overfitting valleys / spikes / weight-norm regrowth and the absolute min/max is uninformative, (4) you want one checkpoint per (metric, mode_kind) tuple with weights + JSON sidecar, (5) extending an existing single-metric CheckpointManager to N metrics without changing on-disk format, (6) detecting change-of-regime in any time-series metric pipeline (LR scheduling, overfitting detection, anomaly detection over training metrics).",
+      "version": "1.0.0",
+      "source": "./skills/training-multi-metric-best-checkpoint-min-after-max.md",
+      "category": "training",
+      "tags": [
+        "checkpointing",
+        "grokking",
+        "phase-transition",
+        "training-dynamics",
+        "regime-change",
+        "min-after-max",
+        "max-after-min",
+        "multi-metric",
+        "overfitting-detection",
+        "transition-tracking"
+      ]
+    },
+    {
+      "name": "training-rl360-xllm-launcher-review-pitfalls",
+      "description": "Review RL360 xLLM Slurm/Ray/SGLang training launchers for launch-time log path failures, W&B secret exposure through Ray runtime envs, and native-first SGLang overlay regressions. Use when: (1) reviewing RL360 training launcher PRs, (2) scripts use Slurm #SBATCH output/error paths, (3) Ray job submit passes runtime env JSON with secrets, (4) xLLM/SGLang bridge files are copied or overlaid.",
+      "version": "1.0.0",
+      "source": "./skills/training-rl360-xllm-launcher-review-pitfalls.md",
+      "category": "training",
+      "tags": [
+        "rl360",
+        "xllm",
+        "slurm",
+        "ray",
+        "wandb",
+        "sglang",
+        "training-launchers",
+        "security"
+      ]
     }
   ]
 }

--- a/skills/automation-pr-review-inline-comment-diff-hunk-validation.md
+++ b/skills/automation-pr-review-inline-comment-diff-hunk-validation.md
@@ -18,7 +18,7 @@ verification: verified-ci
 tags:
   - github-api
   - pull-request-review
-  - 422
+  - "422"
   - unprocessable-entity
   - diff-hunk
   - inline-comments

--- a/skills/gh-token-env-shadows-keyring.md
+++ b/skills/gh-token-env-shadows-keyring.md
@@ -6,7 +6,7 @@ date: 2026-05-29
 version: "1.0.0"
 user-invocable: false
 verification: verified-local
-tags: [gh-cli, github-token, keyring, auth, 403, git-push, pr-merge, agent-shell]
+tags: [gh-cli, github-token, keyring, auth, "403", git-push, pr-merge, agent-shell]
 ---
 
 # GH_TOKEN Env PAT Shadows the Keyring gho_ Token

--- a/skills/python-version-gated-stdlib-import-guard.md
+++ b/skills/python-version-gated-stdlib-import-guard.md
@@ -6,7 +6,7 @@ date: 2026-05-28
 version: "1.0.0"
 user-invocable: false
 verification: verified-ci
-tags: [python, stdlib, tomllib, tomli, version-guard, ci, import, 3.10, 3.11, compatibility]
+tags: [python, stdlib, tomllib, tomli, version-guard, ci, import, "3.10", "3.11", compatibility]
 ---
 
 # Python Version-Gated stdlib Import Guard

--- a/skills/testing-singleton-isolation-circuit-breaker-reset.md
+++ b/skills/testing-singleton-isolation-circuit-breaker-reset.md
@@ -24,7 +24,7 @@ tags:
   - non-transient-retry
   - registry-reset
   - github-api
-  - 422
+  - "422"
   - graphql-schema-error
 ---
 


### PR DESCRIPTION
## Context

The `Update Marketplace` CI workflow began failing after the recent PR-merge batch. Two pre-existing issues surfaced:

### 1. Unquoted numeric YAML tags (schema violation)
Four skills had numeric tags that YAML parses as int/float, violating the marketplace schema (`tags[].type: string`):

| Skill | Tag(s) |
|-------|--------|
| `python-version-gated-stdlib-import-guard` | `3.10`, `3.11` |
| `gh-token-env-shadows-keyring` | `403` |
| `automation-pr-review-inline-comment-diff-hunk-validation` | `422` |
| `testing-singleton-isolation-circuit-breaker-reset` | `422` |

Quoted each (same fix class as prior #1516). Note `504-gateway-timeout` was already a valid string.

### 2. Stale `marketplace.json`
The committed index listed **1060 plugins** but only **515 skill files** exist — 545 entries pointed to skills removed in past consolidations. Regenerated via `scripts/generate_marketplace.py` so the index matches the actual `skills/` tree.

## Verification
- `python3 scripts/validate_plugins.py` → **515/515 valid**
- `python3 -m pytest tests/` → **219 passed** (including the schema test that was failing)
- All numeric tags now parse as strings (YAML-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)