### PR TITLE
chore(marketplace): regenerate after 50-cluster skill consolidation (516->291)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,80 +6,37 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 516,
+  "total_plugins": 291,
   "categories": {
-    "architecture": 67,
-    "ci-cd": 134,
-    "debugging": 38,
-    "documentation": 44,
+    "architecture": 45,
+    "ci-cd": 44,
+    "debugging": 23,
+    "documentation": 16,
     "evaluation": 11,
-    "optimization": 3,
-    "testing": 65,
-    "tooling": 147,
+    "optimization": 2,
+    "testing": 33,
+    "tooling": 110,
     "training": 7
   },
-  "last_updated": "2026-06-07T21:48:07Z",
+  "last_updated": "2026-06-08T01:54:12Z",
   "plugins": [
     {
-      "name": "agent-config-and-tier-architecture",
-      "description": "Design, validate, and consolidate agent tier configurations in the HomericIntelligence agentic hierarchy. Use when: (1) merging redundant junior/senior agent tiers into a parent level with overlapping scope, (2) consolidating many review specialists with identical tooling into a single general specialist, (3) validating YAML frontmatter and configuration correctness before committing agent changes, (4) fixing inconsistent root-level field mapping in tier configurations or enhancing resource prompt suffixes, (5) routing each pipeline phase to the right Claude model tier via a centralized module with env-var overrides, (6) adding REST API client integration wired into a Pydantic config hierarchy.",
+      "name": "agent-config-validation-and-integrity",
+      "description": "Design, validate, and maintain agent configuration integrity in the HomericIntelligence agentic hierarchy. Use when: (1) consolidating redundant junior/senior agent tiers or multiple specialist agents into a parent tier with overlapping scope, (2) adding CI validation that delegates_to frontmatter fields map to real .md files (referential integrity), (3) fixing stale cross-references in agent configs or docs after specialist consolidation deletes agent files, (4) validating YAML frontmatter correctness before committing agent configuration changes, (5) routing pipeline phases to the correct Claude model tier via centralized module with env-var overrides.",
       "version": "1.0.0",
-      "source": "./skills/agent-config-and-tier-architecture.md",
+      "source": "./skills/agent-config-validation-and-integrity.md",
       "category": "architecture",
       "tags": [
         "agent-config",
         "tier-consolidation",
         "yaml-validation",
+        "referential-integrity",
+        "delegates-to",
+        "stale-crossrefs",
         "model-selection",
         "claude-cli",
         "pydantic",
-        "httpx",
-        "rest-api",
-        "prompt-engineering",
         "hephaestus"
-      ]
-    },
-    {
-      "name": "architecture-bot-pr-discovery-synthetic-issue-key",
-      "description": "When an automation tool resolves work via the issue\u2192PR direction ('for each open issue, find its closing PR'), Dependabot PRs and other bot-authored PRs are architecturally invisible \u2014 they have no `Closes #N` link, so the resolver returns nothing. The fix is to union the issue-driven set with every open `user.type == 'Bot'` PR from `gh api --paginate /repos/.../pulls`, using the PR number as a synthetic issue key (same int in both positions of the dedup map). Downstream code that would call `gh issue view <issue_number>` must then short-circuit: a tiny helper `_is_bot_pr_mode(issue_number, pr_number)` returns `True` iff `issue_number == pr_number`, which is the synthetic-key invariant. The discriminator is `user.type == 'Bot'` (REST snake_case), NOT the login string `app/dependabot` \u2014 new bot apps continually appear, and login-based detection ages out. Use when: (1) building a driver that enumerates work by issue and discovers PRs through `Closes #N` parsing, (2) Dependabot or Renovate PRs are open but the driver reports 'nothing to do', (3) an `--all` flag changes the AUTHOR filter but not the discovery DIRECTION and bot PRs are still missed, (4) you're tempted to pass PR numbers as `--issues <pr-number>` and the downstream `gh issue view` 404s on you, (5) you're tempted to add a second pass (`--bot-prs-only`) and want to know why a unioned single pass is cleaner, (6) reviewing automation that calls human-only steps (advise / planning / Mnemosyne lookup) and needs to short-circuit them for synthetic-key bot PRs.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-bot-pr-discovery-synthetic-issue-key.md",
-      "category": "architecture",
-      "tags": [
-        "dependabot",
-        "bot-pr",
-        "issue-driven-discovery",
-        "synthetic-issue-key",
-        "ci-driver",
-        "automation-loop",
-        "user-type-bot",
-        "gh-api-paginate",
-        "closes-link",
-        "include-bot-prs",
-        "short-circuit-guard",
-        "hephaestus-automation"
-      ]
-    },
-    {
-      "name": "architecture-estimate-rewrite-read-substrate-first",
-      "description": "Before estimating a large refactor or rewrite, read the existing substrate code in full \u2014 TODO.md and roadmap LOC estimates are commonly pessimistic by 3-5x because they don't credit infrastructure that already exists. Use when: (1) starting a substrate-rewrite epic, (2) a TODO.md or roadmap estimates thousands of LOC or weeks of work, (3) an audit flags a CRITICAL gap based on docs, (4) before committing to a multi-week refactor estimate to a user or stakeholder.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-estimate-rewrite-read-substrate-first.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "architecture-function-local-imports-coupling-avoidance",
-      "description": "Use function-local imports when a child module would create undesirable coupling or circular dependencies by importing the parent module at module level. Trade-off: one-line import lookup cost on first call (cached) vs. cleaner module graph. Use when: child module needs ambient state from parent but module-level import creates circular dep or import graph bloat.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-function-local-imports-coupling-avoidance.md",
-      "category": "architecture",
-      "tags": [
-        "import-strategy",
-        "circular-dependency",
-        "coupling-avoidance",
-        "module-graph",
-        "ambient-state"
       ]
     },
     {
@@ -117,22 +74,6 @@
         "threading-local",
         "python",
         "immutable-state"
-      ]
-    },
-    {
-      "name": "architecture-mojo-import-ambiguity-alias-pattern",
-      "description": "Resolve Mojo 1.0 'import of X is ambiguous' errors by aliasing the wrapper import locally. Use when: (1) two modules export the same name (e.g., a wrapper struct and a re-exported lower-level type), (2) a consumer imports both in one file and Mojo 1.0 rejects the duplicate name, (3) you want to preserve the public API of both modules without renaming or splitting tests.",
-      "version": "1.0.0",
-      "source": "./skills/architecture-mojo-import-ambiguity-alias-pattern.md",
-      "category": "architecture",
-      "tags": [
-        "mojo",
-        "mojo-1.0",
-        "imports",
-        "alias",
-        "namespace",
-        "api-design",
-        "layered-api"
       ]
     },
     {
@@ -177,24 +118,6 @@
       ]
     },
     {
-      "name": "architecture-shipping-mojo-package-prefix-dev",
-      "description": "End-to-end pattern for making a Mojo library installable via `pixi add <pkg>` from the modular-community channel: idiomatic `src/<package_name>/` layout, `conda.recipe/recipe.yaml` (rattler-build), PR to `modular/modular-community`, and optional Python wheel that bundles the `.mojopkg`. Use when: (1) planning to publish a Mojo library, (2) converting an in-tree `shared/` directory into a distributable package, (3) replacing fictional `mojo install`/`mojo publish` CLI references in docs, (4) deciding between conda channel vs Python wheel vs git dependency for distribution.",
-      "version": "2.0.0",
-      "source": "./skills/architecture-shipping-mojo-package-prefix-dev.md",
-      "category": "architecture",
-      "tags": [
-        "mojo-packaging",
-        "prefix-dev",
-        "modular-community",
-        "rattler-build",
-        "mojopkg",
-        "python-wheel",
-        "conda",
-        "org-fork",
-        "upstream-pr"
-      ]
-    },
-    {
       "name": "asymptotic-safety-quantum-gravity-refs",
       "description": "Key papers, formulas, and physical facts for asymptotic safety quantum gravity and spectral dimension flow in sci-fi mechanism design. Use when: (1) designing a fictional device based on Planck-scale RG-flow physics, (2) citing real quantum gravity results about dimensional reduction to d_s=2, (3) grounding a sci-fi simulation engine in asymptotic-safety or CDT results.",
       "version": "1.0.0",
@@ -235,44 +158,6 @@
       ]
     },
     {
-      "name": "automation-lazy-exports-sdk-surface-pattern",
-      "description": "Pattern for extending public SDK surfaces with peer classes using lazy-loading infrastructure. Use when: (1) adding peer classes to __all__, (2) extending TYPE_CHECKING imports, (3) preventing eager-load regressions, (4) avoiding architectural restructuring.",
-      "version": "1.0.0",
-      "source": "./skills/automation-lazy-exports-sdk-surface-pattern.md",
-      "category": "architecture",
-      "tags": [
-        "sdk-surface",
-        "lazy-loading",
-        "public-interface",
-        "automation",
-        "phase-entrypoint",
-        "pola",
-        "isp"
-      ]
-    },
-    {
-      "name": "automation-review-loop-evidence-based-resolution",
-      "description": "How to build a Python implement->review loop that drives LLM sub-agents to review a PR and fix its review comments, so it converges on an EVIDENCE-BASED GO instead of a self-reported one. SHIPPED & verified-ci (ProjectHephaestus PR #1084 / issue #1083): (a) the fixer agent's address step counts as progress ONLY when `addressed AND committed` are both true -- a clean worktree with prose replies like 'documented as a limitation' must NOT resolve threads; resolution is gated on a real commit, never on the model's self-report; (b) the loop converges ONLY on an explicit `Verdict: GO` -- 'reviewer posted zero threads' regardless of verdict ends AMBIGUOUS/NO-GO too fast; (c) thread RESOLUTION is moved OUT of the fixer and INTO a fresh read-only REVIEWER/validator on the next pass that compares each prior thread against the new diff and resolves only genuinely-addressed ones, re-opening the rest -- the fixer only edits+commits+pushes and must NOT call the resolve mutation; (d) a `state:skip` label (sourced from the state_labels single-source module, auto-provisioned, honored on issue OR PR) skips all phases and is auto-applied on iteration exhaustion; (e) a `--nitpick` flag where the reviewer severity-tags every inline comment (critical/major/minor/nitpick) and SUPPRESSES nitpick by default so the loop doesn't burn iterations on cosmetics; (f) per-comment dispatch -- classify each comment's fix difficulty with a cheap sub-agent, render a `@ <file> Line <#> - <difficulty> - <desc>` todo list, dispatch ONE sub-agent per comment (serialize same-file comments), tier models simple->haiku/medium->sonnet/hard->opus. ALSO captures (UNVERIFIED, found by strict post-merge review of that very code) FOUR design defects to avoid: match threads by thread `id` not `(path, line)`; FETCH+concatenate an existing comment body before `updatePullRequestReviewComment` (it REPLACES, not appends); gate auto-`state:skip` on real iteration exhaustion not blanket non-GO; FENCE untrusted comment text in prompts. Use when: (1) building/auditing a Python loop that has an LLM sub-agent review a PR then fix the inline comments, (2) a review loop resolves threads even though no commit was produced, (3) a loop ends NO-GO/AMBIGUOUS 'too fast' before ever earning a GO, (4) deciding whether the fixer or the reviewer resolves GitHub review threads, (5) adding a skip-label or a nitpick-suppression flag to such a loop, (6) dispatching one fix sub-agent per review comment with tiered models.",
-      "version": "1.0.0",
-      "source": "./skills/automation-review-loop-evidence-based-resolution.md",
-      "category": "architecture",
-      "tags": [
-        "hephaestus-automation-loop",
-        "implement-review-loop",
-        "review-thread-resolution",
-        "evidence-based-resolution",
-        "commit-gated-progress",
-        "verdict-go-convergence",
-        "state-skip-label",
-        "nitpick-severity-suppression",
-        "per-comment-dispatch",
-        "tiered-models",
-        "prompt-injection",
-        "graphql-review-threads",
-        "homericintelligence"
-      ]
-    },
-    {
       "name": "automation-session-naming-pr-scoped-not-commit-scoped",
       "description": "When an automation loop drives a long-lived artifact (issue / PR) with short-lived Claude sessions via `claude --resume <session_id>`, the deterministic session id MUST be scoped to the artifact, not to the live trunk commit. Tuple-scoping the id as `(repo, issue, agent, githash)` produces a new UUID on every main-bump and silently fragments transcripts: `invoke_claude_with_session` cannot `--resume` an id it never minted, so it falls back to `--session-id` (create) and the agent starts from scratch every iteration. Fix: drop `githash` from the session-name and session-uuid tuples (`session_name(repo, issue, agent)`, `session_uuid(repo, issue, agent)`), drop the matching kwarg from `invoke_claude_with_session`, and walk EVERY caller (typical sites: planner, plan_reviewer, implementer, address_review, pr_reviewer, ci_driver \u2014 8 in this repo). Pin the regression with a `**kwargs`-unpacked TypeError test so static analyzers (github-code-quality, mypy, ruff) don't flag the intentional bad kwarg. Use when: building automation that resumes Claude sessions across runs, session resume is silently failing because the deterministic id drifts, a long-lived artifact is being worked on by short-lived sessions, or pinning a removed-argument invariant against a static analyzer that resolves names.",
       "version": "1.0.0",
@@ -291,29 +176,6 @@
         "github-code-quality",
         "kwargs-unpacking",
         "session-scope"
-      ]
-    },
-    {
-      "name": "bf16-apple-silicon-guard",
-      "description": "Add runtime guards to dtype/precision factory methods that raise descriptive errors on unsupported hardware. Use when: adding Apple Silicon BF16 restrictions in Mojo, converting silent dtype misuse into loud runtime errors, or making precision checks testable without target hardware.",
-      "version": "1.0.0",
-      "source": "./skills/bf16-apple-silicon-guard.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "centralized-path-constants",
-      "description": "Create central path constants module to prevent hardcoded path inconsistencies. Use when: (1) multiple files construct the same paths inline, (2) directory structure changes require updating many files, (3) a directory structure has phases (e.g., in_progress/completed) that must be routed at a single point.",
-      "version": "2.0.0",
-      "source": "./skills/centralized-path-constants.md",
-      "category": "architecture",
-      "tags": [
-        "paths",
-        "refactoring",
-        "consistency",
-        "constants",
-        "dry-principle",
-        "phase-routing"
       ]
     },
     {
@@ -427,63 +289,10 @@
       "tags": []
     },
     {
-      "name": "doc-generate-adr",
-      "description": "Generate Architecture Decision Records (ADRs) to document significant architectural decisions",
-      "version": "1.0.0",
-      "source": "./skills/doc-generate-adr.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "doc-validate-markdown",
-      "description": "Validate markdown files for formatting, links, and style compliance using markdownlint",
-      "version": "1.0.0",
-      "source": "./skills/doc-validate-markdown.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "dry-consolidate-to-canonical-refactor",
-      "description": "Canonical workflow for finding code duplication and refactoring to a single canonical source: discovery via grep/AST, classifying true duplicates vs incidental similarity, bulk file migration, type-alias consolidation, decomposing oversized modules by SRP, dict structure consolidation, preserving git history via git mv. Use when: (1) noticing duplicate functions/constants across modules, (2) centralizing path or config constants, (3) decomposing a >2k-line module into SRP-aligned pieces, (4) consolidating duplicate Pydantic models or type aliases, (5) same dict structure built in multiple call sites, (6) bulk-renaming symbols across a codebase.",
-      "version": "1.1.0",
-      "source": "./skills/dry-consolidate-to-canonical-refactor.md",
-      "category": "architecture",
-      "tags": [
-        "merged",
-        "dry",
-        "consolidation",
-        "refactor",
-        "canonical-source",
-        "deduplication"
-      ]
-    },
-    {
-      "name": "dry-consolidation-workflow",
-      "description": "Complete workflow for analyzing codebase duplications and implementing DRY consolidation",
-      "version": "1.0.0",
-      "source": "./skills/dry-consolidation-workflow.md",
-      "category": "architecture",
-      "tags": [
-        "dry-principle",
-        "refactoring",
-        "deduplication",
-        "code-quality",
-        "centralization"
-      ]
-    },
-    {
       "name": "dry-refactoring-workflow",
-      "description": "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Covers private module extraction patterns, test structure mirroring enforcement, and cryptographic commit signing requirements in PR workflows.",
-      "version": "1.1.0",
+      "description": "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Use when: (1) extracting duplicated helper methods into a shared module using TDD (write a failing test against the canonical, delete the duplicate, run green); (2) creating a private leaf module with leading-underscore naming to centralize a repeated internal call (e.g. importlib.metadata version resolution, path construction) and prevent re-introduction across modules; (3) centralizing hardcoded path constants into a single module to prevent drift when directory structure changes (incl. phase-routed in_progress/completed splits); (4) deduplicating LLM JSON extraction, parser logic, or any call-site pattern copy-pasted across several files; (5) test structure must mirror source structure when extracting helpers; (6) running a full DRY consolidation pass (discovery via grep, classifying true duplicates vs intentional variants, dict-structure consolidation) and refactoring to a single canonical source. Also covers cryptographic commit signing requirements in PR workflows.",
+      "version": "1.3.0",
       "source": "./skills/dry-refactoring-workflow.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "dtype-native-migration",
-      "description": "Skill: dtype-native-migration",
-      "version": "1.0.0",
-      "source": "./skills/dtype-native-migration.md",
       "category": "architecture",
       "tags": []
     },
@@ -640,10 +449,10 @@
       ]
     },
     {
-      "name": "mojo-tensor-type-and-view-semantics",
-      "description": "Design and migrate Mojo tensor/ExTensor types with parametric dtypes, view semantics, stride-aware slices, and safe load/store APIs. Use when: (1) designing ExTensor/AnyTensor subscript assignment with compile-time dtype parameterization, (2) implementing zero-copy view semantics (transpose, slice, ravel) for stride-aware tensor access, (3) eliminating raw _data.bitcast UAF patterns via parametric load/store API, (4) inverting runtime-typed wrapper ops to Tensor[dtype] typed cores with AnyTensor dispatch, (5) fixing vacuous-loop bugs in broadcastability helpers or refactoring validate() to return tuple results.",
+      "name": "mojo-tensor-design-view-semantics-numeric-correctness",
+      "description": "Use when: (1) designing ExTensor/AnyTensor types with parametric dtypes, view semantics, and stride-aware slices, (2) implementing or debugging zero-copy view operations (transpose, slice, ravel) for stride-aware tensor access, (3) diagnosing silent correctness bugs in tensor numeric operations (strided layout, dtype mismatch, bitcast corruption, NaN hashing), (4) adding NumPy-style truncation to Mojo tensor __str__ methods, (5) fixing DataLoader N-D batch slicing or shape assumptions, (6) SIMD-vectorizing element-wise tensor ops in Mojo for throughput gains, (7) adding Apple Silicon BF16 runtime guards to dtype/precision factory methods, (8) implementing or testing __hash__ on Mojo tensors with float/int fields and empty-tensor edge cases.",
       "version": "1.0.0",
-      "source": "./skills/mojo-tensor-type-and-view-semantics.md",
+      "source": "./skills/mojo-tensor-design-view-semantics-numeric-correctness.md",
       "category": "architecture",
       "tags": [
         "mojo",
@@ -653,28 +462,32 @@
         "dtype",
         "parametric",
         "view-semantics",
-        "bitcast",
-        "uaf",
         "strides",
-        "load-store",
-        "broadcasting",
-        "slice",
-        "transpose"
+        "bitcast",
+        "nan",
+        "hash",
+        "simd",
+        "vectorization",
+        "bfloat16",
+        "numeric-correctness",
+        "dataloader"
       ]
     },
     {
-      "name": "mojo-type-and-api-migration",
-      "description": "Canonical guide to Mojo type and API migration across language versions: parametric dtype migration, Writable -> WritableTo transition, API version baselines, trait/conformance refactors, method API symmetry, parametric vs runtime dtype, decorator/method-wrapper changes. Use when: (1) upgrading Mojo to a new API baseline, (2) migrating callers after a Mojo stdlib breaking change, (3) reconciling parametric dtype usage with new runtime dtype patterns, (4) fixing trait-conformance compile errors after a stdlib upgrade.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-type-and-api-migration.md",
+      "name": "mojo-type-api-migration-and-import-patterns",
+      "description": "Use when: (1) upgrading Mojo to a new API baseline (Writable->WritableTo, trait/conformance refactors, parametric dtype migration), (2) migrating callers after a Mojo stdlib breaking change, (3) resolving 'import of X is ambiguous' errors caused by two modules exporting the same name, (4) systematically reviewing a large-scale parametric type system migration for dependency order and zero-copy conversion safety, (5) removing ImplicitlyCopyable trait from Mojo structs and fixing resulting compile errors, (6) migrating DType from runtime-typed patterns to native compile-time parametric patterns.",
+      "version": "1.0.0",
+      "source": "./skills/mojo-type-api-migration-and-import-patterns.md",
       "category": "architecture",
       "tags": [
-        "merged",
         "mojo",
         "type-migration",
         "api-migration",
         "parametric-dtype",
-        "trait"
+        "implicitlycopyable",
+        "import-ambiguity",
+        "trait",
+        "dtype-native"
       ]
     },
     {
@@ -738,22 +551,6 @@
       ]
     },
     {
-      "name": "optimizer-conflict-resolution-numeric-equivalence",
-      "description": "Resolve merge-conflicted numerical/optimizer PRs (Mojo, but generalizes) where main independently merged its own version of a shared module after the branch was cut \u2014 WITHOUT silently merging wrong math. Adapt dependent call-sites to main's changed API while PROVING and documenting numeric equivalence, test the math, and DEFER provably-broken algorithms instead of merging stubs. Use when: (1) a feature PR adding an optimizer/numerical kernel is DIRTY because main merged its own version of a shared module (e.g. muon.mojo) after the branch was cut \u2192 add/add conflict; (2) the conflicted PR imports a function whose signature CHANGED on main (e.g. muon_step(momentum=...) vs muon_step(momentum_beta=...)) so dropping the PR copy breaks dependent code; (3) a PR's tests assert numeric thresholds that encoded its now-superseded implementation's hyperparameter defaults; (4) you must decide whether a conflicted optimizer is salvageable vs provably broken (defer it); (5) resolving a multi-optimizer PR where one optimizer is sound and another is broken \u2014 ship the sound one, defer the broken one.",
-      "version": "1.0.0",
-      "source": "./skills/optimizer-conflict-resolution-numeric-equivalence.md",
-      "category": "architecture",
-      "tags": [
-        "optimizer",
-        "conflict-resolution",
-        "numeric-equivalence",
-        "mojo",
-        "merge-conflict",
-        "muon",
-        "defer-broken-math"
-      ]
-    },
-    {
       "name": "optional-scoped-discovery-pola-gate",
       "description": "POLA (Principle of Least Astonishment) pattern for optional CLI flags that gate discovery behavior. When a discovery flag is optional (e.g., `--issues`), gate discovery on its PRESENCE, not its value: operator-provided scope stays narrow (issue-driven); empty/absent scope widens to all candidates (PR-driven). Prevents user surprise when optional flag silently ignores what they meant to scope. Use when: (1) designing CLI with optional filtering that switches between discovery modes, (2) feature toggles need intuitive defaults, (3) preventing 'operator provided --issues but they weren't used' bugs.",
       "version": "1.0.0",
@@ -769,28 +566,6 @@
         "automation-loop",
         "user-experience",
         "feature-toggles"
-      ]
-    },
-    {
-      "name": "org-wide-planned-issue-implementation-swarm",
-      "description": "Org-wide swarm that implements every open GitHub issue already carrying a `# Implementation Plan` comment across all ~12 HomericIntelligence repos, one signed auto-merge PR per issue, at high parallelism. Use when: (1) implementing the entire planned-issue backlog across many HomericIntelligence repos in one session, (2) the 'has a plan' signal is a `# Implementation Plan` issue comment (not the GitHub `planning` label), (3) deciding whether per-repo dispatcher sub-agents can spawn their own implementer sub-agents (they cannot), (4) deduplicating PRs against already-open issue PRs without substring false positives, (5) arming squash auto-merge org-wide where rebase-merge is disabled, (6) telling implementer agents to reconcile a stale plan against current code.",
-      "version": "1.0.0",
-      "source": "./skills/org-wide-planned-issue-implementation-swarm.md",
-      "category": "architecture",
-      "tags": [
-        "org-wide",
-        "multi-repo",
-        "implementation-plan-comment",
-        "myrmidon",
-        "swarm",
-        "l0-fan-out",
-        "sub-agent-tool-limit",
-        "pr-dedup",
-        "closing-keywords",
-        "squash-auto-merge",
-        "signed-commits",
-        "plan-reconciliation",
-        "homeric-intelligence"
       ]
     },
     {
@@ -821,34 +596,6 @@
       ]
     },
     {
-      "name": "parallel-swarm-pr-conflict-reconciliation",
-      "description": "Detect and reconcile overlapping PRs from a parallel issue-implementation swarm, AND turn a coupled repo into a pure-X library via the verified decouple\u2192port\u2192delete extraction playbook (not a deletion-only PR). Use when: (1) you launched one-PR-per-issue across a backlog and multiple PRs auto-merge-race on the same paths so only one squash-merges cleanly, (2) a CONFLICTING PR must be rebased onto an already-merged sibling rather than merging main into it, (3) you are extracting a coupled subsystem out of a repo (e.g. ProjectKeystone \u2192 pure C++20 transport) and a deletion-only PR STALLS because the retained core still references the doomed module or the destination port is incomplete \u2014 decouple FIRST behind a tiny interface, port verify-or-port to the destination, then delete in build-refs\u2192sources\u2192dead-deps order, (4) two sibling PRs both edit a shared lockfile/script so the second goes CONFLICTING and must be rebased (git auto-drops already-upstream commits; re-sign on rebase), (5) several PRs implement the same end-state and you must pick a canonical superset to land and close the subsumed ones, (6) Edit-tool exact-match fails on conflict markers in files with em-dashes or alignment whitespace, or git restore/checkout to discard stale worktree mods is Safety-Net-BLOCKED.",
-      "version": "2.0.0",
-      "source": "./skills/parallel-swarm-pr-conflict-reconciliation.md",
-      "category": "architecture",
-      "tags": [
-        "parallel-swarm",
-        "pr-conflict",
-        "rebase",
-        "file-overlap",
-        "extraction",
-        "decouple-before-delete",
-        "pure-library-refactor",
-        "superset-pr",
-        "force-with-lease",
-        "signed-commits",
-        "nats"
-      ]
-    },
-    {
-      "name": "parametric-type-migration-review",
-      "description": "Systematic review methodology for planning large-scale parametric type system migrations in Mojo. Use when: reviewing compile-time parameterization of runtime-typed structs, dependency analysis for package splits, zero-copy conversion safety, or phased migration orchestration.",
-      "version": "1.0.0",
-      "source": "./skills/parametric-type-migration-review.md",
-      "category": "architecture",
-      "tags": []
-    },
-    {
       "name": "phase-skip-semantics-already-done-success",
       "description": "Distinguish orchestrator-level phase skips (disabled/gated/not-final-loop/shutdown) from worker-internal already-done idempotency, and enforce that 'already done' returns success not failure. Use when: (1) building a multi-phase pipeline driver, (2) a phase's worker has any 'already exists / already done' check, (3) debugging why phase N's downstream phases stopped running, (4) auditing rc semantics across an orchestrator \u2192 worker boundary, (5) reviewing whether a worker's success count includes idempotent skips.",
       "version": "1.0.0",
@@ -868,25 +615,32 @@
       ]
     },
     {
-      "name": "private-module-extraction-helper-pattern",
-      "description": "Extract duplicated internal function calls (especially importlib.metadata version resolution) into a private leaf module with leading-underscore naming. Use when: (1) the same function is called from multiple modules with identical arguments, (2) creating a module to centralize the call, (3) PyPI distribution names or other arbitrary constants must be stored at module level, (4) avoiding circular imports by using leaf modules instead of packages, (5) consolidating version resolution or other metadata lookups across the codebase.",
+      "name": "python-import-patterns-and-compatibility-guards",
+      "description": "Use when: (1) a child module would create circular dependencies by importing the parent at module level \u2014 use function-local imports to defer the lookup and keep the import graph acyclic; (2) extending a public SDK surface with peer classes using lazy-loading __init__.py infrastructure (lazy exports pattern via __getattr__) to prevent eager-load regressions when adding new peers to __all__; (3) code uses a stdlib module added in a later Python version (tomllib in 3.11+, ExceptionGroup in 3.11+) and the CI matrix includes older Python \u2014 add a version-gated try/except import guard so the module remains importable; (4) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError for POSIX-only stdlib modules (curses, fcntl, grp, tzdata) \u2014 add conditional import guards and ensure tzdata is listed as an optional Windows dependency.",
       "version": "1.0.0",
-      "source": "./skills/private-module-extraction-helper-pattern.md",
+      "source": "./skills/python-import-patterns-and-compatibility-guards.md",
       "category": "architecture",
       "tags": [
-        "dry-principle",
-        "private-modules",
-        "code-extraction",
-        "importlib-metadata",
-        "helper-pattern",
-        "circular-imports",
-        "leaf-modules"
+        "import-strategy",
+        "circular-dependency",
+        "coupling-avoidance",
+        "lazy-loading",
+        "sdk-surface",
+        "version-guard",
+        "cross-platform",
+        "windows-ci",
+        "stdlib",
+        "tomllib",
+        "curses",
+        "fcntl",
+        "tzdata",
+        "compatibility"
       ]
     },
     {
       "name": "python-module-decomposition-and-refactor-patterns",
-      "description": "Use when: (1) a Python module or class exceeds 800\u20131000 lines and contains identifiable method clusters with distinct responsibilities, (2) extracting method groups into dedicated collaborator classes or sub-modules via TDD, (3) fixing circular import errors caused by partially-initialized modules or eager __init__.py re-exports, (4) refactoring class methods to purely functional/immutable style, (5) preparing a codebase for extensibility through extraction, parameterization, and protocol-based abstraction, (6) extracting a CLI entry point or main() out of a module while preserving existing patch-based tests without edits (reverse-delegation pattern).",
-      "version": "1.2.0",
+      "description": "Use when: (1) a Python module or class exceeds 800\u20131000 lines and contains identifiable method clusters with distinct responsibilities, (2) extracting method groups into dedicated collaborator classes or sub-modules via TDD, (3) fixing circular import errors caused by partially-initialized modules or eager __init__.py re-exports, (4) refactoring class methods to purely functional/immutable style, (5) preparing a codebase for extensibility through extraction, parameterization, and protocol-based abstraction, (6) extracting a CLI entry point or main() out of a module while preserving existing patch-based tests without edits (reverse-delegation pattern), (7) reducing cyclomatic complexity (CC>15) by extracting helper steps from oversized pipeline methods carrying `# noqa: C901`, (8) refactoring a broad repository-wide scanner to target a single subdirectory using Path.is_relative_to() allow-lists, (9) detecting and fixing double-increment bugs caused by incomplete context-manager refactors where callers still hold stale manual counter management, (10) safely removing legacy dead-code files marked as fallback/reference-only after verifying zero real callers, (11) reading the existing substrate code before estimating a large refactor to avoid 3-5x LOC over-estimation, (12) finalizing code after parallel phases complete by addressing technical debt accumulated during rapid development.",
+      "version": "1.3.0",
       "source": "./skills/python-module-decomposition-and-refactor-patterns.md",
       "category": "architecture",
       "tags": [
@@ -901,48 +655,14 @@
         "extensibility",
         "cli-extraction",
         "patch-routing",
-        "entry-point"
-      ]
-    },
-    {
-      "name": "python-type-system-and-api-alignment",
-      "description": "Use when: (1) mypy with implicit_reexport=false raises 'does not explicitly export attribute X' after a module refactor or symbol move; (2) Pydantic base class hierarchy is incomplete \u2014 domain models inherit directly from BaseModel while siblings have dedicated *Base classes; (3) type aliases shadow explicit domain-specific names causing import ambiguity; (4) functions return bool redundantly when they raise on failure (POLA violation \u2014 return type should be None); (5) auditing or tightening broad except Exception clauses across Python files; (6) legacy model IDs in saved configs cause failures on experiment resume and need a Pydantic field_validator normalization chokepoint; (7) bulk-migrating @dataclass classes to Pydantic BaseModel; (8) enforcing frozen=True immutability consistency across sibling Pydantic base classes.",
-      "version": "1.1.0",
-      "source": "./skills/python-type-system-and-api-alignment.md",
-      "category": "architecture",
-      "tags": [
-        "python",
-        "mypy",
-        "pydantic",
-        "type-system",
-        "reexport",
-        "implicit_reexport",
-        "type-aliases",
-        "frozen",
-        "immutability",
-        "return-type",
-        "POLA",
-        "exceptions",
-        "BLE001",
-        "normalization",
-        "field_validator",
-        "dataclass-migration",
-        "backward-compatibility"
-      ]
-    },
-    {
-      "name": "rebase-full-file-rewrite-conflict",
-      "description": "Resolve a git rebase conflict where one branch completely rewrote a file and the other branch made small targeted changes to the original. Use when: (1) git rebase reports a conflict on a file that one branch replaced entirely, (2) auto-merge produces incoherent output mixing old and new structure, (3) a post-migration rewrite PR conflicts with a small incremental change on main.",
-      "version": "1.0.0",
-      "source": "./skills/rebase-full-file-rewrite-conflict.md",
-      "category": "architecture",
-      "tags": [
-        "git",
-        "rebase",
-        "conflict",
-        "merge",
-        "full-rewrite",
-        "migration"
+        "entry-point",
+        "cyclomatic-complexity",
+        "pipeline-extraction",
+        "scanner-scoping",
+        "context-manager",
+        "dead-code",
+        "estimation",
+        "phase-cleanup"
       ]
     },
     {
@@ -989,14 +709,6 @@
         "packaging",
         "pep508"
       ]
-    },
-    {
-      "name": "shared-fixture-migration",
-      "description": "Migrate duplicated test fixture configs to a centralized shared location. Use when: test fixtures have duplicated configs, find | md5sum shows 40+ duplicates, configs are test-independent.",
-      "version": "1.0.0",
-      "source": "./skills/shared-fixture-migration.md",
-      "category": "architecture",
-      "tags": []
     },
     {
       "name": "silent-boundary-observability-exception-classification",
@@ -1062,24 +774,6 @@
       ]
     },
     {
-      "name": "typing-callable-generic-return-preserve",
-      "description": "Use Callable[..., R] + TypeVar(R) instead of ParamSpec when a wrapper function interleaves keyword-only parameters between *args and **kwargs. ParamSpec violates PEP 612 in this case. Use when: (1) replacing object type-erased signatures with proper generics; (2) wrapping functions with complex parameter layouts (interleaved keyword-only params); (3) the wrapper needs to preserve the return type of the wrapped callable; (4) mypy requires full type coverage without # type: ignore comments.",
-      "version": "1.0.0",
-      "source": "./skills/typing-callable-generic-return-preserve.md",
-      "category": "architecture",
-      "tags": [
-        "typing",
-        "generic",
-        "callable",
-        "typevar",
-        "paramspec",
-        "pep-612",
-        "return-type-preservation",
-        "wrapper-pattern",
-        "mypy"
-      ]
-    },
-    {
       "name": "xterm-plan-mode-fix",
       "description": "Fix xterm.js rendering of TUI modes (Claude Code /plan) in browser-based terminals with Unicode11 addon, binary WebSocket handling, and resize timing",
       "version": "1.0.0",
@@ -1093,116 +787,6 @@
       "version": "1.0.0",
       "source": "./skills/yaml-long-line-refactor.md",
       "category": "architecture",
-      "tags": []
-    },
-    {
-      "name": "automation-ci-driver-honest-success-path-no-silent-noop",
-      "description": "When a CI driver (e.g. `drive_prs_green`) reports 'pushed CI fixes for PR #N' but the remote PR head SHA is unchanged, the driver is silently no-op'ing. Three compounding bugs cause this: (1) bare `git push origin HEAD` pushes to whatever branch HEAD switched to inside the agent session instead of the PR head, (2) worktree setup creates a NEW branch off `main` when the local branch ref doesn't exist instead of resetting to `origin/<pr-head>`, (3) per-issue 'success' is treated as 'repo done' even with open PRs still outstanding. Fix all three: pre-sync the worktree to `origin/<pr-head>`, snapshot HEAD before/after the agent and fail if unchanged, push with explicit refspec `HEAD:<pr-head-branch>`, and gate 'repo done' on `gh api /repos/.../pulls?state=open --paginate` returning 0. Use when: (1) automation driver logs success but remote PR tips are unchanged, (2) `git push --force-with-lease` exits 0 with no remote update, (3) agent session resumed an old transcript and returned in seconds without a commit, (4) multi-repo run script's success/failed buckets don't match GitHub reality, (5) reviewing a driver that pushes commits to many PR branches across many repos.",
-      "version": "1.2.0",
-      "source": "./skills/automation-ci-driver-honest-success-path-no-silent-noop.md",
-      "category": "ci-cd",
-      "tags": [
-        "hephaestus-automation-loop",
-        "drive-prs-green",
-        "ci-driver",
-        "silent-failure",
-        "git-push-refspec",
-        "worktree-sync",
-        "honest-reporting",
-        "repo-done-state",
-        "wait-for-merge",
-        "auto-merge-armed",
-        "dependabot-arming",
-        "re-arm-after-fix",
-        "session-id-collision",
-        "dirty-merge-conflict",
-        "markdownlint-blocker",
-        "homericintelligence"
-      ]
-    },
-    {
-      "name": "automation-learn-on-merge-per-issue-arming-state",
-      "description": "When automation that runs `/learn` (or any learnings-capture step) after CI work fires on the optimistic point (auto-merge enabled) instead of on the truth (detected merge), Mnemosyne fills with lessons from PRs that never shipped AND shared-PR groups silently collapse N issues into 1 capture. Fix: a per-issue arming-record state machine driven by detected-merge, fanned out via the shared-PR dedupe map. Use when: (1) building post-CI learnings-capture in `loop_runner.py` / `ci_driver.py`-style pipelines, (2) capturing lessons keyed on `_enable_auto_merge` succeeding, (3) a dedupe step in `_discover_prs` collapses N issues to 1 worker and each issue is a distinct lesson, (4) you need post-merge detection that survives across runs without polling, (5) deciding when to set `learn_captured_at` (success-only vs best-effort).",
-      "version": "1.0.0",
-      "source": "./skills/automation-learn-on-merge-per-issue-arming-state.md",
-      "category": "ci-cd",
-      "tags": [
-        "automation",
-        "learn-capture",
-        "drive-green",
-        "arming-record",
-        "state-machine",
-        "shared-pr",
-        "detected-merge",
-        "hephaestus-automation-loop",
-        "homericintelligence"
-      ]
-    },
-    {
-      "name": "badge-count-drift-prevention",
-      "description": "Automate README badge count validation to prevent drift. Use when: README badge reflects a file count that grows over time, badge has drifted from actual count, or adding pre-commit enforcement for badge accuracy.",
-      "version": "1.0.0",
-      "source": "./skills/badge-count-drift-prevention.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "batch-pr-rebase-workflow",
-      "description": "Use when: (1) many PRs show DIRTY/CONFLICTING/BLOCKED merge state after main advances, (2) a major refactor causes mass conflicts across 10-160+ PRs, (3) PRs have inter-dependencies requiring sequential wave merging, (4) CI queue is backed up with 50+ queued runs and PRs need consolidation via cherry-pick, (5) PRs conflict on the same files (pixi.lock, plugin.json, core source files), (6) delegating mass rebase to a Myrmidon swarm of parallel agents, (7) orphaned branches need PRs created and CI fixed, (8) a PR expanded a pre-commit hook scope causing self-catch failures on pre-existing violations, (9) small batch (2-10) stale branches need rebase with subsume-vs-integrate conflict analysis, (10) GitHub issue backlog (20+ issues) needs triage, batched PRs, and stale worktree/branch cleanup, (11) 10+ branches all conflict on the same 3-5 core files and are being merged serially \u2014 take HEAD (origin/main) for all conflicted core files since main already contains the union of all prior merged features, (12) main is advancing rapidly via auto-merge during the rebase session and PRs keep going DIRTY again \u2014 repeat rebase in waves until stable, (13) stale worktrees from a previous session are listed in `git worktree list` as unlinked \u2014 check before removing, they may already be detached with no git state to clean up, (14) a rebase 'succeeds' but the branch tip equals main HEAD \u2014 the commit was silently dropped as empty, recover the original SHA and rebase again keeping the PR's file additions, (15) a rebased PR's tests fail because the PR's own implementation was incomplete \u2014 the commit message described a feature but the actual diff didn't include a critical file (e.g., server route for an endpoint the tests expect), (16) stale worktrees from a prior session need auditing \u2014 always diff each one against origin/main before deciding to discard or push, (17) CI overall conclusion shows 'failure' but all required branch-protection checks passed \u2014 use per-job inspection not top-level conclusion, (18) a conanfile.py lacks return annotations on ConanFile subclass methods causing mypy failures, (19) a Dependabot PR and a fix PR both target the same file \u2014 apply the fix directly in the Dependabot branch to avoid a circular dependency chain, (20) branches live in .claude/worktrees/agent-<id>/ paths from sub-agent runs and need rebase using git -C <worktree-path>, (21) rebase in a .claude/worktree ends in detached HEAD \u2014 use git branch -f to reattach before pushing, (22) CHANGELOG.md conflicts during rebase \u2014 always take HEAD/main (consolidation PR handles it separately), (23) two PRs fired with `gh pr merge` concurrently \u2014 one fails with GraphQL 'Base branch was modified' error because the first merge advanced main between API calls, (24) two PRs both add add_executable/gtest_discover_tests blocks at the same CMakeLists.txt location \u2014 additive conflict, keep both sides, (25) a PR removes the %.native: Makefile pattern rule \u2014 CI breaks with make deps.native exit 2, (26) a new CI job (markdownlint or pixi-check) was added to main via a rollout PR and immediately blocks all open skill PRs even though those PRs didn't touch CI config \u2014 root cause is pre-existing violations in shared files (.claude/plugins/) or missing pixi.lock; fix the root cause on main first, then rebase all PRs, (27) two PRs independently amend the same skill file to the same version number (e.g., both v2.9.0) with different content \u2014 treat as additive conflict: read both diffs, produce one merged version with all new learnings, close the redundant PR as superseded, (28) a batch of PRs all show stale CI results (old failing run) after a fix lands on main \u2014 they need a rebase push to trigger a fresh CI run even if their branch content didn't change, (29) before rebasing any Mnemosyne skill PRs, first confirm main itself is green \u2014 rebasing onto a broken main cannot unblock PRs (run `gh run list --branch main --limit 3` to verify main CI is passing before starting any rebase session), (30) a dependabot branch requires `git push --force` rather than `--force-with-lease` \u2014 GitHub auto-rebases dependabot branches between fetch and push, making the lease ref stale, (31) the repo only allows squash merge \u2014 `gh pr merge --auto --rebase` fails with GraphQL error; always check merge methods with `gh api repos/OWNER/REPO --jq '.allow_squash_merge,.allow_rebase_merge,.allow_merge_commit'` before enabling auto-merge, (32) a PR touches `pixi.lock` and was rebased after `pyproject.toml` conflict resolution \u2014 the lock SHA changes after any pyproject.toml edit; always run `pixi lock` before pushing if `pixi.lock` exists in the repo, (33) all open Mnemosyne skill PRs are BLOCKED with markdownlint failures not caused by the PRs themselves \u2014 main's markdownlint workflow uses `globs: \"**/*.md\"` which overrides `.markdownlintignore`; fix the workflow on main first, then rebase all skill PRs, (34) a bulk markdown table reformatter commit touched 1000+ files and all open PRs for those files became CONFLICTING \u2014 the conflict pattern is always add/add or modify/modify on the same .md files; take the PR branch's content then re-apply the formatter, (35) `git checkout --theirs <file>` is blocked by the Safety Net hook during rebase \u2014 use `git show REBASE_HEAD:<file> > /tmp/theirs && cp /tmp/theirs <file>` to extract the PR branch content without triggering the hook, (36) `marketplace.json` conflict during rebase \u2014 always take main's version (`git checkout --ours marketplace.json`) because it has more entries than the PR's stale regenerated version, (37) `gh pr rebase` command does not exist in the gh CLI \u2014 use `git fetch origin && git rebase origin/main` locally instead, (38) enabling auto-merge BEFORE rebasing a CONFLICTING PR has no effect \u2014 GitHub's CONFLICTING state prevents auto-merge from activating; rebase and push first, then enable auto-merge, (39) `git checkout --ours <files>` during rebase conflict resolution is blocked by Safety Net when run from a sub-agent \u2014 the Safety Net hook fires in the sub-agent's context too; escalate the specific `git checkout --ours -- <files>` command to the main conversation to run directly, then resume the sub-agent or continue the rebase from the main conversation, (40) `.pre-commit-config.yaml` has an additive conflict where main added `check-xtrace-exposure` hook and the PR independently added its own new hook at the same position \u2014 resolution is always keep BOTH hooks (they are independent features), (41) a shell script (`run_automation_loop.sh` or similar) has a structural rewrite conflict where main has a 6-phase expanded version and PR has a 2-phase refactored version \u2014 take main's structural skeleton (more phases), apply PR's specific fix (e.g., entry-point binary variables) to the relevant section, (42) a C++ `isSubordinateResult` or similar method conflicts where main added a TASK_FAILED exclusion and the PR has the older version without it \u2014 always take main's version (the exclusion was a deliberate bugfix), (43) a multi-commit PR (14+ commits) being rebased produces conflicts in the same file on multiple sequential commits \u2014 resolve each conflict individually; git rebase will stop once per conflicting commit, (44) `git rebase --continue` does not accept `--no-edit` flag \u2014 use `git rebase --continue` alone (it opens an editor only if explicitly invoked with `-i`; non-interactive rebase continues silently), (45) when cloning a fresh temp dir for rebase work, use `mktemp -d` for each operation rather than pre-cleaning a fixed path \u2014 `rm -rf $FIXED_PATH` may be blocked by Safety Net hooks even for temp dirs outside the workspace, (46) `gh pr merge --auto --squash` returns \"Pull request is in clean status\" for some PRs on first attempt but succeeds on retry seconds later \u2014 this is GitHub API lag; retry immediately before trying a direct merge, (47) a PR's rebase produces a commit whose content is identical to a prior commit that was already on main (e.g., a fix that was cherry-picked to main independently) \u2014 git drops it silently with \"dropping <sha> -- patch contents already upstream\"; this is correct behavior, not data loss, (48) tier-by-complexity merge ordering reduces cascade churn \u2014 sort PRs by total churn (additions+deletions) and process simplest first; smaller PRs cause less DIRTY-flag cascade on siblings than landing big refactors first, (49) 'strict subset' PR pairs (smaller PR \u2282 larger PR with same intent + extras) should be merged in size order: smaller first; larger becomes auto-empty after rebase or self-closes via natural drop, (50) before deploying any rebase swarm, run a single Opus triage agent to dedupe (identify exact-duplicate diffs and obviously-mooted-by-main PRs) \u2014 9 of 46 PRs in our session were close-as-superseded after triage, saving the equivalent of 3 rebase waves, (51) two PRs solving the same problem with different mechanisms (e.g., X-Dead-Letter-Key header vs Authorization Bearer; tomllib pyproject extraction vs requirements.txt sync script) are DESIGN COLLISIONS, not duplicates \u2014 flag for human decision; never silently pick one mechanism over the other, (52) when a hotfix lands mid-flight on main (e.g., regenerated pixi.lock or coverage-gate fix), every already-rebased PR needs ANOTHER rebase pass to inherit it; this second pass is fast (clean rebases) but mandatory before the queue can drain, (53) cascade churn during auto-merge wave: as PRs land in quick succession (e.g., 7 in 5 minutes), siblings touching the same files repeatedly go DIRTY; expect to run 2-3 re-rebase waves on diminishing subsets, not just one, (54) a conflicted file shows as 'both modified' with no visible conflict markers after rebase starts \u2014 git may have auto-applied one side without fully resolving; use `git show :2:<file> | wc -l` vs `git show :3:<file> | wc -l` to identify which version is present, then run `git diff :2:<file> :3:<file>` to see semantic differences; manually apply security fixes from main's version that the PR's side lacks (e.g., `int()` cast for GraphQL parameters, input validation added as a security patch), (55) a Myrmidon swarm dispatched two agents to implement the same GitHub issue concurrently \u2014 both produced identical PRs (same title, same diff, same target files); the first to merge wins; the second PR's commit is silently dropped on rebase with 'patch contents already upstream'; confirm via `git log --oneline origin/main..HEAD` returning empty, then close the duplicate with `gh pr close <N> --comment 'Superseded: identical change merged via PR #<M>'`, (56) a PR's only failing required check is `pr-policy` and the failure message is 'Auto-merge is not enabled on this PR' \u2014 the body already has `Closes #N` and commits are signed; the fix is simply `gh pr merge <N> --auto --squash`; always read the pr-policy job log before rebasing to avoid unnecessary force-push when only auto-merge is missing, (57) several already-rebased sibling PRs go DIRTY again the instant the FIRST one merges because they all touch the same hot files (routes.cpp, CMakeLists.txt, shared test files) \u2014 parallel re-rebase waves never converge here; switch to a strict SERIAL MERGE TRAIN: rebase one \u2192 wait for it to MERGE \u2192 fetch fresh main \u2192 rebase the next; each car rebases onto a main already containing all prior cars, so zero re-conflict churn, (58) order the serial train simplest-footprint-first / widest-footprint-last (sort by count of hot-file hunks) so the biggest PR rebases last onto a main that already absorbed the smaller ones, (59) never block the train on one car \u2014 if a single PR hits an ambiguous conflict (NEEDS-AUTHOR) or its own genuine test failure (RED-OWN-TESTS), flag it and move to the next PR; do not stall the whole train, (60) an automation agent (e.g. a CI-fix bot) committed to a Dependabot PR branch and now `@dependabot rebase` refuses with 'Looks like this PR has been edited by someone other than Dependabot' \u2014 use `@dependabot recreate` to rebuild the PR fresh from clean main (dropping the agent's commits) or rebase manually; also expect `@dependabot rebase` to warn about missing `automated`/`dependencies` labels but still attempt; LESSON: don't let automation commit to bot PRs, (61) a PR is permanently BLOCKED (`mergeStateStatus: BLOCKED`) while `mergeable: MERGEABLE` with ZERO check-runs and ZERO statuses on its head SHA \u2014 branch protection requires named contexts that were never produced because the workflow simply didn't trigger (CI paused/skipped at PR-open, or a `paths:` filter excluded the PR's files); diagnose by comparing required contexts (`gh api .../branches/main/protection --jq '.required_status_checks.contexts[]'`) against actual check-runs (`gh api repos/O/R/commits/<sha>/check-runs`) and statuses (`.../status`); FIX: push an empty signed commit (`git commit --allow-empty -S`) to re-trigger workflows, or fix the workflow `paths:` if it's a genuine path-filter mismatch, (62) a PR is marked 'needs author fix' on a `lint`/syntax-validation failure \u2014 READ THE ACTUAL ERROR first; most are mechanical and self-fixable (e.g. ProjectOdyssey Mojo Syntax Validation rejects the deprecated variadic `List[Type](args)` constructor: convert `var x = List[Int](10, 5)` \u2192 `var x: List[Int] = [10, 5]`, leave empty `List[Int]()` alone), verify by compiling (`pixi run mojo --Werror -I src -I . <file>`) and pre-commit; reserve real 'needs author' only for domain decisions you lack, (63) a `Dependency vulnerability scan` (pip-audit) goes red on EVERY PR because a transitive dep gained new advisories (e.g. `pyjwt 2.12.1` via pygithub \u2192 PYSEC-2026-175/177/178/179, fixed in 2.13.0) \u2014 FIX with an explicit version pin in pixi.toml `[dependencies]` (`pyjwt = \">=2.13.0\"`, same pattern as `pygments = \">=2.20.0\" # CVE-...`), NOT `--ignore-vuln`; check conda-forge availability first (`curl -s https://api.anaconda.org/package/conda-forge/<pkg>`), regenerate `pixi.lock`, verify `pixi run -e lint pip-audit` reports 'No known vulnerabilities found'; ship as a SEPARATE small PR so it merges fast and unblocks ALL repo PRs, then rebase dependents onto it, (64) a CLEAN, mergeable PR that the driver fixed but left with auto-merge NOT armed \u2014 scan for `mergeStateStatus: CLEAN` + no autoMergeRequest and arm directly with `gh pr merge <n> --auto --squash`; they merge immediately, (65) an automation agent committed a self-inflicted lint-failing artifact (e.g. a markdownlint-failing `CI_BLOCKER.md`) to a bot/Dependabot branch \u2014 fix the branch directly via a detached worktree: `git worktree add <tmp> origin/<branch> --detach`, `git rm CI_BLOCKER.md`, signed commit, `git push --force-with-lease origin HEAD:<branch>`, (66) N sibling PRs auto-generated from one backlog all carry their OWN earlier commit touching a shared-infra file (script/config/workflow) that has since landed on main \u2014 every plain `git rebase origin/main` conflicts on that shared file; do NOT rely on rebase conflict-resolution, instead overwrite the file with main's exact version after rebasing (`git show origin/main:path > path; git commit -S`), (67) `git checkout --theirs <shared-file>` during a rebase produces a hybrid/stale tree \u2014 'take theirs' resolves to main-at-that-replay-step, not main's final HEAD, and a PR's own later commit can re-introduce a stale assertion (e.g. `>= 1` instead of main's `== 0`); conflict-resolution \u2260 'make this file match main', (68) a post-rebase CI check (e.g. branch-protection-drift) reports `conclusion=failure` and you assume it is a transient/lagging read \u2014 verify the file at the exact sha (`gh api repos/<o>/<r>/contents/<path>?ref=<sha> --jq .content | base64 -d`) and diff against main before assuming stale; it may be a REAL failure on a stale synced file, (69) a red non-required check (markdownlint, docker-build) looks like the merge blocker but isn't \u2014 compute the REAL required set as the UNION of the ruleset's required_status_checks AND the classic protection's contexts; the classic-layer check (e.g. branch-protection-drift) is often the actual gate (cross-ref [[hi-branch-protection-two-layer]])",
-      "version": "2.20.0",
-      "source": "./skills/batch-pr-rebase-workflow.md",
-      "category": "ci-cd",
-      "tags": [
-        "git",
-        "rebase",
-        "pr",
-        "parallel",
-        "myrmidon",
-        "wave",
-        "batch",
-        "conflict",
-        "ci",
-        "pixi",
-        "mypy",
-        "ruff",
-        "cherry-pick",
-        "dependabot-recreate",
-        "required-checks-never-ran",
-        "transitive-cve-pin",
-        "mechanical-not-author"
-      ]
-    },
-    {
-      "name": "batch-review-plan-implementation",
-      "description": "Implements multiple automated review plans for PRs, handling OPEN PRs via rebase+push and skipping MERGED PRs with only transient CI failures. Use when: automated implementer generated review-plan-*.md files with phase=failed in review JSON, need to process 10+ stale PR branches at once.",
-      "version": "1.0.0",
-      "source": "./skills/batch-review-plan-implementation.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "central-version-manifest-drift-from-automation-bypass",
-      "description": "When a repo declares `versions.yml`/`versions.json`/`versions.toml` as single source of truth for pinned versions, automated bumps (Dependabot, weekly cron, hand-edits) often update only the consumer files (Dockerfiles, workflows) and bypass the manifest. Result: drift + automation silently breaks. Use when: (1) reviewing a base-image / pinned-tool bump PR, (2) auditing why a digest-refresh cron has stopped producing PRs, (3) onboarding a repo that has a centralized versions manifest, (4) writing or modernizing an update workflow that touches Dockerfiles or pinned-tool scripts.",
-      "version": "1.0.0",
-      "source": "./skills/central-version-manifest-drift-from-automation-bypass.md",
-      "category": "ci-cd",
-      "tags": [
-        "manifests",
-        "dependabot",
-        "drift",
-        "base-images",
-        "supply-chain",
-        "single-source-of-truth",
-        "dockerfile",
-        "github-actions"
-      ]
-    },
-    {
-      "name": "cherry-pick-fix-diverged-pr",
-      "description": "Apply a local fix commit to a remote PR branch when histories have diverged (same-content commits with different SHAs). Use when: fix exists locally but can't fast-forward push to PR branch due to diverged history from rebase.",
-      "version": "1.0.0",
-      "source": "./skills/cherry-pick-fix-diverged-pr.md",
-      "category": "ci-cd",
       "tags": []
     },
     {
@@ -1232,96 +816,6 @@
       ]
     },
     {
-      "name": "ci-cd-failure-diagnosis-log-analysis",
-      "description": "Diagnose CI failures by reading logs, identifying error patterns, and classifying root causes. Use when: (1) CI pipeline fails and you need to understand why, (2) tests pass locally but fail in CI, (3) multiple unrelated checks fail simultaneously, (4) CI retry logic labels failures as JIT crashes, (5) need to distinguish Mojo JIT crashes from real compile/test errors, (6) CI fails on a PR but PR changes look unrelated to failures, (7) docs-only or cleanup PRs show red CI, (8) multiple batch PRs all show BLOCKED status, (9) need to decide whether to block merge or proceed, (10) adding or auditing lint/format enforcement jobs to GitHub Actions workflows, (11) cross-repo conflict resolution on rename/refactor PRs, (12) CI-only crashes caused by debug_assert or JIT compilation overhead in Mojo, (13) enforcing required status checks across a GitHub organization, (14) triaging flaky CI failures to separate infrastructure issues from deterministic bugs, (15) fixing justfile build recipes that silently skip library validation, (16) standardizing default branches and fixing broken CI across multiple repos, (17) fixing pre-commit failures from mypy/ruff/coverage issues on cross-Python-version packages, (18) promoting monolithic CI matrix groups to per-subdirectory auto-discovery entries, (19) fixing CI workflows with missing pip dependency installs, (20) optimizing CI wall-clock time via runner pinning and changed-files-only pre-commit, (21) Dependabot PRs conflict after other Dependabot PRs merge to main, (22) gh pr merge fails with squash or merge-commit in rebase-only repos, (23) multiple Dependabot dependency bumps are open and landing sequentially, (24) CodeQL alert flags a workflow for lacking a permissions block, (25) Angular/Karma workflow fails because GitHub Actions runner Chrome sandboxing is inconsistent, (26) CI checks packaged web assets after a rebuild and hashed bundle filenames make git diff gates brittle.",
-      "version": "3.0.0",
-      "source": "./skills/ci-cd-failure-diagnosis-log-analysis.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-failure",
-        "flaky-tests",
-        "mojo-jit",
-        "batch-pr",
-        "diagnosis",
-        "pre-existing",
-        "dependabot",
-        "conflict",
-        "rebase",
-        "codeql",
-        "permissions",
-        "karma",
-        "playwright",
-        "chromium",
-        "frontend",
-        "pipeline-maintenance"
-      ]
-    },
-    {
-      "name": "ci-cd-gha-cancelled-runs-after-force-push",
-      "description": "CANCELLED GitHub Actions runs masquerade as PR failures from TWO distinct triggers. Trigger 1 (force-push): after git push --force-with-lease (e.g. post-rebase), GHA marks in-flight runs on the prior sha as CANCELLED, and these appear in the PR's status-check rollup as failure indicators alongside the new sha's runs. Trigger 2 (concurrency supersession): a rerun's jobs CANCELLED with 'Canceling since a higher priority waiting request for required-Required Checks-<branch> exists' \u2014 gh pr checks shows N fail but they are superseded/cancelled runs, not real failures (concurrency-group supersession reads as failure). PR looks broken even though the current tip / latest run is healthy. Use when: (1) a PR shows many failed checks but mergeStateStatus is BLOCKED with mergeable=MERGEABLE, (2) you need to distinguish real failures from rebase-orphaned or concurrency-superseded cancelled runs, (3) gh pr checks reports 'N fail' right after a rerun, (4) deciding whether to manually relaunch or just wait.",
-      "version": "1.1.0",
-      "source": "./skills/ci-cd-gha-cancelled-runs-after-force-push.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "rebase",
-        "force-push",
-        "concurrency",
-        "supersession",
-        "status-checks",
-        "mergeability",
-        "gh-cli"
-      ]
-    },
-    {
-      "name": "ci-cd-gha-required-checks-workflow-drop",
-      "description": "GitHub Actions Required Checks downstream gate workflows stuck pending forever after a push. Use when: (1) gh pr checks shows the real test workflows (Test, CodeQL, Security, Pre-commit) running and passing but downstream gates (pr-policy, shellcheck, markdownlint, justfile-check, symlink-check, pixi-check, integration-tests) sit at pending:0 and never start; (2) PR cannot auto-merge because branch protection requires those gates green; (3) waiting / gh run rerun / close+reopen did not help. Fix: push one empty signed commit to re-trigger workflow scheduling.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-gha-required-checks-workflow-drop.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "required-checks",
-        "workflow_run",
-        "workflow-drop",
-        "branch-protection",
-        "empty-commit",
-        "re-trigger",
-        "auto-merge"
-      ]
-    },
-    {
-      "name": "ci-cd-github-actions-slash-job-id-parse-failure",
-      "description": "GitHub Actions silently rejects an entire workflow file when any job ID (the YAML key) contains a forward slash. Zero jobs run, no check contexts are reported, and branch rulesets requiring those checks see them as permanently 'never run' \u2192 BLOCKED. Use when: (1) a workflow appears syntactically valid but shows 0 jobs in the Actions UI, (2) PRs are BLOCKED with mergeStateStatus=BLOCKED and all statusCheckRollup entries for the affected workflow are absent, (3) you see job IDs containing '/' in workflow YAML.",
-      "version": "1.1.0",
-      "source": "./skills/ci-cd-github-actions-slash-job-id-parse-failure.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "job-id",
-        "yaml",
-        "parse-failure",
-        "silent-failure",
-        "branch-protection",
-        "ruleset",
-        "check-context"
-      ]
-    },
-    {
-      "name": "ci-cd-github-actions-workflow-platform-scope-documentation",
-      "description": "Document platform asymmetries in GitHub Actions workflows using top-level header comment blocks with issue references. Use when: (1) CI workflows intentionally target only some platforms (e.g., Linux-only), (2) documenting why certain platforms are out of scope, (3) clarifying capability claims despite CI gaps.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-github-actions-workflow-platform-scope-documentation.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "platform-scope",
-        "documentation",
-        "honesty",
-        "ci-cd"
-      ]
-    },
-    {
       "name": "ci-cd-github-code-quality-findings-no-api",
       "description": "Fixing GitHub Code Quality (/security/quality) findings \u2014 a product distinct from CodeQL code-scanning, with NO public REST API. Use when: (1) a /security/quality/rules/py%2F... URL reports open findings, (2) deciding how to locate Code Quality violations when the code-scanning alerts API returns them empty, (3) reconciling ruff vs CodeQL semantic differences for py/unused-local-variable, py/unused-global-variable, py/repeated-import, py/import-and-import-from, py/empty-except, py/undefined-export, (4) a Copilot/AI-findings autofix PR fails to merge, (5) a Code Quality finding is a false positive and you must refactor working code to satisfy the analyser without changing behaviour.",
       "version": "1.0.0",
@@ -1336,173 +830,12 @@
       ]
     },
     {
-      "name": "ci-cd-homeric-intelligence-merge-gotchas",
-      "description": "Recurring HomericIntelligence CI/merge traps that block PR auto-merge even when the code is correct. Use when: (1) pixi-check fails 'lock-file not up-to-date with the workspace' or Lint/Type-Check break after removing pypi-dependencies; (2) a Keystone-style lint job fails fast (~20s) at 'Install build dependencies (just + linters)'; (3) CodeQL cpp/unused-{local,static}-variable flags a genuinely-used C++ variadic template parameter pack; (4) a PR is MERGEABLE with all REQUIRED checks green but auto-merge won't fire; (5) you are driving a chain of dependency-gated PRs and need to auto-arm each downstream PR when its gate merges; (6) a PR is MERGEABLE with every REQUIRED status check green, but mergeStateStatus stays BLOCKED and auto-merge won't fire \u2014 the gate is `required_review_thread_resolution: true` plus unresolved CodeQL/github-advanced-security review threads; detect via GraphQL reviewThreads (the REST field is empty), assess each finding before resolving, document accept-rationale, then resolveReviewThread; (7) the pr-policy required gate fails 'Auto-merge is enabled before implementation review GO' \u2014 do not pre-arm auto-merge before the state:implementation-go label (the inverse 'PR has state:implementation-go but auto-merge is not enabled' also fails); disable premature auto-merge and let the label workflow arm it.",
-      "version": "1.2.0",
-      "source": "./skills/ci-cd-homeric-intelligence-merge-gotchas.md",
-      "category": "ci-cd",
-      "tags": [
-        "pixi",
-        "pixi-lock",
-        "codeql",
-        "auto-merge",
-        "branch-protection",
-        "just-systems",
-        "keystone",
-        "agamemnon",
-        "dependency-gated-pr",
-        "review-thread-resolution",
-        "github-advanced-security",
-        "pr-policy",
-        "implementation-go"
-      ]
-    },
-    {
-      "name": "ci-cd-no-commit-retry-with-review-thread-injection",
-      "description": "When an agent-driven CI-fix loop returns from a session without producing a new commit AND the PR's required CI checks are still red, that combination is itself a bug \u2014 not a 'do nothing' condition. The correct response is exactly ONE bounded retry on the SAME PR-scoped session with a force-engagement prompt that (1) names the failing required check names verbatim, (2) restates the branch invariant (do not create/switch branches), (3) restates the signed-commit + no-`--no-verify` policy, and (4) prepends ALL unresolved PR review threads (fetched via GraphQL `reviewThreads { isResolved, comments { body, path, line } }`) verbatim \u2014 because an unresolved bot or human review comment is usually the actual blocker behind the red CI, and the agent cannot fix what it cannot see. Inject the review-thread block into BOTH the initial CI-fix prompt AND the retry prompt, not just one. Gate the retry on `gh pr checks --required` exit code (don't retry if CI went green via concurrent activity). After the retry, if HEAD still has not advanced, write a `state_dir/repeated-no-commit-<pr>.json` forensics marker and move on \u2014 never loop, never open a new PR. Use when: (1) an agent CI-fix driver logs 'agent session produced no new commit (HEAD unchanged at \u2026); skipping push', (2) the same PR is being skipped run after run while its required checks stay red, (3) reviewing/extending a `_run_ci_fix_session` or `drive_prs_green`-style driver, (4) a no-commit honesty guard (#836-style) is already in place but the driver still gives up after one no-commit turn, (5) a PR review bot left an unresolved comment naming the actual blocker and the fix agent never references it.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-no-commit-retry-with-review-thread-injection.md",
-      "category": "ci-cd",
-      "tags": [
-        "automation",
-        "ci-driver",
-        "force-engagement-retry",
-        "no-commit-honesty-guard",
-        "review-thread-injection",
-        "agent-contract-violation",
-        "drive-green",
-        "same-session-retry",
-        "gh-pr-checks",
-        "graphql-review-threads",
-        "signed-commit-invariant",
-        "forensics-marker",
-        "bounded-retry"
-      ]
-    },
-    {
       "name": "ci-cd-opencode-asset-arch-naming",
       "description": "Documents that opencode (sst/opencode) release assets use x64 (not amd64) in their filenames, requiring a TARGETARCH\u2192arch mapping case statement in Dockerfiles. Use when: building a vessel Dockerfile for opencode or downloading opencode release assets in CI, and getting 404 errors for asset downloads.",
       "version": "1.0.0",
       "source": "./skills/ci-cd-opencode-asset-arch-naming.md",
       "category": "ci-cd",
       "tags": []
-    },
-    {
-      "name": "ci-cd-podman-host-container-build-dir-permissions",
-      "description": "Fix 'mkdir: Permission denied' / PermissionError [Errno 13] when a justfile recipe runs ON THE HOST but writes into build/ or dist/ that a prior rootless-Podman container recipe populated as a subuid-mapped uid. Use when: (1) a just recipe fails writing to build/ or dist/ after another recipe ran in-container, (2) rootless Podman left files owned by a high subuid (e.g. 524288) the host user cannot write, (3) 'pixi: not found' on a CI runner because a recipe ran host-side instead of in-container, (4) chmod -R fails with EPERM on foreign-owned sibling files in a shared dir, (5) deciding whether a justfile recipe belongs host-side or in the container _run wrapper.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-podman-host-container-build-dir-permissions.md",
-      "category": "ci-cd",
-      "tags": [
-        "podman",
-        "rootless",
-        "subuid",
-        "justfile",
-        "permissions",
-        "build-dir",
-        "dist",
-        "container-host-boundary",
-        "chmod",
-        "pixi"
-      ]
-    },
-    {
-      "name": "ci-cd-reusable-workflow-required-checks-aggregator",
-      "description": "Consolidate duplicate GitHub Actions jobs into a reusable workflow so `_required.yml` is a thin aggregator. Use when: (1) two or more workflow files define the same jobs (lint, test, build), causing every PR to run them twice; (2) you want `_required.yml` to depend on existing CI jobs rather than redefine them; (3) a fat required-checks workflow is drifting out of sync with other workflow files.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-reusable-workflow-required-checks-aggregator.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "reusable-workflow",
-        "workflow-call",
-        "required-checks",
-        "dry",
-        "aggregator"
-      ]
-    },
-    {
-      "name": "ci-cd-ruleset-bootstrap-deadlock",
-      "description": "Detect and resolve a CI ruleset chicken-and-egg deadlock where a PR introducing a new workflow file is permanently blocked because the ruleset requires check names that only exist in the workflow being added. Use when: (1) a PR adding a new CI workflow shows mergeStateStatus=BLOCKED with zero failing checks, (2) re-triggering CI produces no new runs, (3) auto-merge is armed but never fires despite all existing checks passing.",
-      "version": "1.1.0",
-      "source": "./skills/ci-cd-ruleset-bootstrap-deadlock.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
-        "rulesets",
-        "branch-protection",
-        "ci-bootstrap",
-        "deadlock",
-        "github-actions"
-      ]
-    },
-    {
-      "name": "ci-cd-skill-validation-failed-attempts-inline-html",
-      "description": "Fix CI failures in skill PRs caused by wrong Failed Attempts table column names or inline HTML from angle-bracket placeholders. Use when: (1) a skill PR fails validate/unit-tests with 'Failed Attempts table missing required columns', (2) a skill PR fails markdownlint MD033 no-inline-html on a <placeholder> pattern in prose, (3) writing a new skill and wanting to avoid these common validation failures.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-skill-validation-failed-attempts-inline-html.md",
-      "category": "ci-cd",
-      "tags": [
-        "markdownlint",
-        "md033",
-        "inline-html",
-        "failed-attempts",
-        "skill-format",
-        "validate",
-        "unit-tests"
-      ]
-    },
-    {
-      "name": "ci-cd-split-advisory-check-out-of-required-gate",
-      "description": "Split a timing-sensitive / orchestration sub-check out of a REQUIRED CI gate (e.g. pr-policy) into its own non-required advisory job so it reports status but never blocks merge. Use when: (1) a required gate bundles a timing-sensitive/orchestration check that fails a correct PR (e.g. `::error::Auto-merge is enabled before implementation review GO.`) and blocks merge; (2) you want a CI check to report status but never block merge (make a check non-blocking / advisory); (3) move the auto-merge \u2194 state:implementation-go state machine out of the pr-policy gate; (4) a required job's sub-check is flaky/timing-dependent and shouldn't gate merge.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-split-advisory-check-out-of-required-gate.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "branch-protection",
-        "required-checks",
-        "pr-policy",
-        "auto-merge",
-        "advisory-check",
-        "ruleset",
-        "implementation-go",
-        "non-blocking",
-        "workflow-split"
-      ]
-    },
-    {
-      "name": "ci-cd-summary-aggregator-job-skip-required-context",
-      "description": "Fix PRs permanently BLOCKED because a required status-check context is a job gated `if: github.event_name != 'pull_request'`: a whole-job skip does NOT satisfy a required check. Replace per-job required contexts with a single `summary` aggregator job (`if: always()`) that asserts `needs.X.result == 'success'` for must-run jobs and `success|skipped` for jobs designed to skip on PRs; then remove the per-job contexts from branch protection. Use when: (1) branch protection requires a context that the workflow legitimately skips on `pull_request`, (2) PRs are BLOCKED with `skipped` (not failing) required checks, (3) extending a CI workflow with registry/secret-dependent jobs that must skip on forked PRs.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-summary-aggregator-job-skip-required-context.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "branch-protection",
-        "required-status-checks",
-        "aggregator",
-        "if-always",
-        "job-skip",
-        "skipped-conclusion",
-        "summary-job"
-      ]
-    },
-    {
-      "name": "ci-cd-triage-pr-vs-systemic-failures",
-      "description": "Distinguish PR-introduced CI regressions from systemic main-branch failures and infrastructure flakes BEFORE bisecting, reverting, or rerunning. Use when: (1) a PR has unexplained CI failures and you're tempted to blame the PR, (2) before invoking `gh run rerun` on any job, (3) before proposing to revert a dependency/toolchain bump, (4) distinguishing GitHub infrastructure flakes (HTTP 500 on git fetch) from real failures, (5) classifying `mojo: error: execution crashed` as libKGEN JIT (modular#6413) vs. an actual PR bug, (6) deciding whether to leave a failure as-is on the surface PR while addressing it in a separate workaround PR. ProjectOdyssey-specific policy: NEVER `gh run rerun` to dismiss as flake, NEVER revert/pin-back a Mojo version bump, ALWAYS file or reference an upstream Modular issue for runtime crashes.",
-      "version": "1.0.0",
-      "source": "./skills/ci-cd-triage-pr-vs-systemic-failures.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-failure",
-        "triage",
-        "mojo-jit",
-        "modular-6413",
-        "github-infra-flake",
-        "main-branch-history",
-        "projectodyssey-policy"
-      ]
     },
     {
       "name": "ci-cd-verify-merged-prs-end-to-end",
@@ -1519,71 +852,6 @@
         "defect-cascade",
         "umbrella-issue",
         "smoke-test"
-      ]
-    },
-    {
-      "name": "ci-complexity-extract-method-fix",
-      "description": "Fix C901 cyclomatic complexity CI failures by extracting helper functions. Use when: (1) pre-commit or CI fails with 'is too complex (N > 10)', (2) adding conditional blocks to an existing function pushes it over the CC limit, (3) multiple rendering/processing passes can be isolated.",
-      "version": "1.1.0",
-      "source": "./skills/ci-complexity-extract-method-fix.md",
-      "category": "ci-cd",
-      "tags": [
-        "pre-commit",
-        "complexity",
-        "refactoring",
-        "ruff",
-        "C901",
-        "method-extraction",
-        "rendering-passes"
-      ]
-    },
-    {
-      "name": "ci-coverage-threshold-single-source",
-      "description": "Establish [tool.coverage.report].fail_under as the single source of truth for coverage thresholds by removing redundant --cov-fail-under from both CI workflows and pyproject.toml addopts. Use when: (1) --cov-fail-under appears in addopts or CI alongside fail_under in pyproject.toml, (2) coverage floor is cosmetically low, (3) local and CI thresholds diverge.",
-      "version": "2.0.0",
-      "source": "./skills/ci-coverage-threshold-single-source.md",
-      "category": "ci-cd",
-      "tags": [
-        "coverage",
-        "pytest",
-        "single-source-of-truth",
-        "pyproject-toml",
-        "ci-cd"
-      ]
-    },
-    {
-      "name": "ci-dependency-floor-semantic-version-guard",
-      "description": "Use when: (1) comparing version specs across manifest files (pyproject.toml, pixi.toml), (2) ensuring dependency floors stay consistent without string-equality surprises (e.g., '9.0' vs '9.0.0'), (3) implementing regression guards for manifest drift, (4) testing that pinned versions are semantically equivalent across files using PEP 440 version comparison.",
-      "version": "1.0.0",
-      "source": "./skills/ci-dependency-floor-semantic-version-guard.md",
-      "category": "ci-cd",
-      "tags": [
-        "dependencies",
-        "version-comparison",
-        "regression-guard",
-        "pytest",
-        "pixi",
-        "pyproject",
-        "semver",
-        "pep-440",
-        "manifest-consistency"
-      ]
-    },
-    {
-      "name": "ci-doctor-script-hook-check-ci-guard",
-      "description": "Shell doctor/health-check scripts that verify local developer setup (git hooks, SSH keys, local config files) must guard against CI environments where that infrastructure doesn't exist. Use when: (1) a doctor.sh CI job fails because .git/hooks/ doesn't exist on GitHub Actions runners, (2) any check_*() function in a health-check script validates developer-local resources that are absent in CI, (3) writing new doctor script checks that should only run locally, (4) debugging CI failures where a health/preflight script exits 1 due to missing local setup artifacts.",
-      "version": "1.0.0",
-      "source": "./skills/ci-doctor-script-hook-check-ci-guard.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci",
-        "doctor",
-        "shell",
-        "git-hooks",
-        "github-actions",
-        "health-check",
-        "ci-guard",
-        "environment-detection"
       ]
     },
     {
@@ -1614,12 +882,21 @@
       ]
     },
     {
-      "name": "ci-grep-deprecation-guard",
-      "description": "Add a CI step that grep-blocks reappearance of deprecated identifiers. Use when: (1) deprecated names/aliases have been removed and you want a regression guard, (2) a cleanup PR removed old identifiers and follow-up CI enforcement is needed, (3) you want a no-build-required lint check for forbidden symbols.",
+      "name": "ci-hygiene-and-validation-gates",
+      "description": "Use when: (1) adding a CI step that grep-blocks reappearance of deprecated identifiers after a cleanup PR, (2) adding a standalone JSON schema validation step to catch config drift even when pre-commit was skipped, (3) detecting orphaned scripts/*.py files not referenced in CI workflows, justfile, or other scripts.",
       "version": "1.0.0",
-      "source": "./skills/ci-grep-deprecation-guard.md",
+      "source": "./skills/ci-hygiene-and-validation-gates.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "ci-cd",
+        "grep",
+        "validation",
+        "deprecation",
+        "schema",
+        "pre-commit",
+        "stale-detection",
+        "regression-guard"
+      ]
     },
     {
       "name": "ci-library-migration-audit-pip-install-coverage",
@@ -1640,140 +917,6 @@
       ]
     },
     {
-      "name": "ci-local-reproduction-environment-conditions",
-      "description": "Reproduce CI-only test failures locally by replicating all three CI environment conditions simultaneously: cold pixi cache, UID mismatch, and no-TTY. Use when: (1) tests pass locally 100% but fail in CI, (2) you've ruled out code-level differences, (3) CI uses Podman with pixi and named volumes.",
-      "version": "1.0.0",
-      "source": "./skills/ci-local-reproduction-environment-conditions.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci",
-        "debugging",
-        "flakiness",
-        "podman",
-        "docker",
-        "reproduction",
-        "uid",
-        "tty",
-        "pixi"
-      ]
-    },
-    {
-      "name": "ci-lychee-bot-403-lycheeignore",
-      "description": "Fix lychee link-check CI failures caused by bot-blocking 403 responses or intermittent connection resets from external sites. Use when: (1) lychee link-check CI job fails with HTTP 403 on claude.ai or other Anthropic URLs that block automated bots, (2) contributor-covenant.org or similar community sites return connection reset (os error 104) intermittently causing flaky CI, (3) a site returns a non-2xx response to lychee's user-agent that is clearly valid when visited in a browser.",
-      "version": "1.0.0",
-      "source": "./skills/ci-lychee-bot-403-lycheeignore.md",
-      "category": "ci-cd",
-      "tags": [
-        "lychee",
-        "link-check",
-        "ci",
-        "403",
-        "lycheeignore",
-        "bot-protection"
-      ]
-    },
-    {
-      "name": "ci-markdownlint-md060-table-separator-spaces",
-      "description": "Use when: (1) CI markdownlint job fails with MD060/table-column-style 'Table pipe is missing space to the right/left for style compact', (2) local pre-commit Markdown Lint hook passes but CI's separate markdownlint job fails on the same .md file, (3) adding or modifying any markdown table in docs/ and you want to pre-empt the CI gate.",
-      "version": "1.0.0",
-      "source": "./skills/ci-markdownlint-md060-table-separator-spaces.md",
-      "category": "ci-cd",
-      "tags": [
-        "markdownlint",
-        "markdownlint-cli2",
-        "MD060",
-        "tables",
-        "table-column-style",
-        "ci-cd",
-        "pre-commit-divergence",
-        "docs"
-      ]
-    },
-    {
-      "name": "ci-merge-preview-coverage-gate",
-      "description": "GitHub CI computes coverage against the merge-preview tree (PR's HEAD merged with main's HEAD), NOT the PR branch alone. This means local coverage on the branch tree can be HIGHER than CI sees, and adding entries to `[tool.coverage.run].omit` for files that aren't on the branch IS the correct fix when those files exist on main. Use when: (1) CI coverage % is lower than local pytest run on same SHA, (2) coverage gate fails despite the PR not touching the flagged files, (3) you're behind main and considering whether to omit files you don't have in your tree.",
-      "version": "1.0.0",
-      "source": "./skills/ci-merge-preview-coverage-gate.md",
-      "category": "ci-cd",
-      "tags": [
-        "github-actions",
-        "coverage",
-        "pytest",
-        "merge-preview"
-      ]
-    },
-    {
-      "name": "ci-mojo-gha-vma-sequential-job",
-      "description": "Fix non-deterministic GHA CI failures caused by Mojo compiler reserving ~3.6 GB virtual address space per invocation on free-tier runners with 7 GB RAM. Use when: (1) CI fails with 'JIT session error: Cannot allocate memory' or SIGSEGV in libKGENCompilerRTShared.so, (2) failures are non-deterministic and max-parallel:1 does not help, (3) ulimit -v on the runner confirms ~3.6 GB reservation per mojo process, (4) GHA matrix strategy is in use for Mojo test groups.",
-      "version": "1.0.0",
-      "source": "./skills/ci-mojo-gha-vma-sequential-job.md",
-      "category": "ci-cd",
-      "tags": [
-        "mojo",
-        "gha",
-        "virtual-memory",
-        "vmpeak",
-        "sequential",
-        "matrix",
-        "ci",
-        "libKGENCompilerRTShared",
-        "memory-exhaustion"
-      ]
-    },
-    {
-      "name": "ci-package-workflow",
-      "description": "Create GitHub Actions workflows for automated package building and distribution. Use in package phase to automate .mojopkg building and release creation.",
-      "version": "2.0.0",
-      "source": "./skills/ci-package-workflow.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "github-actions",
-        "packaging",
-        "release"
-      ]
-    },
-    {
-      "name": "ci-pixi-workspace-version-dedup",
-      "description": "Remove duplicated project version from pixi.toml [workspace] and add drift detection to an existing version-consistency pre-commit script. Use when: (1) pixi.toml has a version field that duplicates pyproject.toml, (2) extending an existing check script to cover additional config files, (3) preventing accidental re-introduction of removed duplicate fields.",
-      "version": "1.0.0",
-      "source": "./skills/ci-pixi-workspace-version-dedup.md",
-      "category": "ci-cd",
-      "tags": [
-        "pixi",
-        "version",
-        "deduplication",
-        "pre-commit",
-        "drift-detection",
-        "pyproject"
-      ]
-    },
-    {
-      "name": "ci-pytest-pip-install-pyproject-addopts-trap",
-      "description": "Slim `pip install pytest` CI jobs silently inherit `addopts` from `pyproject.toml` and fail because pytest-cov (or other plugins in addopts) is not installed. Use when: (1) a matrix CI job does `pip install pytest` without the full project env and crashes with 'unrecognized arguments: --cov=...' or 'no module named yaml', (2) a lightweight test job works locally but fails in CI with missing plugin errors, (3) splitting a pixi/poetry test job into a minimal pip-only job starts failing after addopts was set in pyproject.toml.",
-      "version": "1.0.0",
-      "source": "./skills/ci-pytest-pip-install-pyproject-addopts-trap.md",
-      "category": "ci-cd",
-      "tags": [
-        "pytest",
-        "pip-install",
-        "addopts",
-        "pyproject-toml",
-        "pytest-cov",
-        "pyyaml",
-        "ci-matrix",
-        "pixi"
-      ]
-    },
-    {
-      "name": "ci-schema-validation-standalone-step",
-      "description": "Add a standalone CI step to validate all config files against JSON schemas on every PR, ensuring schema drift is caught even when pre-commit was skipped",
-      "version": "1.0.0",
-      "source": "./skills/ci-schema-validation-standalone-step.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "ci-shell-grep-case-mismatch",
       "description": "Skill: ci-shell-grep-case-mismatch. Use when a shell-tests or smoke-check CI workflow fails because a grep -q assertion checks the wrong casing of a string vs the actual content in a source file \u2014 especially with org names or proper nouns.",
       "version": "1.0.0",
@@ -1782,49 +925,29 @@
       "tags": []
     },
     {
-      "name": "ci-stale-pattern-cleanup",
-      "description": "Use when: (1) a CI matrix has patterns that may reference renamed or deleted test files (detect stale), (2) a test file was deleted but still appears in a GitHub Actions workflow pattern string (remove stale), (3) closing a cleanup issue where the only remaining work is a dangling workflow reference, (4) adding an inverse CI coverage check that flags matrix patterns matching zero existing files as warnings.",
+      "name": "ci-transient-flake-and-environment-failures",
+      "description": "Use when: (1) a CI job fails non-deterministically and re-running resolves it (e.g. Trivy install.sh curl-pipe exit-1, lychee link-check 403/connection-reset from bot-blocking sites), (2) CI passes locally 100% but fails in GitHub Actions and you need a reproduction strategy that covers cold pixi cache + UID mismatch + no-TTY simultaneously, (3) a CI job is failing because a doctor/health-check script validates developer-local resources absent in GitHub Actions runners.",
       "version": "1.0.0",
-      "source": "./skills/ci-stale-pattern-cleanup.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "github-actions",
-        "stale-patterns",
-        "cleanup",
-        "validate-coverage"
-      ]
-    },
-    {
-      "name": "ci-trivy-install-transient-exit-rerun-resolves",
-      "description": "Diagnose and resolve a transient exit-1 from the aquasecurity/trivy install.sh curl-pipe-to-sh step in GitHub Actions, where the install logs end mid-stream with no trivy error message. Use when: (1) a depscan/sbom job fails with `##[error]Process completed with exit code 1.` immediately after the `aquasecurity/trivy info found version: X.Y.Z` log line, (2) the prior pip-audit step in the same job passed cleanly, (3) you are tempted to add `|| true` or `continue-on-error: true` to silence a Trivy install failure.",
-      "version": "1.0.0",
-      "source": "./skills/ci-trivy-install-transient-exit-rerun-resolves.md",
+      "source": "./skills/ci-transient-flake-and-environment-failures.md",
       "category": "ci-cd",
       "tags": [
         "ci",
-        "trivy",
         "github-actions",
         "transient",
         "flake",
-        "depscan",
-        "sbom"
-      ]
-    },
-    {
-      "name": "ci-validate-coverage-steps-fallback",
-      "description": "Use when: (1) a GitHub Actions CI job has been migrated from a matrix (strategy.matrix.test-group) to sequential named steps and the pre-commit validate-test-coverage hook now reports all test files as uncovered (0 covered groups), (2) validate_test_coverage.py parse_ci_matrix() returns an empty dict after removing strategy.matrix from a workflow, (3) adding support for both matrix-style and sequential-steps-style test group definitions in the same validation script.",
-      "version": "1.0.0",
-      "source": "./skills/ci-validate-coverage-steps-fallback.md",
-      "category": "ci-cd",
-      "tags": [
-        "ci-cd",
-        "github-actions",
-        "validate-test-coverage",
-        "sequential-steps",
-        "matrix-migration",
-        "pre-commit",
-        "parse_ci_matrix"
+        "trivy",
+        "lychee",
+        "link-check",
+        "lycheeignore",
+        "reproduction",
+        "podman",
+        "pixi",
+        "uid",
+        "tty",
+        "doctor",
+        "git-hooks",
+        "ci-guard",
+        "environment-detection"
       ]
     },
     {
@@ -1849,8 +972,8 @@
     },
     {
       "name": "code-quality-enforcement-gates",
-      "description": "Canonical guide to code-quality enforcement THRESHOLDS and decisions: when to fail builds on complexity, when to enable mypy strict modes, when to promote warnings to errors, how to scope override subsets, deprecation removal policy. Use when: (1) deciding fix-vs-suppress for a new lint rule, (2) enabling mypy check-untyped-defs or new ruff rules, (3) promoting CI warnings to exit-1, (4) tuning markdownlint MD024 / ruff C901 thresholds, (5) narrowing mypy module override globs to specific paths.",
-      "version": "1.0.0",
+      "description": "Canonical guide to code-quality enforcement THRESHOLDS, remediation workflow, and post-audit verification: when to fail builds on complexity, when to enable mypy strict modes, when to promote warnings to errors, how to scope override subsets, deprecation removal policy, how to fix production asserts/hardcoded paths, how to run a post-remediation audit, and how to verify audit/PR-reviewer findings against ground truth before acting. Use when: (1) deciding fix-vs-suppress for a new lint rule, (2) enabling mypy check-untyped-defs or new ruff rules, (3) promoting CI warnings to exit-1, (4) tuning markdownlint MD024 / ruff C901 thresholds, (5) narrowing mypy module override globs to specific paths, (6) replacing production assert input-validation or hardcoded /tmp paths with safe equivalents, (7) executing a post-remediation audit to close remaining CI/classifier/release/docs gaps after an initial cleanup, (8) strict-mode repo audits or PR-reviewer sub-agents produce hallucinated findings (nonexistent files, phantom CI checks, red-on-main checks cited as PR blockers) \u2014 verify against live state before acting.",
+      "version": "1.1.0",
       "source": "./skills/code-quality-enforcement-gates.md",
       "category": "ci-cd",
       "tags": [
@@ -1860,7 +983,11 @@
         "mypy",
         "ruff",
         "complexity-budget",
-        "deprecation"
+        "deprecation",
+        "post-remediation-audit",
+        "audit-verification",
+        "fact-checking",
+        "production-code-fixes"
       ]
     },
     {
@@ -1872,43 +999,30 @@
       "tags": []
     },
     {
-      "name": "composite-action-expr-in-description",
-      "description": "GitHub Actions evaluates `${{ ... }}` expressions inside composite-action input `description` fields even though that field is documentation-only. Including `${{ runner.os }}` (or any non-`inputs.*` context name) inside an input description \u2014 even backtick-quoted as documentation \u2014 makes the action fail to load with `Unrecognized named-value: 'runner'`. Use plain placeholder text or escape the expression. Use when: (1) writing a composite action that documents the cache-key shape or other runner-context-using value in its input description, (2) seeing `TemplateValidationException` at action-load time with `runner.os` / `github.X` / other context names.",
+      "name": "container-ci-uid-permissions-rootless",
+      "description": "Use when: (1) a justfile recipe fails writing to build/ or dist/ because rootless Podman left those directories owned by a subuid-mapped UID the host user cannot write, (2) fixing rootless Podman CI failures involving Dockerfile ARG scoping across FROM boundaries, workspace UID mapping, or compose provider compatibility, (3) implementing multi-stage Docker builds, multi-arch OCI images, or integrating pixi-volume isolation and GHA cache extraction into container workflows, (4) cleaning up CI workflows referencing non-existent test directories with dead Docker steps.",
       "version": "1.0.0",
-      "source": "./skills/composite-action-expr-in-description.md",
+      "source": "./skills/container-ci-uid-permissions-rootless.md",
       "category": "ci-cd",
       "tags": [
-        "github-actions",
-        "composite-action",
-        "template-expression"
-      ]
-    },
-    {
-      "name": "comprehensive-pr-review-orchestration",
-      "description": "Orchestrate comprehensive PR reviews using specialized sub-reviewers. Use when reviewing complex PRs.",
-      "version": "1.0.0",
-      "source": "./skills/comprehensive-pr-review-orchestration.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "container-build-and-runtime-patterns",
-      "description": "Canonical guide to container build and runtime patterns spanning Docker, Podman, and rootless: multi-stage builds, multi-arch OCI, UID/GID mismatch fixes, layer caching strategies, entrypoint patterns, healthchecks, pixi-volume isolation, GHA cache extraction, Conan-in-Docker chains, dockerfile extras validation. Use when: (1) writing or refactoring a Dockerfile, (2) diagnosing a rootless Podman or UID mismatch crash, (3) extracting / sharing image cache between local and GHA, (4) integrating Conan profiles with a multistage build, (5) container-based E2E test infra.",
-      "version": "1.2.0",
-      "source": "./skills/container-build-and-runtime-patterns.md",
-      "category": "ci-cd",
-      "tags": [
-        "merged",
-        "docker",
         "podman",
-        "container",
-        "dockerfile",
-        "multistage",
         "rootless",
-        "hadolint",
-        "buildx-driver",
+        "subuid",
+        "uid-mapping",
+        "justfile",
+        "permissions",
+        "build-dir",
+        "dist",
+        "docker",
+        "multistage",
+        "oci",
+        "multi-arch",
+        "pixi",
         "gha-cache",
-        "load-true"
+        "dockerfile-arg",
+        "compose",
+        "dead-step-cleanup",
+        "container-ci"
       ]
     },
     {
@@ -1943,42 +1057,6 @@
       ]
     },
     {
-      "name": "cpp-pr-stale-duplicate-commit-detection",
-      "description": "Detect and remove stale duplicate fix commits from a PR branch when the fix already landed on main via another PR. Use when: (1) all sanitizer CI jobs fail identically on a PR that looked correct, (2) a PR has extra commits not part of its stated payload, (3) a race/UB fix was authored in parallel with another branch.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-pr-stale-duplicate-commit-detection.md",
-      "category": "ci-cd",
-      "tags": [
-        "cpp",
-        "pr",
-        "stale-commit",
-        "duplicate-fix",
-        "cherry-pick",
-        "force-with-lease",
-        "tsan",
-        "dangling-reference",
-        "return-by-value"
-      ]
-    },
-    {
-      "name": "cryptographic-signed-commits-pr-policy-validation",
-      "description": "Understand pr-policy CI gate validation of cryptographic commit signatures at the GraphQL layer. Use when: (1) a PR shows auto-merge armed but BLOCKED despite all CI green, (2) gh pr view --json shows mergeStateStatus:BLOCKED but all checks are SUCCESS, (3) pushing unsigned commits when pr-policy validation is in effect, (4) crafting PRs in repositories with required_signatures branch protection, (5) dispatching sub-agents that must create commits with cryptographic signatures, (6) auditing multi-agent sweeps for invisible signing failures, (7) understanding why unsigned commits block auto-merge even when other CI checks pass.",
-      "version": "1.0.0",
-      "source": "./skills/cryptographic-signed-commits-pr-policy-validation.md",
-      "category": "ci-cd",
-      "tags": [
-        "git-signing",
-        "gpg",
-        "commit-signatures",
-        "pr-policy",
-        "ci-cd",
-        "required-signatures",
-        "graphql",
-        "branch-protection",
-        "auto-merge"
-      ]
-    },
-    {
       "name": "deduplicate-issues",
       "description": "Systematically identify and close duplicate or resolved GitHub issues",
       "version": "1.0.0",
@@ -1987,238 +1065,48 @@
       "tags": []
     },
     {
-      "name": "deduplicate-llm-json-extraction",
-      "description": "Skill: deduplicate-llm-json-extraction. Use when working with deduplicate llm json extraction.",
+      "name": "dependency-manifest-single-source-of-truth",
+      "description": "Use when: (1) Python dependencies are declared in multiple manifests (pixi.toml, pyproject.toml, requirements*.txt) with divergent version constraints, (2) aligning floor constraints (e.g., >=9.0 vs >=9.0.0) or upper-cap constraints (e.g., <2 vs <3) across manifests for packages with API-incompatible major versions, (3) removing a duplicated version field from pixi.toml [workspace] that pyproject.toml already owns, (4) implementing semantic-version-aware (PEP 440) regression guards that detect manifest drift in CI, (5) ensuring pip-install users and pixi dev-env users see the same tested package versions.",
       "version": "1.0.0",
-      "source": "./skills/deduplicate-llm-json-extraction.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "delegates-to-file-existence-check",
-      "description": "Add CI validation that every agent name in delegates_to frontmatter maps to a real .md file. Use when: adding referential integrity checks to agent config validators, catching stale cross-agent references automatically on PRs.",
-      "version": "1.0.0",
-      "source": "./skills/delegates-to-file-existence-check.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "dependabot-pr-scope-contamination-check-the-diff",
-      "description": "Before reviewing a Dependabot PR, always run `gh pr diff --name-only` and inspect the commit list. Dependabot PRs frequently arrive contaminated with lockfile-format upgrades or maintainer fixup commits that the title doesn't mention. The title describes the bot's intent; the actual diff may include unrelated cascades. Use this skill when reviewing ANY bot-authored PR to avoid landing surprises. Pattern A: silent lockfile/format upgrades (e.g. pixi.lock v6\u2192v7, 226 add/228 del on a 4-line npm bump). Pattern B: maintainer fixup commits stacked on the bot branch (12 unrelated files added by a `fix: Address CI failures for PR #N` follow-up). Mandatory phase-1 scope check before any verdict: enumerate the actual file scope, count and attribute commits, and REQUEST_CHANGES if scope doesn't match the title.",
-      "version": "1.0.0",
-      "source": "./skills/dependabot-pr-scope-contamination-check-the-diff.md",
-      "category": "ci-cd",
-      "tags": [
-        "dependabot",
-        "pr-review",
-        "scope-bloat",
-        "lockfiles",
-        "supply-chain",
-        "phase-1-verification",
-        "bot-prs",
-        "srp-violation",
-        "pixi-lock",
-        "maintainer-fixup"
-      ]
-    },
-    {
-      "name": "dependency-consolidation-pixi-single-source",
-      "description": "Consolidate Python dependency declarations across pixi.toml, pyproject.toml, and requirements*.txt into pixi.toml as the single source of truth. Use when: (1) dependencies are declared in multiple files with divergent version constraints, (2) pinned versions in requirements.txt conflict with pixi.toml ranges, (3) pyproject.toml duplicates dependency declarations already managed by pixi.",
-      "version": "1.0.0",
-      "source": "./skills/dependency-consolidation-pixi-single-source.md",
+      "source": "./skills/dependency-manifest-single-source-of-truth.md",
       "category": "ci-cd",
       "tags": [
         "pixi",
-        "dependencies",
         "pyproject",
         "requirements",
-        "consolidation",
+        "dependencies",
+        "manifest-consistency",
+        "version-constraints",
+        "regression-guard",
+        "pep-440",
+        "drift-detection",
         "ci-guardrail"
       ]
     },
     {
-      "name": "dependency-floor-consistency-regression-guard",
-      "description": "Detect and prevent dependency floor skew across manifests (pyproject.toml, pixi.toml). Use when managing dependencies with API-incompatible major versions to ensure published install contracts align with tested environments.",
+      "name": "dependency-update-automation-bot-prs",
+      "description": "Use when: (1) a repo uses pixi.toml for conda-forge deps but Dependabot only covers pip/github-actions \u2014 add Renovate to automate conda dep updates, (2) reviewing ANY bot-authored PR (Dependabot, Renovate) \u2014 run gh pr diff --name-only first because bot PRs frequently carry silent lockfile-format upgrades or maintainer fixup commits that the title doesn't mention, (3) a Dependabot PR title describes a single bump but the diff includes a pixi.lock v6->v7 format migration or unrelated files stacked on the bot branch, (4) a repo declares a centralized versions.yml/versions.json as single source of truth but automated bumps (Dependabot, weekly cron, hand-edits) update only the consumer files (Dockerfiles, workflow pins) while bypassing the manifest \u2014 causing silent drift.",
       "version": "1.0.0",
-      "source": "./skills/dependency-floor-consistency-regression-guard.md",
+      "source": "./skills/dependency-update-automation-bot-prs.md",
       "category": "ci-cd",
       "tags": [
-        "dependencies",
-        "manifest-sync",
-        "regression-testing",
-        "pyproject",
+        "dependabot",
+        "renovate",
         "pixi",
-        "PyGithub"
+        "conda-forge",
+        "bot-prs",
+        "pr-review",
+        "scope-bloat",
+        "lockfiles",
+        "pixi-lock",
+        "manifests",
+        "drift",
+        "single-source-of-truth",
+        "dockerfile",
+        "github-actions",
+        "dependency-automation",
+        "supply-chain"
       ]
-    },
-    {
-      "name": "dependency-upper-cap-constraint-alignment",
-      "description": "Synchronize version upper-cap constraints across all install manifests when packages have API-incompatible major versions. Use when: (1) aligning upper-cap constraints (e.g., <2) across pyproject.toml and pixi.toml, (2) ensuring pip-install and dev-env see same tested versions, (3) preventing version skew that bypasses CI testing when major versions have incompatible APIs.",
-      "version": "1.0.0",
-      "source": "./skills/dependency-upper-cap-constraint-alignment.md",
-      "category": "ci-cd",
-      "tags": [
-        "dependency-management",
-        "version-constraints",
-        "manifest-consistency",
-        "regression-testing",
-        "upper-cap"
-      ]
-    },
-    {
-      "name": "diverged-branch-cherry-pick-fix",
-      "description": "Fix a diverged feature branch by resetting to remote and cherry-picking specific fix commits. Use when: local branch has diverged from remote, fix commits exist locally but remote has additional commits.",
-      "version": "1.0.0",
-      "source": "./skills/diverged-branch-cherry-pick-fix.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "doc-config-drift-check",
-      "description": "Add a lightweight CI pre-commit script to detect drift between documented metric values (CLAUDE.md, README.md) and authoritative pyproject.toml config sources, including coverage threshold, --cov path, and README test count claims.",
-      "version": "2.0.0",
-      "source": "./skills/doc-config-drift-check.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "docker-ci-dead-step-cleanup",
-      "description": "Resolve CI workflows referencing non-existent test directories by removing dead steps and documenting deferred testing decisions",
-      "version": "1.0.0",
-      "source": "./skills/docker-ci-dead-step-cleanup.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "docker-mojo-uid-mismatch-crash-fix",
-      "description": "Fix deterministic Mojo runtime crash (exit 134) when container image UID differs from host runner UID. Use when: (1) mojo run crashes before executing any user code with 'filesystem error: status: Permission denied [/home/.../.modular]', (2) CI passes locally (UID 1000) but fails in CI runner (UID 1001+), (3) crash is 100% reproducible \u2014 not a flaky JIT issue, (4) cached CI image was built at a different UID than the current runner's uid, (5) execution crashed with __fortify_fail_abort in libKGENCompilerRTShared.so before any test output, (6) linker fails with 'cannot open output file build/release/X: Permission denied' even after _ensure_writable runs (non-recursive chown left subdirs root:root), (7) sudo chown or sudo mkdir silently failing in entrypoint (plain sudo blocks in podman compose exec -T), (8) training subdirs (datasets/, model weights dir) not writable after container startup.",
-      "version": "1.2.0",
-      "source": "./skills/docker-mojo-uid-mismatch-crash-fix.md",
-      "category": "ci-cd",
-      "tags": [
-        "docker",
-        "mojo",
-        "uid",
-        "permissions",
-        "container",
-        "crash",
-        "modular",
-        "cache-key",
-        "github-actions"
-      ]
-    },
-    {
-      "name": "docker-multistage-build",
-      "description": "Implement multi-stage Docker builds to reduce production image size by separating build-time and runtime dependencies",
-      "version": "1.0.0",
-      "source": "./skills/docker-multistage-build.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "exclude-build-targets-from-linker-errors",
-      "description": "Fix Mojo AOT linker errors by excluding directories that depend on unsupported system libraries (e.g. libm) from the build find command. Use when: mojo build fails with 'undefined reference to fmaxf/sincos/libm' symbols, build recipe silences errors with FAIL_ON_ERROR=0, or example/benchmark files fail AOT but run fine via mojo run.",
-      "version": "1.0.0",
-      "source": "./skills/exclude-build-targets-from-linker-errors.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "extend-workflow-smoke-tests",
-      "description": "Extend an existing workflow-smoke-test CI workflow to cover additional GitHub Actions workflows. Use when: (1) smoke tests exist for one workflow and need expansion, (2) pre-commit/test-matrix/config-validation workflows need regression protection, (3) a second CI job should verify properties of multiple workflow files.",
-      "version": "1.0.0",
-      "source": "./skills/extend-workflow-smoke-tests.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "failing-pr-discovery-gh-enumeration",
-      "description": "Discover failing open PRs via gh CLI using `gh pr list --json number,isDraft,statusCheckRollup,mergeStateStatus`. Filter by check conclusions (FAILURE/CANCELLED/TIMED_OUT) and mergeStateStatus==BLOCKED. Use synthetic-issue-key pattern (pr_num==issue_num) for consistency with issue-driven discovery. Use when: (1) automating PRs without relying on Closes #N issue mapping, (2) need to enumerate BLOCKED PRs from CI failures, (3) discovering work via PR-enumeration instead of issue-enumeration.",
-      "version": "1.0.0",
-      "source": "./skills/failing-pr-discovery-gh-enumeration.md",
-      "category": "ci-cd",
-      "tags": [
-        "gh-pr-list",
-        "statusCheckRollup",
-        "mergeStateStatus",
-        "pr-discovery",
-        "check-failures",
-        "BLOCKED-state",
-        "synthetic-issue-key",
-        "gh-json",
-        "automation-loop",
-        "drive-green-pattern"
-      ]
-    },
-    {
-      "name": "feature-on-refactor-rebase-port",
-      "description": "When a parallel PR wave mixes refactor PRs (decomposition / move-only) with feature PRs that touch the same source files, the feature PR goes DIRTY the moment a refactor merges. Use when: (1) a wave includes both file decomposition and feature wiring on overlapping files, (2) a feature PR conflicts after a sibling refactor merges, (3) you need to port edits from the old monolithic file onto a new sub-package facade structure. Also covers the case where the cross-cutting feature commit becomes uneconomic to port after multiple sibling waves merge \u2014 drop-and-redo as a follow-up PR off post-merge main.",
-      "version": "1.1.0",
-      "source": "./skills/feature-on-refactor-rebase-port.md",
-      "category": "ci-cd",
-      "tags": [
-        "rebase",
-        "parallel-pr",
-        "refactor-collision",
-        "git-worktree",
-        "recovery-agent",
-        "move-only-refactor",
-        "drop-and-redo"
-      ]
-    },
-    {
-      "name": "fix-ci-compilation-and-test-failures",
-      "description": "Use when: (1) CI fails with Mojo compilation error (unknown declaration, deprecated syntax), (2) markdownlint blocks pre-commit (MD051, MD037, MD031, MD040, MD026, MD013), (3) Mojo test assertion errors from edge cases, (4) CI segfaults from UnsafePointer access through copied structs, (5) all PR CI runs fail because of broken plugins on main (missing plugin.json or YAML frontmatter), (6) Dockerfile GID/UID collisions on Ubuntu 24.04, (7) pre-commit bash -c hooks silently lose filenames, (8) Mojo --Werror unused return value errors, (9) CI workflow references a renamed or missing test file, (10) tests pass locally but fail due to symlinks or mock bypass, (11) invalid pinned action SHAs in workflows, (12) need to identify required vs optional CI checks before fixing",
-      "version": "3.0.0",
-      "source": "./skills/fix-ci-compilation-and-test-failures.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-podman-rootless-ci",
-      "description": "Fix rootless Podman CI failures: Dockerfile ARG scoping, workspace UID mapping, compose provider compatibility. Use when: container builds fail with empty ARG values across FROM boundaries, bind-mounted files have Permission denied, or docker-compose doesn't support Podman extensions.",
-      "version": "1.0.0",
-      "source": "./skills/fix-podman-rootless-ci.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-rebased-ci-pr-stack",
-      "description": "Fix CI failures in a stacked PR series after rebase onto main. Use when: (1) multiple PRs diverged from main have CI failures from missing files, expired digests, paid-license actions, or unit tests that test the old structure, (2) a unit test patches or mocks a function by name that was renamed/replaced in the same PR (AttributeError: module does not have attribute 'old_name'), (3) a test was written for the old API that the PR itself replaces and now calls the nonexistent old function.",
-      "version": "1.1.0",
-      "source": "./skills/fix-rebased-ci-pr-stack.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "fix-type-annotation-callsite-errors",
-      "description": "Fix CI failures caused by AI-generated type annotations placed at function call sites instead of definitions, plus cascading mock path and return type errors. Use when: (1) pytest collection errors with SyntaxError on type annotations in function calls, (2) ruff F821 undefined name errors from annotations referencing unimported types, (3) mypy return-value errors from fixtures annotated -> None that return values, (4) mock patch paths changed to wrong modules.",
-      "version": "1.0.0",
-      "source": "./skills/fix-type-annotation-callsite-errors.md",
-      "category": "ci-cd",
-      "tags": [
-        "type-annotations",
-        "mypy",
-        "pytest",
-        "mock-patching",
-        "ci-fix"
-      ]
-    },
-    {
-      "name": "fix-yaml-frontmatter-colon-bug",
-      "description": "Fix YAML frontmatter parsing bugs where line.partition(':') silently truncates values containing colons. Use when: migrating a manual-split frontmatter parser to yaml.safe_load() following the partition-colon bug pattern.",
-      "version": "1.0.0",
-      "source": "./skills/fix-yaml-frontmatter-colon-bug.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "gh-check-ci-status",
-      "description": "Check CI/CD status of a pull request including workflow runs and test results",
-      "version": "1.1.0",
-      "source": "./skills/gh-check-ci-status.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "gh-create-pr-linked",
@@ -2229,114 +1117,115 @@
       "tags": []
     },
     {
-      "name": "gh-fix-pr-feedback",
-      "description": "Fix GitHub PR feedback",
+      "name": "gha-release-package-workflow-patterns",
+      "description": "Use when: (1) creating a tag-triggered release workflow with keepachangelog CHANGELOG format and semver version consistency checks across manifests, (2) implementing automated package building via GitHub Actions with artifact publication and GitHub Release creation, (3) adding pre-commit script validation of Python version drift between pyproject.toml classifiers and Dockerfile FROM line, (4) adding CI steps that replace fragile shell printf emoji byte-escape encoding with dedicated Python scripts for better portability.",
       "version": "1.0.0",
-      "source": "./skills/gh-fix-pr-feedback.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "git-gpg-sign-email-mismatch-silent-unsigned-blocks-merge",
-      "description": "Diagnose and fix silent GPG-signing failure modes that BLOCK PR merge under required_signatures / pr-policy 'every commit is signed' even with green CI. Covers: (a) commit.gpgsign=true plus author/committer email that does not match any UID on the GPG signing key producing commits GitHub reports verified=false reason=no_user (signs fine locally \u2014 %G?=G \u2014 but GitHub rejects); (b) GraphQL pullRequest.commits.signature.state lagging 10+ minutes behind reality so commits appear UNSIGNED in `gh pr view --json commits` while REST /commits/<sha> confirms verified=true; (c) sub-agent shells inheriting commit.gpgsign=true but silently failing to sign because gpg-agent was not pre-warmed (needs GPG_TTY + a priming gpg --batch call); (d) a GitHub +suffix noreply variant (e.g. user+bot@users.noreply.github.com) CANNOT be verified on a GitHub account so adding it as a key UID does NOT fix no_user \u2014 only {id}+{username}@users.noreply.github.com or a real verified email works; (e) bare `git commit -S` picking the wrong default signing key (%G?=E 'No public key') so pass `git -c user.signingkey=<subkey>`; (f) a commit that silently failed (pre-commit hook non-zero) leaves HEAD unchanged and `git log` shows the PREVIOUS commit's signature, masquerading as corruption. Use when: (1) PR shows mergeStateStatus BLOCKED with mergeable MERGEABLE and all CI green, (2) gh api .../commits returns verification.reason=no_user, (3) dispatching sub-agents that override user.email to a bot identity while keeping a personal GPG key, (4) auditing multi-repo sweeps for invisible signing failures, (5) `gh pr view --json commits` shows signature.state=null for newly-pushed commits, (6) sub-agent push produces unsigned commits despite global commit.gpgsign=true config, (7) global ~/.gitconfig sets a bot/automation email that hand-authored commits inherit and that fails verification, (8) building automated re-sign tooling that must validate the resign email against the signing key UIDs.",
-      "version": "2.2.0",
-      "source": "./skills/git-gpg-sign-email-mismatch-silent-unsigned-blocks-merge.md",
-      "category": "ci-cd",
-      "tags": [
-        "git",
-        "gpg",
-        "commit-signing",
-        "required-signatures",
-        "branch-protection",
-        "pull-requests",
-        "agent-dispatch",
-        "silent-failure",
-        "graphql-lag",
-        "gpg-agent"
-      ]
-    },
-    {
-      "name": "github-actions-env-var-lift-for-workflow-injection-hook",
-      "description": "PreToolUse security_reminder_hook (or actionlint / zizmor / CodeQL workflow-injection query) blocks an Edit to a `.github/workflows/*.yml` file because the surrounding `run:` block contains a `${{ \u2026 }}` template expression \u2014 even when the expression is a trusted `steps.*.outputs.*` or `inputs.*` value and your edit does not touch it. Use when: (1) you need to make an unrelated change inside a `run:` block (e.g. prefix a command with `pixi run`) and the hook rejects the diff; (2) the hook fires on `github.event.issue.title`, `.body`, `github.head_ref`, `head_commit.message`, etc.; (3) any linter flags `${{ ... }}` interpolation directly in a shell command line. Fix: lift the templated expression out of `run:` into an `env:` block on the same step, then reference it as a quoted shell variable (`\"$VAR\"`) inside `run:`. Do NOT bypass the hook \u2014 it points at a real injection sink class.",
-      "version": "1.0.0",
-      "source": "./skills/github-actions-env-var-lift-for-workflow-injection-hook.md",
+      "source": "./skills/gha-release-package-workflow-patterns.md",
       "category": "ci-cd",
       "tags": [
         "github-actions",
+        "releases",
+        "keepachangelog",
+        "semver",
+        "git-tags",
+        "version-consistency",
+        "version-drift",
+        "pre-commit",
+        "ci-portability",
+        "release-automation",
+        "package-publishing"
+      ]
+    },
+    {
+      "name": "gha-required-checks-branch-protection",
+      "description": "Use when: (1) PRs are permanently BLOCKED because a required status-check context is a job gated by if: github.event_name != 'pull_request' (skipped != satisfied), (2) consolidating duplicate CI jobs into a reusable workflow so _required.yml is a thin aggregator, (3) validating GitHub branch protection API responses and writing synthetic tests for bash enforcement scripts, (4) a summary aggregator job pattern is needed to replace N individual required contexts with one that handles skip semantics correctly.",
+      "version": "1.0.0",
+      "source": "./skills/gha-required-checks-branch-protection.md",
+      "category": "ci-cd",
+      "tags": [
+        "github-actions",
+        "branch-protection",
+        "required-status-checks",
+        "reusable-workflow",
+        "workflow-call",
+        "aggregator",
+        "summary-job",
+        "if-always",
+        "job-skip",
+        "api-validation",
+        "smoke-tests"
+      ]
+    },
+    {
+      "name": "gha-security-scanning-supply-chain",
+      "description": "Use when: (1) adding CodeQL SAST to TypeScript/JavaScript workflows or Semgrep/Gitleaks to any PR pipeline, (2) CI security scans only trigger on push to main \u2014 not PRs \u2014 and need promotion to PR gates, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) enforcing pinned SHA-based action versions instead of mutable tags, (5) auditing or porting curl|bash installers with SHA-256 verification, (6) a GHA job fails at 'Set up job' due to unresolved transitive action dependency.",
+      "version": "1.0.0",
+      "source": "./skills/gha-security-scanning-supply-chain.md",
+      "category": "ci-cd",
+      "tags": [
+        "codeql",
+        "semgrep",
+        "gitleaks",
+        "sarif",
+        "sast",
+        "secrets-scanning",
+        "dependency-scanning",
+        "pip-audit",
+        "npm-audit",
+        "dependabot",
+        "supply-chain",
+        "sha-pinning",
+        "curl-bash",
+        "installer",
+        "sha256-verification",
+        "github-actions",
+        "trivy",
+        "pixi",
+        "dockerfile"
+      ]
+    },
+    {
+      "name": "gha-workflow-authoring-pitfalls",
+      "description": "Use when: (1) a workflow file is silently ignored or produces 0 jobs due to invalid YAML job IDs (forward slashes), (2) a composite-action input description contains ${{ }} expressions that get evaluated unexpectedly, (3) a security hook blocks editing a workflow run: block because of a ${{ }} injection sink \u2014 and you need the env-var-lift pattern, (4) documenting platform asymmetries (Linux-only, macOS-skipped) in workflow header comments, (5) a WorkflowDispatch or PreToolUse hook fires on an edit to .github/workflows/*.yml.",
+      "version": "1.0.0",
+      "source": "./skills/gha-workflow-authoring-pitfalls.md",
+      "category": "ci-cd",
+      "tags": [
+        "github-actions",
+        "workflow-authoring",
+        "yaml",
+        "job-id",
+        "parse-failure",
+        "composite-action",
+        "template-expression",
         "workflow-injection",
         "security-hook",
-        "pretooluse",
         "env-var-lift",
-        "run-block",
-        "actionlint",
-        "zizmor",
-        "codeql",
-        "pixi"
+        "platform-scope",
+        "documentation",
+        "pretooluse",
+        "edit-tool"
       ]
     },
     {
-      "name": "github-actions-security-scanning-setup",
-      "description": "Use when: (1) adding CodeQL SAST analysis to TypeScript/JavaScript workflows, (2) implementing npm audit with production-only dependency scanning, (3) enforcing Gitleaks on PRs while keeping main branch advisory, (4) isolating security-events:write permissions from base required checks, (5) managing pre-existing CVEs in transitive dependencies.",
+      "name": "github-auto-merge-ci-gating-merge-method",
+      "description": "Use when: (1) a PR has mergeStateStatus CLEAN or MERGEABLE but auto-merge never fires despite all checks passing, (2) gh pr merge --auto --rebase or --squash returns an error or silently fails on a squash-only repo, (3) a PR is BLOCKED because required CI status contexts never post (workflow never triggered, paths filter excluded PR, required check name mismatch), (4) GPG-signing failures or mismatched committer emails cause commits to be unsigned and block the pr-policy gate, (5) branch protection rulesets and classic branch protection disagree and their union blocks merge, (6) a CI ruleset chicken-and-egg deadlock blocks a PR that introduces a new workflow, (7) an advisory check should not block merge but currently does because it lives in the required gate, (8) deciding which merge method a repo supports before arming auto-merge, (9) auditing required-check names after adding or removing CI jobs, (10) state:implementation-go label or pr-policy gates auto-merge arming, (11) per-issue arming-state machine is triggered on the wrong event (optimistic point vs detected merge)",
       "version": "1.0.0",
-      "source": "./skills/github-actions-security-scanning-setup.md",
-      "category": "ci-cd",
-      "tags": [
-        "codeql",
-        "npm-audit",
-        "gitleaks",
-        "github-actions",
-        "sast",
-        "dependency-scanning",
-        "secrets-scanning",
-        "typescript",
-        "workflow-isolation"
-      ]
-    },
-    {
-      "name": "github-actions-workflow-required-checks",
-      "description": "Canonical guide to GitHub Actions workflow configuration and required status check management. Use when: (1) a PR is blocked because a required status context never posts, (2) reconciling branch protection rulesets with actual job names, (3) diagnosing fan-in / paths-filter / job-skip patterns, (4) adding or removing a required check without breaking open PRs, (5) workflow_dispatch + composite-action wiring, (6) hardening workflows with permissions/concurrency/timeouts, (7) SHA-pinning actions for supply-chain security, (8) runner pool saturation in swarm sessions, (9) pixi caching failures, (10) bot push to protected branch pattern, (11) batch PR CI triage.",
-      "version": "1.0.0",
-      "source": "./skills/github-actions-workflow-required-checks.md",
-      "category": "ci-cd",
-      "tags": [
-        "merged",
-        "github-actions",
-        "workflow",
-        "required-checks",
-        "branch-protection",
-        "ruleset"
-      ]
-    },
-    {
-      "name": "github-auto-merge-no-ci-runs",
-      "description": "GitHub auto-merge stalls indefinitely on a CLEAN PR when no CI workflow ever runs on the branch. Use when: (1) PR has mergeStateStatus: CLEAN and auto-merge armed but hasn't merged after hours, (2) gh pr view --json statusCheckRollup returns empty array [], (3) docs-only, pod-spec, or non-code PRs stuck with armed auto-merge, (4) investigating why auto-merge didn't fire on a PR that looks ready, (5) gh pr list returns fewer PRs than expected \u2014 default limit is 30 and silently omits older PRs, (6) gh pr merge --auto --squash returns GraphQL 'Pull request is in clean status' error on a CLEAN PR, (7) gh pr merge --auto --squash returns GraphQL 'Pull request is in unstable status' \u2014 transient; retry after a few seconds, (8) squash-only repos reject --rebase flag on gh pr merge --auto, (9) scheduled workflow (apply.yml) shows failure on main but required checks all pass, (10) PRs armed with --auto --squash do not auto-fire after branch protection rules are relaxed (e.g., review requirement removed) \u2014 must be nudged with manual `gh pr merge <n> --squash`, (11) a required-check gate job (e.g. pr-policy) fails with 'Auto-merge is not enabled' immediately after PR creation though auto-merge IS enabled \u2014 a propagation race; re-run the failed job, (12) PR shows failed/cancelled checks but is actually fine \u2014 a pr-policy auto-merge check failed on the FIRST run and cancelled all sibling jobs (lint/tests/security/markdownlint/shellcheck all show cancelled) via the concurrency group, but the workflow re-ran on the auto_merge_enabled event and went green, (13) auto-merge not firing right after open but pr-policy failing \u2014 the workflow self-heals once gh pr merge --auto --squash propagates and the auto_merge_enabled trigger re-runs it; no manual rerun needed, (14) cancelled CI jobs after opening a PR \u2014 diagnose by comparing statusCheckRollup entries' startedAt: the earlier pr-policy run is the race, the later (re-run) one is authoritative, (15) pr-policy fails 'Auto-merge is enabled before implementation review GO' on a freshly-armed PR \u2014 the repo now gates auto-merge behind a state:implementation-go label (NOT the old propagation race); apply the label with gh pr edit --add-label to make the armed state compliant, (16) you want a pull_request_target labeled workflow to enable squash auto-merge only after state:implementation-go without running PR code, (17) pr-policy fails after an already-merged PR because GitHub cleared autoMergeRequest \u2014 fetch PR state and treat non-OPEN as terminal.",
-      "version": "1.6.0",
-      "source": "./skills/github-auto-merge-no-ci-runs.md",
+      "source": "./skills/github-auto-merge-ci-gating-merge-method.md",
       "category": "ci-cd",
       "tags": [
         "auto-merge",
         "github",
         "ci-cd",
-        "path-filter",
-        "status-checks",
-        "docs-only",
-        "implementation-go",
-        "pull-request-target",
-        "pr-policy"
-      ]
-    },
-    {
-      "name": "github-branch-protection-api-validation",
-      "description": "GitHub branch protection API enforcement with response validation and synthetic testing. Use when: (1) implementing new branch protection rules, (2) adding API PUT calls that need validation, (3) testing bash scripts with environment fixtures.",
-      "version": "1.0.0",
-      "source": "./skills/github-branch-protection-api-validation.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
+        "merge-method",
+        "squash",
         "branch-protection",
-        "api",
-        "bash-testing",
-        "validation"
+        "rulesets",
+        "required-checks",
+        "pr-policy",
+        "implementation-go",
+        "gpg-signing",
+        "arming-state-machine"
       ]
     },
     {
@@ -2346,64 +1235,6 @@
       "source": "./skills/haiku-batch-worktree-agents.md",
       "category": "ci-cd",
       "tags": []
-    },
-    {
-      "name": "hatch-vcs-pyproject-auto-versioning-setup",
-      "description": "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, and update downstream tooling that assumed the static-version world. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily, (5) post-migration, importlib.metadata.version() raises PackageNotFoundError because the import name differs from the distribution name, (6) a version-consistency or single-source check script grep's pyproject.toml for a version field that no longer exists.",
-      "version": "1.1.0",
-      "source": "./skills/hatch-vcs-pyproject-auto-versioning-setup.md",
-      "category": "ci-cd",
-      "tags": [
-        "hatch-vcs",
-        "hatchling",
-        "pyproject",
-        "auto-versioning",
-        "git-tags",
-        "dynamic-version",
-        "importlib-metadata",
-        "distribution-name",
-        "single-source-versioning",
-        "ci-cd"
-      ]
-    },
-    {
-      "name": "hi-branch-protection-two-layer",
-      "description": "HomericIntelligence main-branch protection is split across TWO layers (repo ruleset + classic branch protection) whose UNION GitHub enforces. Use when: (1) managing HI main-branch protection or deciding whether a rule belongs in a ruleset vs classic branch protection, (2) a PR is BLOCKED by a review/check that the ruleset reports as 0/absent (the OTHER layer adds it), (3) a ruleset PUT returns HTTP 422 on required_conversation_resolution, (4) `gh api .../branches/main/protection` 404 body gets parsed as fake required-check contexts, (5) a `branch-protection-drift` required check fails on every PR with HTTP 403 'Resource not accessible by integration' (admin endpoint with the default token) or fails on review-count/dismiss-stale assertions that disagree with the in-repo canonical policy.",
-      "version": "1.1.0",
-      "source": "./skills/hi-branch-protection-two-layer.md",
-      "category": "ci-cd",
-      "tags": [
-        "github",
-        "rulesets",
-        "branch-protection",
-        "classic-protection",
-        "required-signatures",
-        "conversation-resolution",
-        "linear-history",
-        "gh-api",
-        "branch-protection-drift",
-        "drift-check",
-        "rules-endpoint"
-      ]
-    },
-    {
-      "name": "installer-bash-security-pinning-verification",
-      "description": "Use when: (1) adding new curl|bash installers to shell scripts, (2) auditing installer security for unverified pipe-to-shell patterns, (3) porting installers to new projects, (4) hardening existing installation workflows with SHA-256 verification and multi-platform support.",
-      "version": "1.0.0",
-      "source": "./skills/installer-bash-security-pinning-verification.md",
-      "category": "ci-cd",
-      "tags": [
-        "bash",
-        "curl",
-        "installer",
-        "sha256-verification",
-        "supply-chain",
-        "pixi",
-        "dagger",
-        "just",
-        "shell-security",
-        "trust-model"
-      ]
     },
     {
       "name": "justfile-and-local-build-verification",
@@ -2419,24 +1250,6 @@
         "local-verification",
         "pre-commit",
         "ci"
-      ]
-    },
-    {
-      "name": "lcov-coverage-script-ci-fixes",
-      "description": "Fix generate_coverage.sh scripts failing in CI with lcov/geninfo. Use when: (1) coverage script fails with wrong paths after BUILD_DIR is a relative path, (2) cmake source dir is wrong after cd into build dir, (3) lcov fails with gcov version mismatch error on Ubuntu 24.04 with Clang, (4) geninfo fails with 'unable to create link .gcda' when multiple test targets share source files.",
-      "version": "1.0.0",
-      "source": "./skills/lcov-coverage-script-ci-fixes.md",
-      "category": "ci-cd",
-      "tags": [
-        "lcov",
-        "gcov",
-        "geninfo",
-        "coverage",
-        "ci-cd",
-        "clang",
-        "ubuntu",
-        "bash",
-        "generate_coverage"
       ]
     },
     {
@@ -2511,76 +1324,84 @@
       ]
     },
     {
-      "name": "mkdocs-nav-cleanup",
-      "description": "Fix and PREVENT MkDocs build failures from nav or cross-references pointing at deleted files. Use when: (1) about to push a PR that deletes documentation/ADR/repro files (run pre-deletion audit first), (2) CI 'Deploy Documentation' job fails after deleting doc stubs, (3) mkdocs build --strict reports missing files, (4) PR deletes placeholder docs but mkdocs.yml nav still references them, (5) --strict rejects a relative link like ../../docs/dev/file.md that escapes the docs/ root.",
-      "version": "1.2.0",
-      "source": "./skills/mkdocs-nav-cleanup.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "mojo-jit-crash-and-retry-strategies",
-      "description": "HISTORICAL REFERENCE \u2014 most patterns OBSOLETE as of Mojo 1.0.0b2.dev2026052506 (modular/modular#6413 fixed upstream). Do NOT use the retry-wrapper, continue-on-error matrix, gdb-coredump-capture, or 4-hypothesis disproof patterns in NEW code. Use when: (1) reading historical PR/issue context that references these patterns, (2) needing the runtime-crash-bisection minimal-reproducer methodology (still useful for future Mojo bugs), (3) understanding the closed-source boundary for libKGEN/libAsyncRT/libMSupport debugging, (4) needing the AVX-512 wrong-ISA forensics for analogous CPU-feature bugs. NOT a guide for treating Mojo crashes as flakes \u2014 that posture was wrong and is now removed.",
-      "version": "2.1.0",
-      "source": "./skills/mojo-jit-crash-and-retry-strategies.md",
+      "name": "mojo-build-compilation-and-linker-error-patterns",
+      "description": "Use when: (1) adding --Werror to a Mojo build system and auditing all files for hidden warnings, (2) CI fails with Mojo import errors after module renames, mojo-format pre-commit hook line-length failures, or stable vs nightly version mismatch, (3) mojo build fails with 'undefined reference to fmaxf/sincos/libm' symbols from AOT compilation of example or benchmark files, (4) enabling ASAN/TSAN for Mojo CI and diagnosing tcmalloc/sanitizer incompatibility or AVX-512 codegen asymmetry, (5) resolving git rebase conflicts in Mojo test files by converting invalid Python syntax to valid Mojo Bool flag patterns, (6) fixing out-of-bounds List access from DynamicVector\u2192List migration where index assignment was not converted to append.",
+      "version": "1.0.0",
+      "source": "./skills/mojo-build-compilation-and-linker-error-patterns.md",
       "category": "ci-cd",
       "tags": [
-        "obsolete",
-        "historical",
         "mojo",
-        "jit",
-        "crash",
-        "libkgen",
-        "forensics",
-        "avx512",
-        "bisection",
-        "ci"
-      ]
-    },
-    {
-      "name": "mojo-sanitizer-and-build-flags",
-      "description": "Canonical patterns for Mojo sanitizer integration and build-flag matrices: ASAN/TSAN scope, tcmalloc/sanitizer incompatibility, sanitizer-only build flavors, build-flag matrix design, AVX-512 driver-vs-sanitizer codegen asymmetry, compiler-flag conflicts that break Mojo compilation. Use when: (1) enabling a sanitizer for Mojo CI, (2) diagnosing a tcmalloc/sanitizer crash, (3) designing a multi-flag CI matrix for Mojo builds, (4) reconciling conflicting compiler flags that surface only on Mojo, (5) removing AVX-512 strip workarounds after modular/modular#6413 fix, (6) sanitizer builds SIGILL on AVX-512-masked CI runners even after the driver-path fix.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-sanitizer-and-build-flags.md",
-      "category": "ci-cd",
-      "tags": [
-        "merged",
-        "mojo",
+        "build",
+        "compilation",
+        "linker",
+        "werror",
+        "mojo-format",
         "sanitizer",
         "asan",
         "tsan",
-        "build-flags",
-        "tcmalloc",
         "avx512",
-        "target-features",
-        "codegen"
+        "libm",
+        "rebase",
+        "dynamicvector",
+        "ci-cd"
       ]
     },
     {
-      "name": "multi-repo-pr-orchestration-swarm-pattern",
-      "description": "Orchestrate PR management across all HomericIntelligence repos using myrmidon swarm. Use when: (1) multiple repos have open PRs that need merging, conflict resolution, or CI fixes, (2) Odysseus submodule pins need updating after cross-repo PR merges, (3) coordinating parallel waves of agents across 5+ repos with sequential-within-repo merge ordering, (4) a PR branch has a duplicate commit that's already on main and needs rebase, (5) mergeStateStatus is BLOCKED but statusCheckRollup is empty \u2014 CI may not have started yet, (6) running hephaestus-plan-issues and hephaestus-implement-issues across 10+ repos in a cron-style automation loop, (7) multiple repos have failing PRs that need CI diagnosis and fixing via parallel sub-agents, (8) CI failures share common root causes across repos (org policy, missing images, deprecated syntax, formatting), (9) you've already done the planning yourself and want to bypass the orchestrator's Phase-1 re-plan \u2014 dispatch direct `Agent` calls with a shared brief instead of invoking `/hephaestus:myrmidon-swarm`, (10) the same procedure applies to N repos with only minor per-repo deltas, and inline-quoting the instructions would burn parent context, (11) post-dispatch, one agent surfaces a gap (e.g. regex doesn't catch all control-flow boundaries) that should propagate to a follow-up PR on the meta-repo rather than reissuing prompts.",
-      "version": "2.2.0",
-      "source": "./skills/multi-repo-pr-orchestration-swarm-pattern.md",
+      "name": "mojo-ci-runtime-crash-diagnosis-and-mitigation",
+      "description": "Use when: (1) CI fails non-deterministically with 'JIT session error: Cannot allocate memory' or SIGSEGV in libKGENCompilerRTShared.so on GHA free-tier runners (VMA exhaustion from ~3.6 GB per mojo invocation), (2) auditing GHA workflows for unprotected bare 'pixi run mojo' calls and applying retry logic for JIT crash resilience, (3) validating that an upstream Mojo fix (runtime crash, codegen flag, compiler-driver bug) actually landed in a bumped nightly before removing downstream workarounds, (4) diagnosing a 'SIGILL on this host but works on others' crash using 4-layer CPU feature detection (kernel /proc/cpuinfo, raw cpuid, compiler-rt __builtin_cpu_supports, compiler driver target resolution), (5) fixing a deterministic Mojo runtime crash (exit 134) when container image UID differs from host runner UID causing Permission denied on ~/.modular, (6) understanding historically documented JIT retry patterns that are now obsolete after modular/modular#6413.",
+      "version": "1.0.0",
+      "source": "./skills/mojo-ci-runtime-crash-diagnosis-and-mitigation.md",
+      "category": "ci-cd",
+      "tags": [
+        "mojo",
+        "jit",
+        "crash",
+        "ci",
+        "gha",
+        "vma",
+        "libkgen",
+        "sigill",
+        "sigsegv",
+        "cpu-feature-detection",
+        "cpuid",
+        "print-effective-target",
+        "uid-mismatch",
+        "container",
+        "upstream-validation",
+        "retry",
+        "avx512",
+        "modular-6413"
+      ]
+    },
+    {
+      "name": "multi-repo-pr-automation-loop-orchestration",
+      "description": "Use when: (1) running an automation loop (drive-prs-green, hephaestus-automation-loop, loop_runner.py, ci_driver.py) across multiple repos and it skips PRs, reports success incorrectly, silently no-ops, or never arms auto-merge, (2) a multi-repo swarm is orchestrating PRs across 3+ HomericIntelligence repos with sequential-within-repo merge ordering, (3) an ecosystem-wide sweep implements every planned issue across all repos in parallel waves, (4) the automation driver logs success but live GitHub state shows open failing PRs \u2014 always cross-check live state per repo before reporting done, (5) a hephaestus automation loop deadlocks because the drive-green phase skips iterations or the implementer returns early before labeling with state:implementation-go, (6) an org-wide issue backlog across 10+ repos needs parallel implementation with one signed auto-merge PR per issue, (7) automated review-plan files (claude-review-fix-*.md) need to be bulk-processed across stale PR branches, (8) _wait_for_pr_terminal polls the full timeout on a BLOCKED PR \u2014 add early-exit guarded by both _failing_required_check_names and _pending_required_check_names",
+      "version": "1.1.0",
+      "source": "./skills/multi-repo-pr-automation-loop-orchestration.md",
       "category": "ci-cd",
       "tags": [
         "multi-repo",
-        "PR",
-        "merge",
-        "submodule",
+        "pr-automation",
+        "drive-prs-green",
+        "hephaestus-automation-loop",
+        "ci-driver",
+        "loop-runner",
         "myrmidon-swarm",
-        "cross-repo",
-        "orchestration",
-        "odysseus",
-        "duplicate-commit",
-        "pin-audit",
-        "automation-loop",
-        "pixi",
-        "pythonpath",
-        "gh-cli",
-        "rate-limit",
-        "ci-triage",
-        "org-policy",
-        "container-image"
+        "report-vs-live-state",
+        "silent-no-op",
+        "honest-reporting",
+        "wait-for-merge",
+        "auto-merge-armed",
+        "implementation-go-label",
+        "ecosystem-sweep",
+        "org-wide-swarm",
+        "batch-review-plan",
+        "sequential-within-repo",
+        "squash-auto-merge",
+        "homericintelligence",
+        "blocked-pr-early-exit",
+        "pending-required-checks",
+        "wait-for-pr-terminal"
       ]
     },
     {
@@ -2626,150 +1447,110 @@
       "tags": []
     },
     {
-      "name": "pixi-cache-true-unreliable",
-      "description": "Fixes unreliable Pixi caching from setup-pixi's built-in cache: true, AND warns that under locked: true a SECOND actions/cache over .pixi poisons the locked env (downgrades packages, fails pip-audit/dependency-scan). Replace cache: true with explicit actions/cache (non-locked); with locked: true rely ONLY on setup-pixi's built-in cache. Use when: (1) CI logs show 'Saved cache with ID -1', (2) cache hits inconsistent despite cache: true, (3) consolidating Pixi setup into a composite action, (4) dependency-scan/pip-audit fails on an already-patched pixi.lock, (5) setup-pixi installs a newer version than pip-audit then audits.",
-      "version": "2.1.0",
-      "source": "./skills/pixi-cache-true-unreliable.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pixi-precommit-hook-binary-resolution",
-      "description": "Pre-commit hooks that invoke 'pixi run <hephaestus-command>' appear to fail with the system-installed binary (newer version with stricter checks) when the project's own pixi env hasn't been populated via 'pixi run dev-install'. Use when: (1) pre-commit check-dep-sync fails locally with 'pyproject.toml contains [project.optional-dependencies] \u2014 remove it' but the same check passes in CI, (2) 'which hephaestus-*' inside 'pixi run' returns the system ~/.local/bin path instead of .pixi/envs/default/bin, (3) a pre-commit hook that invokes a console-script via 'pixi run' is using a newer/older version of that script than the one in the current repo, (4) CI pre-commit job runs 'pixi run dev-install' before running hooks but local dev environment does not.",
+      "name": "pr-ci-failure-triage-preexisting-vs-introduced",
+      "description": "Use when: (1) a PR has unexpected CI failures and you need to determine if they are PR-introduced or pre-existing main-branch rot before bisecting, reverting, or retriggering, (2) CI fails after a force-push and cancelled runs from the old SHA appear as failures in the PR status rollup, (3) a required CI check fails on a PR whose diff is unrelated to the failing job, (4) CI failures look like flakes (Mojo JIT crash, SIGABRT) and need to be classified before a rerun, (5) stale CI warnings need to be surfaced in PR comments rather than stderr only, (6) CI coverage gate fails because it measures the merge-preview tree rather than the branch alone, (7) a stacked rebased PR has stale CI runs and needs fresh triggering without code changes, (8) sanitizer or compilation jobs fail identically on a PR because stale duplicate commits from another branch are present on the PR branch, (9) deciding whether to fix in-scope, admin-merge, or file a follow-up issue for a blocking failure",
       "version": "1.0.0",
-      "source": "./skills/pixi-precommit-hook-binary-resolution.md",
-      "category": "ci-cd",
-      "tags": [
-        "pixi",
-        "pre-commit",
-        "dev-install",
-        "binary-resolution",
-        "hephaestus",
-        "console-scripts"
-      ]
-    },
-    {
-      "name": "post-remediation-audit",
-      "description": "Execute a structured post-remediation audit to close remaining quality gaps after an initial cleanup round. Use when: preparing a repo for ecosystem integration, verifying CI/classifier/release-gate alignment, or ensuring all code quality gaps are resolved after a first-pass remediation.",
-      "version": "1.0.0",
-      "source": "./skills/post-remediation-audit.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pr-conflict-rebase-workflow",
-      "description": "Rebase conflicting PRs onto main when a merge commit introduces workflow changes. Use when: (1) multiple open PRs are CONFLICTING after a main branch merge, (2) GitHub Actions workflow files conflict over concurrency/permissions/timeout additions, (3) pixi.lock is in a modify/delete conflict during rebase, (4) two independent CI fix branches both modified the same workflow file with different approaches \u2014 one already merged to main and the other needs rebasing, (5) rebasing a consolidation/merge branch that deleted absorbed files, where those files were subsequently modified on the base branch \u2014 produces modify/delete (UD) conflicts on every absorbed file, (6) a test-coverage PR conflicts because main added nearby tests while the PR added helpers or edge-case tests.",
-      "version": "1.3.0",
-      "source": "./skills/pr-conflict-rebase-workflow.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pr-merged-state-not-proof-of-remote-sync",
-      "description": "GitHub API state, your local `origin/<branch>` ref, and your working tree are three independent surfaces that diverge until `git fetch` runs \u2014 in BOTH the read direction (`gh pr view` says MERGED but refs are stale) and the write direction (a local branch and `origin/<same-name>` point at different commits because a parallel process pushed). A matching branch NAME does not imply matching CONTENT. Use when: (1) about to report `PR is merged` based on `gh pr view`, (2) auditing whether a file is present/absent in main after a deletion or rename PR, (3) spawning sub-agents that grep or scan the working tree expecting it matches main, (4) running deletion-validation or migration-completeness workflows, (5) reasoning about whether `origin/main` reflects the latest merges, (6) a sub-agent reports `feature X didn't execute / files missing / wave didn't run` immediately after PRs were marked merged, (7) about to push a local `<issue>-impl` / feature branch to update a PR when a parallel automation process may have pushed to the same branch name, (8) merging main into a local branch and pushing it to a PR branch you did not author end-to-end.",
-      "version": "1.1.0",
-      "source": "./skills/pr-merged-state-not-proof-of-remote-sync.md",
-      "category": "ci-cd",
-      "tags": [
-        "gh-cli",
-        "git-fetch",
-        "audit",
-        "sub-agents",
-        "merge-verification",
-        "working-tree",
-        "branch-divergence",
-        "parallel-automation",
-        "fast-forward-gate",
-        "rev-parse"
-      ]
-    },
-    {
-      "name": "pr-preexisting-failure-triage",
-      "description": "Distinguish PR-introduced CI failures from pre-existing main-branch rot using the GitHub check-runs API per individual check name (NOT workflow name), then resolve confirmed pre-existing failures via the quick-fix / admin-merge / tracking-issue ladder. Use when: (1) a PR is BLOCKED by failing required status checks, (2) a reviewer has labeled failures as PREEXISTING_CI_NOISE (re-verify \u2014 they are wrong ~2/3 of the time), (3) you must decide between fixing in-scope, admin-merging, or filing a follow-up issue.",
-      "version": "1.1.0",
-      "source": "./skills/pr-preexisting-failure-triage.md",
+      "source": "./skills/pr-ci-failure-triage-preexisting-vs-introduced.md",
       "category": "ci-cd",
       "tags": [
         "ci-failure",
-        "pr-blocked",
+        "triage",
         "preexisting",
+        "pr-introduced",
         "check-runs-api",
+        "force-push",
+        "cancelled-runs",
+        "concurrency-supersession",
+        "mojo-jit",
+        "flaky",
+        "stale-cache",
         "admin-merge",
         "tracking-issue",
-        "required-status-check"
+        "stale-duplicate-commit"
       ]
     },
     {
-      "name": "pr-rebase-pipeline",
-      "description": "Fix a systemic CI failure blocking all PRs, then ship fixes in parallel waves using git worktrees. Also covers rebasing a single diverged PR when an automated fix plan has stale state.",
-      "version": "1.1.0",
-      "source": "./skills/pr-rebase-pipeline.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "pr-review-no-action-ci-diagnosis",
-      "description": "Use when: (1) a PR review-fix plan concludes no code changes are required, (2) CI failures appear on a PR but changes are unrelated to the failing jobs, (3) CI flakes need to be distinguished from PR-introduced regressions, (4) a fix commit may be local-only and not yet pushed to remote, (5) a stale branch was force-pushed dropping a fix commit, (6) verifying a PR is ready to merge despite red CI, (7) a REQUIRED status check (e.g. security/dependency-scan, pip-audit) fails identically across multiple unrelated PRs because of a stale build/dependency cache in CI rather than anything in the PR's diff",
-      "version": "2.2.0",
-      "source": "./skills/pr-review-no-action-ci-diagnosis.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "precommit-scope-full-pr-diff-not-current-edit",
-      "description": "Before `git push` for a PR, run pre-commit against the full PR diff (every file changed since the merge-base with the target branch), not just the files of the most recent edit. `pre-commit run --files X Y Z` only checks X, Y, Z; a sub-agent's earlier commit can carry stale-formatter content that no one re-checks locally and that only fails in CI. Use when: (1) handing off work between sub-agents that each ran their own per-file pre-commit, (2) making fixup commits after a delegated change and preparing to push, (3) any time `pre-commit run --all-files` is considered too slow and you reach for `--files`, (4) diagnosing CI mojo-format / ruff-format / formatter failures on files you did not personally edit in this session, (5) writing a pre-push checklist for any repo where formatter hooks rewrite files.",
+      "name": "pr-enumeration-discovery-idempotency",
+      "description": "Use when: (1) gh pr list silently truncates results because the default limit is 30 and a repo has more open PRs, (2) gh label list or gh issue list silently drops entries past the default pagination limit, (3) Dependabot or other bot-authored PRs are invisible to issue-driven automation because they have no Closes #N link \u2014 use synthetic issue-key union pattern, (4) an automation tool creates duplicate PRs for the same issue because it lacks an idempotency check before calling gh pr create, (5) GitHub API reports a PR as merged but the remote ref and local working tree have not yet synced \u2014 merged state is not proof of remote sync, (6) a bulk PR-sync tool times out (HTTP 504) because gh pr list with statusCheckRollup at 50+ PRs is too heavy \u2014 fetch statusCheckRollup per-PR instead, (7) a bulk driver silently skips the whole PR queue by returning an empty list on a gh error instead of raising, (8) stale CI classification marks BEHIND/BLOCKED PRs as FAILING and skips them when they should be rebased",
       "version": "1.0.0",
-      "source": "./skills/precommit-scope-full-pr-diff-not-current-edit.md",
+      "source": "./skills/pr-enumeration-discovery-idempotency.md",
       "category": "ci-cd",
       "tags": [
-        "pre-commit",
-        "mojo-format",
-        "sub-agent-handoff",
-        "pr-diff",
-        "ci-parity",
-        "formatter",
-        "pre-push"
-      ]
-    },
-    {
-      "name": "pytest-coverage-threshold-config",
-      "description": "Configure pytest coverage thresholds to enforce minimum code coverage in CI/CD pipelines with multiple report formats",
-      "version": "1.0.0",
-      "source": "./skills/pytest-coverage-threshold-config.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "python-version-drift-detection",
-      "description": "Detect Python version drift between pyproject.toml classifiers and Dockerfile FROM line. Use when adding CI checks to prevent silent version mismatches.",
-      "version": "1.0.0",
-      "source": "./skills/python-version-drift-detection.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "renovate-pixi-conda-dependency-automation",
-      "description": "Add Renovate config to automate conda-forge/pixi dependency updates that Dependabot cannot parse. Use when: (1) a repo uses pixi.toml for conda-forge deps but Dependabot only covers pip/github-actions, (2) conda deps are updated manually with no automation signal, (3) setting up Renovate to mirror an existing Dependabot cadence/grouping.",
-      "version": "1.0.0",
-      "source": "./skills/renovate-pixi-conda-dependency-automation.md",
-      "category": "ci-cd",
-      "tags": [
-        "renovate",
-        "pixi",
-        "conda",
-        "conda-forge",
+        "gh-pr-list",
+        "gh-api-paginate",
+        "pagination",
+        "silent-truncation",
+        "bot-pr",
+        "synthetic-issue-key",
         "dependabot",
-        "dependency-automation",
-        "renovate-json"
+        "duplicate-pr",
+        "idempotency",
+        "statusCheckRollup",
+        "504-gateway-timeout",
+        "mergeStateStatus",
+        "stale-ci",
+        "merged-state-sync",
+        "pr-discovery",
+        "bulk-pr-sync"
       ]
     },
     {
-      "name": "replace-printf-emoji-with-python-script",
-      "description": "Replace fragile shell printf emoji byte-escape encoding in CI workflows with a dedicated Python script. Use when: CI workflow uses printf with \\xf0\\x9f byte escapes for emoji, or report-building shell steps need to be made locale-independent.",
+      "name": "pr-rebase-conflict-resolution-patterns",
+      "description": "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted \u2014 later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed",
       "version": "1.0.0",
-      "source": "./skills/replace-printf-emoji-with-python-script.md",
+      "source": "./skills/pr-rebase-conflict-resolution-patterns.md",
       "category": "ci-cd",
-      "tags": []
+      "tags": [
+        "git",
+        "rebase",
+        "merge-conflict",
+        "pr",
+        "batch",
+        "stacked-pr",
+        "cherry-pick",
+        "safety-net",
+        "parallel-swarm",
+        "serial-merge-train",
+        "full-rewrite",
+        "shadow-variable",
+        "tdz",
+        "numeric-equivalence",
+        "clang-format",
+        "cmake",
+        "pixi-lock",
+        "force-with-lease",
+        "auto-merge"
+      ]
+    },
+    {
+      "name": "pr-review-loop-orchestration-agent-patterns",
+      "description": "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced \u2014 resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review \u2014 wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing",
+      "version": "1.0.0",
+      "source": "./skills/pr-review-loop-orchestration-agent-patterns.md",
+      "category": "ci-cd",
+      "tags": [
+        "implement-review-loop",
+        "review-thread-resolution",
+        "evidence-based-resolution",
+        "commit-gated-progress",
+        "verdict-go-convergence",
+        "inline-comment-diff-hunk",
+        "422",
+        "unprocessable-entity",
+        "no-commit-retry",
+        "review-thread-injection",
+        "force-engagement-retry",
+        "agent-type-selection",
+        "feature-dev-code-reviewer",
+        "general-purpose",
+        "graphql-field-validation",
+        "schema-introspection",
+        "addPullRequestReviewThreadReply",
+        "self-cancelling-review-plan",
+        "pre-commit-merge-base-diff",
+        "graphql-review-threads",
+        "homericintelligence"
+      ]
     },
     {
       "name": "rescue-broken-prs",
@@ -2780,86 +1561,6 @@
       "tags": []
     },
     {
-      "name": "resolve-mojo-rebase-conflict",
-      "description": "Resolve git rebase conflicts in Mojo test files by converting invalid Python syntax to valid Mojo patterns using Bool flags",
-      "version": "1.0.0",
-      "source": "./skills/resolve-mojo-rebase-conflict.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "retrigger-flaky-ci",
-      "description": "Diagnose and re-trigger pre-existing flaky CI failures on PRs without code changes. Use when: CI fails on a PR with only cosmetic/doc changes, the failure is in test files not touched by the PR, or Mojo runtime crashes (SIGABRT, execution crashed) appear in CI logs.",
-      "version": "1.0.0",
-      "source": "./skills/retrigger-flaky-ci.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "retry-all-mojo-workflow-calls",
-      "description": "Audit GitHub Actions workflows for unprotected bare pixi run mojo calls and apply retry logic. Use when: retry was applied to one workflow but others still have bare pixi run mojo calls, or when auditing CI for JIT crash resilience.",
-      "version": "1.0.0",
-      "source": "./skills/retry-all-mojo-workflow-calls.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "security-scanning-and-supply-chain-hardening",
-      "description": "Use when: (1) CI security scans only trigger on push to main (not PRs), (2) Semgrep or Gitleaks failures are silently masked with continue-on-error, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) GitHub Actions use mutable version tags instead of pinned commit SHAs, (5) a Dockerfile or workflow installs tools via unverifiable curl|sh, npm, or pixi without pinned versions, (6) a GHA job fails at Set up job with Unable to resolve action for a transitive dependency you do not reference directly.",
-      "version": "1.1.0",
-      "source": "./skills/security-scanning-and-supply-chain-hardening.md",
-      "category": "ci-cd",
-      "tags": [
-        "gitleaks",
-        "semgrep",
-        "sarif",
-        "pip-audit",
-        "dependabot",
-        "supply-chain",
-        "sha-pinning",
-        "trivy",
-        "curl-sh",
-        "pixi",
-        "npm",
-        "dockerfile"
-      ]
-    },
-    {
-      "name": "self-cancelling-review-plan",
-      "description": "Recognize and handle review fix files whose plan body declares no changes are needed. Use when: a .claude-review-fix-*.md file says 'implement all fixes' but the embedded Fix Plan concludes the PR is already correct and complete.",
-      "version": "1.0.0",
-      "source": "./skills/self-cancelling-review-plan.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "semantic-pr-rebase-at-scale",
-      "description": "Rebase 50-100 open PRs against main using parallel sub-agents with semantic conflict resolution. Use when: (1) systemic CI fix lands on main breaking all open PRs, (2) 50+ PRs need batch rebase, (3) conflicts need issue-context-aware resolution.",
-      "version": "1.0.0",
-      "source": "./skills/semantic-pr-rebase-at-scale.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "signing-remote-host-ssh-noreply-email",
-      "description": "Make GitHub-VALID (verification.verified==true) signed commits from a remote/headless build host (e.g. aeolus in the HomericIntelligence mesh swarm) using an SSH signing key. Covers: (a) generating an ed25519 SSH signing keypair on the host and wiring git's gpg.format=ssh config + allowed_signers file; (b) registering the PUBLIC key as a SIGNING key on GitHub via `gh ssh-key add --type signing`, which REQUIRES the PAT scope admin:ssh_signing_key (granted interactively, not headlessly); (c) the email-privacy push block where a commit authored with the real private email is REJECTED with 'push declined due to email privacy restrictions', fixed by authoring with the <id>+<login>@users.noreply.github.com email; (d) the finding that GitHub does NOT auto-sign PAT-authored commits made via the Contents REST API. Use when: (1) setting up commit signing on a fresh remote/headless/CI host, (2) commits land Unverified despite a key being added (key added auth-only, missing --type signing), (3) `git push` is rejected for email privacy restrictions even though signing is correct, (4) you need the GitHub noreply email derivation, (5) `gh api user/ssh_signing_keys` returns 404 for missing admin:ssh_signing_key scope, (6) API-authored commits report verification.reason=unsigned.",
-      "version": "1.0.0",
-      "source": "./skills/signing-remote-host-ssh-noreply-email.md",
-      "category": "ci-cd",
-      "tags": [
-        "git",
-        "ssh-signing",
-        "commit-signing",
-        "github",
-        "noreply-email",
-        "email-privacy",
-        "headless",
-        "remote-host",
-        "gh-cli",
-        "admin-ssh-signing-key"
-      ]
-    },
-    {
       "name": "skills-to-plugins-migration",
       "description": "Migrate PRs that add skills to the flat skills/ directory into the correct plugins/<category>/<name>/ structure so CI triggers and the validate check passes. Use when a PR branch puts files under skills/ instead of plugins/, or when the validate CI check never appears on a PR.",
       "version": "1.0.0",
@@ -2868,63 +1569,10 @@
       "tags": []
     },
     {
-      "name": "squash-only-repo-merge-method-docs",
-      "description": "Repo allows squash-only merges (allow_rebase_merge=false); using --rebase silently fails to arm auto-merge (CLI) or fails at runtime (code/API). The wrong merge method hides in docs, code, AND skill/plugin instruction files. The robust fix is settings-aware merge-method selection (query gh api repos/<repo>, pick rebase->squash->merge), not hardcoding a different fixed method. Use when: (1) gh pr merge --auto --rebase returns no error but auto-merge is not armed, (2) project docs or CLAUDE.md instruct --rebase for a repo that has disabled rebase merges, (3) a PyGithub pr.merge(merge_method='rebase') callsite on a squash-only repo fails with 'Rebase merges are not allowed on this repository', (4) verifying which merge method a repo supports before arming auto-merge, (5) updating stale documentation that references the wrong merge flag, (6) auditing a squash-only repo \u2014 grep for BOTH the gh pr merge --rebase CLI form and the merge_method=\"rebase\" code/API form, (7) a skill/plugin instruction file (e.g. /learn, /finish-branch SKILL.md) hardcodes gh pr merge --auto --rebase against a squash-only target repo, (8) deciding the merge method for a cross-repo gh pr merge \u2014 detect allowed methods instead of hardcoding.",
-      "version": "1.2.0",
-      "source": "./skills/squash-only-repo-merge-method-docs.md",
-      "category": "ci-cd",
-      "tags": [
-        "auto-merge",
-        "squash",
-        "rebase",
-        "github",
-        "docs"
-      ]
-    },
-    {
-      "name": "stacked-pr-retarget-lint-fix-orphan",
-      "description": "When PR-B is retargeted onto PR-A's branch, only the commits present at retarget time fast-forward in. Later commits on PR-B's branch (CI/lint fixes) stay orphaned from PR-A and must be cherry-picked. Use when: (1) two open PRs are stacked via gh pr edit --base, (2) CI/lint fix lands on the dependent PR's branch after retarget, (3) the same failure later appears on the prerequisite PR.",
-      "version": "1.0.0",
-      "source": "./skills/stacked-pr-retarget-lint-fix-orphan.md",
-      "category": "ci-cd",
-      "tags": [
-        "stacked-pr",
-        "retarget",
-        "cherry-pick",
-        "ci",
-        "lint",
-        "github"
-      ]
-    },
-    {
-      "name": "stale-ci-warnings-in-pr-comment",
-      "description": "Surface stale CI pattern warnings in PR comment body rather than stderr only. Use when: (1) stale pattern detection exists but output is stderr-only, (2) reviewers need to see stale warnings without inspecting raw CI logs, (3) post_to_pr() should fire even when no uncovered files exist.",
-      "version": "1.0.0",
-      "source": "./skills/stale-ci-warnings-in-pr-comment.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "stale-plan-already-resolved",
       "description": "Detect when an issue's implementation plan is stale because the fix was already applied. Use when: the plan references specific line numbers that don't match current code, or the requested change is already satisfied by a broader fix already in place.",
       "version": "1.1.0",
       "source": "./skills/stale-plan-already-resolved.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "stale-script-detector",
-      "description": "Detect scripts/*.py files not referenced in CI workflows, justfile, or other scripts. Use when: adding automated stale-script checks, following up on manual audit rounds, or wiring orphaned scripts into CI.",
-      "version": "1.0.0",
-      "source": "./skills/stale-script-detector.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
-      "name": "training-tests-weekly-workflow",
-      "description": "Create a weekly GitHub Actions workflow for Mojo training tests excluded from per-PR CI. Use when: test files are in validate_test_coverage.py exclusion list but have no periodic workflow running them.",
-      "version": "1.0.0",
-      "source": "./skills/training-tests-weekly-workflow.md",
       "category": "ci-cd",
       "tags": []
     },
@@ -2945,32 +1593,6 @@
       "tags": []
     },
     {
-      "name": "versioned-releases-changelog-release-workflow",
-      "description": "Implement pinnable versioned releases with keepachangelog CHANGELOG format and tag-triggered GitHub Actions release workflows. Use when: (1) project needs versioned releases with semver tags (v1.0.0+), (2) CHANGELOG entries must be organized by dated release sections with [Unreleased] section, (3) release.yml workflow triggers on semver tags and validates version consistency across manifests, (4) all commits must be signed, (5) pre-commit hooks must validate version fields in manifest files.",
-      "version": "1.0.0",
-      "source": "./skills/versioned-releases-changelog-release-workflow.md",
-      "category": "ci-cd",
-      "tags": [
-        "versioning",
-        "releases",
-        "keepachangelog",
-        "github-actions",
-        "git-tags",
-        "semver",
-        "tag-workflow",
-        "signed-commits",
-        "release-automation"
-      ]
-    },
-    {
-      "name": "werror-compilation-audit",
-      "description": "Systematic parallel compilation audit of all Mojo files with --Werror to find and fix warnings treated as errors. Use when: adding --Werror to a build system, auditing hundreds of files for hidden warnings, or triaging warnings into fixable vs complex categories.",
-      "version": "1.0.0",
-      "source": "./skills/werror-compilation-audit.md",
-      "category": "ci-cd",
-      "tags": []
-    },
-    {
       "name": "workaround-demolition-wave-strategy",
       "description": "Multi-PR sequencing framework for safely ripping out workarounds after an upstream library/compiler bug is fixed. Use when: (1) an upstream dependency (compiler, runtime, library) just shipped a fix for a bug your repo has accumulated workarounds for, (2) workarounds are spread across CI retry loops, continue-on-error flags, build flags, debug infrastructure, ADRs, dev docs, reproducer files, test-file comments, and agent-facing skills/memory, (3) you need to avoid one giant unreviewable demolition PR and instead want a safe, bisectable, reviewable sequence, (4) you have to decide between scorched-earth deletion vs preservation-with-Superseded-markers for documentation/ADRs, (5) some workaround-removals are risky one-liners not exercised by your validation matrix and need their own CI gate, (6) Wave 2 scorched-earth targets a directory (e.g. `repro/`) where files may correspond to DISTINCT upstream bugs sharing only symptom surface \u2014 partition by bug, not by directory, before deletion.",
       "version": "1.1.0",
@@ -2985,14 +1607,6 @@
         "demolition",
         "rollback-strategy"
       ]
-    },
-    {
-      "name": "yaml-frontmatter-validation",
-      "description": "Fix CI failures caused by missing YAML frontmatter in SKILL.md files. Use when plugin validation fails with 'missing YAML frontmatter' errors across multiple PRs.",
-      "version": "1.0.0",
-      "source": "./skills/yaml-frontmatter-validation.md",
-      "category": "ci-cd",
-      "tags": []
     },
     {
       "name": "automation-pipeline-observability-and-dryrun",
@@ -3177,22 +1791,6 @@
       ]
     },
     {
-      "name": "debugging-list-oob-dynamicvector-migration",
-      "description": "Fix out-of-bounds List access from DynamicVector\u2192List migration. Use when: (1) execution crashed on List index assignment, (2) DynamicVector(N) was migrated to List[T]() without changing index assignment to append, (3) shape[0]=size on empty list.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-list-oob-dynamicvector-migration.md",
-      "category": "debugging",
-      "tags": [
-        "mojo",
-        "list",
-        "dynamicvector",
-        "migration",
-        "oob",
-        "crash",
-        "benchmark"
-      ]
-    },
-    {
       "name": "debugging-radiance-graph-load-capture-browser-api-artifacts",
       "description": "Debug Radiance graph-load hangs by correlating the browser console, `/api/v1/radiance/runs*` endpoints, and persisted run artifacts. Use when: (1) the UI spinner hangs after Analyze/Open, (2) a run reaches `succeeded` but the graph does not render, (3) you need to separate backend graph generation failures from frontend Model Explorer rendering failures.",
       "version": "1.0.0",
@@ -3229,22 +1827,6 @@
         "subshell",
         "process-repo",
         "second-cause"
-      ]
-    },
-    {
-      "name": "debugging-symmetric-weight-init-dead-symmetry",
-      "description": "Diagnose and avoid the symmetric-weight-init pathology where uniform-fill weights make multi-layer gradients algebraically zero and produce false 'substrate bug' diagnoses. Use when: (1) a convergence test or training run plateaus at the uniform-distribution loss (e.g., ln(num_classes)), (2) gradients to early layers come back at fp32 cancellation noise magnitude (~1e-8) while later layers have normal-magnitude gradients, (3) writing self-contained test cases for autograd/backward correctness, (4) reviewing test code that initializes weights with a constant fill.",
-      "version": "1.0.0",
-      "source": "./skills/debugging-symmetric-weight-init-dead-symmetry.md",
-      "category": "debugging",
-      "tags": [
-        "autograd",
-        "weight-init",
-        "dead-symmetry",
-        "convergence-test",
-        "backward",
-        "gradient-pathology",
-        "mojo"
       ]
     },
     {
@@ -3306,38 +1888,6 @@
       "tags": []
     },
     {
-      "name": "fix-implicitlycopyable-removal",
-      "description": "Systematic approach to removing ImplicitlyCopyable trait from Mojo structs and fixing resulting compilation errors",
-      "version": "1.0.0",
-      "source": "./skills/fix-implicitlycopyable-removal.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "fix-isolation-mode-export-data-path",
-      "description": "Fix ModuleNotFoundError when patching a scripts/ module that isn't on sys.path during single-file pytest runs; add sys.path guard to conftest.py",
-      "version": "1.0.0",
-      "source": "./skills/fix-isolation-mode-export-data-path.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "fix-mojo-compilation-patterns",
-      "description": "Use when: (1) CI fails with Mojo import errors after module renames, (2) mojo-format pre-commit hook fails due to lines exceeding 88-char limit, (3) Mojo stable vs nightly version mismatch causes compilation failures or deprecation warnings, (4) Python module docstrings contain Mojo migration artifact fragments, (5) mypy fails on union syntax, (6) assert_equal fails to compile for DType comparisons",
-      "version": "2.0.0",
-      "source": "./skills/fix-mojo-compilation-patterns.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "fix-s101-assert-to-runtimeerror",
-      "description": "Skill: fix-s101-assert-to-runtimeerror. Use when fixing Ruff S101 violations in production code by replacing bare assert guards with RuntimeError raises.",
-      "version": "1.0.0",
-      "source": "./skills/fix-s101-assert-to-runtimeerror.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
       "name": "fix-yaml-config-propagation",
       "description": "Debug pattern for fixing YAML config fields that aren't propagating to execution, plus eliminating DRY violations in config dataclasses",
       "version": "1.0.0",
@@ -3352,33 +1902,6 @@
       "source": "./skills/fixme-todo-cleanup.md",
       "category": "debugging",
       "tags": []
-    },
-    {
-      "name": "git-rebase-over-deletion",
-      "description": "Fix CI failure caused by git rebase replaying a deletion commit that over-removes active code. Use when ImportError appears for symbols that should exist after a deprecation-removal commit.",
-      "version": "1.0.0",
-      "source": "./skills/git-rebase-over-deletion.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "linter-as-root-cause-of-repeated-policy-violations",
-      "description": "When two or more separate documents/skills/configs violate the same stated policy in the same way, the linter/validator that enforces that policy is the FIRST suspect \u2014 fix the linter before fixing the dependent files, or the new fixes will fail CI and downstream files will re-introduce the violation. Use when: (1) an audit flags the same policy violation in multiple files, (2) you are tempted to open N parallel PRs to fix N violating files, (3) a CLAUDE.md/CONTRIBUTING.md rule is repeatedly violated despite contributors knowing the rule, (4) a wrong-direction validator silently rejects the correct fix and accepts the wrong one.",
-      "version": "1.0.0",
-      "source": "./skills/linter-as-root-cause-of-repeated-policy-violations.md",
-      "category": "debugging",
-      "tags": [
-        "linter",
-        "validator",
-        "policy-enforcement",
-        "wrong-direction-rule",
-        "root-cause",
-        "audit-remediation",
-        "repeated-violations",
-        "ci-policy",
-        "doc-policy",
-        "meta-debugging"
-      ]
     },
     {
       "name": "logging-subprocess-context-tracking",
@@ -3397,62 +1920,31 @@
       ]
     },
     {
-      "name": "multi-layer-cpu-feature-detection-mismatch-probe",
-      "description": "Language-agnostic 4-layer diagnostic methodology for 'SIGILL on this host but works on others' / 'wrong instruction emitted' reports. Probes (1) kernel-mediated view (`/proc/cpuinfo`, `AT_HWCAP`), (2) silicon-direct view (raw `cpuid` + `xgetbv(0)`), (3) compiler-rt view (`__builtin_cpu_supports`), (4) compiler driver-resolved target (Mojo `--print-effective-target`, `rustc --print=target-features`, `clang -march=native -E -dM`, `llc --print-supported-cpus`). When layers 1-3 agree but layer 4 disagrees, the bug is in the compiler driver's CPU detection path; when layer 1 (kernel) and layer 2 (silicon) disagree, it's hypervisor/kernel CPUID masking. Use when: (1) triaging a SIGILL-on-some-hosts crash across a fleet, (2) pre-flighting a compiled binary for a mixed CPU deployment, (3) validating that a `--target-features=-foo` override is honored, (4) confirming hypervisor CPUID masking behavior, (5) diagnosing modular/modular#6413-style cross-CPU codegen mismatches in LLVM-based toolchains.",
+      "name": "pixi-runtime-env-gotchas",
+      "description": "Use when: (1) pixi silently re-solves the shared .pixi/envs/default and wipes the pip install -e . editable install mid-run after a worktree edit to pyproject.toml, (2) CI logs show 'Saved cache with ID -1' or cache hits are inconsistent despite cache: true in setup-pixi, (3) adding a second actions/cache over .pixi poisons a locked pixi env (downgrades packages, fails pip-audit), (4) a pre-commit hook invoking 'pixi run <command>' resolves to the system-installed binary instead of the project's pixi env binary because dev-install was not run, (5) GLIBC_PRIVATE linker errors appear when using system OpenSSL with a pixi conda-forge compiler toolchain.",
       "version": "1.0.0",
-      "source": "./skills/multi-layer-cpu-feature-detection-mismatch-probe.md",
-      "category": "debugging",
-      "tags": [
-        "cpu-feature-detection",
-        "cpuid",
-        "xgetbv",
-        "hwcap",
-        "builtin-cpu-supports",
-        "target-features",
-        "print-effective-target",
-        "sigill",
-        "hypervisor-masking",
-        "cross-cpu",
-        "codegen",
-        "llvm",
-        "mojo",
-        "rust",
-        "clang",
-        "modular-6413",
-        "diagnostic",
-        "language-agnostic"
-      ]
-    },
-    {
-      "name": "orphan-branch-recovery",
-      "description": "Diagnose and fix branches with no common ancestor that cannot be merged",
-      "version": "1.0.0",
-      "source": "./skills/orphan-branch-recovery.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
-      "name": "pixi-openssl-sysroot-glibc-private",
-      "description": "Fix GLIBC_PRIVATE linker errors when using system OpenSSL with pixi conda-forge compiler. Use when: (1) seeing __libc_siglongjmp@GLIBC_PRIVATE or _dl_sym@GLIBC_PRIVATE errors, (2) linking a C library that depends on OpenSSL in a pixi environment, (3) Conan profile GCC version mismatch with pixi.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-openssl-sysroot-glibc-private.md",
+      "source": "./skills/pixi-runtime-env-gotchas.md",
       "category": "debugging",
       "tags": [
         "pixi",
+        "editable-install",
+        "pip-install-e",
+        "dev-install",
+        "env-resolve",
+        "module-not-found",
+        "swarm-worktree",
+        "actions-cache",
+        "setup-pixi",
+        "cache-poisoning",
+        "pip-audit",
+        "pre-commit",
+        "binary-resolution",
         "openssl",
         "glibc",
         "linker",
         "conda-forge",
         "sysroot"
       ]
-    },
-    {
-      "name": "production-code-quality-fixes",
-      "description": "Skill: production-code-quality-fixes. Use when working with production code quality fixes.",
-      "version": "1.0.0",
-      "source": "./skills/production-code-quality-fixes.md",
-      "category": "debugging",
-      "tags": []
     },
     {
       "name": "pydantic-none-coercion-pattern",
@@ -3493,33 +1985,6 @@
       ]
     },
     {
-      "name": "rebase-merge-shadow-var-tdz-ts-error",
-      "description": "Diagnose and fix TypeScript TS7022 + TS2448 errors that appear only after a rebase or merge, when two non-overlapping branch edits independently introduced a function parameter and a local `const` of the same name in the same scope \u2014 producing a shadowing/TDZ bug that auto-merge cannot detect. Use when: (1) CI fails after rebase with TS7022/TS2448 on adjacent lines for the same identifier, (2) the file compiled cleanly on both source branches individually, (3) no conflict markers appeared during the rebase.",
-      "version": "1.0.0",
-      "source": "./skills/rebase-merge-shadow-var-tdz-ts-error.md",
-      "category": "debugging",
-      "tags": [
-        "typescript",
-        "rebase",
-        "merge",
-        "shadowing",
-        "tdz",
-        "ts7022",
-        "ts2448",
-        "block-scoped",
-        "dagger",
-        "achaeanfleet"
-      ]
-    },
-    {
-      "name": "refactor-context-manager-double-counter-stale-caller",
-      "description": "Detects and fixes double-increment bugs caused by incomplete context-manager refactors where callers still hold stale manual counter management code. Use when: (1) tests asserting counter == 1 observe 2 instead, (2) a context manager was introduced to own resource lifecycle but tests regressed, (3) a refactor moved try/finally lifecycle code into a context manager without auditing callers.",
-      "version": "1.0.0",
-      "source": "./skills/refactor-context-manager-double-counter-stale-caller.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
       "name": "sata-drive-bus-disconnect-diagnosis",
       "description": "Diagnose and triage a SATA drive that has dropped off the bus (capacity=0, DID_BAD_TARGET on every command). Use when: (1) dmesg shows 'detected capacity change from N to 0' on a drive that was previously working, (2) smartctl returns 'A mandatory SMART command failed', (3) wipefs/sgdisk hit 'Read error 5/22' on raw device access.",
       "version": "1.0.0",
@@ -3537,38 +2002,6 @@
       ]
     },
     {
-      "name": "tensor-numeric-correctness-bugs",
-      "description": "Diagnose and fix silent correctness bugs in tensor/array numeric operations. Use when: (1) tensor ops produce wrong values for non-contiguous (strided/transposed) layouts, (2) a destructor frees an offset view pointer causing ASAN bad-free, (3) dtype mismatches silently corrupt values via bitcast (float bits read as int), (4) a missing dtype case (bfloat16) causes silent zero reads/writes, (5) multi-dim slice ignores step, returning all elements instead of strided subset, (6) IEEE 754 NaN bit patterns produce inconsistent hashes across runs, (7) a seed parameter is declared but never wired to the PRNG causing non-reproducible random tensors, (8) byte-pointer arithmetic on a `UnsafePointer[UInt8]` tensor buffer silently copies one byte per element regardless of dtype, leaving 3/4 of float32 storage uninitialized and quietly corrupting training data.",
-      "version": "1.2.0",
-      "source": "./skills/tensor-numeric-correctness-bugs.md",
-      "category": "debugging",
-      "tags": [
-        "tensor",
-        "mojo",
-        "dtype",
-        "stride",
-        "bitcast",
-        "nan",
-        "hash",
-        "asan",
-        "bad-free",
-        "view",
-        "slice",
-        "bfloat16",
-        "reproducibility",
-        "seed",
-        "numeric-correctness"
-      ]
-    },
-    {
-      "name": "validation-test-fixture-symmetry",
-      "description": "Skill: validation-test-fixture-symmetry. Use when working with validation test fixture symmetry.",
-      "version": "1.0.0",
-      "source": "./skills/validation-test-fixture-symmetry.md",
-      "category": "debugging",
-      "tags": []
-    },
-    {
       "name": "vite-wasm-havok-fix",
       "description": "Skill: vite-wasm-havok-fix",
       "version": "1.0.0",
@@ -3577,12 +2010,34 @@
       "tags": []
     },
     {
-      "name": "academic-paper-validation",
-      "description": "Systematic workflow for validating and improving academic paper quality through data accuracy checks, statistical methodology verification, LaTeX compilation fixes, arXiv build preparation, parallel myrmidon swarm review, and post-review mechanical revisions (pronoun voice changes, single-model table cleanup, in-place .tex/.md surgery, duplicate heading detection, item-block deduplication)",
-      "version": "3.3.0",
-      "source": "./skills/academic-paper-validation.md",
+      "name": "academic-paper-accuracy-and-citation-audit",
+      "description": "Use when: (1) performing a multi-pass LaTeX paper audit covering data consistency, cross-references, scientific rigor, and writing quality before submission; (2) verifying every numerical claim in a research paper against source data files (CSV, JSON) with parallel agents and fixing errors; (3) finding academic citations for unsupported claims via parallel web searches and filling citation gaps with real published papers including full BibTeX metadata; (4) verifying every numeric claim in a corpus citation against the cited paper's arXiv abstract via parallel WebFetch agents \u2014 distinguishing fabricated papers from misquoted real ones; (5) fixing LaTeX build errors from unescaped underscores in table cells (Missing $ inserted).",
+      "version": "1.0.0",
+      "source": "./skills/academic-paper-accuracy-and-citation-audit.md",
       "category": "documentation",
-      "tags": []
+      "tags": [
+        "latex",
+        "audit",
+        "paper",
+        "academic",
+        "citation",
+        "bibtex",
+        "arxiv",
+        "data-consistency",
+        "cross-reference",
+        "numerical-accuracy",
+        "parallel-agents",
+        "scientific-rigor",
+        "writing-quality",
+        "fabrication-detection",
+        "webfetch",
+        "web-search",
+        "pandas",
+        "pivot-table",
+        "idxmax",
+        "underscore-escape",
+        "missing-dollar"
+      ]
     },
     {
       "name": "academic-paper-validation-and-publication",
@@ -3600,49 +2055,38 @@
       ]
     },
     {
-      "name": "add-ci-badge-to-readme",
-      "description": "Add a GitHub Actions CI status badge to a README. Use when: a README is missing a CI badge, a new workflow should be surfaced via a badge, or a reviewer requests build status visibility.",
+      "name": "academic-paper-writing-and-publication-workflow",
+      "description": "Use when: (1) assembling a large LaTeX research paper from parallel-agent-written parts and need to merge sections into a compilable .tex with unified bibliography; (2) performing pre-submission quality validation of a LaTeX paper covering data accuracy, statistical methodology, LaTeX compilation, and arXiv build preparation; (3) polishing an arXiv paper for submission \u2014 voice normalization, pronoun changes, duplicate heading removal, BibTeX deduplication, inline arXiv href removal; (4) conducting a final publication-readiness review checklist pass before camera-ready; (5) preparing a LaTeX arXiv paper for final review with a myrmidon swarm of specialist reviewers.",
       "version": "1.0.0",
-      "source": "./skills/add-ci-badge-to-readme.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "adr-directory-tree-accuracy",
-      "description": "Update ADR directory tree listings to reflect actual filesystem contents after file deletions or additions. Use when: (1) a file is deleted/added but the ADR still shows the old listing, (2) a GitHub issue requests verifying helpers/tests directories are accurately documented, (3) an ADR directory tree shows only a subset of the files actually present.",
-      "version": "1.0.0",
-      "source": "./skills/adr-directory-tree-accuracy.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "adr-index-entry",
-      "description": "Add a missing ADR entry to the ADR index table in docs/adr/README.md. Use when: an ADR file exists but is not listed in the index table.",
-      "version": "1.0.0",
-      "source": "./skills/adr-index-entry.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "adr-status-deferred-update",
-      "description": "Update ADR status to Accepted (Deferred) when implementation is bypassed pending platform support. Use when: ADR is marked Accepted but code explicitly bypasses the design, or a known platform limitation prevents activation.",
-      "version": "1.0.0",
-      "source": "./skills/adr-status-deferred-update.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "audit-monolith-documentation-resolution-pattern",
-      "description": "Resolve audit nitpicks for monolithic code by documenting verified design rationale. Use when: (1) auditor questions code organization as violation of SRP, (2) splitting vs. documenting trade-off exists, (3) design decision lacks permanent record.",
-      "version": "1.0.0",
-      "source": "./skills/audit-monolith-documentation-resolution-pattern.md",
+      "source": "./skills/academic-paper-writing-and-publication-workflow.md",
       "category": "documentation",
       "tags": [
-        "audit",
+        "latex",
+        "arxiv",
+        "paper",
+        "publication",
+        "validation",
+        "bibtex",
+        "assembly",
+        "review",
+        "statistical-rigor",
+        "swarm"
+      ]
+    },
+    {
+      "name": "adr-authoring-indexing-and-maintenance",
+      "description": "Use when: (1) generating a new Architecture Decision Record (ADR) to document a significant architectural decision; (2) an ADR file exists but is not listed in the index table (docs/adr/README.md); (3) updating ADR status to Accepted (Deferred) when implementation is bypassed pending platform support; (4) two or more functions have nearly identical limitation comments and need consolidating into a single ADR with cross-references replacing duplicates; (5) updating ADR directory tree listings to reflect actual filesystem contents after file deletions or additions.",
+      "version": "1.0.0",
+      "source": "./skills/adr-authoring-indexing-and-maintenance.md",
+      "category": "documentation",
+      "tags": [
+        "adr",
+        "architecture-decision-record",
         "documentation",
-        "architecture-decision",
-        "monolith",
-        "nitpick"
+        "index-maintenance",
+        "markdownlint",
+        "consolidation",
+        "directory-tree"
       ]
     },
     {
@@ -3660,259 +2104,28 @@
       ]
     },
     {
-      "name": "citation-verification-arxiv-abstract-fetch",
-      "description": "Verify every numeric claim in a corpus citation against the cited paper's arXiv abstract via parallel WebFetch agents. Use when: (1) a research corpus or technical doc makes numeric claims attributed to specific arXiv papers, (2) pattern-based scrubs have declared the corpus clean but no claim-to-source check has run, (3) the corpus contains post-knowledge-cutoff arXiv IDs where you must distinguish 'fabricated paper' from 'real paper, misquoted', (4) the corpus has blanket 'UNVERIFIED' flags that may be over-cautious, (5) a pre-release citation-hygiene gate before publication.",
+      "name": "docstring-api-doc-generation-and-comment-hygiene",
+      "description": "Use when: (1) updating, fixing, or extending docstrings and API documentation in source files to match current implementation semantics \u2014 changed signatures, memory semantics, orphaned fragments, undocumented methods; (2) creating API reference documentation from docstrings for a public module interface; (3) generating docstrings for undocumented functions and classes; (4) auditing and cleaning up inline NOTE/TODO/FIXME/placeholder comments \u2014 normalization, removal of shipped-feature placeholders, magic-number extraction; (5) using a package's public __version__ attribute in demo/example scripts rather than hardcoded strings, so version references stay in sync with releases.",
       "version": "1.0.0",
-      "source": "./skills/citation-verification-arxiv-abstract-fetch.md",
-      "category": "documentation",
-      "tags": [
-        "citation",
-        "verification",
-        "arxiv",
-        "webfetch",
-        "primary-source",
-        "fabrication-detection",
-        "parallel-agents",
-        "research-corpus"
-      ]
-    },
-    {
-      "name": "consolidate-duplicate-adr-references",
-      "description": "Consolidate duplicate inline comments or docstring Notes into a single ADR, then replace each duplicate with a short cross-reference. Use when: two or more functions have nearly identical limitation comments, or an issue asks to reduce maintenance burden by centralizing a workaround note in an ADR.",
-      "version": "1.0.0",
-      "source": "./skills/consolidate-duplicate-adr-references.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "demo-scripts-dynamic-version-from-package-attr",
-      "description": "Use a package's public __version__ attribute in demo/example scripts rather than hardcoded strings or direct importlib.metadata calls. Use when: (1) demo/example scripts display or reference the package version, (2) you want sample code to stay in sync with releases automatically, (3) replacing a placeholder version string with the actual installed version, (4) teaching users how to consume version the same way their own code should.",
-      "version": "1.0.0",
-      "source": "./skills/demo-scripts-dynamic-version-from-package-attr.md",
-      "category": "documentation",
-      "tags": [
-        "version-management",
-        "demo-scripts",
-        "example-code",
-        "package-public-interface",
-        "idiomatic-python"
-      ]
-    },
-    {
-      "name": "doc-audit-policy-violations",
-      "description": "Skill: Audit Documentation Examples for Policy Violations",
-      "version": "1.0.0",
-      "source": "./skills/doc-audit-policy-violations.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "docs-contributing-md-case-clash-redirect",
-      "description": "Resolve CONTRIBUTING.md case-clash and circular cross-reference between root CONTRIBUTING.md and docs/contributing.md. Use when: (1) a repo has both CONTRIBUTING.md (root) and docs/contributing.md with a circular 'See also' mutual reference, (2) docs/contributing.md duplicates content from the root canonical file, (3) docs hygiene audit flags CONTRIBUTING case ambiguity on case-insensitive filesystems.",
-      "version": "1.0.0",
-      "source": "./skills/docs-contributing-md-case-clash-redirect.md",
-      "category": "documentation",
-      "tags": [
-        "contributing",
-        "docs",
-        "case-clash",
-        "redirect",
-        "duplication",
-        "hygiene"
-      ]
-    },
-    {
-      "name": "docstring-and-api-documentation-update",
-      "description": "Update, fix, and extend docstrings and API documentation in source files to match current implementation semantics. Use when: (1) a function signature changed and the module docstring still shows the old call, (2) memory semantics (copy vs view) are mislabeled or inconsistent across sibling methods, (3) inline # NOTE comments in __init__ files need promotion to docstring Note: sections, (4) a catalog doc (backward-pass-catalog.md, testing-strategy.md) needs a new module section, formula, or gotcha subsection, (5) placeholder 'requires implementation' language persists after tests are written, (6) module docstrings have orphaned lowercase continuation fragments, (7) a new dunder/trait method is undocumented, (8) a utility function has an undocumented error-handling contract (swallows exceptions silently, returns special error shapes on failure).",
-      "version": "1.2.0",
-      "source": "./skills/docstring-and-api-documentation-update.md",
+      "source": "./skills/docstring-api-doc-generation-and-comment-hygiene.md",
       "category": "documentation",
       "tags": [
         "docstring",
         "api-docs",
-        "copy-vs-view",
-        "mojo",
-        "module-docstring",
-        "backward-pass-catalog",
-        "re-export",
-        "float16",
-        "placeholder",
-        "error-handling-contract",
-        "POLA",
-        "silent-error"
-      ]
-    },
-    {
-      "name": "documentation-citation-gap-web-search-workflow",
-      "description": "Find academic citations for unsupported claims in LaTeX papers using parallel web searches. Use when: (1) a paper makes assertions without \\cite references, (2) you need to fill citation gaps with real, published papers, (3) you want to upgrade hedged language ('anecdotal evidence') to properly cited claims, (4) you need full BibTeX metadata (authors, venue, year, DOI, volume, pages) for discovered papers.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-citation-gap-web-search-workflow.md",
-      "category": "documentation",
-      "tags": [
-        "citation",
-        "web-search",
-        "latex",
-        "bibtex",
-        "academic-writing",
-        "citation-gap",
-        "paper-discovery",
-        "parallel-search"
-      ]
-    },
-    {
-      "name": "documentation-latex-paper-audit-methodology",
-      "description": "Perform a multi-pass audit of a LaTeX academic paper covering data consistency, cross-references, scientific rigor, and writing quality. Use when: (1) a LaTeX paper needs pre-submission quality verification, (2) you need to verify every hardcoded number against source data, (3) you need to check all \\ref/\\cite/\\input chains for broken references, (4) you need to find orphaned or unincluded table/figure files, (5) you want parallel agent-based audit for speed on large papers, (6) you need to verify scientific claims match the statistical evidence, (7) you need to catch ceiling effects, power analysis gaps, or unreliable score interpretations.",
-      "version": "1.1.0",
-      "source": "./skills/documentation-latex-paper-audit-methodology.md",
-      "category": "documentation",
-      "tags": [
-        "latex",
-        "audit",
-        "paper",
-        "academic",
-        "cross-reference",
-        "citation",
-        "data-consistency",
-        "parallel-agents",
-        "scientific-rigor",
-        "writing-quality"
-      ]
-    },
-    {
-      "name": "documentation-workflow-meta-patterns",
-      "description": "Meta-patterns for documentation-only PR workflows. Use when: (1) starting any documentation task and needing to detect already-done work before beginning, (2) handling a review fix plan that concludes no changes are needed, (3) triaging a security review on a docs-only PR, (4) implementing a small targeted doc edit, (5) merging two overlapping markdown docs into one canonical source, (6) documenting a pre-commit hook incompatibility in CONTRIBUTING.md, or (7) expanding bare NOTE/TODO markers with structured deferred-item format.",
-      "version": "1.0.0",
-      "source": "./skills/documentation-workflow-meta-patterns.md",
-      "category": "documentation",
-      "tags": [
-        "documentation",
-        "workflow",
-        "preflight",
-        "no-op",
-        "review",
-        "security",
-        "pre-commit",
-        "deferred-items",
-        "duplicate-detection"
-      ]
-    },
-    {
-      "name": "fix-broken-doc-references",
-      "description": "Skill: Fix Broken Documentation References",
-      "version": "1.0.0",
-      "source": "./skills/fix-broken-doc-references.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "fix-markdown-agent-docs",
-      "description": "Fix common markdown issues in agent hierarchy docs: malformed closing code fences, stale agent counts, and line length violations. Use when: (1) markdownlint fails on agents/hierarchy.md, (2) agent counts in docs diverge from actual .claude/agents/ files, (3) closing code fences have language specifiers, (4) markdownlint reports MD040 or MD031 on closing fence line.",
-      "version": "1.1.0",
-      "source": "./skills/fix-markdown-agent-docs.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "fix-stale-agent-crossrefs",
-      "description": "Fix stale cross-references in agent configs and docs after specialist consolidation. Use when: (1) agent files are deleted during consolidation and remaining configs still reference them, (2) agent files are deleted or consolidated and docs still reference old agent names.",
-      "version": "2.0.0",
-      "source": "./skills/fix-stale-agent-crossrefs.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "fix-tier-label-mismatches",
-      "description": "Fix incorrect tier labels in ProjectScylla documentation (T3\u2192T2, T4\u2192T3, T5\u2192T4 pattern). Use when quality audits flag tier name/number mismatches in .claude/shared/metrics-definitions.md or CLAUDE.md tier table references.",
-      "version": "1.0.0",
-      "source": "./skills/fix-tier-label-mismatches.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "getting-started-doc-audit",
-      "description": "Audit and rewrite getting-started documentation stubs by sourcing real commands from justfile and versions from pixi.toml, removing fabricated APIs. Use when: stub files contain placeholder text, follow-up audit after installation.md is written, or markdown linting fails on broken fenced code blocks.",
-      "version": "1.0.0",
-      "source": "./skills/getting-started-doc-audit.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "inline-comment-and-note-cleanup",
-      "description": "Systematically audit and clean up inline NOTE/TODO/FIXME/placeholder comments in source code. Use when: (1) a cleanup issue targets NOTE/TODO/FIXME markers for normalization, removal, or tracing, (2) runtime print statements carry NOTE prefixes that confuse users, (3) magic-number comments need extracting into named constants, (4) generator-script TODOs need reclassifying as TEMPLATE markers, (5) shipped-feature placeholders or no-op placeholder tests need removal.",
-      "version": "1.0.0",
-      "source": "./skills/inline-comment-and-note-cleanup.md",
-      "category": "documentation",
-      "tags": [
+        "docstring-generation",
+        "comment-hygiene",
         "note-cleanup",
         "comment-normalization",
         "placeholder",
         "todo",
+        "copy-vs-view",
+        "module-docstring",
+        "error-handling-contract",
+        "POLA",
+        "version-management",
+        "demo-scripts",
         "mojo",
         "python"
-      ]
-    },
-    {
-      "name": "installation-anchor-validator",
-      "description": "Validate anchor fragments in markdown deep-links to an installation guide. Use when: README or other docs link to specific sections of installation.md and you need CI to catch broken anchors when headings are renamed or removed.",
-      "version": "1.0.0",
-      "source": "./skills/installation-anchor-validator.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "latex-paper-parallel-assembly",
-      "description": "Assemble a large LaTeX research paper from parallel-agent-written parts. Use when: (1) a single agent cannot hold the full paper in context, (2) you have 20+ ideas/sections to write and want parallel speedup, (3) you need to merge N part files into one compilable .tex, (4) you need post-assembly error remediation (unicode, missing bib entries, tabular column drift, undefined commands), (5) removing inline arXiv hrefs from assembled paper body, (6) consolidating scattered verdict codes into a single Future Work section, (7) deduplicating bib entries introduced by parallel agents writing their own citation stubs.",
-      "version": "1.1.0",
-      "source": "./skills/latex-paper-parallel-assembly.md",
-      "category": "documentation",
-      "tags": [
-        "latex",
-        "parallel",
-        "assembly",
-        "pdflatex",
-        "bibtex",
-        "cleanup",
-        "citations",
-        "verdicts"
-      ]
-    },
-    {
-      "name": "latex-table-underscore-escape-missing-dollar",
-      "description": "Use when: (1) a LaTeX build fails with '! Missing $ inserted' and the error context shows an underscore character, (2) table cells in .tex files contain identifier-style text with underscores (e.g., code_quality, build_pipeline), (3) pdflatex or tectonic reports subscript-related errors in plain text mode",
-      "version": "1.0.0",
-      "source": "./skills/latex-table-underscore-escape-missing-dollar.md",
-      "category": "documentation",
-      "tags": [
-        "latex",
-        "pdflatex",
-        "underscore",
-        "tables",
-        "paper"
-      ]
-    },
-    {
-      "name": "markdown-linting-and-build-fixes",
-      "description": "Use when: (1) markdownlint CI reports MD056/table-column-count errors from pipes inside backtick code spans in table cells, (2) mkdocs --strict build fails with out-of-tree relative links pointing outside docs/, (3) CLAUDE.md exceeds a line/token budget and needs trimming without losing critical rules, (4) shared documentation files are missing link-backs in an index/root markdown file, (5) an entire PR queue is red on the same markdownlint check pointing to the same file:line \u2014 systemic main-branch regression needing fix + bulk queue recovery",
-      "version": "1.2.0",
-      "source": "./skills/markdown-linting-and-build-fixes.md",
-      "category": "documentation",
-      "tags": [
-        "markdownlint",
-        "MD056",
-        "MD060",
-        "tables",
-        "pipe-escape",
-        "mkdocs",
-        "strict-mode",
-        "claude-md",
-        "token-budget",
-        "ci-unblocking",
-        "queue-unblock",
-        "admin-merge",
-        "MD033",
-        "MD018",
-        "MD059",
-        "false-positives"
       ]
     },
     {
@@ -3924,95 +2137,45 @@
       "tags": []
     },
     {
-      "name": "paper-final-review-publication-readiness-workflow",
-      "description": "Paper Final Review - Publication Readiness Workflow",
-      "version": "1.0.0",
-      "source": "./skills/paper-final-review-publication-readiness-workflow.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "parallel-paper-correctness-audit",
-      "description": "Multi-agent parallel workflow for verifying every numerical claim in a research paper against underlying data files (CSV, JSON), fixing errors, ensuring internal consistency across inline tables, generated tables, figure data, and post-correction narrative audit",
-      "version": "1.4.0",
-      "source": "./skills/parallel-paper-correctness-audit.md",
+      "name": "mkdocs-markdown-doc-site-build-and-pr-workflow",
+      "description": "Use when: (1) MkDocs build failures from nav or cross-references pointing at deleted files \u2014 run a pre-deletion audit, fix mkdocs.yml nav, repair --strict out-of-tree links; (2) markdownlint CI reports MD056/table-column-count from pipes inside backtick spans, MD060/table-column-style from compact (unspaced) table separators, MD012/no-multiple-blanks caused by a trailing double newline at EOF, MD040/MD031 from a language-tagged closing code fence, or MD013/MD032/MD022 on docs; or mkdocs --strict fails with relative links escaping docs/, or a systemic main-branch markdownlint regression is blocking a PR queue; (3) adding a CI pre-commit script to detect drift between documented metric values (CLAUDE.md, README.md) and pyproject.toml config sources (coverage threshold, test counts); (4) starting any documentation-only PR task \u2014 detect already-done work, handle a review fix plan that concludes no changes are needed, merge overlapping markdown docs, validate markdown for formatting/links/style, reconcile stale agent-hierarchy counts, document pre-commit hook incompatibilities in CONTRIBUTING.md.",
+      "version": "1.1.0",
+      "source": "./skills/mkdocs-markdown-doc-site-build-and-pr-workflow.md",
       "category": "documentation",
       "tags": [
-        "latex",
-        "paper",
-        "audit",
-        "verification",
-        "cross-reference",
-        "numerical-accuracy",
-        "parallel-agents",
-        "inline-tables",
-        "aggregation-mismatch",
-        "pandas",
-        "data-pipeline",
-        "post-correction",
-        "figure-caption",
-        "narrative-consistency",
-        "vl-json",
-        "idxmax",
-        "tiebreaker",
-        "myrmidon-swarm",
-        "pre-flight-recomputation",
-        "srh",
-        "kruskal-wallis",
-        "pivot-table",
-        "cross-experiment-averaging",
-        "spearman",
-        "krippendorff",
-        "inter-rater",
-        "silent-aggregation"
+        "mkdocs",
+        "markdownlint",
+        "strict-mode",
+        "nav-cleanup",
+        "MD056",
+        "MD060",
+        "MD012",
+        "eof-newline",
+        "end-of-file-fixer",
+        "closing-fence",
+        "pipe-escape",
+        "doc-config-drift",
+        "documentation-workflow",
+        "pre-commit",
+        "ci-unblocking"
       ]
     },
     {
-      "name": "phantom-dir-reference-fix",
-      "description": "Remove phantom directory references from documentation when a referenced path does not exist in the repository.",
+      "name": "readme-badges-live-sources-and-count-drift-prevention",
+      "description": "Use when: (1) adding badges to a README and need live-source badge endpoints (shields.io, GitHub Actions status, PyPI JSON API) instead of hardcoded values; (2) adding missing PR-critical workflow badges to a README badge block; (3) automating README badge count validation to prevent drift when file/test counts grow; (4) verifying package names via PyPI before committing badge URLs; (5) replacing hardcoded test/file counts in README badges and prose with live commands users can run, preventing flakiness when counts change frequently.",
       "version": "1.0.0",
-      "source": "./skills/phantom-dir-reference-fix.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "placeholder-and-stub-doc-lifecycle",
-      "description": "Manage the full lifecycle of placeholder and stub documentation. Use when: (1) stub files contain only placeholder text and should be deleted under YAGNI, (2) a navigation index loses sections after stub deletion and needs a deferred comment placeholder, (3) a design doc Future Improvements list needs structured deferral annotations, (4) a placeholder doc needs rewriting with accurate codebase- grounded content (quickstart, installation, README, or other guides), (5) an existing installation doc needs IDE setup section or version-constraint tightening.",
-      "version": "1.0.0",
-      "source": "./skills/placeholder-and-stub-doc-lifecycle.md",
-      "category": "documentation",
-      "tags": [
-        "placeholder",
-        "stub",
-        "documentation",
-        "yagni",
-        "deferred",
-        "installation",
-        "readme",
-        "rewrite"
-      ]
-    },
-    {
-      "name": "readme-badges-live-sources-verification",
-      "description": "Use live-source badge endpoints (shields.io, GitHub Actions, PyPI JSON API) instead of hardcoded values. Verify package names via PyPI before committing. Use when: adding badges to README, updating badge rows, validating badge accuracy, or implementing cross-project badge standards.",
-      "version": "1.0.0",
-      "source": "./skills/readme-badges-live-sources-verification.md",
+      "source": "./skills/readme-badges-live-sources-and-count-drift-prevention.md",
       "category": "documentation",
       "tags": [
         "documentation",
         "badges",
-        "semantic-anchors",
         "live-sources",
-        "pypi-verification"
+        "ci-badges",
+        "pypi-verification",
+        "count-drift",
+        "shields-io",
+        "pre-commit"
       ]
-    },
-    {
-      "name": "readme-ci-badges",
-      "description": "Add GitHub Actions status badges for key CI workflows to a README badge block. Use when: adding missing PR-critical workflow badges, improving CI health visibility at a glance, or following up on a badge audit issue.",
-      "version": "1.0.0",
-      "source": "./skills/readme-ci-badges.md",
-      "category": "documentation",
-      "tags": []
     },
     {
       "name": "recurring-tier-label-fix",
@@ -4041,14 +2204,6 @@
         "execution-model",
         "divergence-escalation"
       ]
-    },
-    {
-      "name": "replace-hardcoded-counts-with-live-commands",
-      "description": "Replace hardcoded test/file counts in README badges and prose with a live command users can run. Use when a CI check enforces doc accuracy but counts change frequently, making the docs flaky.",
-      "version": "1.0.0",
-      "source": "./skills/replace-hardcoded-counts-with-live-commands.md",
-      "category": "documentation",
-      "tags": []
     },
     {
       "name": "scifi-mechanism-single-device-design",
@@ -4105,26 +2260,23 @@
       ]
     },
     {
-      "name": "skill-arxiv-paper-publication-polish",
-      "description": "Skill: arXiv Paper Publication Polish",
+      "name": "stale-documentation-audit-and-broken-reference-repair",
+      "description": "Use when: (1) running a doc-drift audit across a corpus \u2014 detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation \u2014 deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings.",
       "version": "1.0.0",
-      "source": "./skills/skill-arxiv-paper-publication-polish.md",
-      "category": "documentation",
-      "tags": []
-    },
-    {
-      "name": "stale-documentation-audits-and-sync",
-      "description": "Canonical workflow for detecting and remediating stale documentation: doc-drift grep audits, stale-count fixes, metric discrepancy reconciliation, ecosystem-role drift detection, multi-file doc sync, README audit workflows, cross-doc citation drift defenses, doc-contradiction resolution. Use when: (1) running a doc-drift audit across a corpus, (2) reconciling docs to current implementation, (3) fixing stale agent/file/test counts in README, (4) catching cross-doc contradictions before publication, (5) syncing docs after a structural change.",
-      "version": "1.1.0",
-      "source": "./skills/stale-documentation-audits-and-sync.md",
+      "source": "./skills/stale-documentation-audit-and-broken-reference-repair.md",
       "category": "documentation",
       "tags": [
-        "merged",
         "doc-drift",
         "stale-doc",
-        "doc-sync",
+        "broken-references",
+        "phantom-dir",
+        "placeholder",
+        "stub",
+        "anchor-validation",
+        "tier-labels",
         "doc-audit",
-        "citation-drift"
+        "doc-sync",
+        "merged"
       ]
     },
     {
@@ -4153,25 +2305,6 @@
         "platform-data",
         "web-research",
         "investor-platform-primary-source"
-      ]
-    },
-    {
-      "name": "verify-audit-findings-before-acting",
-      "description": "Strict-mode repo audits AND PR-reviewer sub-agents routinely hallucinate critical findings (references to nonexistent files, claims of missing CI checks that already exist, REQUEST_CHANGES citing a red CI check that is ALSO red on main) AND miss real ones (linter bugs, root causes). Verify each finding against ground truth (filesystem state or `gh run list --branch main`) BEFORE writing a remediation plan or posting a review verdict, and search for inverse hypotheses (what the audit MISSED) before acting. Use when: (1) consuming output from /repo-analyze-strict or any swarm-audit, (2) about to write a remediation plan from audit output, (3) about to bulk-file remediation issues, (4) deciding which audit majors are real, (5) the audit's CRITICAL/MAJOR count differs from what you can verify on disk, (6) about to post a REQUEST_CHANGES verdict that cites a red CI check as the blocker.",
-      "version": "1.3.0",
-      "source": "./skills/verify-audit-findings-before-acting.md",
-      "category": "documentation",
-      "tags": [
-        "audit",
-        "code-review",
-        "fact-checking",
-        "remediation",
-        "phase-1-verification",
-        "inverse-hypothesis-search",
-        "audit-corrections-section",
-        "root-cause-discovery",
-        "remediation-plan-corrections",
-        "pr-reviewer-verdict-verification"
       ]
     },
     {
@@ -4390,45 +2523,6 @@
       ]
     },
     {
-      "name": "runtime-resource-optimization-mojo-python",
-      "description": "Runtime performance and resource management across Mojo SIMD/vectorisation and Python infrastructure. Use when: (1) SIMD-vectorizing element-wise tensor operations (NaN/Inf detection, gradient clipping, norm accumulation) in Mojo for 4-16x throughput; (2) validating Mojo language patterns (out self, mut, List, trait conformances, ownership transfer); (3) identifying SIMD optimization opportunities or checking memory safety in Mojo code; (4) fixing OOM crashes in multi-stage Claude CLI/NATS pipelines via session reuse and payload pruning; (5) preventing machine crashes from unbounded workspace accumulation or concurrent process limits in E2E runs; (6) adding module-level caching to eliminate redundant JSON schema file reads; (7) parallelizing I/O-bound subprocess loops with ThreadPoolExecutor; (8) validating checkpoint results before re-running expensive API calls; (9) deduplicating shared artifacts across E2E judge/run directories.",
-      "version": "1.1.0",
-      "source": "./skills/runtime-resource-optimization-mojo-python.md",
-      "category": "optimization",
-      "tags": [
-        "mojo",
-        "simd",
-        "vectorization",
-        "memory-safety",
-        "oom",
-        "nats",
-        "claude-cli",
-        "threadpoolexecutor",
-        "checkpoint",
-        "schema-cache",
-        "artifact-dedup",
-        "performance",
-        "python",
-        "wsl2"
-      ]
-    },
-    {
-      "name": "assert-to-runtime-error-migration",
-      "description": "Skill: assert-to-runtime-error-migration. Use when replacing assert guards in production code with explicit RuntimeError raises to eliminate Ruff S101 suppressions.",
-      "version": "1.0.0",
-      "source": "./skills/assert-to-runtime-error-migration.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "auto-discover-parametrize-fixtures",
-      "description": "TRIGGER CONDITIONS: A pytest.mark.parametrize list hardcodes fixture filenames that must be manually updated when new fixtures are added. Use when replacing a hardcoded list with glob-based auto-discovery so new fixtures are picked up automatically.",
-      "version": "1.0.0",
-      "source": "./skills/auto-discover-parametrize-fixtures.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "batch-retry-errors-checkpoint-reset",
       "description": "Fix --retry-errors in batch mode to detect and reset failed/rate-limited runs inside checkpoints of tests that are marked 'success' at the batch level. Use when batch reruns silently skip tests with internal checkpoint failures, or when rate_limited runs are not being retried.\n",
       "version": "1.0.0",
@@ -4464,76 +2558,12 @@
       ]
     },
     {
-      "name": "bulk-test-type-annotation",
-      "description": "TRIGGER CONDITIONS: Annotating hundreds of unannotated test functions in tests/unit/ to satisfy mypy disallow_untyped_defs. Use when removing a [[tool.mypy.overrides]] suppress block for a test directory, adding -> None to test methods, and adding typing.Any to pytest fixture parameters in bulk.",
-      "version": "1.0.0",
-      "source": "./skills/bulk-test-type-annotation.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "checkpoint-state-machine-test-fixtures",
-      "description": "Use when: (1) writing integration or unit tests for ProjectScylla checkpoint-based state machines (StateMachine / SubtestStateMachine / TierStateMachine / ExperimentStateMachine), (2) debugging tests where checkpoint states are unexpectedly reset to pending, (3) adding orphan/integrity detectors to resume pipelines, (4) verifying additive/non-destructive resume behavior across sequential invocations, (5) testing zombie detection with real disk I/O, (6) verifying DataLoader reset behavior in Mojo training/validation loops, or (7) extracting shared pytest fixtures to eliminate per-test boilerplate.",
-      "version": "1.1.0",
-      "source": "./skills/checkpoint-state-machine-test-fixtures.md",
-      "category": "testing",
-      "tags": [
-        "checkpoint",
-        "state-machine",
-        "test-fixtures",
-        "pytest",
-        "integration-tests",
-        "orphan-detection",
-        "resume",
-        "zombie-detection",
-        "dataloader",
-        "mojo"
-      ]
-    },
-    {
-      "name": "ci-tests-agent-subprocess-claude-absent",
-      "description": "Automation/agent-orchestration unit tests pass locally but fail in CI because the dev machine has the `claude` CLI on PATH and CI does not \u2014 an unpatched agent call (invoke_claude_with_session / _run_advise / _run_learn) spawns a REAL claude subprocess. Use when: (1) you add an agent-invoking method to code under test, (2) a unit test reaches an invoke_claude_with_session / _run_advise / _run_learn call, (3) automation/orchestration tests are green locally but red in CI, (4) you are auditing fixtures that do not disable agent gates. Fix: default agent gates OFF in shared fixtures + reproduce CI locally by hiding ~/.local/bin (where claude lives) from PATH while keeping pixi + gh.",
-      "version": "1.0.0",
-      "source": "./skills/ci-tests-agent-subprocess-claude-absent.md",
-      "category": "testing",
-      "tags": [
-        "testing",
-        "ci-cd",
-        "test-isolation",
-        "claude-cli",
-        "agent-orchestration",
-        "automation",
-        "subprocess",
-        "mock",
-        "fixtures",
-        "path",
-        "pixi",
-        "invoke-claude-with-session",
-        "flaky-ci",
-        "local-green-ci-red"
-      ]
-    },
-    {
       "name": "cmd-visualize-filter-format-coverage",
       "description": "cmd_visualize Filter \u00d7 Format Coverage Tests",
       "version": "1.0.0",
       "source": "./skills/cmd-visualize-filter-format-coverage.md",
       "category": "testing",
       "tags": []
-    },
-    {
-      "name": "coverage-module-floors-integration-backstop",
-      "description": "Enforce per-module coverage floors and integration tests for omitted modules. Use when: (1) aggregate coverage gates hide under-tested critical modules, (2) some modules are omitted from measurement (live orchestration, TTY), (3) need end-to-end backstop without false negatives.",
-      "version": "1.0.0",
-      "source": "./skills/coverage-module-floors-integration-backstop.md",
-      "category": "testing",
-      "tags": [
-        "coverage",
-        "testing",
-        "module-floors",
-        "integration-tests",
-        "cobertura"
-      ]
     },
     {
       "name": "cpp-rate-limiter-test-fixture-burst-capacity-trap",
@@ -4561,14 +2591,6 @@
       "tags": []
     },
     {
-      "name": "deduplicate-test-fixtures",
-      "description": "Eliminate duplicated test fixture files using runtime block-based composition. Use when: test fixtures have duplicate YAML blocks, find | md5sum shows duplication, want single source of truth for shared configs.",
-      "version": "1.0.0",
-      "source": "./skills/deduplicate-test-fixtures.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "defensive-analysis-patterns",
       "description": "Defensive programming patterns for statistical analysis pipelines to handle data quality issues gracefully",
       "version": "1.0.0",
@@ -4581,14 +2603,6 @@
       "description": "Add runtime DeprecationWarning to a legacy dataclass superseded by a Pydantic model, track usages in CI, and document migration timeline",
       "version": "1.0.0",
       "source": "./skills/deprecation-warning-migration.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "expand-tier-fixture-coverage",
-      "description": "Expand YAML fixture files and test parametrize lists when adding new tiers to the testing tier registry. Use when tier count assertions or schema parametrize lists are out of sync with fixture files.",
-      "version": "1.0.0",
-      "source": "./skills/expand-tier-fixture-coverage.md",
       "category": "testing",
       "tags": []
     },
@@ -4609,55 +2623,12 @@
       "tags": []
     },
     {
-      "name": "fix-tests-after-config-refactor",
-      "description": "Fix Tests After Config Refactor",
-      "version": "1.0.0",
-      "source": "./skills/fix-tests-after-config-refactor.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "frontmatter-colon-split-fix",
-      "description": "Fix YAML frontmatter parsers that use manual line.split(':', 1) instead of yaml.safe_load(), which silently truncates values containing colons. Use when: auditing frontmatter parsers for colon-split bugs, adding regression tests for URL/ratio values in YAML fields, or fixing description fields that lose data after the first colon.",
-      "version": "1.0.0",
-      "source": "./skills/frontmatter-colon-split-fix.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "generate-fix-suggestions",
       "description": "Generate fix suggestions based on error patterns and best practices",
       "version": "1.0.0",
       "source": "./skills/generate-fix-suggestions.md",
       "category": "testing",
       "tags": []
-    },
-    {
-      "name": "generate-tests",
-      "description": "Create test cases for functions and modules. Use when implementing TDD or improving coverage.",
-      "version": "1.0.0",
-      "source": "./skills/generate-tests.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "gradient-checking-and-backward-pass-testing",
-      "description": "Use when: (1) writing numerical gradient checks for conv2d, depthwise conv2d, batch norm, layer norm, or pooling backward passes in Mojo, (2) a gradient check reports analytical\u22480 vs numerical\u2248nonzero for a normalization layer, (3) migrating from check_gradients() to check_gradient() or choosing tolerances for float32 backward tests, (4) extending backward coverage to inference mode, 4D inputs, multi-channel configs, or all three gradient fields (grad_input, grad_weights, grad_bias), (5) implementing analytically tractable exact-value tests for conv2d backward with all-ones configs, (6) adding end-to-end convergence tests as a complementary class to per-op finite-difference checks for validating the full forward\u2192backward\u2192optimizer\u2192writeback loop",
-      "version": "1.1.0",
-      "source": "./skills/gradient-checking-and-backward-pass-testing.md",
-      "category": "testing",
-      "tags": [
-        "gradient-checking",
-        "backward-pass",
-        "batch-norm",
-        "layer-norm",
-        "conv2d",
-        "depthwise-conv2d",
-        "pooling",
-        "finite-differences",
-        "float32-precision",
-        "mojo"
-      ]
     },
     {
       "name": "liza-go-tests-embedded-cache",
@@ -4674,85 +2645,25 @@
       ]
     },
     {
-      "name": "manager-proxy-type-hints",
-      "description": "Skill: manager-proxy-type-hints. Use when working with manager proxy type hints.",
+      "name": "mojo-tensor-unit-test-and-gradient-checking",
+      "description": "Use when: (1) writing or extending Mojo tensor unit tests (dtype-aware string/repr, BFloat16 NaN canonicalization, UInt bitwise boundary tests, view vs copy semantics in slice tests), (2) re-enabling NOTE-disabled or TODO-stubbed Mojo test files and resolving TODO(#N) markers, (3) writing numerical gradient checks for conv2d, depthwise conv2d, batch norm, layer norm, or pooling backward passes in Mojo, (4) a gradient check reports analytical\u22480 vs numerical\u2248nonzero for a normalization layer (often caused by symmetric weight initialization), (5) adding end-to-end convergence tests as a complement to per-op finite-difference checks, (6) diagnosing symmetric-weight-init dead-symmetry pathology where uniform-fill weights produce algebraically zero gradients to early layers, (7) adding hardware-guarded BF16 precision recommendations to dtype selection functions.",
       "version": "1.0.0",
-      "source": "./skills/manager-proxy-type-hints.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "migrate-odyssey-deeply-nested-subdir-test",
-      "description": "Pattern for testing multi-level directory nesting in shutil.copytree migrations. Use when: adding coverage for recursive copy of auxiliary subdirectories, verifying deep paths survive migration.",
-      "version": "1.0.0",
-      "source": "./skills/migrate-odyssey-deeply-nested-subdir-test.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "mock-and-test-isolation-patterns",
-      "description": "Use when: (1) writing chaos/fault injection tests where a mock service must simulate latency, kill, or queue-starvation side effects \u2014 not just record the fault command, (2) a FastAPI/Pydantic endpoint test expects a specific HTTP status code (e.g. 503) but receives 500 because MagicMock attributes fail Pydantic response serialization, (3) tests pass individually but fail together due to mock pollution across test files and real file I/O with tmp_path is a cleaner alternative, (4) a test name says 'and' but only one side is asserted \u2014 a patch.object is missing 'as mock_X' and assert_called_once(), (5) a test bypasses the runner entry point and calls an internal delegate directly, leaving the full path untested, (6) adding unit tests for a class that constructs collaborators internally \u2014 patch the instance attribute after construction, (7) testing RuntimeError precondition guards (if-None, subprocess returncode, or _is_setup state) with parametrize or side_effect lists, (8) testing closure guards inside action-builder methods without a full state machine, (9) tests pass in isolation but fail when run after a test that calls importlib.reload() \u2014 patch.object on a module-imported object becomes stale after reload; use patch() string form instead.",
-      "version": "1.1.0",
-      "source": "./skills/mock-and-test-isolation-patterns.md",
-      "category": "testing",
-      "tags": [
-        "mock",
-        "test-isolation",
-        "pydantic",
-        "magicmock",
-        "fastapi",
-        "chaos-testing",
-        "fault-injection",
-        "tmp-path",
-        "patch-object",
-        "runtime-error",
-        "guard-tests",
-        "instance-attribute-patching",
-        "subprocess",
-        "importlib-reload",
-        "stale-reference",
-        "string-patch"
-      ]
-    },
-    {
-      "name": "mojo-dtype-shape-and-package-edges",
-      "description": "Canonical edge-case patterns for Mojo dtype handling, shape inference, and package builds: bfloat16/NaN canonicalization, exotic dtype defaults, shape-bound inference, parametric vs runtime dtype, package re-export rules, package-build edges, test patterns for dtype matrices, dtype string serialization. Use when: (1) implementing dtype-aware kernels and dealing with bfloat16/fp16 edge cases, (2) writing shape-bound inference for parametric tensors, (3) building/publishing a Mojo package and dealing with re-exports, (4) constructing dtype/shape test matrices, (5) implementing or testing __hash__ on a Mojo tensor with float/int fields and empty-tensor edge cases, (6) enforcing # NOTE (Mojo vX.Y.Z): format via pre-commit hook.",
-      "version": "1.1.0",
-      "source": "./skills/mojo-dtype-shape-and-package-edges.md",
-      "category": "testing",
-      "tags": [
-        "merged",
-        "mojo",
-        "dtype",
-        "shape",
-        "package",
-        "bfloat16",
-        "parametric",
-        "hash",
-        "notes",
-        "docstrings"
-      ]
-    },
-    {
-      "name": "mojo-tensor-unit-test-patterns",
-      "description": "Test patterns specific to Mojo tensor and operator implementations. Use when: (1) activating TODO-guarded __str__/__repr__ placeholder tests in Mojo, (2) adding dtype-aware string/repr formatting for integer or bool types, (3) writing BFloat16 NaN canonicalization or regression tests, (4) adding UInt bitwise NOT or overflow/wrap-around boundary tests, (5) closing value-correctness gaps in structural tensor tests, (6) fixing view vs copy semantics mismatches in slice tests, (7) replacing hardcoded /tmp paths with unique per-run paths, (8) re-enabling NOTE-disabled or TODO-stubbed Mojo test files, (9) annotating pass-only placeholder tests against staleness, (10) resolving TODO(#N) markers after a blocking issue closes.",
-      "version": "1.0.0",
-      "source": "./skills/mojo-tensor-unit-test-patterns.md",
+      "source": "./skills/mojo-tensor-unit-test-and-gradient-checking.md",
       "category": "testing",
       "tags": [
         "mojo",
         "tensor",
-        "extensor",
-        "dtype",
+        "unit-test",
+        "gradient-checking",
+        "backward-pass",
+        "finite-differences",
         "bfloat16",
-        "uint",
-        "view",
-        "copy",
-        "str",
-        "repr",
-        "placeholder",
-        "todo",
-        "re-enable"
+        "dtype",
+        "weight-init",
+        "dead-symmetry",
+        "conv2d",
+        "batch-norm",
+        "layer-norm"
       ]
     },
     {
@@ -4764,26 +2675,10 @@
       "tags": []
     },
     {
-      "name": "multi-division-fixture-management",
-      "description": "TRIGGER CONDITIONS: Use when adding a second division's fixture set to a flat tests/fixtures/ directory, or when capture-fixtures CLI needs named subdirs, or when integration tests need to auto-discover all fixture sets.",
-      "version": "1.0.0",
-      "source": "./skills/multi-division-fixture-management.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "multi-language-judge-pipelines",
       "description": "Add language-specific build pipelines to E2E test judge systems",
       "version": "1.0.0",
       "source": "./skills/multi-language-judge-pipelines.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "multi-pattern-stale-detection",
-      "description": "Detect stale CI matrix patterns at the sub-pattern level when space-separated multi-pattern strings are used. Use when: extending CI coverage validators, a group has multiple patterns where a subset may silently go stale, or implementing check_stale_patterns() style functions.",
-      "version": "1.0.0",
-      "source": "./skills/multi-pattern-stale-detection.md",
       "category": "testing",
       "tags": []
     },
@@ -4801,14 +2696,6 @@
         "graphql",
         "shell-testing"
       ]
-    },
-    {
-      "name": "nd-tensor-dataloader-fix",
-      "description": "Fix DataLoader.next() to support N-D tensors by replacing hardcoded 2D shape assumption with ExTensor.slice(). Use when: DataLoader produces wrong batch shapes for 3D/4D data, or adding N-D batch slicing tests in Mojo.",
-      "version": "1.0.0",
-      "source": "./skills/nd-tensor-dataloader-fix.md",
-      "category": "testing",
-      "tags": []
     },
     {
       "name": "port-feature-branch-impl",
@@ -4834,81 +2721,127 @@
       ]
     },
     {
-      "name": "pytest-asyncio-hang-and-mock-hazards",
-      "description": "Diagnosing and fixing pytest tests that hang or produce false results due to asyncio event loops, sleep mocks, and coroutine patching. Use when: (1) pytest CI step times out without reporting a test failure \u2014 hang signature, (2) async daemon tests block in epoll.poll(-1) and pytest-timeout does not interrupt them, (3) a coroutine internally reassigns a global asyncio.Event making pre-set fixtures ineffective, (4) patch('module.time.sleep') causes OOM via runaway retry loops, (5) FastAPI Depends() ignores a patched get_settings because the function reference was captured at import time, (6) a code-quality bot flags `await <asyncio.Task>` as a no-effect statement.",
-      "version": "1.1.0",
-      "source": "./skills/pytest-asyncio-hang-and-mock-hazards.md",
+      "name": "pytest-async-mock-isolation-patterns",
+      "description": "Use when: (1) pytest CI step times out or hangs due to asyncio event loops, epoll blocking, or runaway retry loops caused by sleep mocks; (2) an asyncio coroutine internally reassigns a global Event making pre-set fixtures ineffective; (3) writing integration tests for asyncio code that calls httpx.AsyncClient and need stateful fault injection (500/503/timeouts) via respx without nested context issues; (4) tests pass individually but fail together due to module-level singleton state (circuit breaker, cache, registry) not reset between tests; (5) a class-level patch.object becomes stale after importlib.reload() \u2014 use patch() string form; (6) FastAPI Depends() ignores a patched get_settings because the function reference was captured at import time; (7) an automation/agent-orchestration unit test reaches an invoke_claude subprocess gate that is absent in CI; (8) tests pass in isolation but fail when run after a test that mutates shared asyncio objects; (9) a mock service must simulate latency, kill, or queue-starvation side effects \u2014 not just record the fault command; (10) a test name says 'and' but only one assertion is made and a mock assertion is missing.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-async-mock-isolation-patterns.md",
       "category": "testing",
       "tags": [
-        "asyncio",
         "pytest",
+        "asyncio",
+        "mock",
+        "test-isolation",
         "hang",
         "timeout",
         "epoll",
+        "event-loop",
         "AsyncMock",
-        "coroutine",
         "patch",
         "time-sleep",
         "oom",
+        "respx",
+        "httpx",
+        "fault-injection",
+        "circuit-breaker",
+        "singleton",
+        "module-singleton",
+        "autouse-fixture",
+        "conftest-scope",
+        "importlib-reload",
+        "stale-reference",
+        "string-patch",
         "fastapi",
         "pydantic-settings",
-        "event-loop",
-        "python",
-        "pytest-timeout",
-        "false-positive",
-        "unmocked-blocking-call",
-        "subprocess-hang",
-        "baseline-duration-diagnosis",
-        "faulthandler"
+        "claude-cli",
+        "agent-orchestration",
+        "subprocess",
+        "full-suite-before-green",
+        "cross-test-contamination",
+        "python"
       ]
     },
     {
-      "name": "pytest-configuration-and-isolation-pitfalls",
-      "description": "Use when: (1) CI Python test job hangs until timeout with no explicit failure, (2) pytest warns 'ignoring pytest config in pyproject.toml!' or a pytest.ini coexists with pyproject.toml, (3) test collection count is suspiciously low or ImportError on a scripts/ module, (4) coverage gate fires for a partial test run (e.g., pytest -m integration) but full-suite coverage is fine, (5) a test is flaky only in the full suite and uses class-level patch.object, (6) YAML fixture timeouts are far too conservative and inflate CI job duration, (7) a test suddenly fails in CI with no code changes and references hardcoded calendar dates or Unix timestamps.",
+      "name": "pytest-configuration-discovery-and-ci-pitfalls",
+      "description": "Use when: (1) CI Python test job hangs until timeout with no explicit failure \u2014 hang signature from asyncio daemon tasks blocking epoll; (2) pytest warns 'ignoring pytest config in pyproject.toml!' or pytest.ini coexists with pyproject.toml causing dual-config conflicts; (3) test collection count is suspiciously low or ImportError on a scripts/ module \u2014 conftest.py missing sys.path guard; (4) slim 'pip install pytest' CI jobs silently inherit addopts from pyproject.toml and fail because pytest-cov or other plugins in addopts are not installed; (5) developers run bare pytest and only unit tests are discovered because tests/integration/ is not in testpaths; (6) CI test counts differ from local collection counts \u2014 marker-based selection (-m unit, -m integration) inconsistency; (7) a CI matrix has patterns referencing renamed or deleted test files \u2014 stale pattern detection; (8) pytest-watch dependency must be replaced with an alternative watcher dependency; (9) test is flaky only in the full suite due to class-level patch.object or hardcoded calendar dates/Unix timestamps; (10) coverage gate fires for a partial test run (e.g. pytest -m integration) but full-suite coverage is fine; (11) a ModuleNotFoundError fires when patching a scripts/ module not on sys.path during single-file pytest runs \u2014 add sys.path guard to conftest.py.",
       "version": "1.0.0",
-      "source": "./skills/pytest-configuration-and-isolation-pitfalls.md",
+      "source": "./skills/pytest-configuration-discovery-and-ci-pitfalls.md",
       "category": "testing",
       "tags": [
         "pytest",
         "configuration",
-        "isolation",
-        "coverage",
-        "mock",
-        "fixture",
-        "timeout",
-        "date-bomb",
-        "pythonpath",
-        "fail-under"
-      ]
-    },
-    {
-      "name": "pytest-testpaths-integration-discovery",
-      "description": "Use when: (1) developers run bare `pytest` and only unit tests are discovered, (2) integrating a new `tests/integration/` suite but default test invocation skips it, (3) you want to enable marker-based test selection (`-m unit`, `-m integration`) without fragmenting test discovery, (4) CI test counts differ from local collection counts, (5) you need consistent test discovery behavior across all invocation patterns.",
-      "version": "1.0.0",
-      "source": "./skills/pytest-testpaths-integration-discovery.md",
-      "category": "testing",
-      "tags": [
-        "pytest",
-        "testpaths",
         "test-discovery",
-        "integration-tests",
+        "testpaths",
         "markers",
-        "pytest-markers"
+        "pytest-ini",
+        "pyproject-toml",
+        "addopts",
+        "pythonpath",
+        "conftest",
+        "sys-path",
+        "ci-matrix",
+        "stale-patterns",
+        "pytest-watcher",
+        "coverage",
+        "isolation",
+        "mock"
       ]
     },
     {
-      "name": "python-script-unit-test-coverage-expansion",
-      "description": "Use when: (1) a Python script in scripts/ has zero test coverage and needs tests added; (2) a coverage threshold audit reveals that scripts/ is under-tested vs. the threshold; (3) a follow-up issue requests tests for specific untested modules; (4) you need to close CLI command-handler test gaps (cmd_run/cmd_repair style); (5) you need to audit existing tests before writing new ones to avoid duplication; (6) you are running a coverage swarm with one PR per source file or test shard; (7) new tests must be documented and added to CI workflows that enumerate files manually.",
-      "version": "1.1.0",
-      "source": "./skills/python-script-unit-test-coverage-expansion.md",
+      "name": "pytest-coverage-threshold-and-enforcement",
+      "description": "Use when: (1) establishing [tool.coverage.report].fail_under as the single source of truth by removing redundant --cov-fail-under from CI and pyproject.toml addopts; (2) configuring multiple coverage report formats (xml, html, lcov) for CI and local use; (3) CI coverage % is lower than local because GitHub computes coverage against the merge-preview tree (PR HEAD merged with main HEAD) \u2014 adding entries to coverage.run.omit for files not on the branch IS the correct fix; (4) aggregate coverage gates hide under-tested critical modules \u2014 enforce per-file floors via parse_module_coverage() + coverage.toml + CI step; (5) some modules are intentionally omitted from measurement (live CLI/TTY) and need an integration backstop to catch import-time regressions; (6) pytest.importorskip() guards hide easy coverage wins \u2014 install optional deps and write targeted branch tests; (7) tuning coverage thresholds to match actual baselines and avoid false CI failures; (8) generate_coverage.sh fails in CI with wrong paths, cmake source dir errors, lcov gcov version mismatch on Ubuntu 24.04, or geninfo 'unable to create link .gcda'; (9) coverage is raised by adding targeted tests for uncovered branches plus unlocking skipped optional-dependency test groups.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-coverage-threshold-and-enforcement.md",
       "category": "testing",
       "tags": [
-        "python",
-        "pytest",
-        "unit-tests",
         "coverage",
-        "mocking",
-        "scripts"
+        "pytest",
+        "fail-under",
+        "single-source-of-truth",
+        "per-module-floors",
+        "merge-preview",
+        "integration-backstop",
+        "optional-deps",
+        "importorskip",
+        "lcov",
+        "gcov",
+        "ci-cd"
+      ]
+    },
+    {
+      "name": "pytest-fixture-patterns-and-deduplication",
+      "description": "Use when: (1) pytest.mark.parametrize lists hardcode fixture filenames that must be manually updated when new fixtures are added \u2014 replace with glob-based auto-discovery; (2) test fixtures have duplicated YAML configs \u2014 find | md5sum shows 40+ duplicates and runtime block-based composition eliminates them; (3) duplicated test fixture configs should be migrated to a centralized shared location; (4) a schema validation test parametrizes over tier fixture files but only early tiers exist (e.g. t0/t1) and new tiers need coverage across the full range; (5) YAML fixture files and test parametrize lists must be expanded when new tiers are added to the tier registry; (6) a second division's fixture set is added to a flat tests/fixtures/ directory and capture-fixtures CLI needs named subdirs; (7) testing multi-level directory nesting in shutil.copytree migrations where deep paths must survive migration; (8) fixture and implementation symmetry must be validated \u2014 fixture YAML keys must match tested interface fields; (9) checkpoint state machine fixtures encode multi-state test scenarios and need refactoring for reuse; (10) an autouse fixture in conftest.py must reset module-level singleton state (asyncio objects, circuit breakers) at the broadest scope.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-fixture-patterns-and-deduplication.md",
+      "category": "testing",
+      "tags": [
+        "pytest",
+        "fixtures",
+        "parametrize",
+        "deduplication",
+        "test-fixtures",
+        "auto-discovery",
+        "tier-fixtures",
+        "shared-fixtures",
+        "copytree",
+        "checkpoint"
+      ]
+    },
+    {
+      "name": "pytest-test-splitting-matrix-and-parametrization",
+      "description": "Use when: (1) a monolithic test file exceeds the Edit tool's ~25K token limit and must be split into focused sub-modules preserving test count and git history; (2) coverage tracking is needed for _partN.mojo test files split from a single logical test \u2014 validate_test_coverage.py must group part files by base name using regex; (3) adding or splitting test groups in a CI matrix \u2014 group splitting by filesystem structure, glob pattern evolution, zero-discovery guards, matrix status checks; (4) a CI matrix sub-pattern level silently goes stale when space-separated multi-pattern strings are used and a subset stops matching files; (5) building E2E workspace lifecycle code with staged parallel test generation; (6) pytest-asyncio with auto mode where fixture and test both run in the same event loop and parametrize interacts with async fixtures; (7) creating a weekly GitHub Actions workflow for Mojo training tests excluded from per-PR CI because they are in the validate_test_coverage.py exclusion list; (8) a test file was split across part files and a CI workflow pattern must be updated to match the new filenames.",
+      "version": "1.0.0",
+      "source": "./skills/pytest-test-splitting-matrix-and-parametrization.md",
+      "category": "testing",
+      "tags": [
+        "pytest",
+        "test-splitting",
+        "ci-matrix",
+        "parametrize",
+        "coverage-tracking",
+        "stale-detection",
+        "weekly-workflow",
+        "e2e",
+        "glob-pattern"
       ]
     },
     {
@@ -4944,20 +2877,23 @@
       "tags": []
     },
     {
-      "name": "split-file-group-tracking",
-      "description": "TRIGGER CONDITIONS: Use when adding coverage tracking for _partN.mojo test files split from a single logical test, or when validate_test_coverage.py needs to group part files by base name using regex.",
+      "name": "tdd-workflow-and-test-coverage-expansion",
+      "description": "Use when: (1) creating tests before implementation or during a TDD phase \u2014 generate test files, coordinate red-green-refactor loops, close CLI command-handler test gaps; (2) a Python script in scripts/ has zero test coverage and needs tests added \u2014 audit existing tests before writing new ones to avoid duplication; (3) a unit test exposes a latent parsing bug where single-line vs multi-line input shapes behave differently \u2014 test-driven bug discovery; (4) a hephaestus/ module has no tests or low coverage and uses subprocess.run or shutil.which \u2014 add mock-based unit tests to reach >85% coverage without real command execution; (5) tests fail after a config refactor \u2014 fixtures and mocks need updating to match the new config surface; (6) enforcing import layer boundaries using AST-level CI tests to prevent circular import regressions \u2014 catch both direct and lazy/function-local imports that violate architecture; (7) annotating hundreds of unannotated test functions in tests/unit/ to satisfy mypy disallow_untyped_defs; (8) running a coverage swarm with one PR per source file or test shard; (9) new tests must be documented and added to CI workflows that enumerate files manually; (10) writing tests that expose latent bugs in text-processing or subprocess-output parsing functions.",
       "version": "1.0.0",
-      "source": "./skills/split-file-group-tracking.md",
+      "source": "./skills/tdd-workflow-and-test-coverage-expansion.md",
       "category": "testing",
-      "tags": []
-    },
-    {
-      "name": "split-large-test-file",
-      "description": "Split a monolithic test file exceeding the Edit tool's ~25K token limit into focused sub-modules, preserving test count and git history",
-      "version": "1.0.0",
-      "source": "./skills/split-large-test-file.md",
-      "category": "testing",
-      "tags": []
+      "tags": [
+        "tdd",
+        "pytest",
+        "unit-tests",
+        "coverage",
+        "mocking",
+        "subprocess",
+        "bug-discovery",
+        "ast",
+        "import-boundary",
+        "red-green-refactor"
+      ]
     },
     {
       "name": "test-diff-analyzer",
@@ -4968,133 +2904,12 @@
       "tags": []
     },
     {
-      "name": "test-driven-bug-discovery",
-      "description": "Writing unit tests that expose latent parsing bugs in text-processing functions \u2014 particularly functions that process subprocess/external tool output where single-line vs. multi-line input shapes behave differently.",
-      "version": "1.0.0",
-      "source": "./skills/test-driven-bug-discovery.md",
-      "category": "testing",
-      "tags": [
-        "pytest",
-        "unit-testing",
-        "bug-discovery",
-        "string-parsing",
-        "git",
-        "porcelain",
-        "subprocess"
-      ]
-    },
-    {
       "name": "test-implementation-gap-analysis",
       "description": "Test-Implementation Gap Analysis \u2014 detects gaps between test expectations and implementation, including PR commit message/diff mismatches where a route or feature is described but never added to the relevant source file",
       "version": "1.1.0",
       "source": "./skills/test-implementation-gap-analysis.md",
       "category": "testing",
       "tags": []
-    },
-    {
-      "name": "test-matrix-and-e2e-infrastructure",
-      "description": "Canonical patterns for test matrix management and E2E test infrastructure: group splitting by filesystem structure, glob pattern evolution, zero-discovery guards, matrix status checks, workspace lifecycle, checkpoint/resume mechanics, parallel test generation, staged execution. Use when: (1) adding or splitting test groups in a CI matrix, (2) preventing silent test drops from glob refactors, (3) building E2E workspace lifecycle code, (4) staging parallel E2E generation.",
-      "version": "1.0.0",
-      "source": "./skills/test-matrix-and-e2e-infrastructure.md",
-      "category": "testing",
-      "tags": [
-        "merged",
-        "test-matrix",
-        "e2e",
-        "fixture",
-        "parallel-test",
-        "workspace-lifecycle"
-      ]
-    },
-    {
-      "name": "testing-ast-import-layer-enforcement",
-      "description": "Enforce import layer boundaries in Python packages using AST-level CI tests. Use when: (1) you've fixed a circular import and want to prevent regressions, (2) you have a strict layering rule (module A must never import from module B) and need it enforced in CI, (3) you want to catch both direct and lazy/function-local imports that violate architecture boundaries.",
-      "version": "1.0.0",
-      "source": "./skills/testing-ast-import-layer-enforcement.md",
-      "category": "testing",
-      "tags": [
-        "python",
-        "ast",
-        "import-boundary",
-        "circular-imports",
-        "layer-enforcement",
-        "ci",
-        "testing"
-      ]
-    },
-    {
-      "name": "testing-asyncio-fixture-state-reset",
-      "description": "Reset asyncio objects (Lock, Event) in autouse fixtures with lazy imports for test isolation. Use when: (1) tests depend on fresh asyncio state per test, (2) manual per-test initialization is fragile and error-prone, (3) asyncio.Lock or asyncio.Event instance must be reset both before (setup) and after (teardown) each test, (4) import-order coupling or circular dependencies complicate fixture setup.",
-      "version": "1.0.0",
-      "source": "./skills/testing-asyncio-fixture-state-reset.md",
-      "category": "testing",
-      "tags": [
-        "asyncio",
-        "pytest-fixture",
-        "autouse-fixture",
-        "test-isolation",
-        "asyncio-lock",
-        "asyncio-event",
-        "lazy-import",
-        "conftest",
-        "state-reset"
-      ]
-    },
-    {
-      "name": "testing-cli-entrypoint-help-smoke",
-      "description": "Smoke-test Python CLI entry points with --help subprocess calls and import verification. Use when: (1) a package declares [project.scripts] entry points, (2) entry points need regression protection, (3) an issue asks for CLI importability tests.",
-      "version": "1.1.0",
-      "source": "./skills/testing-cli-entrypoint-help-smoke.md",
-      "category": "testing",
-      "tags": [
-        "python",
-        "cli",
-        "integration-testing",
-        "entry-points",
-        "smoke-tests"
-      ]
-    },
-    {
-      "name": "testing-coverage-per-module-floor-enforcement",
-      "description": "Enforce minimum coverage thresholds at per-file granularity using parse_module_coverage() + coverage.toml + CI step. Use when: (1) aggregate coverage gate masks under-tested modules, (2) need per-file coverage floors, (3) want to prevent skipped test modules from regressing.",
-      "version": "1.0.0",
-      "source": "./skills/testing-coverage-per-module-floor-enforcement.md",
-      "category": "testing",
-      "tags": [
-        "coverage",
-        "per-module",
-        "cobertura",
-        "ci-gate"
-      ]
-    },
-    {
-      "name": "testing-coverage-raise-targeted-branches-plus-optional-deps",
-      "description": "Unlock skipped tests by installing optional dependency in test environment + write targeted unit tests for remaining uncovered branches. Use when: (1) coverage is lower than expected, (2) pytest.importorskip() guards hide easy wins, (3) optional deps are skipped in test config but could be installed.",
-      "version": "1.0.0",
-      "source": "./skills/testing-coverage-raise-targeted-branches-plus-optional-deps.md",
-      "category": "testing",
-      "tags": [
-        "coverage",
-        "optional-deps",
-        "pytest-importorskip",
-        "branch-coverage",
-        "skipped-tests"
-      ]
-    },
-    {
-      "name": "testing-integration-backstop-omitted-modules",
-      "description": "Prevent silent growth of coverage omit list by enforcing that omitted modules remain importable + console scripts work. Use when: (1) modules are intentionally omitted from coverage (live CLI/TTY), (2) want to catch import-time regressions, (3) need proof that entry points are functional.",
-      "version": "1.0.0",
-      "source": "./skills/testing-integration-backstop-omitted-modules.md",
-      "category": "testing",
-      "tags": [
-        "testing",
-        "integration",
-        "omit-list",
-        "backstop",
-        "smoke-test",
-        "console-scripts"
-      ]
     },
     {
       "name": "testing-integration-fake-binary-on-path",
@@ -5109,20 +2924,6 @@
         "monkeypatch",
         "fake-binaries",
         "test-fixtures"
-      ]
-    },
-    {
-      "name": "testing-package-module-mock-coverage",
-      "description": "Add comprehensive mock-based unit tests for installed Python package modules with subprocess/shutil calls. Use when: (1) a hephaestus/ module has no tests or low coverage, (2) the module uses subprocess.run or shutil.which, (3) you need >85% coverage without real command execution.",
-      "version": "1.0.0",
-      "source": "./skills/testing-package-module-mock-coverage.md",
-      "category": "testing",
-      "tags": [
-        "mock",
-        "subprocess",
-        "coverage",
-        "hephaestus",
-        "package-module"
       ]
     },
     {
@@ -5141,71 +2942,6 @@
       ]
     },
     {
-      "name": "testing-respx-async-mock-fixtures-with-stateful-faults",
-      "description": "Use when: (1) writing integration tests for asyncio code that calls httpx.AsyncClient (REST API clients, etc.), (2) testing error scenarios (500, 409, 503, timeouts) via HTTP mocking without nested contexts or async/sync boundary issues, (3) needing stateful fault injection (permanent status override, task status queue, exception flags) without redefining the mock for each test, (4) validating HTTP request payloads with assertions that survive schema evolution, (5) using respx 0.21+ with route names for call inspection, (6) pytest-asyncio with auto mode where fixture and test both run in same event loop.",
-      "version": "1.0.0",
-      "source": "./skills/testing-respx-async-mock-fixtures-with-stateful-faults.md",
-      "category": "testing",
-      "tags": [
-        "respx",
-        "httpx",
-        "async",
-        "asyncio",
-        "pytest-asyncio",
-        "fixture",
-        "mock",
-        "http",
-        "fault-injection",
-        "integration-test",
-        "state-machine",
-        "payload-validation",
-        "rest-api",
-        "python"
-      ]
-    },
-    {
-      "name": "testing-singleton-isolation-circuit-breaker-reset",
-      "description": "Test isolation for module-level singleton instances (e.g., circuit breaker, cache, registry) requires calling .reset() on the held reference directly \u2014 in a pytest autouse fixture in conftest.py at the broadest scope, OR at the top of any new test that trips the singleton \u2014 not via a registry-clearing reset helper that orphans the import-time-bound instance; AND you must run the FULL test suite (not just the changed subdirectory) before declaring green, because the breaker cascade only surfaces at full scope. Use when: (1) adding tests that intentionally trigger failures/exceptions to a class whose code path goes through a module-level circuit breaker / rate limiter / retry primitive, (2) new tests pass in isolation but make UNRELATED sibling tests fail with a 'circuit breaker is open'/unavailable error when the whole class runs, (3) a reset helper clears a registry (`_registry.clear()`) rather than resetting the import-time-bound instance, (4) testing code with module-level singleton instances (breakers, caches, registries, contextvar defaults) that maintain internal state across test runs, (5) a test passes locally in isolation but fails in CI with cross-test contamination, (6) the same test fails identically on multiple Python versions in CI (3.10/3.11/3.12/3.13) \u2014 a fingerprint of order-dependent shared state, (7) deciding where to put a pytest autouse fixture: single test file vs package conftest.py, (8) extending a non-transient/fail-fast error classifier and verifying it, (9) deciding whether HTTP 422 or GraphQL schema errors should be retried (they should NOT \u2014 they are deterministic), (10) you added a NEW side-effecting call (a gh/network/db call) inside a function existing tests already exercise and ran only the touched subdirectory's tests \u2014 audit every existing caller's test and mock the new call, then run the FULL suite, (11) CI shows a cascade of CircuitBreakerOpenError across many unrelated tests \u2014 treat it as a symptom and find the EARLIEST non-breaker failure (the real root cause that tripped the breaker).",
-      "version": "1.3.0",
-      "source": "./skills/testing-singleton-isolation-circuit-breaker-reset.md",
-      "category": "testing",
-      "tags": [
-        "test-isolation",
-        "singleton",
-        "circuit-breaker",
-        "module-singleton",
-        "test-pollution",
-        "shared-state",
-        "pytest-fixture",
-        "autouse-fixture",
-        "conftest-scope",
-        "cross-test-contamination",
-        "ci-only-failure",
-        "stateful-objects",
-        "fail-fast",
-        "non-transient-retry",
-        "registry-reset",
-        "github-api",
-        "422",
-        "graphql-schema-error",
-        "full-suite-before-green",
-        "run-all-tests",
-        "test-subset-trap",
-        "new-side-effecting-call",
-        "mock-every-caller",
-        "cascade-symptom",
-        "earliest-failure"
-      ]
-    },
-    {
-      "name": "tier-fixture-schema-coverage",
-      "description": "TRIGGER CONDITIONS: Use when schema validation tests parametrize over tier fixture files but only early tiers exist (e.g. t0/t1), or when new tier-specific boolean fields need coverage across the full tier range.",
-      "version": "1.0.0",
-      "source": "./skills/tier-fixture-schema-coverage.md",
-      "category": "testing",
-      "tags": []
-    },
-    {
       "name": "tiered-skill-migration-tests",
       "description": "Pattern for testing auxiliary subdir copying in tiered skill migrations. Use when: verifying tier-1/tier-2 skills with scripts/, templates/, and references/ are migrated correctly.",
       "version": "1.0.0",
@@ -5220,31 +2956,6 @@
       "source": "./skills/validate-tier-id-filename-consistency.md",
       "category": "testing",
       "tags": []
-    },
-    {
-      "name": "validate-upstream-mojo-fix-hostile-home-matrix",
-      "description": "Validate that an upstream Mojo fix (runtime crash, codegen flag resolution, compiler-driver bug, JIT mis-emission, etc.) actually landed in your newly-bumped nightly BEFORE removing downstream workarounds or starting a demolition wave. Uses a 4-gate progression: (Gate 1) cheapest local signal \u2014 either a hostile-`$HOME` matrix for filesystem-error class bugs, or `mojo build --print-effective-target` codegen check for compiler-driver / target-resolution bugs, or any analogous bug-class-specific micro-repro; (Gate 2) \u226510\u00d7 consecutive dispatches of the project's existing `repro-<issue#>` workflow on the bump branch; (Gate 3) full-iteration soak workflow if one exists; (Gate 4) \u22658 consecutive green required-check runs on the bump branch. Includes the load-bearing caveat that pre-fix infrastructure (coredump capture, gdb wrappers) often breaks for reasons unrelated to the fix \u2014 read the actual Mojo invocation logs, not the workflow's pass/fail summary. Use when: (1) you bumped the pinned Mojo version past an upstream fix-shipped date and want to confirm the fix landed in your build, (2) you are about to peel back a downstream workaround (Dockerfile chmod, entrypoint mkdir, BUILD_FLAGS pin to specific `--target-cpu`, sudoers `_ensure_writable`) and need deterministic confirmation, (3) an upstream Modular issue closed with 'fix in next nightly' and you want to verify before commenting or opening a workaround-removal / demolition PR, (4) you need to position a validation branch as a durable canary spanning the demolition wave.",
-      "version": "2.0.0",
-      "source": "./skills/validate-upstream-mojo-fix-hostile-home-matrix.md",
-      "category": "testing",
-      "tags": [
-        "mojo",
-        "modular",
-        "upstream-validation",
-        "container",
-        "permissions",
-        "filesystem-error",
-        "getAcceleratorArchOrEmpty",
-        "hostile-home",
-        "workaround-removal",
-        "rootless-podman",
-        "codegen-flags",
-        "avx512",
-        "target-cpu",
-        "four-gate-protocol",
-        "ci-canary",
-        "print-effective-target"
-      ]
     },
     {
       "name": "advise-before-planning",
@@ -5337,47 +3048,6 @@
       ]
     },
     {
-      "name": "automation-duplicate-pr-prevention-idempotency-guards",
-      "description": "Use when: (1) an automation pipeline creates duplicate PRs for one issue, (2) two PRs land on the same branch, (3) a worktree manager rebuilds a branch from base and discards remote history, (4) gh pr create runs unconditionally without checking for an existing PR, (5) making issue->branch->PR creation idempotent",
-      "version": "1.0.0",
-      "source": "./skills/automation-duplicate-pr-prevention-idempotency-guards.md",
-      "category": "tooling",
-      "tags": [
-        "automation",
-        "duplicate-pr",
-        "idempotency",
-        "git-worktree",
-        "gh-pr-create",
-        "ls-remote",
-        "pr-creation"
-      ]
-    },
-    {
-      "name": "automation-github-graphql-field-validation-live-schema",
-      "description": "A GitHub GraphQL mutation/query that selects a non-existent output field \u2014 OR names a mutation whose Input type lacks the argument you pass \u2014 fails on EVERY call (`Field 'X' doesn't exist on type 'Y'` for a bad output selection; `InputObject '<Input>' doesn't accept argument '<arg>'` + `Variable $X is declared by <Mutation> but not used` for a wrong mutation name), and a code path with no direct unit test can ship such a broken query indefinitely. Validate every field selection AND every input argument against the LIVE schema via introspection before shipping. Use when: (1) writing or editing a raw `gh api graphql` query/mutation string (especially `addPullRequestReview`, `addPullRequestReviewThreadReply`, `reviewThreads`, or any PR-review traversal), (2) a runtime log shows `gh: Field '<field>' doesn't exist on type '<Type>'`, `gh: InputObject '<Input>' doesn't accept argument '<arg>'`, `Variable $X is declared by <Mutation> but not used`, or repeated identical mutation failures, (3) you need to read a parent object off a child node (e.g. a comment's thread or review) and are assuming a reverse edge exists, (4) a function that builds a GraphQL query has no direct unit test and is only mocked out by higher-level callers, (5) an automation loop treats a PR as NOGO/re-runs forever because an in-loop review/comment/reply never posts.",
-      "version": "1.1.0",
-      "source": "./skills/automation-github-graphql-field-validation-live-schema.md",
-      "category": "tooling",
-      "tags": [
-        "graphql",
-        "github-api",
-        "schema-introspection",
-        "field-validation",
-        "input-argument-validation",
-        "wrong-mutation-name",
-        "addPullRequestReview",
-        "addPullRequestReviewThreadReply",
-        "resolveReviewThread",
-        "reviewThreads",
-        "pull-request-review",
-        "silent-broken-query",
-        "missing-unit-test",
-        "child-to-parent-edge",
-        "gh-api-graphql",
-        "automation-pipeline"
-      ]
-    },
-    {
       "name": "automation-graphql-parameterisation-prevent-injection",
       "description": "Pattern for parameterising GraphQL queries to prevent injection attacks. Use when: (1) building dynamic GraphQL queries with user/caller-supplied data (issue numbers, PR numbers, owner/repo names), (2) eliminating f-string interpolation in raw GraphQL queries, (3) handling batch queries with aliases (one scalar variable per batch element since GraphQL has no list indexing for aliases), (4) need to bind multiple scalar values to a single query safely.",
       "version": "1.0.0",
@@ -5428,24 +3098,6 @@
       ]
     },
     {
-      "name": "automation-pr-review-inline-comment-diff-hunk-validation",
-      "description": "Validate LLM/agent-generated inline PR-review comments against the PR diff hunks before POSTing the review, so GitHub does not reject the entire review with HTTP 422. Use when: (1) writing/editing code that POSTs a PR review with inline comments via `gh api -X POST .../pulls/{n}/reviews`, (2) a runtime log shows `gh: Unprocessable Entity (HTTP 422)` on a review POST, (3) an LLM/agent generates inline review comments (path/line/side) that may not lie on a changed line, (4) an automation loop records a spurious NOGO/Grade=F because the in-loop review POST failed, (5) the diff shown to a review model is truncated so it can cite real-but-out-of-hunk lines.",
-      "version": "1.0.0",
-      "source": "./skills/automation-pr-review-inline-comment-diff-hunk-validation.md",
-      "category": "tooling",
-      "tags": [
-        "github-api",
-        "pull-request-review",
-        "422",
-        "unprocessable-entity",
-        "diff-hunk",
-        "inline-comments",
-        "llm-generated-comments",
-        "fail-open",
-        "automation-pipeline"
-      ]
-    },
-    {
       "name": "automation-reuse-repo-clone-with-worktree-per-pr",
       "description": "Use when: (1) code clones the SAME repo once per PR/branch/item inside a loop, (2) a fleet/batch tool re-clones a repo for every item causing redundant network+disk I/O that scales with item count, (3) refactoring a per-item-clone hot loop to a single clone + git worktree per item, (4) a per-item working dir is created in a temp subdir via full `git clone`, (5) you need isolated per-item checkouts of one repo for rebase/conflict/agent work.",
       "version": "1.0.0",
@@ -5481,42 +3133,10 @@
       ]
     },
     {
-      "name": "bash-upstream-pr-review-traps",
-      "description": "Implement a feature or fix in a forked bash project and navigate maintainer review rounds. Use when: (1) contributing a new flag/env-var to an upstream bash CLI extension, (2) performing two-round review of bash scripts for logic and safety bugs, (3) debugging git branch --list exit-code trap or bash function-before-definition hazard, (4) filing separate bug issues found during code review and opening one PR per bug with correct branch dependencies.",
-      "version": "2.0.0",
-      "source": "./skills/bash-upstream-pr-review-traps.md",
-      "category": "tooling",
-      "tags": [
-        "bash",
-        "git-branch",
-        "function-definition",
-        "arg-parsing",
-        "ansi-color",
-        "env-var",
-        "upstream-pr",
-        "fork",
-        "open-source",
-        "review",
-        "gh-tidy",
-        "word-splitting",
-        "multi-pr",
-        "issue-filing",
-        "branch-dependency"
-      ]
-    },
-    {
       "name": "batch-image-to-idx-conversion",
       "description": "Extend a single-image IDX converter to batch mode with --batch flag accepting a directory or glob. Use when: (1) users need to pass a whole directory of images to a Mojo inference pipeline in one shot, (2) extending png-jpeg-to-idx-conversion to multi-image IDX format, (3) the IDX reader expects count>1.",
       "version": "1.0.0",
       "source": "./skills/batch-image-to-idx-conversion.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "bf16-precision-recommendation",
-      "description": "Add hardware-guarded BF16 support to dtype recommendation functions. Use when: enabling BF16 for large Mojo ML models, adding Apple Silicon hardware guard for BF16, or extending precision recommendation with hardware capability parameters.",
-      "version": "1.0.0",
-      "source": "./skills/bf16-precision-recommendation.md",
       "category": "tooling",
       "tags": []
     },
@@ -5568,14 +3188,6 @@
       "tags": []
     },
     {
-      "name": "claude-plugin-format",
-      "description": "Official Claude Code plugin format requirements and marketplace registration workflow. Use when creating new plugins, debugging \"plugin has invalid manifest\" errors, registering a marketplace, or when skills/commands don't appear after installation.",
-      "version": "1.1.0",
-      "source": "./skills/claude-plugin-format.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "clear-open-issue-backlog-myrmidon-swarm",
       "description": "End-to-end orchestrator recipe for clearing an entire open GitHub issue backlog with a single myrmidon-swarm session: preflight the whole backlog, re-grade each issue against current code, map file ownership, dispatch wave-based parallel agents, trust-but-verify each PR, and close out. Use when: (1) an open-issue backlog has 5+ issues to triage and implement in one session, (2) planning a myrmidon swarm to close out accumulated issues, (3) managing file-ownership collisions across parallel agents, (4) deciding which issues to flag to the user vs dispatch to agents.",
       "version": "1.0.0",
@@ -5601,23 +3213,6 @@
       "source": "./skills/cli-adapter-implementation.md",
       "category": "tooling",
       "tags": []
-    },
-    {
-      "name": "cli-dry-run-help-standardization",
-      "description": "Standardize --dry-run help text across multiple CLIs using a shared constant and helper function. Use when: (1) Multiple CLIs need identical --dry-run semantics, (2) Token-cost caveats must be user-visible at --help time, (3) Refactoring CLI parsers to extract testable _build_parser() entrypoints, (4) Adding parametrized help-text tests across CLI modules.",
-      "version": "1.0.0",
-      "source": "./skills/cli-dry-run-help-standardization.md",
-      "category": "tooling",
-      "tags": [
-        "argparse",
-        "cli",
-        "help-text",
-        "dry-run",
-        "testing",
-        "parametrized-tests",
-        "DRY-principle",
-        "refactoring"
-      ]
     },
     {
       "name": "cli-flag-validation-prevent-silent-noop",
@@ -5710,28 +3305,6 @@
       "tags": []
     },
     {
-      "name": "coverage-threshold-tuning",
-      "description": "Tune pytest coverage thresholds to match actual coverage baselines and avoid CI failures",
-      "version": "1.0.0",
-      "source": "./skills/coverage-threshold-tuning.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "cpp-conflict-resolution-clang-format-cmake-and-local-build",
-      "description": "Avoid breaking the build during a C++ rebase/merge conflict resolution: NEVER run clang-format on non-C++ files (it silently mangles CMakeLists.txt into a CMake parse error), and build the resolved merge LOCALLY before pushing to catch sibling-PR signature changes. Use when: (1) resolving a rebase/merge conflict that touches both C++ and CMakeLists/*.cmake/*.yaml; (2) clang-format ran on a build/config file and CI now fails with a CMake `Parse error`/`Expected a newline`; (3) `include(cmake / X.cmake)` with stray spaces around `/` appears after formatting; (4) you hand-resolved a conflict in compiled code and want to verify it before a slow CI round; (5) a sibling PR changed a function signature and your call sites (including tests) fail with 'too few/many arguments' after rebase.",
-      "version": "1.0.0",
-      "source": "./skills/cpp-conflict-resolution-clang-format-cmake-and-local-build.md",
-      "category": "tooling",
-      "tags": [
-        "clang-format",
-        "cmake",
-        "rebase",
-        "conflict",
-        "local-build"
-      ]
-    },
-    {
       "name": "cross-repo-script-and-library-porting",
       "description": "Systematic patterns for porting scripts, utilities, and libraries between repositories. Use when: (1) migrating utility scripts or full libraries from one project to another with dependency elimination and CI validation, (2) diff-analyzing two repos' diverged implementations to cherry-pick missing features without downgrading the destination, (3) porting skills from upstream OSS repos (Modular Apache 2.0, third-party MIT, or Agent Skills Standard format) with attribution, (4) installing and adapting external skills into a local Codex environment, or (5) creating re-export shims in the source repo after a successful port.",
       "version": "1.0.0",
@@ -5815,42 +3388,6 @@
       ]
     },
     {
-      "name": "ecosystem-wide-multi-repo-sweep-orchestration",
-      "description": "Orchestrating ecosystem-wide sweeps across 3+ HomericIntelligence repos using parallel classifier agents, wave/bundle execution, and phase ordering. Use when: (1) executing a sweep across 3+ HomericIntelligence repos simultaneously, (2) classifying 500+ open issues with parallel Phase-A classifier agents, (3) choosing between PR-per-issue (v1) and bundle-PR-per-repo (v2) sweep variants, (4) dispatching 50+ wave agents with sequential within-repo merge ordering, (5) clearing a stuck PR queue with a sequential rebase loop after a systemic fix lands on main, (6) bulk-merging N PRs against the same base branch without hitting the GraphQL base-branch race, (7) batch-rebasing local branches whose commits were parallel-merged or squash-absorbed upstream.",
-      "version": "1.0.0",
-      "source": "./skills/ecosystem-wide-multi-repo-sweep-orchestration.md",
-      "category": "tooling",
-      "tags": [
-        "ecosystem-wide",
-        "multi-repo",
-        "easy-sweep",
-        "classifier-swarm",
-        "wave-execution",
-        "bundle-per-repo",
-        "rebase-loop",
-        "sequential-merge",
-        "pr-queue",
-        "gh-tidy",
-        "parallel-merge",
-        "squash-absorb",
-        "rate-limit-event"
-      ]
-    },
-    {
-      "name": "edit-tool-blocked-workflow-files",
-      "description": "Workaround for the security_reminder_hook.py blocking the Edit tool on .github/workflows/*.yml files. Use when an agent needs to modify CI/CD workflow files and receives a PreToolUse:Edit hook error.\n",
-      "version": "1.0.0",
-      "source": "./skills/edit-tool-blocked-workflow-files.md",
-      "category": "tooling",
-      "tags": [
-        "edit-tool",
-        "security-hook",
-        "workflow-files",
-        "github-actions",
-        "workaround"
-      ]
-    },
-    {
       "name": "evaluate-model",
       "description": "Measure model performance on test datasets. Use when assessing accuracy, precision, recall, and other metrics.",
       "version": "1.0.0",
@@ -5867,49 +3404,10 @@
       "tags": []
     },
     {
-      "name": "extensor-str-truncation",
-      "description": "Add NumPy-style truncation to Mojo tensor __str__ methods to prevent performance issues with large tensors. Use when: (1) a tensor __str__ iterates all elements, (2) NumPy-compatible display semantics are desired, (3) printing large tensors causes slowdowns.",
-      "version": "1.0.0",
-      "source": "./skills/extensor-str-truncation.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "feature-dev-code-reviewer-cannot-execute-shell-commands",
-      "description": "The `feature-dev:code-reviewer` agent type has only read-only tools \u2014 it can analyze a PR but cannot post `gh pr review`. Use this skill to (1) choose the right agent type for tasks that need to write back, (2) structure prompts so analysis-only agents return parseable bodies the orchestrator can post, (3) avoid wasting agent tokens composing `gh` commands the agent cannot execute, (4) detect the failure signature (`I cannot run shell commands` / `Available tools: Read, WebFetch, ...`) when sub-agents report blockers, (5) decide between `general-purpose` (full toolset, can post) and `feature-dev:code-reviewer` (read-only, analysis only) for PR-review delegation.",
-      "version": "1.0.0",
-      "source": "./skills/feature-dev-code-reviewer-cannot-execute-shell-commands.md",
-      "category": "tooling",
-      "tags": [
-        "agent-types",
-        "code-review",
-        "sub-agents",
-        "shell-access",
-        "gh-cli",
-        "tool-availability",
-        "read-only-agent",
-        "prompt-design",
-        "delegation",
-        "orchestrator-pattern",
-        "write-back",
-        "feature-dev",
-        "general-purpose",
-        "analysis-only"
-      ]
-    },
-    {
       "name": "fix-hardcoded-target-path",
       "description": "Fix hardcoded output/target directory paths in migration and tooling scripts by adding CLI flag, env var fallback, and safe default. Use when: a script has a hardcoded absolute path that fails on other machines.",
       "version": "1.0.0",
       "source": "./skills/fix-hardcoded-target-path.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "generate-api-docs",
-      "description": "Create API reference documentation from docstrings. Use when documenting public module interfaces.",
-      "version": "1.0.0",
-      "source": "./skills/generate-api-docs.md",
       "category": "tooling",
       "tags": []
     },
@@ -5933,14 +3431,6 @@
         "parsing",
         "conventional-commits"
       ]
-    },
-    {
-      "name": "generate-docstrings",
-      "description": "Create docstrings for functions and classes. Use when documenting code APIs.",
-      "version": "1.0.0",
-      "source": "./skills/generate-docstrings.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "gh-issue-author-or-assignee-union",
@@ -5970,6 +3460,51 @@
         "git-push",
         "pr-merge",
         "agent-shell"
+      ]
+    },
+    {
+      "name": "git-branch-state-triage-and-recovery",
+      "description": "Diagnose and recover branches that have entered an invalid or obsolete state. Use when: (1) a branch is many commits behind main and its remote tracking ref is gone \u2014 determine whether any net-new contribution remains before creating a PR, (2) a branch has no common ancestor with main ('fatal: refusing to merge unrelated histories') and needs content extraction and recreation, (3) a stacked PR was retargeted and lint/CI fix commits made after retarget are orphaned from the prerequisite PR and must be cherry-picked, (4) fix commits exist locally but cannot fast-forward push to a remote PR branch because histories diverged after a rebase \u2014 cherry-pick onto the remote tip instead",
+      "version": "1.0.0",
+      "source": "./skills/git-branch-state-triage-and-recovery.md",
+      "category": "tooling",
+      "tags": [
+        "git",
+        "branch",
+        "triage",
+        "recovery",
+        "stale",
+        "superseded",
+        "orphan",
+        "diverged",
+        "merge-base",
+        "cherry-pick",
+        "fork-point",
+        "diff-filter",
+        "unrelated-histories",
+        "non-fast-forward"
+      ]
+    },
+    {
+      "name": "git-commit-signing-failures-and-setup",
+      "description": "Diagnose and fix commit signing failures that block PR merge under required_signatures / pr-policy gates. Use when: (1) a PR shows mergeStateStatus BLOCKED with all CI green and mergeable MERGEABLE \u2014 suspect unsigned or unverified commits, (2) GPG commit.gpgsign=true produces commits GitHub reports as verified=false with reason=no_user because the author email has no matching UID on the signing key, (3) sub-agent shells inherit commit.gpgsign=true but silently fail to sign due to un-warmed gpg-agent or wrong default key, (4) setting up commit signing on a fresh remote/headless/CI host for the first time using SSH signing keys, (5) git push is rejected with 'push declined due to email privacy restrictions' even though signing appears correct, (6) the pr-policy required-check gate reports unsigned commits even though local git log shows signatures",
+      "version": "1.0.0",
+      "source": "./skills/git-commit-signing-failures-and-setup.md",
+      "category": "tooling",
+      "tags": [
+        "git",
+        "gpg",
+        "ssh-signing",
+        "commit-signing",
+        "required-signatures",
+        "pr-policy",
+        "branch-protection",
+        "noreply-email",
+        "email-privacy",
+        "gpg-agent",
+        "graphql-lag",
+        "headless",
+        "agent-dispatch"
       ]
     },
     {
@@ -6042,22 +3577,6 @@
       "tags": []
     },
     {
-      "name": "github-bulk-issue-and-pr-operations",
-      "description": "Canonical guide to bulk GitHub issue and PR operations via gh CLI / gh api / GraphQL: rate-limit recovery, batch-create/close/comment, parallel PR remediation waves, mass label edits, idempotent filing with duplicate detection. Use when: (1) creating or closing 20+ issues/PRs in one operation, (2) recovering from primary or secondary rate limits, (3) coordinating parallel-fix swarms via gh CLI, (4) GraphQL bulk operations that span multiple repos, (5) auto-merge / admin-merge mechanics for batches.",
-      "version": "1.1.0",
-      "source": "./skills/github-bulk-issue-and-pr-operations.md",
-      "category": "tooling",
-      "tags": [
-        "merged",
-        "gh-cli",
-        "github-api",
-        "bulk",
-        "graphql",
-        "rate-limit",
-        "parallel-pr"
-      ]
-    },
-    {
       "name": "github-issue-workflow-and-preflight-gates",
       "description": "Use when: (1) starting work on any GitHub issue \u2014 run preflight checks to avoid duplicate implementation, (2) building or maintaining automated preflight safety gates in issue-implementation workflows, (3) filing 10\u201340 audit findings as a tracked GitHub issue queue with a parent tracker, (4) filing issues that cite repo-internal markdown docs \u2014 push docs to origin/main first so URLs resolve on first render, (5) posting structured progress updates or completion summaries to GitHub issues, (6) filing a feature request against a third-party OSS repo with a proposed patch and duplicate check, (7) verifying an already-resolved issue and closing it with grep evidence",
       "version": "1.1.0",
@@ -6117,20 +3636,6 @@
       ]
     },
     {
-      "name": "legacy-code-deletion-safe-removal-pattern",
-      "description": "Safe removal of legacy dead code files marked as fallback/reference-only. Use when a code file claims \"kept for reference/fallback only\" but has zero real callers across the codebase, leading to stale back-references in production code that create cognitive load during maintenance.",
-      "version": "1.0.0",
-      "source": "./skills/legacy-code-deletion-safe-removal-pattern.md",
-      "category": "tooling",
-      "tags": [
-        "legacy-code",
-        "code-deletion",
-        "refactoring",
-        "yagni",
-        "dead-code"
-      ]
-    },
-    {
       "name": "luks-encrypted-drive-readonly-recovery",
       "description": "Read-only recovery of files from a hotplugged LUKS-encrypted drive, prioritizing data safety over speed. Use when: (1) a SATA/USB drive with LUKS partitions needs file extraction, (2) drive health is unknown or suspect and you must not write to it, (3) imaging-first vs mount-directly tradeoff needs to be decided.",
       "version": "1.0.0",
@@ -6148,29 +3653,31 @@
       ]
     },
     {
-      "name": "markdownlint-md012-trailing-blank-eof",
-      "description": "Diagnose markdownlint MD012/no-multiple-blanks errors that are actually caused by a trailing double newline at end-of-file, not by visible double blanks at the reported line. Use when: (1) markdownlint CI reports MD012 at a line number close to the file's last content line, (2) the same MD012 error appears across multiple PRs touching different markdown files, (3) you almost stripped blank lines inside a fenced code block trying to fix MD012 (MD012 ignores blanks inside code fences by default), (4) you want a one-line POSIX fix that strips trailing whitespace and re-adds a single newline terminator.",
-      "version": "1.0.0",
-      "source": "./skills/markdownlint-md012-trailing-blank-eof.md",
-      "category": "tooling",
-      "tags": [
-        "markdownlint",
-        "MD012",
-        "no-multiple-blanks",
-        "eof-newline",
-        "end-of-file-fixer",
-        "ci-unblocking",
-        "pre-commit",
-        "diagnostics"
-      ]
-    },
-    {
       "name": "model-config-explicit-model-id",
       "description": "Skill: model-config-explicit-model-id",
       "version": "1.0.0",
       "source": "./skills/model-config-explicit-model-id.md",
       "category": "tooling",
       "tags": []
+    },
+    {
+      "name": "mojo-package-build-and-distribution",
+      "description": "Use when: (1) planning to publish a Mojo library via the modular-community conda channel \u2014 idiomatic src/<pkg>/ layout, conda.recipe/recipe.yaml (rattler-build), PR workflow, (2) converting an in-tree shared/ directory into a distributable .mojopkg, (3) creating GitHub Actions workflows for automated .mojopkg building and release creation, (4) deciding between conda channel vs Python wheel vs git dependency for distributing a Mojo library, (5) replacing fictional 'mojo install'/'mojo publish' CLI references in documentation with the correct pixi-channel workflow.",
+      "version": "1.0.0",
+      "source": "./skills/mojo-package-build-and-distribution.md",
+      "category": "tooling",
+      "tags": [
+        "mojo-packaging",
+        "mojopkg",
+        "modular-community",
+        "prefix-dev",
+        "rattler-build",
+        "conda",
+        "python-wheel",
+        "github-actions",
+        "release",
+        "distribution"
+      ]
     },
     {
       "name": "monorepo-subproject-gitignore-and-github-template-gotchas",
@@ -6270,21 +3777,6 @@
       "tags": []
     },
     {
-      "name": "packaging-pep561-py-typed-marker",
-      "description": "Add PEP 561 py.typed marker to Python packages using hatchling. Use when: (1) making a typed Python package discoverable by mypy/pyright, (2) configuring hatch build targets for type marker files.",
-      "version": "1.0.0",
-      "source": "./skills/packaging-pep561-py-typed-marker.md",
-      "category": "tooling",
-      "tags": [
-        "pep-561",
-        "py.typed",
-        "mypy",
-        "hatchling",
-        "packaging",
-        "typing"
-      ]
-    },
-    {
       "name": "parallel-agent-myrmidon-swarm-orchestration",
       "description": "Canonical guide to parallel-agent and Myrmidon swarm orchestration: wave-based dispatch, hierarchical tier assignment (Opus L0 \u2192 Sonnet L1/L2 \u2192 Haiku L4), agent prompt patterns, dispatcher discipline, multi-repo coordination. Use when: (1) dispatching 5+ parallel agents on independent tasks, (2) coordinating a multi-repo swarm operation, (3) designing tier assignments (Opus vs Sonnet vs Haiku), (4) ensuring deterministic dispatch without orchestrator hand-holding.",
       "version": "1.0.0",
@@ -6367,26 +3859,10 @@
       ]
     },
     {
-      "name": "phase-cleanup",
-      "description": "Refactor and finalize code after parallel phases complete, addressing technical debt. Use in cleanup phase to polish code before merge.",
-      "version": "1.0.0",
-      "source": "./skills/phase-cleanup.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "phase-implement",
       "description": "Coordinate implementation phase by delegating tasks and ensuring code quality. Use during implementation phase to manage engineer tasks.",
       "version": "1.0.0",
       "source": "./skills/phase-implement.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "phase-package",
-      "description": "Create distributable packages including .mojopkg files and archives. Use during package phase to prepare components for distribution.",
-      "version": "1.0.0",
-      "source": "./skills/phase-package.md",
       "category": "tooling",
       "tags": []
     },
@@ -6399,14 +3875,6 @@
       "tags": []
     },
     {
-      "name": "phase-test-tdd",
-      "description": "Generate test files and coordinate test-driven development (TDD). Use when creating tests before implementation or during test phase.",
-      "version": "1.0.0",
-      "source": "./skills/phase-test-tdd.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "pil-grayscale-method-flag",
       "description": "Add a --grayscale-method {luma,average,max} CLI flag to image preprocessing scripts using PIL. Use when: adding configurable grayscale strategies to a PIL-based script, fixing broken PIL image tests, or extending argparse CLIs with algorithm-selection flags.",
       "version": "1.0.0",
@@ -6415,56 +3883,25 @@
       "tags": []
     },
     {
-      "name": "pipeline-step-extraction",
-      "description": "Skill: Pipeline Step Extraction (CC>15 Reduction)",
+      "name": "pixi-env-task-config",
+      "description": "Use when: (1) setting up a new Mojo/MAX/Python project with pixi.toml and choosing between nightly/stable channels, (2) wrapping pixi tasks with a justfile for cross-repo convention alignment, (3) eliminating DRY violations by using pixi feature composition (environments = {features = [shared, dev]}) to share dev tools across environments, (4) adding justfile delegation recipes to a meta-repo, (5) auditing pixi task definitions for consistency with CI workflows.",
       "version": "1.0.0",
-      "source": "./skills/pipeline-step-extraction.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "pixi-env-resolve-drops-editable-install",
-      "description": "Pixi silently re-solves the shared `.pixi/envs/default` and wipes the `pip install -e .` editable install whenever a worktree edit to `pyproject.toml` (especially `[project.scripts]`, `[project.dependencies]`, or `[project.optional-dependencies]`) is followed by a `pixi run` invocation. Long-running automation that imports the package then fails with `ModuleNotFoundError: No module named '<pkg>'` starting at the exact env-resolve timestamp. Use when: (1) `ModuleNotFoundError: No module named 'hephaestus'` (or your package) starts mid-run, (2) every repo started AFTER a specific UTC timestamp fails identically while every repo started BEFORE it succeeded, (3) a swarm/parallel agent run touched `pyproject.toml` in any worktree sharing `.pixi/envs/default`, (4) `stat -c '%Y' .pixi/envs/default/conda-meta` is newer than the last `pixi run dev-install`.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-env-resolve-drops-editable-install.md",
+      "source": "./skills/pixi-env-task-config.md",
       "category": "tooling",
       "tags": [
         "pixi",
-        "editable-install",
-        "pip-install-e",
-        "dev-install",
-        "site-packages",
-        "env-resolve",
-        "module-not-found",
-        "pyproject",
-        "project-scripts",
-        "swarm-worktree",
-        "long-running-driver",
-        "shared-pixi-env"
-      ]
-    },
-    {
-      "name": "pixi-feature-composition-deduplicate-tools",
-      "description": "Eliminate DRY violations when the same dev tools are declared in multiple pixi feature blocks by using feature composition (environments = {features = [shared, dev]}) to merge dependencies. Use when: (1) six or more conda/PyPI tools appear in multiple [feature.*] blocks, (2) version floors need to be synchronized across environments, (3) solving each environment independently while sharing tool definitions.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-feature-composition-deduplicate-tools.md",
-      "category": "tooling",
-      "tags": [
-        "pixi",
-        "dependencies",
+        "justfile",
+        "mojo",
+        "max",
+        "project-setup",
         "feature-composition",
         "deduplication",
         "dry-principle",
+        "ecosystem",
+        "convention",
+        "meta-repo",
         "solve-groups"
       ]
-    },
-    {
-      "name": "pixi-pypi-upper-bounds",
-      "description": "Add explicit upper version bounds to pixi.toml [pypi-dependencies]. Use when auditing or hardening dependency version constraints to prevent silent breakage on major releases.",
-      "version": "1.0.0",
-      "source": "./skills/pixi-pypi-upper-bounds.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "plan-mode-blocks-subagent-writes",
@@ -6504,17 +3941,9 @@
       "tags": []
     },
     {
-      "name": "pr-merge-conflict-resolution",
-      "description": "Systematic workflow for rebasing PRs and resolving merge conflicts. Use when: (1) a PR branch is behind main with conflicts, (2) bulk-fixing similar conflicts across many files (e.g., YAML frontmatter), (3) a stacked-PR cascade-rebase produces identical trivial conflicts on the same files across many branches (typically caused by `pre-commit end-of-file-fixer` touching trailing-blank-line drift in workflow YAMLs or single-line drift in pixi.toml/CHANGELOG-style files), (4) you need a sed-based auto-resolver loop that strips the entire conflict block keeping HEAD's side and continues the rebase \u2014 only safe when conflicts are whitespace-only and HEAD is proven correct.",
-      "version": "1.1.0",
-      "source": "./skills/pr-merge-conflict-resolution.md",
-      "category": "tooling",
-      "tags": []
-    },
-    {
       "name": "pre-commit-hooks-and-linting-config",
-      "description": "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes \u2014 system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed \u2014 the hook checks ALL .py files on disk including untracked ones.",
-      "version": "1.7.0",
+      "description": "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes \u2014 system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed \u2014 the hook checks ALL .py files on disk including untracked ones, (9) CI ruff-format hook fails even though local `ruff check` passed \u2014 `ruff check` (lint) and `ruff format --check` (formatter) are SEPARATE tools sharing one binary and running only `check` never exercises the formatter, (10) running pre-commit against the full PR diff (every file changed since merge-base) with `--from-ref/--to-ref` not just `--files <current edit>` \u2014 a sub-agent's earlier commit can carry stale-formatter content that fails only in CI, (11) adding .editorconfig for cross-editor formatting consistency on non-Python files (YAML, JSON, Markdown, shell, Makefile), (12) an automated PR-reviewer flags lint/formatter/pre-commit-forced incidental churn as scope creep \u2014 toolchain-forced churn is exempt from YAGNI/scope review while author-chosen opportunistic work is still flagged.",
+      "version": "1.8.0",
       "source": "./skills/pre-commit-hooks-and-linting-config.md",
       "category": "tooling",
       "tags": [
@@ -6530,7 +3959,13 @@
         "pixi-environment",
         "bandit",
         "markdownlint",
-        "sast"
+        "sast",
+        "ruff-format",
+        "editorconfig",
+        "pr-diff",
+        "ci-parity",
+        "pr-review",
+        "yagni"
       ]
     },
     {
@@ -6558,35 +3993,6 @@
       "tags": []
     },
     {
-      "name": "pyproject-scripts-not-def-main",
-      "description": "When sweeping a change across every console_script, enumerate `[project.scripts]` in pyproject.toml \u2014 NOT `grep '^def main'`. The grep misses *_main-suffixed callables (e.g. check_version_consistency_main). Use when: (1) adding a flag to every CLI, (2) refactoring shared CLI infrastructure, (3) writing a parametrized integration test that must cover every binary.",
-      "version": "1.0.0",
-      "source": "./skills/pyproject-scripts-not-def-main.md",
-      "category": "tooling",
-      "tags": [
-        "python",
-        "packaging",
-        "cli",
-        "console-scripts",
-        "pyproject"
-      ]
-    },
-    {
-      "name": "pytest-watch-to-watcher-dependency-replacement",
-      "description": "Replace the unmaintained pytest-watch (last release 2018) with pytest-watcher, a modern actively maintained fork. Removes deprecated docopt 0.6.2 transitive dependency while preserving ptw CLI compatibility. Use when: (1) pytest-watch is declared in pixi.toml, (2) docopt deprecation warnings appear, (3) pytest 9.x compatibility testing flags legacy dependencies.",
-      "version": "1.0.0",
-      "source": "./skills/pytest-watch-to-watcher-dependency-replacement.md",
-      "category": "tooling",
-      "tags": [
-        "pytest",
-        "pytest-watcher",
-        "dependency",
-        "pixi",
-        "docopt",
-        "deprecation"
-      ]
-    },
-    {
       "name": "python-cli-cwd-github-repo-detect",
       "description": "Package a pip-installable Python CLI that auto-detects (org, repo) from cwd via git rev-parse + git remote get-url origin (handles both SSH and HTTPS URLs). Use when: (1) shipping a CLI that should default to acting on the current GitHub repo (POLA), (2) want a $PATH binary without `pixi run` / `python -m` wrappers.",
       "version": "1.0.0",
@@ -6601,25 +4007,49 @@
       ]
     },
     {
-      "name": "python-packaging-and-distribution",
-      "description": "Canonical guide to Python packaging and distribution: wheel/sdist builds, hatchling/setuptools/hatch-vcs/conan integration, pixi.lock management, PyPI trusted-publishing, pip-audit CVE pinning and allowlists, cross-repo dependency hotfixes, pydantic-migration packaging, wheel-only builds. Use when: (1) shipping a Python package to PyPI, (2) regenerating or rebasing pixi.lock after a dep change, (3) handling a pip-audit CVE finding (override hard-pin / allowlist / migration), (4) configuring hatchling force-include for sdist/wheel parity, (5) packaging Conan-based C++ tooling for PyPI distribution, (6) CI fails with 'lock-file not up-to-date with the workspace', (7) pip-audit step flipped from advisory to fail-fast surfacing CVEs, (8) cross-repo shared lib not yet published to PyPI blocks consumer PRs, (9) hatch-vcs editable install makes pixi.lock perpetually stale, (10) migrating from FetchContent-only to hybrid Conan+CMake packaging, (11) double-rebase pixi.lock commit conflict requiring --skip, (12) second commit in rebase chain patches migrated code, (13) dependency version-pin lock drift (Environment is not consistent with the lockfile), (14) Dependabot multi-PR sequential pixi.lock fixing.",
-      "version": "1.1.0",
-      "source": "./skills/python-packaging-and-distribution.md",
+      "name": "python-cli-dry-run-and-entrypoint-patterns",
+      "description": "Use when: (1) adding a --dry-run flag to a CLI script that exits 1 on errors, letting developers preview all violations without blocking pre-commit or CI during bulk migrations; (2) standardizing --dry-run help text across multiple CLIs using a shared constant and testable _build_parser() entrypoint helper; (3) smoke-testing Python CLI entry points declared in [project.scripts] with --help subprocess calls and import verification to prevent regressions; (4) refactoring CLI parsers to extract testable _build_parser() functions and adding parametrized help-text tests across CLI modules.",
+      "version": "1.0.0",
+      "source": "./skills/python-cli-dry-run-and-entrypoint-patterns.md",
       "category": "tooling",
       "tags": [
-        "merged",
+        "python",
+        "cli",
+        "argparse",
+        "dry-run",
+        "help-text",
+        "entry-points",
+        "smoke-tests",
+        "parametrized-tests",
+        "DRY-principle",
+        "refactoring"
+      ]
+    },
+    {
+      "name": "python-packaging-pyproject-editable-install",
+      "description": "Use when: (1) migrating a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, (2) a newly-merged [project.scripts] entry yields 'command not found' after git pull because the editable install is stale \u2014 re-run 'pixi run dev-install' or 'pip install -e .', (3) a console-script sweep needs to enumerate [project.scripts] in pyproject.toml rather than grep for 'def main' (misses *_main-suffixed callables), (4) migrating from pytest-watch to pytest-watcher to drop the unmaintained docopt transitive dependency, (5) shipping a Python package to PyPI with hatchling/hatch-vcs/pixi.lock and configuring trusted-publishing.",
+      "version": "1.0.0",
+      "source": "./skills/python-packaging-pyproject-editable-install.md",
+      "category": "tooling",
+      "tags": [
         "python-packaging",
-        "pypi",
-        "pixi",
-        "hatchling",
-        "conan",
-        "pip-audit",
-        "wheel",
+        "pyproject",
         "hatch-vcs",
-        "sdist",
+        "hatchling",
+        "editable-install",
+        "pip-install-e",
+        "dev-install",
+        "console-scripts",
+        "entry-points",
+        "dynamic-version",
+        "git-tags",
+        "importlib-metadata",
+        "distribution-name",
+        "command-not-found",
+        "pypi",
         "trusted-publishing",
-        "cve",
-        "pixi-lock"
+        "pixi",
+        "pytest-watcher"
       ]
     },
     {
@@ -6631,22 +4061,29 @@
       "tags": []
     },
     {
-      "name": "python-version-gated-stdlib-import-guard",
-      "description": "Guard stdlib modules that were added in a later Python version so that code remains importable on older versions in the test matrix. Use when: (1) CI matrix includes Python 3.10 and code does a bare import of a 3.11+ stdlib module (tomllib, ExceptionGroup, etc.), (2) test file collection fails with ModuleNotFoundError for a stdlib module on the lowest Python in the matrix, (3) adding tomllib usage and the repo supports Python <3.11, (4) any bare stdlib import causes collection errors on the minimum supported Python version.",
+      "name": "python-type-hints-and-mypy-patterns",
+      "description": "Canonical guide to Python type annotation and mypy compliance patterns. Use when: (1) mypy with implicit_reexport=false or disallow_untyped_defs raises errors after a module refactor, (2) annotating hundreds of unannotated test functions in tests/unit/ to satisfy mypy strict mode, (3) AI-generated type annotations are placed at call sites instead of function definitions causing CI failures, (4) a manager/proxy class needs correct Callable or TypeVar generics to preserve return types without ParamSpec violations, (5) adding PEP 561 py.typed marker to make a typed package discoverable by mypy/pyright, (6) Pydantic model field types diverge from function signatures causing implicit-reexport or attribute-export errors.",
       "version": "1.0.0",
-      "source": "./skills/python-version-gated-stdlib-import-guard.md",
+      "source": "./skills/python-type-hints-and-mypy-patterns.md",
       "category": "tooling",
       "tags": [
         "python",
-        "stdlib",
-        "tomllib",
-        "tomli",
-        "version-guard",
-        "ci",
-        "import",
-        "3.10",
-        "3.11",
-        "compatibility"
+        "mypy",
+        "type-hints",
+        "type-annotations",
+        "typing",
+        "callable",
+        "typevar",
+        "paramspec",
+        "pep-612",
+        "pep-561",
+        "py.typed",
+        "implicit_reexport",
+        "disallow_untyped_defs",
+        "pydantic",
+        "manager-proxy",
+        "bulk-annotation",
+        "ci-fix"
       ]
     },
     {
@@ -6684,29 +4121,26 @@
       ]
     },
     {
-      "name": "review-rubric-exempt-toolchain-forced-churn",
-      "description": "Use when: (1) an automated PR-review agent flags lint/formatter/pre-commit-driven incidental changes as scope creep or YAGNI, (2) designing or fixing a code-review rubric's scope/YAGNI dimension, (3) a reviewer demands removal of whitespace/import-sort/mypy-annotation churn that the toolchain forced, (4) distinguishing toolchain-forced churn from author-chosen opportunistic work in review prompts",
+      "name": "ruff-specific-rule-fixes",
+      "description": "Patterns for fixing specific Ruff lint rule violations and addressing systemic linter policy failures. Use when: (1) fixing Ruff S101 violations in production code by replacing bare assert guards with explicit RuntimeError raises, (2) fixing Ruff C901 cyclomatic complexity violations by extracting helper functions, (3) the same policy violation reappears in two or more independent documents or configs \u2014 indicating the linter/validator that should enforce the policy is absent or misconfigured (root-cause fix: add the lint rule, not re-fix every instance), (4) deciding between adding a noqa suppression, fixing the violation, or promoting the rule to error-level enforcement.",
       "version": "1.0.0",
-      "source": "./skills/review-rubric-exempt-toolchain-forced-churn.md",
+      "source": "./skills/ruff-specific-rule-fixes.md",
       "category": "tooling",
       "tags": [
-        "pr-review",
-        "rubric",
-        "yagni",
-        "scope-creep",
-        "pre-commit",
+        "ruff",
         "lint",
-        "automation",
-        "review-agent"
+        "S101",
+        "C901",
+        "assert",
+        "runtimeerror",
+        "cyclomatic-complexity",
+        "method-extraction",
+        "noqa",
+        "linter",
+        "policy-enforcement",
+        "root-cause",
+        "pre-commit"
       ]
-    },
-    {
-      "name": "safety-net-rebase-conflict-python-workaround",
-      "description": "Use when: (1) git rebase conflict resolution is blocked by Safety Net (git restore --theirs, git checkout --theirs, or git checkout --ours -- <file> produce BLOCKED errors), (2) sub-agents need to resolve merge conflicts in an automated rebase wave, (3) Safety Net custom rules cannot whitelist built-in protections, (4) Safety Net says 'Use git stash first' but you have unmerged paths and can't stash, (5) you need a quick shell-only one-liner (no Python) to take ours or theirs during a conflict \u2014 use the git show :2:/:3: stage-index pattern.",
-      "version": "1.2.0",
-      "source": "./skills/safety-net-rebase-conflict-python-workaround.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "scan-vulnerabilities",
@@ -6717,20 +4151,21 @@
       "tags": []
     },
     {
-      "name": "scope-scanner-to-subdirectory",
-      "description": "Pattern for refactoring a broad repository-wide Python file scanner to target a single subdirectory. Replaces EXCLUDED_PREFIXES deny-list approach with a Path.is_relative_to() allow-list helper. Covers implementation, test updates, and fixture migration when existing tests break due to new scope.",
+      "name": "skill-consolidation-nuance-audit-workflow",
+      "description": "Use when: (1) a bulk skill consolidation (10+ skills merged into bundles) has just completed and you need to verify no knowledge was lost, (2) a canonical skill was absorbed into a larger bundle and the bundle must preserve all failed attempts, trigger conditions, and copy-paste commands, (3) you need to run a parallel swarm audit across many source\u2192bundle pairs and automatically generate amendment PRs for any detected gaps",
       "version": "1.0.0",
-      "source": "./skills/scope-scanner-to-subdirectory.md",
+      "source": "./skills/skill-consolidation-nuance-audit-workflow.md",
       "category": "tooling",
-      "tags": []
-    },
-    {
-      "name": "script-dry-run-flag",
-      "description": "TRIGGER CONDITIONS: Adding a --dry-run flag to a CLI script that exits 1 on errors. Use when developers need to preview all violations/errors across many files without blocking a pre-commit hook or CI step \u2014 especially during bulk config migrations or refactors.",
-      "version": "1.0.0",
-      "source": "./skills/script-dry-run-flag.md",
-      "category": "tooling",
-      "tags": []
+      "tags": [
+        "audit",
+        "consolidation",
+        "nuance",
+        "knowledge-loss",
+        "bundle",
+        "parallel-swarm",
+        "amendment",
+        "skills"
+      ]
     },
     {
       "name": "skill-corpus-count-excludes-notes-and-history-files",
@@ -6765,6 +4200,25 @@
       ]
     },
     {
+      "name": "skill-file-format-frontmatter-and-validation",
+      "description": "Canonical reference for skill/plugin file format, YAML frontmatter rules, and validation failure fixes. Use when: (1) a skill PR fails CI with 'YAML frontmatter missing' or 'Failed Attempts table missing required columns', (2) fixing frontmatter parsers that use line.partition(':') or split(':',1) and silently truncate colon-containing values, (3) creating a new Claude Code plugin and need to satisfy format requirements or marketplace registration, (4) a skill description or agent field needs the agent routing pattern for Claude Code v2.1.0+, (5) debugging 'plugin has invalid manifest' or 'Unrecognized key(s)' errors after installation.",
+      "version": "1.0.0",
+      "source": "./skills/skill-file-format-frontmatter-and-validation.md",
+      "category": "tooling",
+      "tags": [
+        "yaml",
+        "frontmatter",
+        "validation",
+        "markdownlint",
+        "md033",
+        "failed-attempts",
+        "plugin-format",
+        "marketplace",
+        "agent-field",
+        "ci-cd"
+      ]
+    },
+    {
       "name": "skill-teaching-stale-practices-contradicting-canonical-docs",
       "description": "When a skill or guide teaches practices contradicting CLAUDE.md or other canonical docs, wholesale rewrite (not patching) is required to prevent contradiction persistence. Use when: (1) a skill teaches deprecated tools (flake8, black, requirements.txt, setup.py) contradicting CLAUDE.md Language Preference, (2) a skill references stale Python versions (3.8\u20133.9) contradicting current baseline (3.10+), (3) supporting files (session logs, references) contain the same stale practices as the main skill file, (4) patching individual sections would leave dangerous contradictions elsewhere, (5) stale guidance could mislead downstream consumers before they discover the newer canonical docs.",
       "version": "1.0.0",
@@ -6777,14 +4231,6 @@
         "wholesale-rewrite",
         "skill-maintenance"
       ]
-    },
-    {
-      "name": "skills-agent-field",
-      "description": "Pattern for specifying which agent type should execute a skill using the agent field in Claude Code v2.1.0.",
-      "version": "1.0.0",
-      "source": "./skills/skills-agent-field.md",
-      "category": "tooling",
-      "tags": []
     },
     {
       "name": "split-figure-per-tier",
@@ -6872,46 +4318,6 @@
       "tags": []
     },
     {
-      "name": "tooling-automation-verify-report-vs-live-state",
-      "description": "Automation tools' headline summaries are observation reports, not ground truth: a `Driven: 8 / Failed: 4` banner can be technically true (the driver was invoked) AND operationally misleading (the driver was architecturally blind to the work that actually needed doing). NEVER conclude a run succeeded just because the script's `_summary.json` says so. Always cross-check live GitHub state per repo (`gh pr list --state open ...`, `gh pr view <pr> --json state,mergedAt,commits`) BEFORE reporting success. The script reports what it observed; what it observed may have been gated by a `Closes #<open-issue>` filter, an `@me` author scope, a `--limit` cap, or a done-gate that fires on noise. Use when: (1) consuming output from `drive-prs-green-ecosystem.sh` / any ecosystem-wide driver / loop runner, (2) about to tell a user 'all repos are green', (3) the run summary disagrees with what you can see in the GitHub UI, (4) a 'Failed' classification feels suspicious (the most-successful repo can be marked failed because of a done-gate firing on Dependabot noise), (5) building or reviewing the verification protocol for any automation that reports per-repo rc codes.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-automation-verify-report-vs-live-state.md",
-      "category": "tooling",
-      "tags": [
-        "automation-honesty",
-        "trust-but-verify",
-        "cross-check-live-state",
-        "drive-prs-green",
-        "audit-automation-report",
-        "ground-truth-check",
-        "architecturally-blind",
-        "dependabot-flood",
-        "done-gate",
-        "reality-vs-claim",
-        "headline-summary"
-      ]
-    },
-    {
-      "name": "tooling-bulk-pr-sync-statuscheck-504-stale-classify",
-      "description": "Three compounding bugs that stop a bulk PR-sync tool (e.g. hephaestus.github.fleet_sync) from rebasing a large PR queue after a fix lands on main. (1) statusCheckRollup 504: `gh pr list --json ...,statusCheckRollup --limit 100` returns HTTP 504 Gateway Timeout at ~50+ open PRs because the rollup aggregates every check on every PR; drop statusCheckRollup from the bulk list and fetch CI per-PR via `gh pr view <n> --json statusCheckRollup` (one PR per call does not 504), downgrading a flaky per-PR fetch to CI=UNKNOWN instead of aborting. (2) Silent no-op on list failure: code that catches the gh error and `return []` logs 'No open PRs' and exits SUCCESS while skipping the whole queue; distinguish 'no PRs' from 'list failed' and RAISE on a genuine list failure so the run's exit status reflects the unprocessed queue. (3) Stale-failing misclassification: marking ANY CI=FAILURE PR as FAILING (skip) strands the queue, because after a fix lands on main every BEHIND PR shows its OLD failing run; require mergeStateStatus==CLEAN for the FAILING classification \u2014 a BEHIND/BLOCKED+MERGEABLE red PR must classify as OUTDATED so it gets rebased (re-running CI fresh); CONFLICTING stays CONFLICTED. Use when: (1) building or debugging any tool that bulk-lists PRs via gh, (2) a gh pr list with statusCheckRollup times out / 504s at scale, (3) a fix landed on main and the whole PR queue needs rebasing, (4) a sync tool reports 'no PRs' or success but did nothing, (5) PRs show stale failing CI after a main fix and the tool skips them all, (6) a classifier needs to tell genuine PR-specific failures from stale red CI on behind branches.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-bulk-pr-sync-statuscheck-504-stale-classify.md",
-      "category": "tooling",
-      "tags": [
-        "fleet-sync",
-        "gh-pr-list",
-        "statusCheckRollup",
-        "504-gateway-timeout",
-        "mergeStateStatus",
-        "stale-ci",
-        "silent-noop",
-        "bulk-pr-sync",
-        "pr-classification",
-        "rebase-queue",
-        "per-pr-ci-fetch"
-      ]
-    },
-    {
       "name": "tooling-bulk-rename-relative-path-trap",
       "description": "Bulk path renames (sed/perl across a repo) silently break relative-pattern argument lists like `just test-group \"tests\" \"shared/fuzz/test_*.mojo\"` because the relative arg already has an implicit base path. Use when: (1) planning a `shared/`->`src/<pkg>/` rename, (2) refactoring any directory name that appears in wrapper-script invocations (just, xargs, find -path, Makefile includes, Dockerfile COPY), (3) debugging a CI coverage validator that fails after an otherwise-green bulk refactor, (4) writing perl/sed sweeps with path-boundary lookbehinds and want to audit the false-negative cases.",
       "version": "1.0.0",
@@ -6984,19 +4390,6 @@
       "tags": []
     },
     {
-      "name": "tooling-editorconfig-cross-editor-consistency",
-      "description": "Add .editorconfig for cross-editor formatting consistency. Use when: (1) repository lacks .editorconfig, (2) contributors use different editors with inconsistent indentation/whitespace, (3) non-Python files (YAML, JSON, Markdown, shell) need formatting standards beyond what ruff covers.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-editorconfig-cross-editor-consistency.md",
-      "category": "tooling",
-      "tags": [
-        "editorconfig",
-        "developer-experience",
-        "formatting",
-        "cross-editor"
-      ]
-    },
-    {
       "name": "tooling-force-push-blocked-reopen-as-fresh-branch",
       "description": "When the Claude Code harness sandbox denies `git push --force` and `git push --force-with-lease`, you cannot complete the canonical post-rebase workflow. The `--force` token in the argv is what the sandbox is matching on; `--force-with-lease` and shell redirection (`2>&1`) do not bypass the denial. PREFERRED fix (keep the same PR/branch instead of close-and-reopen): convert the rewritten history to a fast-forward via merge \u2014 reset to the remote tip, then merge the base, then resolve every conflict to the already-rebased tree (`git checkout <rebased-sha> -- <file>`), then plain-push (no `--force` token, so the sandbox does not block it). The merge commit's TREE is made byte-identical to the rebase result while its HISTORY stays a fast-forward descendant of the old remote tip; squash-merge flattens the merge commit at merge time. Fallback (when a fresh branch is acceptable): push the rebased branch under a NEW remote ref name, close the original PR, open a fresh PR with the same title and `Closes #<N>` body. Use when: (1) `git push --force` is denied by the sandbox without a permission prompt, (2) `git push --force-with-lease` is denied by the same pattern, (3) a PR hit a merge conflict and needs a rebase but force-push is unavailable, (4) the standard rebase workflow's last step (`git push --force-with-lease origin <branch>`) is blocked by harness restrictions, (5) you need to ship a rebased PR under harness sandbox constraints and cannot wait for the restriction to be lifted, (6) you want to keep the same PR/branch instead of close-and-reopen (review history or a PR stack to preserve), (7) you need to convert rewritten history to a fast-forward via merge so a plain push avoids the `--force` token the sandbox blocks, (8) you reset to the remote tip then merge the base then resolve to the rebased tree then plain-push, (9) a PR went DIRTY after a stacked dependency merged into main and retargeted it, (10) PR #843 hit a conflict after PR #842 merged and the rebased branch must reach origin under a new name, (11) PR #1079 went DIRTY after stacked dependency PR #1073 merged and retargeted it to main.",
       "version": "2.0.0",
@@ -7017,101 +4410,22 @@
       ]
     },
     {
-      "name": "tooling-gh-label-list-default-limit-truncation",
-      "description": "`gh label list --json name` silently truncates to 30 rows by default. When the labels you're validating sort late alphabetically (e.g. `state:*`, `tier:*` in a repo with a rich audit/severity taxonomy), validation queries report 0 matches even when the labels exist \u2014 no error, no warning, no exit-code signal, just truncated JSON. The same default-30 pagination bites `gh issue list`, `gh pr list`, `gh release list`, and other `gh <noun> list` subcommands when used in scripts. Fix: always pass `--limit 200` (or higher) when reading list output in scripts. Use when: (1) `gh label list` returns 0 but labels exist when checked interactively, (2) a labels-provisioning script reports success but validation script says labels missing, (3) any `gh <noun> list --json` scripted usage that filters by name/state, (4) batching org-wide repo audits that read labels/issues/PRs across many repos, (5) `gh CLI default pagination 30` is suspected as a root cause, (6) validation script silently missing labels despite create commands succeeding, (7) scripting `gh issue/pr/label` inventory with `jq` filters, (8) writing a CI step that reads `gh` list output and gates on counts.",
+      "name": "tooling-hephaestus-implementer-no-changes-state-skip",
+      "description": "When hephaestus implementer_phase_runner raises RuntimeError('No changes produced...') from pr_manager because a branch has 0 commits vs main (work already merged), detect this specific case and apply state:skip + return WorkerResult(success=True) instead of failing. Use when: (1) an automation loop inflates rc=1 for issues whose work already landed via a prior merged PR, (2) diagnosing why drive-green stays suppressed after implementation loops 1-4 even though the actual code change is already merged, (3) implementing or reviewing error handling in _implement_issue in implementer_phase_runner.py.",
       "version": "1.0.0",
-      "source": "./skills/tooling-gh-label-list-default-limit-truncation.md",
+      "source": "./skills/tooling-hephaestus-implementer-no-changes-state-skip.md",
       "category": "tooling",
       "tags": [
-        "gh-cli",
-        "gh-label-list",
-        "gh-issue-list",
-        "gh-pr-list",
-        "pagination",
-        "silent-truncation",
-        "default-limit",
-        "validation-script",
-        "scripting",
-        "jq",
-        "org-wide-automation"
-      ]
-    },
-    {
-      "name": "tooling-gh-pr-list-limit-cap-use-api-paginate",
-      "description": "`gh pr list --limit N` (and `gh issue list`, `gh repo list`, etc.) is a hard cap, not a page size: pass `--limit 100` and you get at most 100 rows, period. A repo with 200 dependabot PRs silently passes a `gh pr list --limit 100 --json number | jq length == 0` 'no remaining PRs' check after looking at only the first 100. There is no `--no-limit` form, and `gh pr list` does NOT accept `--paginate` \u2014 only `gh api` does. The fix is to call the REST endpoint directly: `gh api --paginate /repos/<owner>/<name>/pulls?state=open&per_page=100`, which walks the `Link: rel=\"next\"` header and emits a single concatenated JSON array with NO upper bound. Same pattern works for issues, branches, releases, runs, etc. Note: REST responses use snake_case nested shapes (`head.ref`, `auto_merge`) while `gh pr list --json` returns camelCase flat fields (`headRefName`, `autoMergeRequest`) \u2014 normalise at the boundary so downstream consumers don't need to know which path produced the data. Use when: (1) building a 'repo is done / clean / quiescent' check that lists ALL remaining open PRs or issues, (2) a repo has hundreds of dependabot PRs and a `--limit 100` check would silently truncate, (3) you tried `--paginate` on `gh pr list` and got 'unknown flag', (4) you want a true 'enumerate every open PR' query for org-wide automation, (5) migrating from `gh pr list --json` to `gh api` and need the field-name mapping.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-gh-pr-list-limit-cap-use-api-paginate.md",
-      "category": "tooling",
-      "tags": [
-        "gh-cli",
-        "gh-pr-list",
-        "gh-api",
-        "paginate",
-        "pagination",
-        "hard-cap",
-        "silent-truncation",
-        "rest-api",
-        "dependabot-flood",
-        "repo-done-check",
-        "field-name-mapping",
-        "snake-case",
-        "camel-case"
-      ]
-    },
-    {
-      "name": "tooling-hephaestus-automation-loop-drive-green-broken-design",
-      "description": "Two complementary deadlocks keep the hephaestus automation loop from driving PRs to green. (A) `--phases drive-green` skips every loop or every repo ('SKIP not final loop' / 'SKIP no open issues') and leaves failing PRs untouched -- FOUR layered loop-runner design bugs (issues #818-#821, NOT shipped); use the documented bypass. (B) SHIPPED FIX: an existing open PR never gets the `state:implementation-go` label because the implementer hard-returned early on PRs that already exist (the 'skip existing PRs' shortcut) before the in-loop review loop that adds the label -- so a green PR but auto-merge never arms, forever. Use when: (1) `--phases drive-green --loops N` SKIPs every iteration for N>1, (2) `--phases drive-green --loops 1` prints SKIP no open issues even though failing PRs exist, (3) an existing PR never gets state:implementation-go / green PR but auto-merge never arms, (4) implementer skips open PRs / drive-green refuses to merge unlabeled PR, (5) calling `drive_prs_green.py` directly errors on the `--issues required` argument or the HEPH_LOOP_INDEX gate, (6) ci_driver state-{n}.json vs issue-{n}.json session-path mismatch, (7) scoping audits for the loop-runner's phase model, PR-vs-issue discovery, or the implementer per-issue lifecycle.",
-      "version": "2.0.0",
-      "source": "./skills/tooling-hephaestus-automation-loop-drive-green-broken-design.md",
-      "category": "tooling",
-      "tags": [
-        "hephaestus-automation-loop",
-        "drive-prs-green",
-        "ci-driver",
-        "homericintelligence",
-        "design-bug",
-        "loop-runner",
-        "phase-model",
-        "pr-discovery",
-        "implementation-go-label",
-        "existing-pr-deadlock",
+        "implementer",
         "implementer-phase-runner",
-        "review-loop",
-        "session-resume-uuid5"
-      ]
-    },
-    {
-      "name": "tooling-justfile-pixi-ecosystem-wrapping",
-      "description": "Add justfile wrapping pixi tasks for ecosystem convention alignment. Use when: (1) a project uses pixi.toml but lacks a justfile, (2) Python library repo needs consistent CLI, (3) cross-repo task invocation needs just <project>-<task> convention, (4) adding BATS tests to verify justfile-pixi sync, (5) docs reference individual pixi run commands instead of just recipes, (6) adding just <prefix>-<recipe> delegation recipes to a meta-repo (Odysseus) that delegate to submodule justfiles.",
-      "version": "4.0.0",
-      "source": "./skills/tooling-justfile-pixi-ecosystem-wrapping.md",
-      "category": "tooling",
-      "tags": [
-        "justfile",
-        "pixi",
-        "ecosystem",
-        "bats",
-        "convention",
-        "meta-repo",
-        "submodule",
-        "myrmidon-swarm",
-        "delegation"
-      ]
-    },
-    {
-      "name": "tooling-modular-project-setup-wizard",
-      "description": "Set up a new Modular/Mojo/MAX project with correct structure. Use when: (1) creating a new Mojo or MAX project from scratch, (2) initializing pixi or uv environment for Mojo/MAX, (3) choosing between nightly and stable channels.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-modular-project-setup-wizard.md",
-      "category": "tooling",
-      "tags": [
-        "mojo",
-        "max",
-        "project-setup",
-        "pixi",
-        "uv",
-        "scaffolding",
-        "modular-upstream"
+        "no-changes-produced",
+        "state-skip",
+        "workerresult",
+        "pr-manager",
+        "no-commits-vs-main",
+        "automation-loop",
+        "rc-inflation",
+        "drive-green"
       ]
     },
     {
@@ -7153,60 +4467,6 @@
       ]
     },
     {
-      "name": "tooling-pyproject-scripts-dev-install-after-merge",
-      "description": "After git pull/merge that touches [project.scripts] in pyproject.toml, re-run editable install (pixi run dev-install / pip install -e .) \u2014 the source tree updates but console-script entry points stay stale until re-install. Use when: (1) command not found after git pull/merge, (2) new hephaestus-* CLI not on PATH after merge, (3) [project.scripts] entry not visible after pull, (4) editable install stale entry points, (5) python -m module works but the registered console-script binary does not.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-pyproject-scripts-dev-install-after-merge.md",
-      "category": "tooling",
-      "tags": [
-        "python",
-        "pyproject",
-        "console-scripts",
-        "editable-install",
-        "pip-install-e",
-        "dev-install",
-        "entry-points",
-        "pixi",
-        "command-not-found",
-        "post-merge"
-      ]
-    },
-    {
-      "name": "tooling-rebase-conflict-semantic-analysis",
-      "description": "Resolve git rebase conflicts using semantic analysis rather than blindly taking --ours or --theirs. Use when: (1) git rebase origin/main produces conflicts and you are tempted to use --ours/--theirs for all hunks without inspecting each one, (2) a rebase conflict involves documentation or code that both branches modified for different reasons, (3) you need to verify that a 'take ours' or 'take theirs' decision is actually correct rather than just expedient.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-rebase-conflict-semantic-analysis.md",
-      "category": "tooling",
-      "tags": [
-        "git",
-        "rebase",
-        "conflict",
-        "semantic-analysis",
-        "merge"
-      ]
-    },
-    {
-      "name": "tooling-ruff-format-precommit-check-trap",
-      "description": "Running `pixi run ruff check` (or `ruff check`) locally does NOT exercise `ruff format --check` \u2014 they are SEPARATE tools sharing a binary. `check` is the linter (errors/warnings); `format` is the formatter (line-wrap/style). A worktree-driven edit that passes `ruff check`, `mypy`, and `pytest` locally can still fail the CI pre-commit gate because the project's pre-commit config runs `ruff-format` (which uses `--diff`/`--check` mode) and finds reflowable multi-line signatures. Use when: (1) CI pre-commit ruff-format hook failed but local `ruff check` passed, (2) deciding what to run before pushing a worktree edit, (3) `ruff check` vs `ruff format` difference unclear, (4) pre-commit hooks running locally before push, (5) ProjectHephaestus pre-push `pytest -q` passed but CI lint/pre-commit failed formatter checks, (6) editor format-on-save bypassed because edits came from tooling/Edit calls instead of editor save, (7) muscle-memory says 'I ran ruff' but the format step was skipped, (8) lint and tests pass yet CI rejects with multi-line function signatures or compact comprehensions that should fit on one line under the 100-col limit.",
-      "version": "1.1.0",
-      "source": "./skills/tooling-ruff-format-precommit-check-trap.md",
-      "category": "tooling",
-      "tags": [
-        "ruff",
-        "ruff-format",
-        "ruff-check",
-        "pre-commit",
-        "formatter",
-        "linter",
-        "worktree",
-        "pre-push",
-        "ci-parity",
-        "pixi",
-        "projecthephaestus",
-        "ci-lint"
-      ]
-    },
-    {
       "name": "tooling-sonnet-content-filter-contributor-covenant",
       "description": "Documents Claude Sonnet subagent HTTP 400 content filtering failures when writing Contributor Covenant or similar conduct policy files. Use when: (1) delegating CODE_OF_CONDUCT.md writes to Sonnet subagents, (2) any subagent returns 'Output blocked by content filtering policy' on governance/conduct document writes.",
       "version": "1.0.0",
@@ -7228,24 +4488,6 @@
       "source": "./skills/tooling-wave-b-pr-fix-mesh-playbook.md",
       "category": "tooling",
       "tags": []
-    },
-    {
-      "name": "tooling-windows-ci-posix-only-stdlib-guards",
-      "description": "Keep Python packages importable on Windows when they reference POSIX-only stdlib modules (curses, fcntl) and timezone data (tzdata). Use when: (1) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError, (2) authoring a subpackage that imports curses/fcntl/termios/grp/pwd, (3) using zoneinfo.ZoneInfo and seeing 'No time zone found' on Windows.",
-      "version": "1.0.0",
-      "source": "./skills/tooling-windows-ci-posix-only-stdlib-guards.md",
-      "category": "tooling",
-      "tags": [
-        "windows",
-        "cross-platform",
-        "ci",
-        "python",
-        "stdlib",
-        "curses",
-        "fcntl",
-        "tzdata",
-        "zoneinfo"
-      ]
     },
     {
       "name": "track-implementation-progress",


### PR DESCRIPTION
Regenerates `.claude-plugin/marketplace.json` to reflect the full-corpus skill consolidation (273 skills merged into 50 canonicals; corpus 518->291).

The auto-regen workflow (`update-marketplace.yml`) cannot open PRs because org policy blocks GitHub Actions from creating pull requests, so the committed marketplace was stale (516 entries). This brings it back in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)