### PR TITLE
ci: run update-marketplace weekly, drop push trigger

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 291,
+  "total_plugins": 999,
   "categories": {
     "architecture": 45,
     "ci-cd": 44,

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 999,
+  "total_plugins": 291,
   "categories": {
     "architecture": 45,
     "ci-cd": 44,

--- a/.github/workflows/update-marketplace.yml
+++ b/.github/workflows/update-marketplace.yml
@@ -1,13 +1,10 @@
 name: Update Marketplace
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'skills/**'
-      - 'plugins/**'
-      - '!.claude-plugin/marketplace.json'
+  schedule:
+    # Weekly, Sunday 00:00 UTC — regenerates marketplace.json on a cadence so it
+    # self-heals even when individual merges don't trigger a regeneration.
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changes the `update-marketplace.yml` trigger:

- **Adds** a weekly schedule: `cron: '0 0 * * 0'` (Sunday 00:00 UTC) so marketplace.json regenerates on a cadence.
- **Removes** the `push` trigger — the workflow no longer runs on every `skills/`/`plugins/` change, so it's no longer part of normal PR/push analysis. Manual `workflow_dispatch` is retained.

The 'Open PR' step is unchanged (still opens a review PR per #1463). Note: that step currently needs the org to allow Actions to create PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)