### PR TITLE
feat(skill): amend worktree-per-pr with branch-collision reuse + dirty-decide (v1.1.0)

### DIFF
--- a/skills/automation-reuse-repo-clone-with-worktree-per-pr.history
+++ b/skills/automation-reuse-repo-clone-with-worktree-per-pr.history
@@ -1,3 +1,41 @@
+<!-- markdownlint-disable MD024 -->
+
+# History: automation-reuse-repo-clone-with-worktree-per-pr
+
+This file preserves the amendment history and superseded snapshots of the
+`automation-reuse-repo-clone-with-worktree-per-pr` skill.
+
+## v1.1.0 (2026-06-08)
+
+**Changed by:** ProjectHephaestus PR #1110 (worktree branch-collision reuse + dirty-decide)
+**Verification:** verified-ci — shipped to ProjectHephaestus as PR #1110; full unit +
+ci_driver suites green in CI; PR CLEAN/MERGEABLE.
+
+**What changed and why:**
+
+- Added a new **trigger**: `git worktree add` fails exit 128 because the branch is already
+  checked out in another worktree; you need reuse-not-force.
+- Added a **Verified-Workflow** subsection covering the `_worktree_holding_branch` detect +
+  reuse pattern AND the dirty-reuse agent-decide (COMMIT/STASH) guard.
+- Added a new **Failed-Attempts** row for `git worktree add <path> <branch>` when the branch
+  is held by another worktree (git forbids one branch in two worktrees → exit 128).
+
+Motivation: ProjectHephaestus' automation loop resolves an existing PR's REAL head branch,
+which may be named after a DIFFERENT issue (e.g. issue #725's PR #996 lives on branch
+`708-auto-impl`). Adding a worktree for that branch failed exit 128 because the `issue-708`
+worktree already had `708-auto-impl` checked out, blocking the whole review of #725. The
+fix detects the collision and REUSES the existing worktree instead of forcing or adding a
+second one, with a dirty-working-tree guard so a concurrent session's uncommitted work is
+never silently discarded by the sync's `reset --hard`.
+
+## v1.0.0 (2026-06-06)
+
+Initial version. Captured the single-clone + git-worktree-per-PR refactor of
+`hephaestus/github/fleet_sync.py` (ProjectHephaestus PR #1045, closed #1044).
+
+### Snapshot of v1.0.0 body
+
+```yaml
 ---
 name: automation-reuse-repo-clone-with-worktree-per-pr
 description: "Use when: (1) code clones the SAME repo once per PR/branch/item inside a loop,
@@ -7,15 +45,15 @@ description: "Use when: (1) code clones the SAME repo once per PR/branch/item in
   `git clone`, (5) you need isolated per-item checkouts of one repo for rebase/conflict/agent
   work."
 category: tooling
-date: 2026-06-08
-version: "1.1.0"
+date: 2026-06-06
+version: "1.0.0"
 user-invocable: false
 verification: verified-ci
-history: automation-reuse-repo-clone-with-worktree-per-pr.history
 tags: [git-worktree, clone-reuse, fleet-sync, batch-automation, performance, per-pr-checkout,
-  idempotent-clone, dry-run-real-step, github-automation, branch-collision, worktree-reuse,
-  dirty-working-tree]
+  idempotent-clone, dry-run-real-step, github-automation]
 ---
+```
+
 # Automation: Reuse One Repo Clone with a Git Worktree Per PR
 
 ## Overview
@@ -42,9 +80,6 @@ full `git clone` per item is expensive network+disk I/O that scales linearly wit
   work, without the items stepping on each other's working tree or branch.
 - You are refactoring a per-item-clone hot loop and want the clone created lazily (only when an
   item actually needs a checkout — e.g. READY PRs that merge via `gh` never need one).
-- `git worktree add` fails exit 128 because the branch is already checked out in another
-  worktree; you need reuse-not-force (detect the holding worktree and reuse it instead of
-  forcing or adding a second worktree for the same branch).
 
 ## Verified Workflow
 
@@ -116,68 +151,6 @@ force-creates a real (idempotent) clone. Preserve such "must run for real even i
 steps when refactoring: gate the side-effecting action (agent spawn, push), not the inspection
 that the gate decision depends on.
 
-### Branch-Collision Reuse (one branch can't live in two worktrees)
-
-Git forbids the SAME branch checked out in two worktrees: `git worktree add <path> <branch>`
-fails with `fatal: '<branch>' is already used by worktree at '<other-path>'` (exit 128) when
-another worktree already holds `<branch>`.
-
-Concrete case: ProjectHephaestus' automation loop resolves an existing PR's REAL head branch,
-which may be named after a DIFFERENT issue — e.g. issue #725's PR #996 lives on branch
-`708-auto-impl`. `WorktreeManager.create_worktree(issue=725, branch="708-auto-impl")` then ran
-`git worktree add .../issue-725 708-auto-impl`, but the `issue-708` worktree already had
-`708-auto-impl` checked out → exit 128, blocking the entire review of #725.
-
-The fix (REUSE chosen over `--force`; force would stomp the other worktree's branch): before
-adding a worktree, detect whether the branch is already checked out in another worktree and
-REUSE that worktree instead.
-
-```python
-def _worktree_holding_branch(self, branch_name: str) -> Path | None:
-    target_ref = f"refs/heads/{branch_name}"
-    for wt in self.list_worktrees():           # parses `git worktree list --porcelain`
-        if wt.get("branch") == target_ref:     # branch reported as the FULL ref refs/heads/<name>
-            return Path(wt["path"])
-    return None
-
-# In create_worktree(), BEFORE the add:
-existing = self._worktree_holding_branch(branch_name)
-if existing is not None and existing != worktree_path:
-    self.worktrees[issue_number] = existing    # register under THIS issue too
-    return existing                            # reuse; caller then syncs it
-```
-
-Key facts:
-
-- Match on the FULL `refs/heads/<name>` ref, not the bare branch name — `git worktree list
-  --porcelain` reports the branch as `branch refs/heads/<name>`.
-- Reuse-not-force is the chosen contract: `--force` would re-point/stomp the branch in the
-  other worktree.
-- The caller then updates the reused worktree to the PR head via the existing
-  `sync_worktree_to_remote_branch` (`git fetch origin <branch>` + `git reset --hard
-  origin/<branch>`) — no extra rebase code needed.
-
-#### Dirty-reuse guard (don't clobber a concurrent session's work)
-
-A reused worktree may carry uncommitted changes from the OTHER issue's in-flight session that
-`reset --hard` would silently discard. The throwaway-worktree `reset --hard` is otherwise safe,
-but the dirty guard prevents clobbering a CONCURRENT session's work:
-
-- Guard the sync with `is_clean_working_tree(worktree_path)` — `git status --porcelain` empty
-  means clean.
-- Only when DIRTY, dispatch a bounded agent turn (reuse the existing
-  `invoke_claude_with_session` AGENT_ADVISE dispatch) that inspects `git status --porcelain` +
-  `git diff HEAD` and replies COMMIT (changes belong to this branch) or STASH (unrelated or
-  uncertain). Apply the decision, then sync.
-- SAFE DEFAULT on any agent failure or when the model is Codex: stash (`git stash push -u`) —
-  never discard.
-
-#### Test note
-
-On the non-collision add-path tests, patch `_worktree_holding_branch` → `None` so the extra
-`git worktree list` call introduced by the collision check does not shift those tests' mock
-call counts.
-
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -186,7 +159,6 @@ call counts.
 | Clone into per-run temp dir only | Clone lived in a per-run `tempfile.TemporaryDirectory` | Nothing reused across the repo's PRs; nothing persisted across runs | Keep ONE clone per repo in a stable `clone_dir`; `git fetch --prune` on reuse instead of re-cloning |
 | Honor `--dry-run` on the conflict-resolver clone | Skipped the clone when `--dry-run` was set | Conflict inspection needs a real checkout to surface conflicts; with no clone the resolver had nothing to inspect | Force a real idempotent clone there; gate only the agent SPAWN under dry-run, not the rebase/inspection |
 | Test cleanup without pre-creating the work dir | Asserted `remove_worktree` ran by mocking `_git` and checking for a `worktree remove` call | `remove_worktree` no-ops when the path is absent, so the test never exercised removal | Pre-create the work dir in the test so the no-op guard passes and the removal path actually runs |
-| `git worktree add <path> <branch>` when the branch is held by another worktree | Added a worktree for a PR's real head branch (named after a different issue) while another issue's worktree already had it checked out | git forbids one branch in two worktrees → exit 128, blocking the issue | Detect via `git worktree list --porcelain` matching `refs/heads/<name>` and REUSE that worktree (register it under the new issue); guard the reused worktree's `reset --hard` behind a dirty check + agent commit/stash decision |
 
 ## Results & Parameters
 
@@ -214,3 +186,4 @@ call counts.
   construct with keyword args / a helper, not positionally.
 - **General lesson:** loop over many items against the SAME repo → clone once, `git worktree add`
   per item; never re-clone per item.
+```


### PR DESCRIPTION
Amends `automation-reuse-repo-clone-with-worktree-per-pr` to **v1.1.0** (minor — new failed-attempt + new trigger; date 2026-06-08).

## What changed
- New **trigger**: `git worktree add` fails exit 128 because the branch is already checked out in another worktree; you need reuse-not-force.
- New **Verified-Workflow** subsection: the `_worktree_holding_branch` detect-and-reuse pattern (match the FULL `refs/heads/<name>` ref; reuse rather than `--force`) plus the dirty-reuse guard that dispatches a bounded agent turn to decide COMMIT vs STASH before `reset --hard`, defaulting to stash on any failure/Codex.
- New **Failed-Attempts** row for the exit-128 branch-collision case.
- First amendment, so the `*.history` file is created (full v1.0.0 snapshot + v1.1.0 entry) and a `history:` field added to frontmatter.

## Source
Verified-ci: shipped to ProjectHephaestus as PR #1110, full unit + ci_driver suites green in CI; PR CLEAN/MERGEABLE.

Validated with `python3 scripts/validate_plugins.py` — 294/294 valid.