### PR TITLE
feat: add tooling-state-skip-label-recovers-skip-capped-prs skill

### DIFF
--- a/skills/tooling-state-skip-label-recovers-skip-capped-prs.md
+++ b/skills/tooling-state-skip-label-recovers-skip-capped-prs.md
@@ -1,0 +1,116 @@
+---
+name: tooling-state-skip-label-recovers-skip-capped-prs
+description: "The state:skip label silently blocks the hephaestus automation loop from re-attempting a PR; the review-iteration cap (MAX_REVIEW_ITERATIONS) applies it stickily and it persists even after the original blocker is fixed. Remove the label (gh issue edit <N> --remove-label state:skip), rebase the PR if DIRTY, then re-run the loop to recover. Use when: (1) hephaestus-automation-loop --issues <N> logs 'Skipping #<N> (state:skip)' and does nothing (planned=1 implemented=1 skipped=1, ~3s loops), (2) a PR's review comments never get addressed no matter how many times you re-run the loop, (3) a PR was adjudicated during a known-bad period (broken main, since-fixed loop bug) and is now stuck, (4) recovering skip-capped PRs after fixing the original blocking condition."
+category: tooling
+date: 2026-06-11
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - state-skip
+  - hephaestus-automation-loop
+  - skip-capped
+  - max-review-iterations
+  - iteration-cap
+  - re-attempt
+  - sticky-label
+  - remove-label
+  - dirty-pr-rebase
+  - recovery
+---
+
+# Recovering Skip-Capped PRs: Remove the `state:skip` Label
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-11 |
+| **Objective** | Recover PRs the automation loop permanently skips because the review-iteration cap applied a sticky `state:skip` label that persists even after the original blocking condition is fixed. |
+| **Outcome** | Verified locally — removing the label + rebasing let the loop re-attempt issue #719 / PR #1013, which reached GO + CI-pending this session (not yet merged at capture). |
+| **Verification** | verified-local |
+
+## When to Use
+
+- `hephaestus-automation-loop --issues <N>` runs but the implementer logs `Skipping #<N> (state:skip)` and does nothing (`planned=1 implemented=1 skipped=1`, ~3-second loops).
+- A PR never gets its review comments addressed no matter how many times you re-run the loop.
+- A PR was adjudicated during a KNOWN-BAD period (broken main, a contaminated review context, a since-fixed loop bug) and is now stuck.
+- You want to give a skip-capped PR another honest try on a now-fixed baseline.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Confirm the issue is skip-capped
+gh issue view <N> --json labels | grep state:skip
+
+# 2. Remove the sticky label (ONLY after the original blocker is genuinely fixed)
+gh issue edit <N> --remove-label state:skip
+
+# 3. If the PR is also DIRTY, rebase the branch onto current origin/main
+#    (worktree + rebase + resign with the key email + force-with-lease)
+git fetch origin
+git rebase origin/main          # resolve conflicts (e.g. SKILL.md)
+git push --force-with-lease
+
+# 4. Re-run the loop scoped to the issue
+hephaestus-automation-loop --issues <N>
+```
+
+### Detailed Steps
+
+1. **Recognize the symptom.** The loop completes in ~3 seconds with `planned=1 implemented=1 skipped=1` and the log line `Skipping #<N> (state:skip)`. The PR's review comments are never addressed.
+
+2. **Understand the root cause.** The loop applies `state:skip` to an issue when its in-loop review hits `MAX_REVIEW_ITERATIONS` (the 3-iteration cap) without reaching GO. Once labeled, the implementer permanently skips it. This is a SAFETY cap, but it is STICKY — it persists even after the ORIGINAL blocking condition (a broken main, a contaminated review context, a now-fixed bug) is resolved.
+
+3. **Verify the blocker is genuinely fixed FIRST.** Only remove `state:skip` when the original blocker is actually resolved. Removing it means "give it another honest try on a fixed baseline," NOT "force it through." If the blocker still exists, the loop will just re-hit the cap and re-apply the label.
+
+4. **Remove the label.** `gh issue edit <N> --remove-label state:skip`.
+
+5. **Rebase the PR if it is DIRTY.** If the PR branch has drifted from `origin/main` (mergeable state DIRTY), rebase it: worktree + `git rebase origin/main` (resolve conflicts), resign commits with the GPG key email, then `git push --force-with-lease`. The loop will not productively touch a DIRTY PR.
+
+6. **Re-run the loop scoped to the issue.** `hephaestus-automation-loop --issues <N>`. With the skip gone and a fresh/green context, the loop re-attempts and can reach GO.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Re-run the loop repeatedly without removing the label | `hephaestus-automation-loop --issues <N>` over and over | The implementer checks `state:skip` at the top and logs `Skipping #<N> (state:skip)`; every run is a ~3s no-op (`planned=1 implemented=1 skipped=1`). The PR's review comments are never addressed. | The skip is sticky. No number of re-runs clears it — you must explicitly `--remove-label state:skip`. |
+| Remove the label while the PR was still DIRTY | Removed `state:skip`, re-ran the loop, but left the branch behind `origin/main` | The loop will not productively advance a DIRTY PR; it needs a clean rebase first. | Rebase the branch onto current `origin/main` (resolve conflicts, resign, force-with-lease) BEFORE re-running. |
+| Remove the label before fixing the original blocker | (anti-pattern) Strip `state:skip` while the broken baseline still exists | The loop re-runs, the in-loop review re-hits `MAX_REVIEW_ITERATIONS` without GO, and re-applies `state:skip` — back to square one. | Only remove the label once the original blocker is genuinely resolved. Removal is "another honest try," not "force-through." |
+
+## Results & Parameters
+
+### The label and log line
+
+- Label: `state:skip`
+- Loop log line: `Skipping #<N> (state:skip)`
+- No-op loop signature: `planned=1 implemented=1 skipped=1`, ~3-second iterations.
+
+### Detection
+
+```bash
+gh issue view <N> --json labels | grep state:skip
+```
+
+Several issues can be skip-capped at once. This session: issues #710 (PR #995) and #725 (PR #996) are STILL skip-capped (both verified to carry `state:skip`).
+
+### Verified recovery (this session)
+
+- Issue #719 / PR #1013: skip-capped → removed `state:skip` → rebased a `SKILL.md` conflict → re-ran the loop → reached GO + CI-pending (not yet merged at capture). verified-local.
+
+### Caution
+
+Only remove `state:skip` when the original blocker is genuinely resolved — otherwise the loop will just re-hit the `MAX_REVIEW_ITERATIONS` cap and re-apply it.
+
+### Related
+
+- Pair with the unpushed-fix-oscillation recovery (the loop may carry an unpushed fix commit).
+- Pair with rebasing DIRTY PRs before the loop will touch them.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Recovering skip-capped PRs (issue #719 / PR #1013) by removing state:skip + rebasing | verified-local; reached GO + CI-pending, not yet merged at capture; issues #710/#725 still skip-capped; 2026-06-11 |


### PR DESCRIPTION
## Summary

New skill. Documents that the `state:skip` label silently blocks the hephaestus automation loop from re-attempting a PR, and how to recover skip-capped PRs by removing the label (then rebasing a DIRTY PR) once the original blocker is fixed.

- The review-iteration cap (MAX_REVIEW_ITERATIONS) applies `state:skip` stickily; it persists after the original blocker is fixed.
- Symptom: `Skipping #<N> (state:skip)`, ~3s no-op loops (`planned=1 implemented=1 skipped=1`); review comments never addressed.
- Recovery: `gh issue edit <N> --remove-label state:skip`, rebase the PR if DIRTY, re-run the loop.

## Verification Level

**verified-local**

Removing the label + rebasing let the loop re-attempt issue #719 / PR #1013, which reached GO + CI-pending this session. Not yet merged at capture, so not verified-ci.

## Key Findings

**What Worked**:
- Removing `state:skip` then rebasing the DIRTY branch let the loop re-attempt and reach GO (issue #719 / PR #1013).

**What Failed**:
- Re-running the loop without removing the label → endless ~3s no-ops.
- Removing the label while the PR was still DIRTY → loop won't productively advance.
- Removing the label before fixing the blocker → loop re-hits the cap and re-applies `state:skip`.

## Test Plan

- [ ] Validate with \`python3 scripts/validate_plugins.py\`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: state:skip, skip-capped, MAX_REVIEW_ITERATIONS

Closes #N/A

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>