### PR TITLE
feat: amend ci-hygiene-and-validation-gates skill (build/ untracked guard)

### DIFF
--- a/skills/ci-hygiene-and-validation-gates.md
+++ b/skills/ci-hygiene-and-validation-gates.md
@@ -407,7 +407,7 @@ pattern. The same principle applies: ignore + guard, never delete runtime-regene
 
 ```bash
 git check-ignore -v build/
-# Expected: .gitignore:5:build/	build/
+# Expected: .gitignore:5:build/    build/
 ```
 
 Do NOT edit `.gitignore` — `build/` is already ignored. Do NOT delete the nested live clone or
@@ -488,7 +488,6 @@ This rides the already-required lint gate, so **no new workflow** is needed.
 then `git clean -fdX build/` (removes only ignored files under `build/`). The guard does not
 delete anything — it only asserts the tracked-file invariant.
 
-
 ---
 
 ## Failed Attempts
@@ -505,11 +504,10 @@ delete anything — it only asserts the tracked-file invariant.
 | Install with `--no-deps` (Pattern 4) | `pip install -e . --no-deps` to match a leaner CI image | The checker imports `packaging` (a declared dep) and `ModuleNotFoundError`s at runtime; under `set -e` that is a crash, not an assertion | A checker that imports declared deps must be installed WITH deps |
 | Just delete the no-op job (Pattern 4) | Remove the dead `deps-version-sync` job entirely | The context `deps/version-sync` is pinned in the org ruleset; deletion leaves every PR BLOCKED on a check that never reports | De-list the required context first (admin API) OR make the job real in-place; never delete a pinned-context job in a code PR |
 | `pixi lock --check` for leg 3 (Pattern 4) | Used `pixi lock --check` to verify the lockfile | The repo pins pixi `v0.69.0` everywhere (composite `setup-pixi-env`, `pixi-check`); `--check` availability on that exact version was unverified, and a prior skill documented older pixi lacking the `lock` subcommand entirely | Use `pixi install --locked` (proven on the pinned version, already used by `pixi-check`), not a flag verified only on a newer local pixi |
-| Confirmed clean PASS only (Pattern 4) |
+| Confirmed clean PASS only (Pattern 4) | Ran the rewritten gate on a clean branch, saw green, called it done | A dead gate ALSO shows a clean PASS; only a synthetic-FAIL test distinguishes a real gate from a no-op | Two-sided verification (clean PASS **and** synthetic FAIL) is mandatory for any gate change |
 | Edit `.pre-commit-config.yaml` directly (Pattern 5) | Used the normal `Edit` tool to add the `check-build-dir-untracked` hook | Blocked by a config-file security hook ("don't ask mode" / config-file guard) — same class as the workflow-file block noted in Pattern 2 | Apply the change via a Python `read → str.replace → write` script; assert the anchor appears exactly once and the addition isn't already present before writing |
 | Delete on-disk `build/*.log` to "clean up" (Pattern 5) | `rm build/*.log` / `git clean` to remove scratch junk | A live automation loop regenerates the logs within seconds — deletion is futile and the on-disk presence was never the problem | The problem is *tracking*, not presence: gitignore + an untracked-invariant guard. Never delete runtime-regenerated state |
 | Make the Pattern 5 guard exit 0 like the stale-script detector | Soft-warn instead of hard-fail, mirroring Pattern 3 | A tracked file under a gitignored scratch dir is a *true invariant breach* that would then pass CI silently and could ship logs in a distribution | Hard-fail (exit 1) is correct for a true-invariant guard; the exit-0 rule applies only to heuristic discovery tooling (Pattern 3), not invariant assertions |
- Ran the rewritten gate on a clean branch, saw green, called it done | A dead gate ALSO shows a clean PASS; only a synthetic-FAIL test distinguishes a real gate from a no-op | Two-sided verification (clean PASS **and** synthetic FAIL) is mandatory for any gate change |
 
 ## Results & Parameters
 
@@ -553,7 +551,7 @@ git ls-files build/
 
 # 2. Confirm build/ is gitignored, and at which .gitignore line
 git check-ignore -v build/
-# Expected: .gitignore:5:build/	build/
+# Expected: .gitignore:5:build/    build/
 
 # 3. Auto-discovered parametrized smoke test for the new script (rides existing
 #    parametrized test that imports every scripts/*.py and runs its main()).
@@ -653,7 +651,7 @@ ruleset admin), `console-scripts-exit-code-discipline` (exit-code semantics unde
 `set -e`), `lockfile-and-release-pipeline-management` (lockfile-sync verification), and
 the companion worktree-`__file__` skill (why `-m` beats a `scripts/<x>.py` shim).
 
-## Verified On
+## Verified On (Extended)
 
 | Project | Context | Details |
 | --------- | --------- | --------- |

--- a/skills/ci-hygiene-and-validation-gates.md
+++ b/skills/ci-hygiene-and-validation-gates.md
@@ -1,9 +1,9 @@
 ---
 name: ci-hygiene-and-validation-gates
-description: "Use when: (1) adding a CI step that grep-blocks reappearance of deprecated identifiers after a cleanup PR, (2) adding a standalone JSON schema validation step to catch config drift even when pre-commit was skipped, (3) detecting orphaned scripts/*.py files not referenced in CI workflows, justfile, or other scripts, (4) you discover a NAMED required CI check that asserts nothing (a dead gate that computes-and-discards its verdict, or whose only failure path is unreachable) and must make it genuinely enforce in place because its context is pinned in the org ruleset and cannot be deleted."
+description: "Use when: (1) adding a CI step that grep-blocks reappearance of deprecated identifiers after a cleanup PR, (2) adding a standalone JSON schema validation step to catch config drift even when pre-commit was skipped, (3) detecting orphaned scripts/*.py files not referenced in CI workflows, justfile, or other scripts, (4) you discover a NAMED required CI check that asserts nothing (a dead gate that computes-and-discards its verdict, or whose only failure path is unreachable) and must make it genuinely enforce in place because its context is pinned in the org ruleset and cannot be deleted, (5) a gitignored scratch directory whose name collides with a packaging-output convention (e.g. `build/`) needs a guard that the directory never has tracked files swept into a distribution."
 category: ci-cd
 date: 2026-06-12
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 history: ci-hygiene-and-validation-gates.history
 tags:
@@ -24,6 +24,10 @@ tags:
   - defense-in-depth
   - pip-install-deps
   - pixi-locked
+  - build-dir
+  - untracked-guard
+  - packaging-collision
+  - git-ls-files
 ---
 ## Overview
 
@@ -43,6 +47,7 @@ tags:
 - A `scripts/` directory has grown organically and you want to surface orphaned `*.py` files not referenced in `.github/`, `justfile`, `.pre-commit-config.yaml`, or other scripts (stale-script detector).
 - A follow-up issue explicitly asks for a "regression guard" or "automated drift check" without requiring code review.
 - A required status check shows green on every PR but you suspect it "asserts nothing": it computes a verdict and `echo`s it without ever testing it, or its only `exit 1` is behind a condition that is never true in this repo (dead gate). The context is pinned in the org ruleset, so you must make the existing job enforce its named contract in place rather than delete it (Pattern 4).
+- A gitignored scratch directory whose name collides with a packaging-output convention (e.g. `build/`, `dist/`) needs a guard ensuring it never has tracked files swept into a distribution (tracked-file-under-gitignored-dir guard, Pattern 5).
 
 ## Verified Workflow
 
@@ -380,6 +385,112 @@ invocation (clean venv + `pip install -e .` WITH deps + bare `python`/`-m`, **no
 not "verified" until you have demonstrated BOTH a clean PASS and a synthetic FAIL for
 every leg.
 
+#### Pattern 5 — tracked-file-under-gitignored-dir guard
+
+> **Verification: verified-precommit (CI pending).** The new `check-build-dir-untracked`
+> hook passed locally via `pre-commit run --files`, all 76 scripts unit tests passed, and
+> ruff was clean — but full CI on PR #1250 had not been confirmed green at capture time.
+> The patterns above remain verified-ci; only this Pattern 4 is verified-precommit.
+
+**The collision.** A directory (`build/`) is the sanctioned, gitignored scratch location for
+an automation loop, but its *name* collides with the packaging-output convention. The risk is
+not on-disk junk — it is a stray `git add build/...` or a widened sdist `only-include` allowlist
+silently sweeping automation logs into a published distribution.
+
+**The durable fix is a regression guard, not deletion.** Assert the directory stays *untracked*
+(`git ls-files build/` must be empty). Do NOT delete on-disk logs: a live loop regenerates them
+within seconds, so deletion is futile. (Cross-reference the sibling skill
+`claude-code-scheduled-tasks-lockfile-gitignore` — the "runtime-state file, gitignore-don't-delete"
+pattern. The same principle applies: ignore + guard, never delete runtime-regenerated state.)
+
+**Step 1 — Confirm the dir is already gitignored** and find the exact line:
+
+```bash
+git check-ignore -v build/
+# Expected: .gitignore:5:build/	build/
+```
+
+Do NOT edit `.gitignore` — `build/` is already ignored. Do NOT delete the nested live clone or
+its logs.
+
+**Step 2 — Implement `scripts/check_build_dir_untracked.py`** (stdlib only):
+
+```python
+#!/usr/bin/env python3
+"""Guard that the gitignored `build/` scratch dir never has tracked files.
+
+`build/` is the sanctioned scratch location for the automation loop, but its name
+collides with the packaging-output convention. A stray `git add build/...` or a
+widened sdist allowlist could sweep automation logs into a distribution. This guard
+hard-fails (exit 1) if any file under build/ is tracked — a true invariant breach.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+
+def tracked_build_files(repo_root: Path) -> List[str]:
+    """Return tracked files under build/ (empty list = invariant holds)."""
+    result = subprocess.run(
+        ["git", "ls-files", "build/"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    tracked = tracked_build_files(repo_root)
+    if tracked:
+        print("ERROR: build/ is a gitignored scratch dir but has TRACKED files:")
+        for f in tracked:
+            print(f"  {f}")
+        print("\nbuild/ must stay untracked. Remove with: git rm --cached <file>")
+        print("To clean ignored on-disk files (after stopping the loop): git clean -fdX build/")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Key decisions:
+- `git ls-files build/` with `cwd=repo_root, check=True` — relies on git's own tracked-file
+  index, so it is exact and ignore-aware.
+- **Hard-fail (exit 1)** is INTENTIONAL and is a deliberate divergence from Pattern 3's
+  "always exit 0 for discovery tooling" rule. A tracked file under a gitignored scratch dir is a
+  *true invariant breach*, not a soft warning — so it must block. The two patterns are not
+  contradictory: stale-script detection is heuristic discovery; this is an invariant assertion.
+
+**Step 3 — Add the pre-commit hook** inside the existing `- repo: local` block. Use
+`pass_filenames: false` (whole-repo invariant) and `always_run: true` (the breach can be
+introduced by a commit that touches no `build/` path, e.g. a `git add` staged earlier):
+
+```yaml
+- id: check-build-dir-untracked
+  name: Check build/ stays untracked
+  description: Fail if any file under the gitignored build/ scratch dir is tracked
+  entry: python3 scripts/check_build_dir_untracked.py
+  language: system
+  pass_filenames: false
+  always_run: true
+```
+
+This rides the already-required lint gate, so **no new workflow** is needed.
+
+**Step 4 — Document the cleanup convention in CONTRIBUTING.md** (not automated): stop the loop,
+then `git clean -fdX build/` (removes only ignored files under `build/`). The guard does not
+delete anything — it only asserts the tracked-file invariant.
+
+
+---
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -394,7 +505,11 @@ every leg.
 | Install with `--no-deps` (Pattern 4) | `pip install -e . --no-deps` to match a leaner CI image | The checker imports `packaging` (a declared dep) and `ModuleNotFoundError`s at runtime; under `set -e` that is a crash, not an assertion | A checker that imports declared deps must be installed WITH deps |
 | Just delete the no-op job (Pattern 4) | Remove the dead `deps-version-sync` job entirely | The context `deps/version-sync` is pinned in the org ruleset; deletion leaves every PR BLOCKED on a check that never reports | De-list the required context first (admin API) OR make the job real in-place; never delete a pinned-context job in a code PR |
 | `pixi lock --check` for leg 3 (Pattern 4) | Used `pixi lock --check` to verify the lockfile | The repo pins pixi `v0.69.0` everywhere (composite `setup-pixi-env`, `pixi-check`); `--check` availability on that exact version was unverified, and a prior skill documented older pixi lacking the `lock` subcommand entirely | Use `pixi install --locked` (proven on the pinned version, already used by `pixi-check`), not a flag verified only on a newer local pixi |
-| Confirmed clean PASS only (Pattern 4) | Ran the rewritten gate on a clean branch, saw green, called it done | A dead gate ALSO shows a clean PASS; only a synthetic-FAIL test distinguishes a real gate from a no-op | Two-sided verification (clean PASS **and** synthetic FAIL) is mandatory for any gate change |
+| Confirmed clean PASS only (Pattern 4) |
+| Edit `.pre-commit-config.yaml` directly (Pattern 5) | Used the normal `Edit` tool to add the `check-build-dir-untracked` hook | Blocked by a config-file security hook ("don't ask mode" / config-file guard) — same class as the workflow-file block noted in Pattern 2 | Apply the change via a Python `read → str.replace → write` script; assert the anchor appears exactly once and the addition isn't already present before writing |
+| Delete on-disk `build/*.log` to "clean up" (Pattern 5) | `rm build/*.log` / `git clean` to remove scratch junk | A live automation loop regenerates the logs within seconds — deletion is futile and the on-disk presence was never the problem | The problem is *tracking*, not presence: gitignore + an untracked-invariant guard. Never delete runtime-regenerated state |
+| Make the Pattern 5 guard exit 0 like the stale-script detector | Soft-warn instead of hard-fail, mirroring Pattern 3 | A tracked file under a gitignored scratch dir is a *true invariant breach* that would then pass CI silently and could ship logs in a distribution | Hard-fail (exit 1) is correct for a true-invariant guard; the exit-0 rule applies only to heuristic discovery tooling (Pattern 3), not invariant assertions |
+ Ran the rewritten gate on a clean branch, saw green, called it done | A dead gate ALSO shows a clean PASS; only a synthetic-FAIL test distinguishes a real gate from a no-op | Two-sided verification (clean PASS **and** synthetic FAIL) is mandatory for any gate change |
 
 ## Results & Parameters
 
@@ -426,6 +541,41 @@ DepthwiseSeparableConv2dNoBiasBackwardResult
   if: matrix.test-group.name == 'unit'
   run: pixi run python scripts/validate_config_schemas.py config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml
 ```
+
+### Pattern 5 — tracked-file-under-gitignored-dir guard
+
+Verification command set (run before adding the guard, and to confirm it):
+
+```bash
+# 1. The invariant: build/ must have zero tracked files
+git ls-files build/
+# Expected: (empty output)
+
+# 2. Confirm build/ is gitignored, and at which .gitignore line
+git check-ignore -v build/
+# Expected: .gitignore:5:build/	build/
+
+# 3. Auto-discovered parametrized smoke test for the new script (rides existing
+#    parametrized test that imports every scripts/*.py and runs its main()).
+#    All 76 scripts unit tests passed locally including the new module.
+pixi run python -m pytest tests/unit/scripts/ -v
+
+# 4. Hook fires on demand
+pre-commit run check-build-dir-untracked --all-files
+```
+
+The hook is `pass_filenames: false` + `always_run: true` (whole-repo invariant, breach can be
+staged by a commit touching no `build/` path). Exit 1 on any tracked file — INTENTIONAL hard-fail,
+unlike Pattern 3's exit-0 discovery semantics. Cleanup of on-disk ignored files (manual, after
+stopping the loop): `git clean -fdX build/`.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectOdyssey | Issue #3834 (grep deprecation guard) — follow-up from #3267/#3059; PR #4810 | 8 deprecated backward-result aliases blocked in `comprehensive-tests.yml` `mojo-syntax-check` job |
+| ProjectScylla | Issue #1443 (schema validation) — follow-up from #1382; PR #1466 | `validate_config_schemas.py` + pre-commit hook already existed; CI step was the only missing piece |
+| ProjectOdyssey | Issue #3969 (stale-script detector) — follow-up from #3148/#3337; PR #4844 | stdlib-only detector + pre-commit hook + 20 unit tests; 22 stale candidates surfaced |
 
 ### Pattern 3 — stale-script detector
 
@@ -510,4 +660,5 @@ the companion worktree-`__file__` skill (why `-m` beats a `scripts/<x>.py` shim)
 | ProjectOdyssey | Issue #3834 (grep deprecation guard) — follow-up from #3267/#3059; PR #4810 | 8 deprecated backward-result aliases blocked in `comprehensive-tests.yml` `mojo-syntax-check` job |
 | ProjectScylla | Issue #1443 (schema validation) — follow-up from #1382; PR #1466 | `validate_config_schemas.py` + pre-commit hook already existed; CI step was the only missing piece |
 | ProjectOdyssey | Issue #3969 (stale-script detector) — follow-up from #3148/#3337; PR #4844 | stdlib-only detector + pre-commit hook + 20 unit tests; 22 stale candidates surfaced |
+| ProjectHephaestus | Issue #1214 / PR #1250 (tracked-file-under-build guard) | stdlib-only `check_build_dir_untracked.py` + `repo: local` pre-commit hook; asserts `git ls-files build/` empty (hard-fail exit 1). verified-precommit (CI pending) |
 | ProjectHephaestus | Issue #1181 (dead required gate) — PR #1266; `deps/version-sync` passed in CI in 13s on the fix branch | `deps-version-sync` job in `.github/workflows/_required.yml` computed-and-discarded a `DYNAMIC` verdict with its only `exit 1` behind a non-existent `VERSION` file; rewired to install WITH deps + `python -m hephaestus.scripts_lib.check_version_single_source` under `set -euo pipefail` + `pixi install --locked` (pinned pixi v0.69.0); context pinned in org ruleset so fixed in place, not deleted; two-sided verified |


### PR DESCRIPTION
Amends the existing `ci-hygiene-and-validation-gates` skill (v1.0.0 -> v1.1.0, minor) by adding **Pattern 4 — tracked-file-under-gitignored-dir guard**.

## What's new

- **Pattern 4**: a stdlib-only `scripts/check_build_dir_untracked.py` (`tracked_build_files(repo_root)` runs `git ls-files build/`; `main()` returns 1 if non-empty) plus a `repo: local` pre-commit hook with `pass_filenames: false` and `always_run: true`. Rides the existing required lint gate — no new workflow.
- A directory (`build/`) is the sanctioned gitignored scratch location for an automation loop, but its name collides with the packaging-output convention. The durable fix is a regression guard asserting the dir stays *untracked*, not deletion of on-disk logs (a live loop regenerates them within seconds).
- The guard **hard-fails (exit 1)** — an intentional divergence from Pattern 3's exit-0 discovery-tooling rule, because a tracked file under a gitignored scratch dir is a true invariant breach. The contrast is called out explicitly so the two patterns don't look contradictory.

## Edits

- New "When to Use" bullet, Pattern 4 subsection (full script + hook YAML), 3 Failed-Attempts rows (Edit-tool config-file block, futile log deletion, exit-0-vs-hard-fail), Pattern 4 Results & Parameters, a Verified On row.
- Frontmatter `version` -> 1.1.0, `date` -> 2026-06-12, new tags `build-dir` / `untracked-guard` / `packaging-collision` / `git-ls-files`. Frontmatter keeps `verification: verified-ci`; Pattern 4 is marked verified-precommit (CI pending) inline.
- History file prepends a v1.1.0 entry with the full pre-amendment v1.0.0 snapshot.

## Verification

- `python3 scripts/validate_plugins.py` → **296/296 valid** (exit 0).
- Source: ProjectHephaestus issue #1214 / PR #1250 — verified-precommit at capture time.