### PR TITLE
feat: add mcp-config-deliberate-absence-posture skill

### DIFF
--- a/skills/mcp-config-deliberate-absence-posture.md
+++ b/skills/mcp-config-deliberate-absence-posture.md
@@ -1,0 +1,125 @@
+---
+name: mcp-config-deliberate-absence-posture
+description: "How to handle a repo audit finding that flags 'no MCP server configuration'. Use when: (1) an audit reports missing .mcp.json / mcpServers, (2) deciding whether to add live MCP server entries vs document a deliberate absence, (3) distinguishing Claude Code plugin marketplaces from MCP servers."
+category: tooling
+date: 2026-06-12
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [mcp, claude-code, config, audit, documentation]
+---
+
+# MCP Config: Deliberate-Absence Posture
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-12 |
+| **Objective** | Decide the correct response to a repo audit finding of "no MCP server configuration / missing `.mcp.json` / no `mcpServers`" without breaking Claude Code tool startup. |
+| **Outcome** | An audit "no MCP configuration" finding is often a FALSE GAP: the referenced "MCP-style integration" is usually a Claude Code PLUGIN MARKETPLACE, not a Model Context Protocol server. The KISS/YAGNI-correct fix is to DOCUMENT the deliberate absence and ship an inert `.mcp.example.json` template — NOT to fabricate live `mcpServers` entries pointing at servers that aren't installed/reachable. |
+| **Verification** | `unverified` — planning learning from ProjectHephaestus issue #1186; the plan was produced but NOT executed or merged. |
+
+### Key Insight
+
+- An audit finding of "no MCP configuration" is often a **false gap**. "MCP-style
+  integrations" in an ecosystem frequently turn out to be Claude Code **plugin
+  marketplaces** (a different mechanism, e.g. the Mnemosyne marketplace) — NOT
+  Model Context Protocol servers. Verify what the integration actually is before
+  adding MCP config.
+- The KISS/YAGNI-correct fix is usually to **document the deliberate absence**
+  and ship an inert `.mcp.example.json` template, NOT to fabricate live
+  `mcpServers` entries pointing at servers that aren't installed or reachable.
+  Claude Code auto-loads `.mcp.json` and starts every listed server on session
+  load, so a fabricated block breaks tool startup.
+
+## When to Use
+
+- An audit (e.g. `repo-analyze`) reports a missing `.mcp.json` or absent `mcpServers` block.
+- You are deciding whether to add live MCP server entries vs. document a deliberate absence.
+- You need to distinguish a Claude Code plugin marketplace from an MCP server before wiring anything.
+- A repo references an "MCP-style integration" and you must confirm the actual mechanism.
+
+## Verified Workflow
+
+> **Warning (Proposed Workflow):** This workflow has NOT been validated
+> end-to-end. It is a planning learning from issue #1186 — the plan was produced
+> but not implemented or merged. Treat every step as a hypothesis until CI
+> confirms. Verification level: `unverified`.
+
+### Quick Reference
+
+```
+1. grep repo for `mcpServers` / `.mcp.json`.
+   - Hits only in audit-skill checklists  -> no real MCP usage (false gap).
+2. Identify the REAL cross-process substrate (NATS event bus, HTTP REST).
+   - These are NOT MCP.
+3. Trace the "MCP-style" reference to its source.
+   - Plugin marketplace vs MCP server? (usually marketplace).
+4. Ship inert template + docs + regression test (see below).
+5. gitignore the active `.mcp.json` so local-only servers aren't committed broken.
+
+Rule of thumb: ship `.mcp.example.json` (inert), never an active `.mcp.json`.
+```
+
+Detailed steps:
+
+1. `grep` the repo for `mcpServers` / `.mcp.json`. If the only hits are inside
+   audit-skill checklists, there is no real MCP usage — the finding is a false gap.
+2. Identify the **real** cross-process integration substrate (e.g. a NATS event
+   bus, HTTP REST). These are not MCP and should not be re-expressed as MCP servers.
+3. Trace the "MCP-style" reference back to its source and confirm whether it is a
+   Claude Code **plugin marketplace** or an actual **MCP server**.
+4. Ship the deliberate-absence artifacts:
+   - `.mcp.example.json` — an inert template with empty `{"mcpServers": {}}`.
+   - `docs/mcp.md` — rationale for the deliberate absence and opt-in instructions.
+   - An `AGENTS.md` subsection pointing to the rationale.
+   - A regression test asserting (a) the template is valid JSON, and (b) **if** an
+     active `.mcp.json` exists, every `command` is on `PATH` (via `shutil.which`).
+5. `gitignore` the active `.mcp.json` so local-only servers are never committed in
+   a broken state.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Fabricate a live MCP block | Add a live `mcpServers` block copied from another ecosystem repo | Claude Code starts every listed server on session load; unreachable commands break tool startup | Never ship config pointing at servers not installed in THIS environment (per knowledge-base `claude-config-branch-audit` "What Failed"). |
+| Commit an active config file | Ship `.mcp.json` (active) instead of `.mcp.example.json` | The active file auto-loads and triggers connection attempts on every session | Use the inert `.example` suffix for templates; gitignore any active `.mcp.json`. |
+| Trust the audit's vocabulary | Assume the audit's "MCP-style integration" reference means an MCP server | It was actually a Claude Code plugin marketplace (Mnemosyne), a different mechanism | Verify the mechanism (marketplace vs MCP server) before wiring anything. |
+
+## Results & Parameters
+
+**Verified on:** ProjectHephaestus, issue #1186 planning session (plan produced,
+not yet implemented or merged). Verification level: `unverified`.
+
+### Recommended artifacts
+
+| Artifact | Purpose |
+|----------|---------|
+| `.mcp.example.json` | Inert template, empty `{"mcpServers": {}}` — copy to `.mcp.json` to opt in. |
+| `docs/mcp.md` | Rationale for the deliberate absence + opt-in instructions. |
+| `AGENTS.md` subsection | Pointer to the MCP rationale for agents. |
+| Regression test | Asserts template is valid JSON, and any active `.mcp.json` has every `command` on PATH. |
+| `.gitignore` entry for `.mcp.json` | Prevents committing local-only/broken server configs. |
+
+### Unverified assumptions / reviewer risks
+
+These are the highest-value durable content — capture and re-confirm before relying on them.
+
+- **ASSUMPTION (unverified):** Claude Code auto-loads root `.mcp.json` and starts
+  every listed server on session start. This drove the `.example`-vs-active
+  decision but was NOT verified against Claude Code docs in-session. A reviewer
+  should confirm against current Claude Code MCP loading behavior.
+- **ASSUMPTION (unverified):** `docs/index.md` exists and links other docs the same
+  way — the plan edits it but the exact link format/section was not confirmed.
+- **ASSUMPTION (unverified):** markdownlint config permits the `docs/mcp.md`
+  structure (a nested fenced code block inside a list item — a known markdownlint
+  friction point, MD031 / fenced-code-in-list). **Reviewer risk:** the
+  illustrative ```json block nested inside the numbered "Opting in" list may trip
+  markdownlint, which is a repo-wide PR-blocking gate.
+- **ASSUMPTION (unverified):** the regression test's
+  `Path(__file__).resolve().parents[2]` resolves to repo root from `tests/unit/` —
+  standard for this repo but confirm the depth.
+- **RISK:** `test ! -f .mcp.json` as an "acceptance criterion" encodes "deliberate
+  absence" as a permanent invariant; if a future contributor legitimately adds MCP,
+  this test must be **updated, not deleted**.


### PR DESCRIPTION
## Summary
New skill capturing the planning learning from ProjectHephaestus issue #1186: how to respond to an audit finding of 'no MCP server configuration'.

- Verify whether 'MCP-style integration' references are actually MCP servers or Claude Code plugin marketplaces (often the latter).
- Prefer documenting a deliberate absence + inert .mcp.example.json template over fabricating live mcpServers entries.
- Captures unverified assumptions (Claude Code .mcp.json auto-load/start behavior) and reviewer risks (markdownlint nested fenced code, permanent-absence invariant test).

## Verification Level
**unverified** — this is a planning learning; the #1186 plan was produced but not yet implemented or merged. Treat the workflow as a hypothesis until CI confirms.

## Key Findings
**What Worked**: distinguishing plugin marketplaces from MCP servers; inert template approach.
**What Failed**: copying live mcpServers blocks from other repos breaks Claude Code tool startup.

## Test Plan
- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>