### PR TITLE
feat: amend pixi-pip-dep-floor-cap-pinning skill (v1.1.0)

### DIFF
--- a/skills/pixi-pip-dep-floor-cap-pinning.history
+++ b/skills/pixi-pip-dep-floor-cap-pinning.history
@@ -1,11 +1,12 @@
+## v1.0.0 — 2026-06-13
+
 ---
 name: pixi-pip-dep-floor-cap-pinning
 description: "Use when: (1) pixi.toml has pip listed as `\"*\"` (unbounded) in [dependencies] while all other deps are pinned, (2) planning a floor/cap constraint for conda-managed pip to guard PEP 660 editable-install compatibility, (3) adding a regression test to ensure pip stays within a safe range after a version bump, (4) checking whether pixi.lock needs to be committed after constraining pip."
 category: ci-cd
 date: 2026-06-13
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
-history: pixi-pip-dep-floor-cap-pinning.history
 tags:
   - pixi
   - pip
@@ -28,7 +29,7 @@ tags:
 | **Date** | 2026-06-13 |
 | **Objective** | Constrain the `pip` entry in `pixi.toml [dependencies]` from unbounded `"*"` to a `>=floor,<cap` range that guarantees PEP 660 editable-install compatibility while preventing silent breakage from major pip upgrades |
 | **Outcome** | Proposed plan for GitHub issue #1202 — `pip = ">=23.0,<27"` — derived from the installed pip version (26.1.2) and the PEP 660 stable-support floor (23.0); regression test class `TestPipPinning` to be added to `tests/unit/scripts/test_dependency_floor_consistency.py` |
-| **Verification** | unverified (plan revised in R1; not yet applied to CI) |
+| **Verification** | verified-local (pixi list confirmed 26.1.2; not yet merged to CI) |
 
 ## When to Use
 
@@ -40,7 +41,7 @@ tags:
 
 ## Verified Workflow
 
-> **WARNING**: This workflow was proposed in R0 and revised in R1 (2026-06-13). It has NOT yet been applied to CI. Treat as "Proposed Workflow" until issue #1202 merges.
+> **WARNING**: This workflow was proposed and verified locally (pip 26.1.2 confirmed via `pixi list`). It has NOT yet been applied to CI as of 2026-06-13. Treat as "Proposed Workflow" until issue #1202 merges.
 
 ### Quick Reference
 
@@ -56,10 +57,9 @@ pixi list | grep "^pip "
 # 3. Apply to pixi.toml [dependencies]
 #    pip = ">=23.0,<27"
 
-# 4. Re-solve and check lockfile drift  ← MANDATORY EXPLICIT STEP
+# 4. Re-solve and check lockfile drift
 pixi install
-git diff pixi.lock
-git add pixi.lock   # ALWAYS add if pixi.lock changed — CI fails on dirty lockfile
+git diff pixi.lock   # If changed, commit pixi.lock in the same PR
 
 # 5. Verify pip is importable at the constrained version
 pixi run python -c "import pip; print(pip.__version__)"
@@ -117,22 +117,14 @@ pip = "*"
 pip = ">=23.0,<27"
 ```
 
-#### 5. Re-solve and lockfile check — MANDATORY EXPLICIT STEP
-
-This is the most common landability gap for pixi.toml edits. When any `[dependencies]` constraint changes, `pixi install` re-solves `pixi.lock`. The plan **must** include all three sub-steps:
+#### 5. Re-solve and lockfile check
 
 ```bash
-# (a) Re-solve the environment
 pixi install
-
-# (b) Check if the lockfile changed
 git diff pixi.lock
-
-# (c) Stage the lockfile if it changed
-git add pixi.lock
 ```
 
-If `pixi.lock` changed and is omitted from the commit, CI fails on the locked-install check. This was the primary cause of the R0 plan receiving a NOGO. The lockfile re-solve is a side effect of `pixi install` — not an explicit file edit — so it is easy to forget. It must appear in both the **Files to Modify** list and the **Implementation Order** steps of any plan touching `pixi.toml`.
+If `pixi.lock` changed, it **must** be committed in the same PR. Omitting it causes CI to fail on the locked-install check. The plan for #1202 notes this risk explicitly.
 
 #### 6. Add a regression test
 
@@ -144,8 +136,6 @@ tests/unit/scripts/test_dependency_floor_consistency.py
 
 Do NOT create a new file. The existing file already exercises pixi.toml dependency constraints — `TestPipPinning` extends that coverage.
 
-**Use the existing `_floor()` and `_upper_cap()` module-level helpers** — do not write substring checks inline. Every other class in the file delegates to these helpers. Using them is required for DRY compliance.
-
 ```python
 class TestPipPinning:
     """Regression tests for pip version bounds in pixi.toml."""
@@ -154,44 +144,40 @@ class TestPipPinning:
         """pip must have both a >= floor and a < cap."""
         spec = pixi_deps.get("pip", "")
         assert spec, "pip must appear in pixi.toml [dependencies]"
-        # Delegate to module-level helpers (DRY — consistent with all other classes)
-        floor = _floor(spec)   # raises AssertionError if >= clause absent
-        cap = _upper_cap(spec) # raises AssertionError if < clause absent
-        assert floor is not None, f"pip spec must have a >= floor, got: {spec!r}"
-        assert cap is not None, f"pip spec must have a strict < cap, got: {spec!r}"
+        assert ">=" in spec, f"pip spec must have a >= floor, got: {spec!r}"
+        assert "<" in spec and not spec.startswith("<="), (
+            f"pip spec must have a strict < cap (not <=), got: {spec!r}"
+        )
 
     def test_pip_floor_is_pep660_compatible(self, pixi_deps: dict[str, str]) -> None:
         """pip floor must be >= 23.0 (first stable PEP 660 release)."""
         from packaging.version import Version
 
         spec = pixi_deps.get("pip", "")
-        floor = _floor(spec)
+        floor_match = re.search(r">=(\d+[\.\d]*)", spec)
+        assert floor_match, f"Could not parse >= floor from pip spec: {spec!r}"
+        floor = Version(floor_match.group(1))
         assert floor >= Version("23.0"), (
             f"pip floor {floor} is below 23.0 (minimum for stable PEP 660 editable installs)"
         )
 
-    def test_pip_cap_blocks_next_major_only(self, pixi_deps: dict[str, str]) -> None:
-        """pip cap must block the next major (27) but not be a downgrade cap.
-
-        Two-sided bound: Version("26") < cap <= Version("27")
-        - Lower bound rejects a downgrade cap like <24 (which was the installed major).
-        - Upper bound rejects an over-permissive cap like <28.
-        # TODO: update lower bound to Version("27") when CI tests pip 27.x.
-        """
+    def test_pip_cap_blocks_next_major(self, pixi_deps: dict[str, str]) -> None:
+        """pip < cap must block at least the next major after the installed version."""
         from packaging.version import Version
 
         spec = pixi_deps.get("pip", "")
-        cap = _upper_cap(spec)
-        assert Version("26") < cap <= Version("27"), (
-            f"pip cap {cap} must be exactly <27 (two-sided: not a downgrade, not over-permissive); "
-            "bump this test when the cap is intentionally raised"
+        cap_match = re.search(r"<(\d+)", spec)
+        assert cap_match, f"Could not parse < cap from pip spec: {spec!r}"
+        cap = Version(cap_match.group(1))
+        assert cap <= Version("27"), (
+            f"pip cap {cap} is too permissive; bump this test when the cap is intentionally raised"
         )
 ```
 
-**Test design notes (R1 revision)**:
-- `_floor(spec)` and `_upper_cap(spec)` are module-level helpers already present in `test_dependency_floor_consistency.py`. Always use them — do not write `"<" in spec` substring checks inline.
-- The two-sided cap assertion `Version("26") < cap <= Version("27")` rejects both a downgrade cap (e.g., `<24`) and an over-permissive cap (e.g., `<28`). A one-sided `cap <= Version("27")` would silently accept `<24`. The lower bound must be the current installed major.
-- The hardcoded `Version("26")` lower bound is a future maintenance burden: it must be updated to `Version("27")` when CI upgrades to pip 27.x. The test comment marks this explicitly.
+**Test fragility notes**:
+- `assert "<" in spec and not spec.startswith("<=")` only checks that `<` appears AND the spec doesn't start with `<=`. A spec like `"!=26.0,<27"` would pass even without `>=` — but the sibling `">=" in spec` assertion catches that separately.
+- The `_upper_cap` helper pattern (used elsewhere in the file) relies on `<` detection and does not handle `<=`-style caps. This is fine for pip's conventional constraint style but worth noting if the style changes.
+- `cap <= Version("27")` uses `<=`, meaning a cap of exactly `<27` passes (correct). A future bump to `<28` will fail this assertion and require a deliberate test update.
 
 ## Failed Attempts
 
@@ -199,9 +185,7 @@ class TestPipPinning:
 | --------- | ---------------- | --------------- | ---------------- |
 | Adding `TestPipPinning` to a new test file | Considered `tests/unit/scripts/test_pip_pinning.py` | The existing `test_dependency_floor_consistency.py` already covers pixi dep constraints; a new file would duplicate infra | Always check the existing test file in `tests/unit/scripts/` before creating a new one — the right home is the closest existing file |
 | Using `">=23,<27"` (integer floor) | Minor-version-only floor like `>=23` | Technically valid but inconsistent with the rest of the codebase which uses dotted floors like `>=23.0` | Use `>=MAJOR.MINOR` (dotted) for consistency with other dep specs in the project |
-| Omitting `pixi.lock` from the PR (R0) | Changed only `pixi.toml` in Files to Modify; no `pixi install` step in Implementation Order | `pixi install` triggered a lockfile re-solve; CI `--locked` check failed because `pixi.lock` diverged | Whenever a `pixi.toml` dependency constraint changes, `pixi.lock` must appear in Files to Modify AND the plan must include: (a) `pixi install`, (b) `git diff pixi.lock`, (c) `git add pixi.lock`. This was the primary R0 NOGO cause. |
-| Inline `"<" in spec` substring check in `test_pip_has_floor_and_cap` (R0) | Used `"<" in spec and not spec.startswith("<=")` directly instead of `_upper_cap()` | Reviewer flagged as DRY violation (existing helpers ignored) and fragile — a spec like `!=26.0,<27` passes even without a clean `<cap` clause | Always delegate to `_floor(spec)` / `_upper_cap(spec)` which raise AssertionError when the clause is absent; do not write inline substring checks |
-| One-sided cap assertion `cap <= Version("27")` (R0) | Used upper bound only | Silently accepts a downgrade cap like `<24` (which is below the installed major); reviewer flagged as incomplete | Use two-sided bound: `Version("26") < cap <= Version("27")` — lower bound is the current installed major, upper bound is installed_major + 1 |
+| Omitting `pixi.lock` from the PR | Changed only `pixi.toml` | `pixi install` triggered a lockfile re-solve; CI `--locked` check failed because `pixi.lock` diverged | Whenever a `pixi.toml` dependency constraint changes, always check `git diff pixi.lock` and commit it in the same PR if it changed |
 
 ## Results & Parameters
 
@@ -212,15 +196,6 @@ class TestPipPinning:
 | Floor | `>=23.0` | First pip release with stable PEP 660 editable-install support (community consensus; cross-check against pip 23.0 release notes before lowering) |
 | Cap | `<installed_major + 1` | Blocks the next major version; requires an explicit bump when the new major is tested |
 | Example (2026-06-13) | `>=23.0,<27` | pip 26.1.2 installed → cap = 27 |
-
-### Implementation Order checklist (mandatory for any pixi.toml edit)
-
-1. Edit `pixi.toml` — change `pip = "*"` to `pip = ">=23.0,<27"`
-2. Run `pixi install` — re-solves `pixi.lock` as a side effect
-3. Run `git diff pixi.lock` — check if lockfile changed
-4. Run `git add pixi.lock` if changed — **must be in the same commit/PR**
-5. Add `TestPipPinning` to `tests/unit/scripts/test_dependency_floor_consistency.py` using `_floor()` / `_upper_cap()` helpers
-6. Run `pixi run pytest tests/unit/scripts/test_dependency_floor_consistency.py -v`
 
 ### Verification commands
 
@@ -239,23 +214,20 @@ git diff pixi.lock   # should be empty after committing
 pixi run pytest tests/unit/scripts/test_dependency_floor_consistency.py::TestPipPinning -v
 ```
 
-### Reviewer checklist (from the #1202 session, updated R1)
+### Reviewer checklist (from the #1202 session)
 
 - Confirm `pixi install` completes cleanly after the constraint change.
 - Check whether `pixi.lock` changed; if so, verify it is committed in the same PR.
-- Verify that `test_pip_has_floor_and_cap` delegates to `_floor()` / `_upper_cap()` — not inline substring checks.
-- Verify the two-sided cap assertion: `Version("26") < cap <= Version("27")`. The lower bound rejects downgrade caps; the upper bound rejects over-permissive caps.
-- The hardcoded `Version("26")` lower bound in `test_pip_cap_blocks_next_major_only` must be updated to `Version("27")` when CI upgrades to pip 27.x.
+- Verify the `test_pip_cap_blocks_next_major` assertion: `cap <= Version("27")` uses `<=`, so a cap of exactly `<27` (parsed as `Version("27")`) passes correctly. A future bump to `<28` will intentionally break this test.
+- The `_upper_cap` helper in the test file uses `<` detection but does not handle `<=`-style caps; this is intentional — pip conventionally uses strict `<` caps.
 
 ### Uncertain assumptions (flag for future verification)
 
 - **Floor `>=23.0`**: Based on PEP 660 stable-support community consensus, NOT independently cross-checked against the actual pip 23.0 release notes. If the project needs to lower the floor, verify against `https://pip.pypa.io/en/stable/news/`.
 - **Lockfile re-solve**: Constraining pip MAY trigger a full lockfile re-solve depending on the current pixi version. Always check `git diff pixi.lock` before committing.
-- **Hardcoded lower bound `Version("26")`** in `test_pip_cap_blocks_next_major_only`: This will need updating when pip 27.x lands in CI. The test comment flags this explicitly, but the hardcoded value remains a future maintenance burden.
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| ProjectHephaestus | Issue #1202 — pip `"*"` → `">=23.0,<27"` (R0) | pip 26.1.2 confirmed via `pixi list`; R0 plan received NOGO (missing lockfile step, inline substring check, one-sided cap) |
-| ProjectHephaestus | Issue #1202 — R1 revision | Lockfile step made explicit, `_floor`/`_upper_cap` helpers mandated, two-sided cap assertion added; not yet merged to CI |
+| ProjectHephaestus | Issue #1202 — pip `"*"` → `">=23.0,<27"` | pip 26.1.2 confirmed via `pixi list`; plan written 2026-06-13; not yet merged |


### PR DESCRIPTION
## Summary

- Bumps `pixi-pip-dep-floor-cap-pinning` from v1.0.0 to v1.1.0 with R1 revision learnings from GitHub issue #1202 planning iteration
- Archives v1.0.0 snapshot in `pixi-pip-dep-floor-cap-pinning.history`
- Adds `history:` frontmatter field linking to the history file

## New Learnings (R1 additions)

**What Worked:**
- Lockfile drift must be an explicit Implementation Order step: when any `[dependencies]` constraint changes in pixi.toml, the plan must include `pixi install` → `git diff pixi.lock` → `git add pixi.lock`. Omitting this was the primary R0 NOGO cause.
- Use existing `_floor()` / `_upper_cap()` module-level helpers in tests — DRY compliance with every other class in `test_dependency_floor_consistency.py`; do not write inline `"<" in spec` substring checks.
- Two-sided cap assertion `Version("26") < cap <= Version("27")` rejects both downgrade caps (e.g., `<24`) and over-permissive caps (e.g., `<28`). One-sided `cap <= Version("27")` silently accepts downgrades.

**Failed Attempts Added:**
- R0 inline `"<" in spec` substring check — flagged as DRY violation and fragile
- R0 missing lockfile step — omitted `pixi.lock` from Files to Modify and Implementation Order

**Uncertain assumption documented:**
- Hardcoded `Version("26")` lower bound in `test_pip_cap_blocks_next_major_only` is a future maintenance burden when pip 27.x lands in CI.

## Verification

Skill validated locally via `python3 scripts/validate_plugins.py` — passes.
Plan not yet applied to CI (verification status: unverified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)