### PR TITLE
feat(skills): amend planning-check-already-shipped-before-planning to v1.2.0

### DIFF
--- a/skills/planning-check-already-shipped-before-planning.history
+++ b/skills/planning-check-already-shipped-before-planning.history
@@ -1,5 +1,71 @@
 # planning-check-already-shipped-before-planning — History
 
+## v1.2.0 (2026-06-15)
+
+**Changed by:** ProjectHephaestus issue #1357 planning session (continued) — after confirming the
+work was already on disk, the plan-loop reviewer returned NOGO (Grade D) on a plan that was
+actually a retrospective status note, exposing a lesson v1.1.0 did not cover.
+**Verification:** verified-local (the boundary/mypy/ruff gates ran GREEN this session, resolving
+v1.1.0's "not run" caveats for those gates; the full `tests/unit/automation` suite still had no
+reported pass/fail count, so the suite-wide claim stays conservative)
+
+### What changed
+
+- Added the core NEW lesson: even when the work is already on disk, the plan-loop demands a
+  FORWARD-LOOKING plan. A "status note" (bullets describing what shipped + caveats) is a category
+  error and gets NOGO'd (Grade D) on Completeness/Concreteness/Verification-Plan/Stage-Handoff —
+  "on disk being correct does not rehabilitate the plan artifact itself."
+- Added the stage-handoff lesson: never DEFER a checkable gate (boundary tests, mypy) to the
+  reviewer as "follow-up"; run it during planning and cite it as completed.
+- Added a When-to-Use trigger: "the plan-loop reviewer NOGO'd your plan as a 'status note' /
+  retrospective."
+- Added Verified-Workflow steps 9 (emit a forward-looking plan even for landed work) and 10 (run
+  every gate yourself; mypy-duplicate-module and pytest `--no-cov` gotchas; subset-coverage is an
+  artifact).
+- Added 4 Failed Attempts rows: status-note-as-plan → NOGO; defer-gate-to-reviewer → stage-handoff
+  failure; `pixi run mypy <paths>` → Duplicate module error; subset `pixi run pytest` without
+  `--no-cov` → unrecognized `--cov`.
+- Added a Results & Parameters subsection with the GREEN gate outputs (2 passed boundary; mypy
+  clean on 402 files; ruff clean; 2449 lines; 25 stubs; preservation methods at :781/:880/:943/
+  :1019) and the explicit note that mypy proves type-level DIP but NOT behavioral SRP.
+- Extended the planner decision tree with the forward-plan-even-when-done branch and the
+  subset/`--no-cov`/`mypy`-bare notes; added a second Verified On row for the NOGO→fix.
+- Frontmatter: bumped `version` 1.1.0 → 1.2.0, kept `date` 2026-06-15, broadened `description`,
+  kept `verification: verified-local`.
+
+### Why
+
+v1.1.0 captured "the work may already be done (merged OR uncommitted) — verify before planning."
+It did not cover what to do with the PLAN ARTIFACT once you confirm the work is done. The #1357
+session learned that the plan-loop still grades the artifact, not the disk: a descriptive status
+note is NOGO'd as a category error, and deferring a runnable gate to the reviewer is a
+stage-handoff failure. The fix is to emit a genuine forward-looking plan (design + files +
+build order + per-criterion verification) and to run every gate yourself. The session ran the
+previously-deferred boundary/mypy/ruff gates GREEN, which also upgrades v1.1.0's call-site DIP
+inference to type-level proof.
+
+### Previous version (v1.1.0) snapshot
+
+```markdown
+---
+name: planning-check-already-shipped-before-planning
+description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. Use when: (1) planning a follow-up or consolidation issue, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory."
+category: architecture
+date: 2026-06-15
+version: "1.1.0"
+user-invocable: false
+verification: verified-local
+history: planning-check-already-shipped-before-planning.history
+tags: []
+---
+```
+
+(Full v1.1.0 body is reconstructable from this changelog + the v1.0.0 snapshot below; the v1.2.0
+edits are purely additive — a new trigger, steps 9–10, 4 Failed Attempts rows, a Results
+subsection, decision-tree branches, and a Verified On row.)
+
+---
+
 ## v1.1.0 (2026-06-15)
 
 **Changed by:** ProjectHephaestus issue #1357 planning session — wrote a decomposition plan against a repo state where the implementation had already landed uncommitted in an untracked `1-fix` worktree.

--- a/skills/planning-check-already-shipped-before-planning.md
+++ b/skills/planning-check-already-shipped-before-planning.md
@@ -1,9 +1,9 @@
 ---
 name: planning-check-already-shipped-before-planning
-description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. Use when: (1) planning a follow-up or consolidation issue, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory."
+description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. And even when the work IS already on disk, the plan-loop still demands a FORWARD-LOOKING plan — a retrospective status note gets NOGO'd, and gates you defer to the reviewer are stage-handoff failures. Use when: (1) planning a follow-up or consolidation issue, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory, (4) the plan-loop reviewer NOGO'd your plan as a 'status note' / retrospective."
 category: architecture
 date: 2026-06-15
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
 history: planning-check-already-shipped-before-planning.history
@@ -17,9 +17,9 @@ tags: []
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-15 |
-| **Objective** | Detect whether a GitHub issue's fix is already done before writing an implementation plan — whether merged to `main` OR landed uncommitted on disk in a sibling worktree |
-| **Outcome** | Successful — caught both a shipped fix (PR #1308, merged) and a fix that had already landed uncommitted in an untracked `1-fix` worktree (issue #1357) that `git log` would never have surfaced |
-| **Verification** | verified-local (the uncommitted-worktree finding ran only a SUBSET of tests locally; the original merged-fix example remains verified-ci) |
+| **Objective** | Detect whether a GitHub issue's fix is already done before writing an implementation plan — and, even when it IS done, still emit a FORWARD-LOOKING plan (not a retrospective status note) and run every gate yourself instead of deferring to the plan reviewer |
+| **Outcome** | Successful — caught both a shipped fix (PR #1308, merged) and a fix that had already landed uncommitted in an untracked `1-fix` worktree (issue #1357); then diagnosed why a "status note" plan for that landed work was NOGO'd (Grade D) and what reshaping + gate-running resolves it |
+| **Verification** | verified-local (the uncommitted-worktree finding ran a SUBSET of tests; the boundary/mypy/ruff gates ran GREEN this session; the original merged-fix example remains verified-ci) |
 | **History** | [changelog](./planning-check-already-shipped-before-planning.history) |
 
 ## When to Use
@@ -29,6 +29,7 @@ tags: []
 - Picking up an issue from a batch/backlog queue — the fix may have been merged hours or days ago
 - **`git status` shows an untracked sibling worktree directory** (e.g. `1-fix/`) — the implementation may already be done there but not yet committed/merged, so `git log` on `main` shows nothing
 - The issue describes a refactor/decomposition as FUTURE work but a parallel branch/worktree may have already completed it
+- **The plan-loop reviewer NOGO'd your plan as a "status note" / retrospective** — discovering the work is already on disk does NOT exempt you from writing a forward-looking implementation plan; describing what shipped (bullets + caveats) fails the rubric even when the code is correct
 - Before any implementation plan step — running this check costs seconds and avoids wasted (and worse, duplicate/conflicting) work
 
 ## Verified Workflow
@@ -84,6 +85,10 @@ pixi run pytest tests/unit/path/to/relevant_tests.py -v
 
 8. **Document for auditability** — Even when already done, record the evidence: for merged work the commit SHA + PR number + `file:line` range + covering tests; for uncommitted-worktree work the worktree path, the `wc -l`/method counts observed, and which tests passed. Note that line numbers cited from an uncommitted tree may SHIFT if that work is rebased/squashed before merge.
 
+9. **Still emit a FORWARD-LOOKING plan even when the work is already on disk** — The plan-loop reviewer grades the PLAN ARTIFACT, not the on-disk reality. "The fact that the underlying work appears correct on disk does not rehabilitate the plan artifact itself." Writing 5 bullets that DESCRIBE what shipped (plus caveats) is a **category error** — it is a retrospective status note, not a plan, and gets NOGO'd (Grade D) on Completeness, Concreteness, Verification-Plan, and Stage-Handoff. Reshape it as a real plan even when describing already-landed code: frame each module as a "files to create/modify" step with the actual code, give a numbered build order, and give a per-acceptance-criterion verification command. The plan reads as forward-looking; the only honest footnote is "implemented identically to this on disk."
+
+10. **RUN the gates yourself — never DEFER a verification you could run to the reviewer** — Listing a checkable gate (e.g. ADR-0001 boundary tests, `mypy`) as "highest-value follow-up for the plan reviewer" is a **stage-handoff failure** that triggers NOGO. If you can run it during planning, run it and cite it as completed. For the #1357 decomposition this session ran and observed GREEN: the import-surface + automation-boundary tests (ADR-0001 intact), whole-tree `mypy` (the real proof of DIP — no collaborator secretly takes `self`/`CIDriver`, upgrading step 7's call-site inference to proof), `ruff`, and an import-graph confirmation that all 4 collaborators import only sibling `hephaestus.automation.*` + `hephaestus.agents.runtime`, never the base `hephaestus` surface (dependency arrow points automation→library, never reversed). **Gotchas:** (a) the `pixi run mypy` task already targets the whole tree — passing file paths causes `error: Duplicate module named ...`; run `pixi run mypy` with NO arguments. (b) `pixi run pytest` injects `--cov`; ad-hoc subset runs need `--no-cov` (or `-p no:cov`) or pytest errors `unrecognized arguments: --cov`. (c) a subset run reporting low TOTAL coverage (e.g. 9.18%) is a SUBSET ARTIFACT — never cite it as the suite being red OR green.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -95,6 +100,10 @@ pixi run pytest tests/unit/path/to/relevant_tests.py -v
 | Trust the issue's stated LOC/method counts | Planned a decomposition against the issue's "3,570 lines, ~60 methods" starting condition | The file was already 2,449 lines (at the target), all four collaborator modules already existed, tests already green | Measure with `wc -l` / `grep -cE "^\\s+def "` before trusting the issue's narrative; planning blind would re-do landed work and risk a conflicting duplicate |
 | Infer DIP from `__init__` call site | Asserted "no collaborator receives self" by reading only the `__init__` wiring | Never opened each collaborator's own constructor to confirm none accept a back-reference — the claim was inferred, not proven | Verify constructor signatures directly (or let `mypy` prove it); label call-site inferences as "inferred" until confirmed |
 | Treat a green test SUBSET as "done" | Ran 211 tests across the facade + 4 helper files; all passed | The coverage gate FAILED (9.18%) purely because the subset left most modules unexercised; full suite, mypy, ruff, import-surface tests were NOT run | A green subset is `verified-local`, not `verified-ci`; a failing coverage gate on a subset is a gate artifact, not a code failure — run the full gate before claiming done |
+| Submit a "status note" as the plan | Wrote 5 descriptive bullets + caveats summarizing what already shipped, instead of a forward-looking plan | NOGO, Grade D — a category error: it described reality rather than planning work; failed Completeness/Concreteness/Verification-Plan/Stage-Handoff. "On disk being correct does not rehabilitate the plan artifact" | Even when the work is done, emit a REAL plan: design + files-to-modify-with-code + numbered build order + per-criterion verification commands |
+| Defer a checkable gate to the reviewer | Listed `test_import_surface.py` / `test_automation_boundary.py` / `mypy` as "highest-value follow-up for the plan reviewer" | Stage-handoff failure → NOGO; a verification you can run yourself must not be punted downstream | RUN every gate you can during planning and cite it as completed; only genuinely-unrunnable checks may be handed off |
+| Run `pixi run mypy <paths>` | Passed explicit file paths to the mypy task to type-check only the touched files | `error: Duplicate module named ...` — the `pixi run mypy` task already targets the whole tree, so extra paths double-register modules | Run `pixi run mypy` bare (no arguments); it already covers the whole source tree |
+| Run subset `pixi run pytest <files>` without `--no-cov` | Invoked an ad-hoc subset pytest run to check a few modules | `pytest: error: unrecognized arguments: --cov` — the pixi pytest task injects `--cov`, which the bare pytest invocation rejects | Add `--no-cov` (or `-p no:cov`) for ad-hoc subset runs; and treat any low TOTAL-coverage number from a subset as an artifact, not a result |
 
 ## Results & Parameters
 
@@ -154,6 +163,48 @@ Caveats recorded honestly for this finding (why it is `verified-local`, not `ver
   current; the actual diff was not inspected.
 - Cited line numbers come from the uncommitted tree and may shift if `1-fix` is rebased/squashed.
 
+### Concrete example (issue #1357 — the NOGO and what resolved it)
+
+After confirming the #1357 work was on disk, the first plan submitted was a retrospective
+status note: ~5 bullets describing the landed facade + collaborators, plus the caveats above.
+The plan-loop reviewer returned **NOGO, Grade D** — a category error: a status note is not a
+plan. It failed Completeness, Concreteness, Verification-Plan, and Stage-Handoff. The reviewer
+was explicit: "the fact that the underlying work appears correct on disk does not rehabilitate
+the plan artifact itself." The specific stage-handoff trigger was deferring the ADR-0001 boundary
+check (`test_import_surface.py` / `test_automation_boundary.py` / `mypy`) to the reviewer as
+"highest-value follow-up" instead of running it during planning.
+
+Two-part fix that resolves the NOGO: (1) RUN the deferred gates and cite them as completed;
+(2) RESHAPE the artifact into a forward-looking plan (each module as a "files to create/modify"
+step with its actual code, a numbered build order, a per-criterion verification command).
+
+Gate outputs observed GREEN this session (these RESOLVE the "not run" caveats above for
+mypy/ruff/boundary; the full `tests/unit/automation` suite still had no reported pass/fail count
+at write time, so the strongest defensible claim remains "affected ci_driver + 4 collaborator
+helper tests pass (211) AND the boundary/mypy/ruff gates are green," not "entire automation
+suite is green"):
+
+```text
+pixi run pytest tests/unit/validation/test_import_surface.py \
+                tests/unit/validation/test_automation_boundary.py --no-cov
+  → 2 passed                       # ADR-0001 automation→library boundary intact
+
+pixi run mypy                      # NO arguments — task already targets the whole tree
+  → Success: no issues found in 402 source files   # proves type-level DIP
+
+pixi run ruff check hephaestus/automation/
+  → All checks passed.
+
+wc -l hephaestus/automation/ci_driver.py
+  → 2449                           # ≤ 2450 target; 25 delegation stubs
+  # preservation methods present at ci_driver.py:781 / :880 / :943 / :1019
+```
+
+What mypy-green does and does NOT prove: it proves the import-graph boundary holds and DIP at the
+type level (no collaborator secretly takes `self`/`CIDriver`), upgrading step 7's call-site
+inference to proof. It does NOT prove each collaborator is behaviorally SRP (single reason to
+change) — that remains asserted from the responsibility table, not demonstrated.
+
 ### Decision tree for planners
 
 ```
@@ -169,12 +220,18 @@ Before writing any implementation plan:
 │
 ├─ 3. Grep for the new behavior / ls the "to-be-created" modules
 │   ├─ FOUND on disk → check BOTH git log (merged?) AND the worktree (uncommitted?)
-│   │   └─ implementation present + tests pass → REPORT AS ALREADY DONE (do not re-plan)
+│   │   └─ implementation present + tests pass → it's ALREADY DONE
+│   │       └─ STILL write a FORWARD-LOOKING plan (NOT a status note):
+│   │           design + files-to-modify-with-code + numbered build order
+│   │           + per-criterion verification command, and RUN every gate
+│   │           yourself (boundary/mypy/ruff) rather than deferring to the
+│   │           reviewer — a status note or a deferred gate = NOGO (Grade D)
 │   └─ NOT FOUND → proceed with implementation planning
 │
-└─ 4. Run tests for the relevant module
-    ├─ SUBSET green → verified-local only (coverage gate fails on subsets — a gate artifact)
-    ├─ FULL suite + mypy + ruff green → verified-ci, safe to report done
+└─ 4. Run tests + gates for the relevant module
+    ├─ SUBSET green → verified-local only (coverage gate fails on subsets — a gate artifact;
+    │                 run subsets with --no-cov; run `pixi run mypy` bare, no paths)
+    ├─ FULL suite + mypy + ruff + boundary green → verified-ci, safe to report done
     └─ SOME FAIL → issue is genuinely open; proceed with planning
 ```
 
@@ -184,3 +241,4 @@ Before writing any implementation plan:
 |---------|---------|---------|
 | ProjectHephaestus | Issue #1291 — YAML sequence support in CI matrix extractor | PR #1308 merged 2026-06-13, commit dd15c35f (verified-ci) |
 | ProjectHephaestus | Issue #1357 — CIDriver god-class decomposition already landed in an uncommitted `1-fix` worktree | `ci_driver.py` measured 2,449 lines (≤ target), all 4 collaborator modules present, 211 subset tests green; full gate not run (verified-local) |
+| ProjectHephaestus | Issue #1357 — plan-loop NOGO (Grade D) on a retrospective "status note" for the landed work | Reshaped into a forward plan + ran the deferred gates: boundary tests 2 passed, `pixi run mypy` clean (402 files), ruff clean, 25 delegation stubs; full automation suite count unconfirmed (verified-local) |


### PR DESCRIPTION
## Summary

Amends `planning-check-already-shipped-before-planning` from v1.1.0 to v1.2.0.

v1.1.0 captured "the work may already be done (merged OR uncommitted) — verify before planning." It did not cover what to do with the PLAN ARTIFACT once you confirm the work is done. The continued ProjectHephaestus #1357 session learned that the plan-loop still grades the artifact, not the disk:

- A descriptive "status note" (bullets summarizing what shipped + caveats) is a **category error** — it gets NOGO'd (Grade D) on Completeness/Concreteness/Verification-Plan/Stage-Handoff. "On disk being correct does not rehabilitate the plan artifact itself."
- Deferring a runnable gate (ADR-0001 boundary tests, mypy) to the reviewer as "follow-up" is a **stage-handoff failure** that triggers NOGO.
- Fix: emit a genuine forward-looking plan (design + files-to-modify-with-code + numbered build order + per-criterion verification) AND run every gate yourself.

This amend adds: a When-to-Use trigger (reviewer NOGO'd your plan as a status note), workflow steps 9-10, 4 Failed Attempts rows, a Results subsection with the green gate outputs, decision-tree branches, and a Verified On row.

## Verification Level

**verified-local**

The boundary/mypy/ruff gates ran GREEN this session (2 passed boundary; `pixi run mypy` clean on 402 files; ruff clean; ci_driver.py 2449 lines, 25 stubs), which resolves v1.1.0's "not run" caveats for those gates and upgrades the DIP claim from call-site inference to type-level proof. The full `tests/unit/automation` suite still had no reported pass/fail count, so the suite-wide claim stays conservative. mypy proves type-level DIP but NOT behavioral SRP. Validate + markdownlint + pre-commit pass locally. Will bump to verified-ci only after this PR's own validate + markdownlint gates are observed green.

## Gotchas captured

- `pixi run mypy` already targets the whole tree — passing file paths causes `Duplicate module named ...`; run it bare.
- `pixi run pytest` injects `--cov`; ad-hoc subset runs need `--no-cov`.
- A subset run's low TOTAL coverage (e.g. 9.18%) is an artifact, not a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)