### PR TITLE
feat: amend pre-commit hooks skill

### DIFF
--- a/skills/pre-commit-hooks-and-linting-config.history
+++ b/skills/pre-commit-hooks-and-linting-config.history
@@ -1,6 +1,1451 @@
 <!-- markdownlint-disable MD024 -->
 # pre-commit-hooks-and-linting-config -- History
 
+## v2.3.0 (2026-06-17) -- Add TOML validity and locked Ruff hook parity pattern (Inference360 PR #157)
+
+**Changed by:** Inference360 PR #157 TOML/pre-commit quality-gate fix
+**Verification:** verified-ci
+
+### What changed
+
+- Added `check-toml` guidance for duplicate or malformed TOML tables that Ruff does not validate.
+- Added locked Ruff pre-commit parity guidance: keep `astral-sh/ruff-pre-commit` `rev:` equal to `v<locked ruff version>` from `uv.lock` or the active lockfile.
+- Documented that both `ruff` and `ruff-format` hook IDs are required because linting and formatting are separate gates.
+- Added a regression-test pattern that parses `.pre-commit-config.yaml` and `uv.lock` to assert `check-toml`, `ruff`, `ruff-format`, and locked Ruff `rev:` parity.
+- Documented the `install-hooks` recipe pattern using `${PYTHON:-python3} -m pre_commit install` and `PYTHON=.venv/bin/python just install-hooks` for hosts with broken default Python resolution.
+- Added 4 Failed Attempts rows and an Inference360 verification row.
+
+### Why
+
+Inference360 PR #157 fixed a CI setup failure caused by a duplicate `[tool.coverage.paths]` table in `pyproject.toml`. Ruff did not catch the TOML structural error, and keeping only the `ruff` hook would still miss `ruff-format` drift. The durable pattern is to gate TOML syntax with `check-toml`, keep Ruff hook `rev:` synchronized with the lockfile, keep both Ruff hook IDs, and backstop the hook contract with a regression test.
+
+### Previous version (v2.2.0) snapshot
+
+```markdown
+---
+name: pre-commit-hooks-and-linting-config
+description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes — system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed — the hook checks ALL .py files on disk including untracked ones, (9) CI ruff-format hook fails even though local `ruff check` passed — `ruff check` (lint) and `ruff format --check` (formatter) are SEPARATE tools sharing one binary and running only `check` never exercises the formatter, (10) running pre-commit against the full PR diff (every file changed since merge-base) with `--from-ref/--to-ref` not just `--files <current edit>` — a sub-agent's earlier commit can carry stale-formatter content that fails only in CI, (11) adding .editorconfig for cross-editor formatting consistency on non-Python files (YAML, JSON, Markdown, shell, Makefile), (12) an automated PR-reviewer flags lint/formatter/pre-commit-forced incidental churn as scope creep — toolchain-forced churn is exempt from YAGNI/scope review while author-chosen opportunistic work is still flagged, (13) removing a duplicate standalone markdownlint CI job when the lint job already runs pre-commit --all-files — MUST verify the job is NOT a required-check context in branch protection before deleting it, and MUST pre-scan the newly-in-scope files for violations that --fix cannot auto-fix, (14) the pre-commit hook exclude pattern for .claude/ may be LOAD-BEARING (not merely defensive) — confirm with git ls-files .claude/ before removing it; two tracked .md files (.claude/security/guidelines.md and .claude/workflows/development.md) exist in ProjectHephaestus and must remain excluded to match the standalone CI job's intent, (15) after removing a duplicate markdownlint CI job update every doc that names that job by its old CI name (e.g. docs/DEFINITION_OF_DONE.md and .github/README.md) or CI job name references become stale; (16) BOTH the required `lint` check AND the `pre-commit` check are red in a PR — they share the same `ruff format` hook, so a single `ruff format <files>` run clears both; do not debug as two separate problems; (17) adding a commit-msg-stage hook (e.g. conventional-commit validator) — must set `default_install_hook_types: [pre-commit, commit-msg]` in .pre-commit-config.yaml or plain `pre-commit install` silently omits the commit-msg stage and the hook is permanently inert for all contributors; (18) verifying that a commit-msg-stage hook actually fires — `pre-commit run --all-files` does NOT invoke commit-msg-stage hooks; drive them via `pre-commit run --hook-stage commit-msg --commit-msg-filename <file>` instead."
+category: tooling
+date: 2026-06-13
+version: "2.2.0"
+user-invocable: false
+verification: verified-ci
+history: pre-commit-hooks-and-linting-config.history
+tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionlint, hooks, pixi-environment, bandit, markdownlint, sast, ruff-format, editorconfig, pr-diff, ci-parity, pr-review, yagni, commit-msg, default-install-hook-types]
+---
+
+# Pre-commit Hooks and Linting Configuration
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-18 |
+| **Objective** | Canonical single-entry-point for all pre-commit hook and linting advice across the HomericIntelligence ecosystem |
+| **Outcome** | Consolidated from 53 narrow skills; verified-local |
+
+## When to Use
+
+- Writing or amending `.pre-commit-config.yaml` (adding hooks, updating `rev:`, tuning `files:`)
+- Diagnosing CI failures that pass locally (version drift, environment mismatch)
+- Deciding whether to fix or suppress a lint finding (ruff, mypy, bandit, hadolint, shellcheck)
+- Adding a new linter (golangci-lint, yamllint, actionlint, markdownlint-cli2) to a pipeline
+- Reconciling ruff/mypy config across repos (`pyproject.toml` vs `mypy.ini` vs hook args)
+- Investigating pre-commit timing / performance regressions
+- Migrating bandit, golangci-lint (v1->v2), or mypy hook to pixi environment
+- Fixing markdownlint MD060 table formatting issues in bulk
+- Handling stale branches with diverged linter config (rebase strategy)
+- Enforcing no-suppression policy (`continue-on-error: true`, `--exit-zero`)
+- Adding pygrep hook with exclusion logic (language: system over language: pygrep)
+- Setting up per-directory mypy baseline or per-file invocation for hyphenated dirs
+- Ensuring `pass_filenames:` is correct for hook scripts
+- A pre-commit hook using a pixi console script (`hephaestus-check-dep-sync`, etc.) false-fails locally with stricter errors than CI — system-installed package in `~/.local/bin` shadows the pixi default env version; fix with `pixi run dev-install`
+- Unit-testing pre-commit hook regex logic with pytest
+- Pre-commit hook shells out to `pixi run <task>` and reports `command not found` for a package entry point (pixi environment selection)
+- Designing CI workflow that invokes pre-commit when the repo declares multiple pixi environments (e.g. `default` vs `lint`)
+- Bandit SAST hook reports 100+ LOW findings (B404/B603/B607) masking real MEDIUM+ findings — tune `--severity-level medium`
+- A stray agent-prompt artifact file (e.g. `.claude-prompt-NNN.md`) is committed to the repo root and fails markdownlint MD033 due to inline HTML tags (`<NONCE>`, `<LABEL>`) — remove and add `.gitignore` pattern
+- ruff pre-commit fires `I001` (import block unsorted) or `RUF059` (unpacked variable never used) on newly added test functions that contain inline imports or unused tuple returns
+- mypy pre-commit hook fails on an **untracked** test file that references methods not yet in the staged commit — you are doing a multi-commit workflow where commit 2 adds the methods referenced in a test file that is already on disk
+- Ruff B904: "Within an `except` clause, raise exceptions with `raise ... from err`" — bare `raise X(...)` inside `except ImportError`
+- Ruff C901: "`main` is too complex (N > 10)" — inline `main()` function with many branches
+- CI `ruff-format` (or `ruff format --check`) hook failed even though local `pixi run ruff check` passed — `ruff check` (lint) and `ruff format` (style) are SEPARATE tools sharing one binary; running `check` never exercises the formatter
+- You finished a worktree/tooling-driven multi-file edit (Edit calls, codegen, scripted refactors that bypass editor format-on-save) and are about to `git push`
+- Before pushing a PR where one or more sub-agents committed, you need pre-commit to cover the FULL PR diff (every file changed since merge-base), not just the files of your most recent edit
+- Diagnosing CI formatter failures (mojo-format / ruff-format) on files you did not personally edit this session — a sub-agent's `--files`-scoped pre-commit missed them
+- Repository lacks `.editorconfig` and contributors use different editors with inconsistent indentation/whitespace on non-Python files (YAML, JSON, Markdown, shell, Makefile)
+- An automated PR-review agent (or human reviewer) flags lint/formatter/pre-commit-forced incidental churn (whitespace, import-sort, trailing-newline, mypy annotations) as scope creep or YAGNI, or you are designing a review rubric's scope/YAGNI dimension
+- Removing a duplicate standalone markdownlint CI job that runs the same check the `lint` job already runs via `pre-commit run --all-files` — the dedup is correct but three preconditions must hold before deletion: (a) the job name is NOT listed as a required-check context in branch protection, (b) all files that will newly fall under the pre-commit hook's `files:` pattern are pre-scanned for violations that `--fix` cannot auto-fix, (c) every document that names the removed job by its CI name is updated to avoid stale references
+- Verifying that a pre-commit `exclude:` pattern for `.claude/` is defensive vs. load-bearing — run `git ls-files .claude/ | grep '\.md$'` first; if tracked `.md` files exist the exclusion is load-bearing and MUST be preserved (see ProjectHephaestus: `.claude/security/guidelines.md` and `.claude/workflows/development.md`)
+- `gh pr checks` shows BOTH the required `lint` check AND the `pre-commit` check red while everything else (unit-tests, build, integration) is green — both stem from the SAME `ruff format --check` diff; treat as ONE problem, not two
+- A `pre-commit` job fails with "files were modified by this hook" / "N files reformatted" — a formatter hook mutated files in CI's check mode; you must run the formatter and commit the result (pre-commit fails any time a hook changes a file, even with zero lint violations)
+- BOTH the required `lint` job AND the required `pre-commit` job go red together on a Python PR — suspect a SINGLE `ruff format` drift FIRST; both jobs invoke the same formatter so one drift surfaces as two red checks
+- A prior commit hand-wrapped a list/generator comprehension (or call) across multiple lines that fits within `line-length` — `ruff format` collapses it back to one line and `--check` reports "Would reformat"; the author never ran `ruff format` locally
+- Adding a `commit-msg`-stage hook (e.g. conventional-commit-format validator) and discovering it never fires — check whether `default_install_hook_types` is set; without it, plain `pre-commit install` only wires the `pre-commit` stage, leaving the hook permanently inert for every contributor
+- A commit-msg hook appears in `.pre-commit-config.yaml` with `stages: [commit-msg]` and `pre-commit run --all-files` returns green — but the hook has never actually been invoked; `--all-files` skips commit-msg-stage hooks entirely; use `pre-commit run --hook-stage commit-msg --commit-msg-filename <file>` to exercise it
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# --- DAILY COMMANDS ---
+# Run all hooks on all files
+pre-commit run --all-files
+
+# Run a single hook
+pre-commit run <hook-id> --all-files
+
+# Run on staged files only (fastest)
+pre-commit run
+
+# Skip a hook temporarily (document reason)
+SKIP=hook-name git commit -m "message"
+
+# Update all hook revisions to latest
+pre-commit autoupdate
+
+# Install hooks (one-time setup)
+pre-commit install
+
+# --- PIXI ENVIRONMENT (preferred) ---
+pixi run --environment lint pre-commit run --all-files --show-diff-on-failure
+pixi run pre-commit run --all-files
+
+# --- DEBUG CI FAILURES ---
+gh run view <run-id> --log-failed 2>&1 | head -400
+SKIP=mojo-format pixi run pre-commit run --all-files --show-diff-on-failure
+
+# --- VERSION DRIFT CHECK ---
+pixi run python scripts/check_precommit_versions.py
+# Expected: OK: all pre-commit hook versions are consistent with pixi.toml
+
+# --- RUFF (check and format are SEPARATE tools, one binary) ---
+pixi run ruff format .          # FORMATTER: line-wrap/whitespace/quotes (rewrites in place)
+pixi run ruff check --fix .     # LINTER: errors/unused-imports/RUF/F/E/I rules
+# Running `check` does NOT exercise `format` — run BOTH before push. CI checks format separately:
+pixi run --environment lint ruff format --check .   # what CI runs; fails if any file would reflow
+# Exclude generated files in pyproject.toml [tool.ruff] exclude = ["path/_version.py"]
+
+# --- PRE-COMMIT SCOPE BEFORE PUSH (full PR diff, not just current edit) ---
+# Covers EVERY file changed since merge-base, incl. files a sub-agent committed earlier:
+pixi run pre-commit run --from-ref origin/main --to-ref HEAD
+# WRONG before push (literal file list — sub-agent's files skipped):
+pixi run pre-commit run --files train.sh foo.py   # misses other PR-diff files
+# --files is fine DURING dev for the single file you just edited.
+
+# --- MYPY (pixi) ---
+pixi run mypy <path> --explicit-package-bases --python-version 3.10
+# Hyphenated dirs need per-file invocation:
+pixi run python scripts/mypy-each-file.py --ignore-missing-imports --check-untyped-defs
+
+# --- MARKDOWNLINT ---
+pixi run npx markdownlint-cli2 "**/*.md"
+pixi run npx markdownlint-cli2 --fix "**/*.md"
+# Note: MD060 --fix is a silent no-op; write a Python script for bulk table normalization
+
+# --- YAMLLINT ---
+yamllint .github/workflows/ci.yml
+# Fix trailing blank lines (portable):
+python3 -c "
+import sys
+with open(sys.argv[1]) as f: c = f.read()
+with open(sys.argv[1], 'w') as f: f.write(c.rstrip() + '\n')
+" path/to/file.yml
+
+# --- BANDIT ---
+pixi run bandit -r <path> --ini .bandit
+# Always pass --ini .bandit explicitly; bandit only searches target dir, not repo root
+
+# --- GOLANGCI-LINT (v2) ---
+# .golangci.yml must have top-level version: "2"
+golangci-lint run ./...
+
+# --- HADOLINT ---
+# .hadolint.yaml: failure-threshold: error  (not warning)
+
+# --- SHELLCHECK ---
+pre-commit run shellcheck --all-files
+
+# --- ACTIONLINT ---
+pre-commit run actionlint --all-files
+
+# --- COMMIT-MSG STAGE HOOKS ---
+# Wire both stages so plain `pre-commit install` covers pre-commit AND commit-msg:
+# (add to top of .pre-commit-config.yaml)
+# default_install_hook_types: [pre-commit, commit-msg]
+
+# Verify a commit-msg hook fires (--all-files does NOT run commit-msg stage):
+echo "feat: my message" > /tmp/test_commit_msg.txt
+pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/test_commit_msg.txt
+
+# --- LOCK FILE CONFLICT (pre-commit stash) ---
+git add pixi.lock  # Stage lock file before commit to avoid stash conflict
+git commit -m "your message"
+
+# --- STALE BRANCH REBASE ---
+git fetch --all
+git rebase origin/main
+git push --force-with-lease origin <stale-branch>
+
+# --- PRE-COMMIT FORMATTER RE-STAGE ---
+# After hook modifies files, re-stage and commit again (never --no-verify)
+git add <files>
+git commit --amend --no-edit  # if not yet pushed
+```
+
+### Detailed Steps
+
+#### Adding a new linter (single-source-of-truth pattern)
+
+1. Add the linter entry ONLY to `.pre-commit-config.yaml`.
+2. CI runs `pixi run --environment lint pre-commit run --all-files --show-diff-on-failure` -- same command as local.
+3. Test locally: `pre-commit run <hook-id> --all-files`.
+4. Update `rev:` to exactly match `pixi run <tool> --version` output (no semver ranges).
+5. Run `scripts/check_precommit_versions.py` to confirm no drift.
+
+#### Fixing version drift (CI vs local mismatch)
+
+1. Run `pixi run <tool> --version` to get installed version.
+2. Update `rev:` in `.pre-commit-config.yaml` to exact matching tag.
+3. Never use semver ranges in `rev:`; always exact git tags.
+4. For JS tools (markdownlint-cli2): npm and conda-forge version numbers differ -- exclude from drift tracking.
+
+#### Migrating bandit from pygrep to AST hook
+
+1. Replace pygrep hook with `bandit -r <dirs> -ll --ini .bandit`.
+2. Move `--skip` flags from CLI to `.bandit` ini file (adds comments explaining each skip).
+3. Create `pixi run bandit` task using same ini.
+4. Pre-scan new directories before extending `files:` pattern.
+
+#### golangci-lint v1 to v2 migration
+
+1. Add `version: "2"` to `.golangci.yml` top-level.
+2. Rename `linters-settings` to `linters.settings`.
+3. Add `linters.default: none` to disable v2 default fastset.
+4. Use `golangci/golangci-lint-action@v6` with `version: latest` in CI (not pinned Docker image).
+5. Fix all new findings -- do not suppress via `issues.exclude-rules`.
+
+#### mypy with pixi and hyphenated directories
+
+1. Add `mirrors-mypy` hook with `additional_dependencies: [types-PyYAML, ...]`.
+2. For hyphenated dirs (`alexnet-cifar10/`): use `scripts/mypy-each-file.py` wrapper.
+3. Use `mypy.ini` for overrides (auto-discovered); avoid `pyproject.toml` for hook config.
+4. Run with `--explicit-package-bases --python-version 3.10`.
+
+#### No-suppression policy
+
+- Forbidden: `continue-on-error: true`, `|| true` (in CI), `--exit-zero`, `--exit-code 0`, `--no-fail`
+- Advisory `::warning::` wrappers also forbidden (v2.0.0+ runbook)
+- Legitimate non-blocking: `echo "WARN:"` to stdout only
+- `|| true` in test helpers: refactor to captured-rc pattern: `_rc=0; cmd || _rc=$?`
+
+#### pygrep hook with exclusion logic
+
+Use `language: system` (not `language: pygrep`) when exclusion is needed:
+
+```yaml
+- id: ban-dunder-call-sites
+  name: Ban dunder call sites
+  entry: bash -c 'grep -rnP "pattern" "$@" | grep -v "exclusion" && exit 1 || exit 0' --
+  language: system
+  files: \.mojo$
+  pass_filenames: true
+```
+
+#### Pixi environment selection for hooks that invoke `pixi run <task>`
+
+When a repository declares multiple pixi environments (e.g. `default` with the editable package install + dev tools, and `lint` with just ruff/mypy), `pixi run <task>` resolves the environment from the **current shell state**, not from `pixi.toml` task defaults. This bites in two places:
+
+1. **Local pre-commit invocation** — if a developer starts pre-commit from inside an env that does not have the package installed (`pixi run --environment lint pre-commit run`), every hook that shells out to a package console script (`pixi run hephaestus-check-dep-sync`) inherits the `lint` env and fails with `command not found`.
+2. **CI workflow** — running `pre-commit run --all-files` after `pixi install --environment default` is not enough on its own when the package itself is not declared as a self-dependency. The package's editable install must be explicit (`pixi run dev-install` -> `pip install -e . --no-deps`) so console scripts resolve.
+
+Two rules:
+
+1. **Every pre-commit hook that shells out to a package entry point MUST pin the environment explicitly:**
+
+   ```yaml
+   - id: check-dep-sync
+     name: Check dependency sync
+     entry: pixi run --environment default hephaestus-check-dep-sync
+     language: system
+     pass_filenames: false
+   ```
+
+   Never write `entry: pixi run hephaestus-check-dep-sync` — the env is whatever shell happens to be active when pre-commit fires.
+
+2. **CI must install the package into the default env before running pre-commit:**
+
+   ```yaml
+   # .github/workflows/pre-commit.yml
+   - run: pixi install --environment default
+   - run: pixi run dev-install          # pip install -e . --no-deps
+   - run: pre-commit run --all-files
+   ```
+
+   `pixi install` installs declared deps but does NOT install the host package itself (especially once the self-reference is removed from `pyproject.toml` to stop lockfile churn). Skipping `dev-install` means console scripts will not exist for hooks to call.
+
+Verified by ProjectHephaestus PRs #483, #526, and #532.
+
+#### markdownlint MD060 bulk table fix
+
+```python
+# MD060 --fix is a silent no-op; two-pass fix required:
+# Pass 1: normalize separator rows
+# Pass 2: strip wide padding from header/data cells
+python3 scripts/fix_md_tables.py --all
+# Then lint the script itself:
+ruff check --fix scripts/fix_md_tables.py
+```
+
+#### Removing a duplicate standalone markdownlint CI job (dedup to pre-commit)
+
+When a repo has both a standalone `markdownlint` CI job (e.g. in `_required.yml`) AND a `lint`
+job that already runs `pre-commit run --all-files` (which includes a markdownlint hook), the
+standalone job is pure duplication. Consolidating to pre-commit as the single source of truth is
+correct — but two preconditions MUST be verified before deleting the job:
+
+**Precondition 1 — Confirm the job is NOT a required-check context.**
+
+```bash
+# Check branch protection rulesets for the exact job name:
+gh api repos/{owner}/{repo}/rulesets --jq '.[].conditions'
+gh api repos/{owner}/{repo}/branches/main/protection/required_status_checks \
+  --jq '.checks[].context' 2>/dev/null
+# OR check the GitHub repository Settings → Branches → Protection rules UI.
+# If "markdownlint" (or the exact job name) appears in the required contexts list,
+# removing the job will BLOCK every PR indefinitely (ci-driver-blocked-required-context-drift).
+# Fix: remove the context from the ruleset BEFORE or simultaneously with deleting the job.
+```
+
+**Precondition 2 — Pre-scan newly-in-scope files for violations `--fix` cannot auto-fix.**
+
+When the pre-commit hook's `files:` pattern is widened to cover new directories (e.g. `docs/*.md`
+that the old standalone job covered but the hook did not), run `--fix` first and check for
+residual violations:
+
+```bash
+# Dry-run fix on newly-in-scope files:
+pixi run npx markdownlint-cli2 --fix "docs/**/*.md"
+# Then check whether any violations remain:
+pixi run npx markdownlint-cli2 "docs/**/*.md"
+# If violations remain after --fix, CI will immediately fail after the scope change.
+# Fix them manually before merging (see MD060 bulk table fix section for tables).
+```
+
+**Safe deletion checklist:**
+
+1. `grep -n 'needs:' .github/workflows/_required.yml` — confirm zero jobs depend on the standalone job (safe DAG deletion).
+2. Verify the job name is absent from all required-check contexts (Step 1 above).
+3. Pre-scan newly-in-scope files (Step 2 above); fix all residual violations.
+4. Check whether the hook's `exclude:` pattern covers `.claude/`: run `git ls-files .claude/ | grep '\.md$'` — if results exist the exclusion is load-bearing and MUST be preserved (see `.claude/` exclusion note below).
+5. Widen the hook's `exclude:` pattern in `.pre-commit-config.yaml` to NOT exclude the files the old job covered (or verify it already doesn't exclude them).
+6. Delete the job block from the workflow file.
+7. Update every documentation file that names the removed job by its CI job name (e.g. `docs/DEFINITION_OF_DONE.md:31` "CI job `markdownlint`" → "CI job `lint`"; `.github/README.md:44` aggregated-checks list). Stale job-name references in docs are a recurring pain point discovered in ProjectHephaestus issue #1199.
+8. Run `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` locally before push.
+
+**Note on `.claude/` exclusion in pre-commit hooks:** pre-commit only runs against git-tracked
+files. Excluding `.claude/` from the hook's `exclude:` pattern can be either defensive OR
+load-bearing — you MUST verify before removing it:
+
+```bash
+# Determine if the exclusion is load-bearing:
+git ls-files .claude/ | grep '\.md$'
+```
+
+If the command returns any paths (e.g. `.claude/security/guidelines.md`,
+`.claude/workflows/development.md`), the exclusion is **load-bearing**: removing it would
+bring those files into markdownlint scope and change the effective lint surface to be wider
+than the standalone job ever covered. Keep the exclusion unless you intentionally want to
+lint `.claude/` files. Only treat the exclusion as "defensive" (safe to remove) when
+`git ls-files .claude/ | grep '\.md$'` returns nothing.
+
+**ProjectHephaestus-specific:** As of 2026-06-13, `git ls-files .claude/ | grep '\.md$'`
+returns `.claude/security/guidelines.md` and `.claude/workflows/development.md` — both
+tracked. The exclusion is load-bearing.
+
+**Verification (fragile grep criterion):** a post-change grep like
+`grep -c 'markdownlint' .github/workflows/_required.yml` to assert a specific count is fragile
+if the edit also changes a step name that contains "markdownlint" elsewhere in the file. Verify
+the expected count matches actual state after ALL edits are applied.
+
+Partially verified (planning phase, 2026-06-13): docs/*.md pre-scan confirmed 0 violations with markdownlint-cli2; .claude/ exclusion confirmed load-bearing (two tracked .md files); doc-drift targets identified (docs/DEFINITION_OF_DONE.md:31, .github/README.md:44). Implementation (job deletion + pre-commit-config.yaml edit) not yet executed — verified-ci pending PR merge for ProjectHephaestus issue #1199.
+
+#### Bandit SAST severity-level tuning (silence LOW noise without disabling checks)
+
+When a new bandit hook is added (e.g. via a CI improvement PR), it commonly reports 100+ LOW
+findings — mostly B404 (subprocess import), B603/B607 (subprocess call/exec), B311 (random
+jitter), and B101 (assert). These LOW findings drown out real MEDIUM/HIGH issues. The correct
+fix is to add `--severity-level medium` to the pixi task (not the hook) so the threshold
+applies both locally and in CI:
+
+```toml
+# pixi.toml
+[tasks]
+sast = { cmd = "bandit -r hephaestus scripts -ll --severity-level medium --ini .bandit" }
+```
+
+For each remaining MEDIUM+ finding, decide per finding:
+- `# nosec BXXX -- <one-line rationale>` for false positives (e.g. B310 urlopen on a
+  hardcoded HTTPS URL; B301 pickle.load on MD5-verified CIFAR data)
+- `contextlib.suppress(...)` instead of bare `except ...: pass`
+- Real fix for anything that is a genuine security issue
+
+Do NOT blanket-suppress via `--skip` flags. Always add rationale comments for `# nosec`.
+
+Verified by ProjectHephaestus PR #657.
+
+#### mypy pre-commit failure on untracked test file (multi-commit workflow)
+
+When creating two atomic commits (e.g., commit 1 = implementation, commit 2 = tests that use the new API), mypy runs on ALL `.py` files on disk — including **untracked** files — not just the staged files. If commit 2's test file is already on disk when you attempt commit 1, mypy sees it, notices methods it references do not exist yet, and fails with `attr-defined` or `module-attribute` errors.
+
+**Workaround (verified):** temporarily move the untracked test file out of the worktree before commit 1, then restore it for commit 2.
+
+```bash
+# Before commit 1 (implementation only):
+cp tests/unit/foo/test_new_feature.py /tmp/test_new_feature_backup.py
+rm tests/unit/foo/test_new_feature.py
+
+# Create commit 1 — mypy no longer sees the untracked test file
+git add hephaestus/foo/new_feature.py tests/unit/foo/test_existing.py
+git commit -S -m "feat(foo): add new_feature"
+
+# Restore test file for commit 2:
+cp /tmp/test_new_feature_backup.py tests/unit/foo/test_new_feature.py
+git add hephaestus/foo/new_feature.py tests/unit/foo/test_new_feature.py
+git commit -S -m "test(foo): cover new_feature"
+```
+
+Two caveats:
+1. This only works in a **worktree** (not the main checkout) — move the file to `/tmp`, not to another path inside the same repo.
+2. The pre-commit hook may also stash unstaged changes; confirm the stash restore completed cleanly after commit 1.
+
+Alternatively, refactor the two commits so the test file only references methods that exist in the same commit. This is cleaner but not always possible when task requirements impose atomic commit ordering.
+
+Verified by ProjectHephaestus PR #670 (Issues #615/#616).
+
+#### Removing stray agent-prompt artifact files (markdownlint MD033 fix)
+
+Agent-prompt artifacts like `.claude-prompt-NNN.md` are occasionally committed to the repo
+root when CI scaffolding runs. They fail MD033 (no-inline-html) because they contain tags
+like `<NONCE>` and `<LABEL>`. The fix:
+
+```bash
+# 1. Confirm the file is an accident (check recent git log)
+git log --oneline -- .claude-prompt-NNN.md
+
+# 2. Confirm nothing references it
+grep -rn 'claude-prompt-NNN' .
+
+# 3. Remove and add gitignore entry
+git rm .claude-prompt-NNN.md
+echo '/.claude-prompt-*.md' >> .gitignore
+```
+
+Add the `.gitignore` pattern BEFORE the next CI run to prevent recurrence.
+
+Verified by ProjectHephaestus PR #657.
+
+#### `ruff check` vs `ruff format` — the pre-commit trap
+
+`ruff` ships TWO subcommands sharing one binary and one config (`pyproject.toml [tool.ruff]`)
+but enforcing ORTHOGONAL rule sets: `ruff check` is the **linter** (errors, unused imports,
+import order, RUF/F/E/I); `ruff format` is the **formatter** (line wrap, whitespace, quote
+style). Running one tells you nothing about the other. Pre-commit registers `ruff-check`
+and `ruff-format` as SEPARATE hooks; `ruff-format` runs in check/diff mode in CI and fails
+if any file *would* be reformatted.
+
+**The trap:** an agent edits Python via tooling, runs `ruff check`/`mypy`/`pytest` locally
+(all green), pushes — and CI's `ruff-format` fails with `Would reformat: <file>` (a
+multi-line signature the formatter collapses under the 100-col limit). The local gates never
+invoked `ruff format`; editor format-on-save does not help because tooling edits bypass the
+editor (no save event). Fix: run the **4-command pre-push sequence** — `ruff format` →
+`ruff check` → `mypy` → `pre-commit run --files <touched>` (see Quick Reference). Commit the
+reflow as a dedicated `style(ruff):` commit (never `--amend` once pushed). Never delete the
+`ruff-format` hook believing `ruff check` covers it.
+
+Verified by ProjectHephaestus PRs #707 and #913 (local `ruff check`/pytest/pre-push all
+green, CI `ruff-format` still failed).
+
+#### Pre-commit scope before push: full PR diff, not the current edit
+
+`pre-commit run --files X Y Z` runs each hook on the LITERAL list `[X, Y, Z]`; the installed
+git hook runs only on STAGED files. So if a sub-agent committed file `A` and you commit file
+`B`, neither commit's hook saw the other under the current formatter baseline — two partial
+checks ≠ full coverage, and a sub-agent's `model.mojo` can pass its per-file pre-commit yet
+fail CI mojo-format after your fixup push. Canonical pre-push check (full PR diff at PR-diff
+cost): `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` (see Quick Reference).
+Prefer it over `--all-files` (slow → engineers fall back to `--files`) and over
+`--files <recent edits>` (misses sub-agent files). If hooks rewrite files, `git add` and
+make a NEW commit (never `--no-verify`/`--amend` on shared history); then `gh pr checks
+--watch` for CI-only validators.
+
+**Decision matrix:**
+
+| Scenario | Command |
+| ---------- | --------- |
+| During dev, after editing one file | `pre-commit run --files <file>` |
+| Before `git push` of a PR | `pre-commit run --from-ref origin/main --to-ref HEAD` |
+| After upgrading a formatter/hook version, or onboarding to a repo | `pre-commit run --all-files` (baseline changed) |
+
+If a sub-agent reports a `SKIP=hook-id` bypass (e.g. `SKIP=mojo-format` on older-GLIBC
+hosts), the orchestrator MUST re-run that hook against the full PR diff before pushing.
+
+Verified by ProjectOdyssey PR #5453 (sub-agent's `.mojo` files passed per-file pre-commit,
+failed CI mojo-format; full-diff scope fixed it).
+
+#### Adding `.editorconfig` for cross-editor consistency
+
+`.editorconfig` configures the editor *before* you type (indent, line endings, trailing
+whitespace, final newline) for ALL file types — complementary to ruff/black (which fix
+Python *after* save) and `.gitattributes` (which normalizes at the git layer). Add one
+when the repo lacks it or non-Python files (YAML, JSON, Markdown, shell, Makefile) have no
+formatting standard. Always set `root = true` (stops parent-dir search). Critically, set
+`trim_trailing_whitespace = false` for Markdown — two trailing spaces create a `<br>` line
+break. Makefiles MUST use tabs. Template in Results & Parameters.
+
+Verified by ProjectScylla PR #1556 (audit finding S13).
+
+#### Exempting toolchain-forced churn from PR-review scope/YAGNI rubrics
+
+When an automated PR-review agent enforces a scope/YAGNI rule ("flag scope creep,
+opportunistic refactors"), an unbounded "flag everything" rule fights the linter: it
+demands removal of CI-required edits (whitespace, import-sort, trailing-newline, mypy
+annotations) the toolchain *forced* to land the change. The carve-out is intent-based, not
+size-based — *who chose the change*:
+
+- **ACCEPTABLE (stay silent):** toolchain-FORCED churn — formatter/whitespace, import
+  sorting, trailing-newline, mypy-required annotations, lint/pre-commit auto-fixes — on
+  files the change already touches.
+- **STILL FLAG:** author-CHOSEN work — opportunistic refactors, unrelated rewrites,
+  "while we're here" features, dependency bumps that weren't asked for, config knobs
+  without a consumer.
+- **Key principle:** *"The test is intent, not size: churn the toolchain requires is fine;
+  churn the author chose is a finding."*
+
+A scope rule feeding multiple per-stage rubrics is almost always DUPLICATED (ProjectHephaestus:
+`_SEVEN_PRINCIPLES_DIMENSIONS` P2, `_PR_STRICT_RUBRIC_DIMENSIONS` D2, `_IMPL_LOOP_STRICT_RUBRIC`
+dim 6); a per-stage copy overrides the shared carve-out, so apply the SAME carve-out to all
+blocks. TDD both directions: assert carve-out language is present (anchor on stable substrings
+like `pre-commit`, `toolchain`, `opportunistic`) AND that scope-creep detection is retained.
+
+Verified by ProjectHephaestus PR #1019 (closes #1017; false positive originated from
+PR #1015 inline comment r3366637812).
+
+#### commit-msg-stage hooks and `default_install_hook_types`
+
+A hook declared with `stages: [commit-msg]` is **silently inert** for every contributor who
+runs the documented `pre-commit install` command unless `default_install_hook_types` is set
+in `.pre-commit-config.yaml`. By default, `pre-commit install` only wires the `pre-commit`
+stage. The commit-msg hook exists in the config file, pre-commit shows no warnings, and
+`pre-commit run --all-files` returns green — but the hook has never fired for anyone.
+
+**The fix — one line at the top of `.pre-commit-config.yaml`:**
+
+```yaml
+# .pre-commit-config.yaml
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  # ... existing hooks ...
+  - repo: local
+    hooks:
+      - id: conventional-commit
+        name: Validate conventional commit format
+        language: system
+        entry: python3 scripts/check_commit_msg.py
+        stages: [commit-msg]
+        pass_filenames: true   # pre-commit passes the commit-msg file as $1
+```
+
+After adding `default_install_hook_types`, every developer who runs `pre-commit install`
+(or re-runs it) gets both stages wired. Developers who installed before the change must
+re-run `pre-commit install` once to pick up the commit-msg stage.
+
+**Verifying the hook fires (the `--all-files` trap):**
+
+`pre-commit run --all-files` does **NOT** run commit-msg-stage hooks — the framework skips
+any hook whose `stages` list does not include the currently-active stage. A green
+`--all-files` run is NOT evidence that a commit-msg hook works. Drive it explicitly:
+
+```bash
+# Write a test commit message to a temp file:
+echo "feat: add conventional commit validator" > /tmp/test_commit_msg.txt
+
+# Invoke only the commit-msg stage (works even without a real commit in flight):
+pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/test_commit_msg.txt
+
+# Expected: hook id listed, "Passed" if the message is valid
+# Also test an invalid message:
+echo "bad commit message without type" > /tmp/bad_commit_msg.txt
+pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/bad_commit_msg.txt
+# Expected: hook id listed, "Failed" and error output from the validator script
+```
+
+**Commit-msg validator hook YAML pattern:**
+
+```yaml
+- repo: local
+  hooks:
+    - id: conventional-commit
+      name: Validate conventional commit format
+      language: system
+      entry: python3 scripts/check_commit_msg.py
+      stages: [commit-msg]
+      pass_filenames: true
+```
+
+Use `language: system` (not `language: python` or `language: script`) so the hook runs in
+the project's ambient Python environment (pixi, venv, etc.). Use `pass_filenames: true` —
+pre-commit passes the commit-msg file path as `sys.argv[1]`; the script reads it with
+`Path(sys.argv[1]).read_text()`.
+
+**Ruff D301 — raw-string docstring when the string contains escape sequences:**
+
+If the commit-msg validator script contains a docstring with `\n` or other backslash
+sequences, ruff flags D301: "Use `r\"\"\"` if any backslashes in a docstring". Convert the
+docstring to a raw string:
+
+```python
+# Before (ruff D301):
+def check(msg: str) -> bool:
+    """Validate message.\n\nReturns True if valid."""
+    ...
+
+# After:
+def check(msg: str) -> bool:
+    r"""Validate message.\n\nReturns True if valid."""
+    ...
+```
+
+**"Your pre-commit configuration is unstaged" abort:**
+
+If `.pre-commit-config.yaml` is modified but not yet staged, pre-commit may abort with:
+
+```
+Your pre-commit configuration is unstaged.
+`git add .pre-commit-config.yaml` to fix this.
+```
+
+This occurs because pre-commit reads the config from the index (staged version), not the
+working tree. Stage the config file before running hooks:
+
+```bash
+git add .pre-commit-config.yaml
+pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/test_commit_msg.txt
+```
+
+**`core.hooksPath` note — blocked `install` does not block `--hook-stage` verification:**
+
+In repos where `git config core.hooksPath` is set to a non-standard path (e.g. a shared
+hooks directory), `pre-commit install` may fail or install hooks to the wrong location.
+This does NOT prevent `--hook-stage` invocation: `pre-commit run --hook-stage commit-msg`
+bypasses the git hook installation entirely and invokes the framework directly. Use it for
+verification even when `install` is blocked.
+
+Verified by closed PR #2353 (HomericIntelligence/ProjectMnemosyne).
+
+## Hook-Specific Patterns
+
+### detect-private-key: False Positive Handling
+
+Use when `detect-private-key` fires on files that contain fake/test credentials (TLS unit tests,
+Kubernetes secret manifests, example certs). Do **not** delete the hook — that would miss real
+leaks. Use `exclude:` to scope it.
+
+**Trigger conditions**:
+
+- `detect-private-key` hook false-fires on test fixtures, TLS unit tests, or k8s secret manifests
+  containing fake/test PEM headers (`BEGIN CERTIFICATE`, `BEGIN PRIVATE KEY`, `BEGIN RSA PRIVATE KEY`,
+  `BEGIN EC PRIVATE KEY`, `BEGIN CERTIFICATE REQUEST`).
+
+**Quick Reference**:
+
+```yaml
+# .pre-commit-config.yaml — under detect-private-key hook entry:
+- id: detect-private-key
+  exclude: '^(k8s/metrics-security\.yaml|tests/unit/test_grpc_tls\.cpp)$'
+```
+
+For broader exclusions (test directories, example certs, k8s secret patterns):
+
+```yaml
+- id: detect-private-key
+  exclude: '^(tests/|fixtures/|examples/|k8s/.*-secret.*\.yaml|k8s/.*-security.*\.yaml)$'
+```
+
+**Step-by-step**:
+
+1. **Identify flagged files** — read CI log from the `detect-private-key` hook; it lists each triggering path.
+2. **Confirm they are test fixtures** — verify the file is a unit test, example cert, generated credential, or Kubernetes manifest. If it contains real credentials, fix that instead of excluding.
+3. **Locate the hook entry** in `.pre-commit-config.yaml` — find the `repo: https://github.com/pre-commit/pre-commit-hooks` block and `- id: detect-private-key`.
+4. **Add `exclude:` directly under the hook id** — value is a Python regex anchored with `^...$`.
+5. **Escape regex metacharacters**: forward slashes `/` do not need escaping; dots `.` in filenames must be escaped as `\.`.
+6. **Verify locally**: `pre-commit run detect-private-key --all-files` — excluded files should pass; all other paths still checked.
+7. **Commit** — `.pre-commit-config.yaml` is in version control; CI picks it up automatically.
+
+**Regex rules for the `exclude:` field**:
+
+| Pattern | Matches |
+| --------- | --------- |
+| `^path/to/file\.ext$` | Exact file |
+| `^(file1\.yaml\|file2\.cpp)$` | Either of two exact files |
+| `^tests/` | All files under `tests/` |
+| `^k8s/.*-secret.*\.yaml$` | Any k8s YAML with `-secret` in the name |
+| `^k8s/.*-security.*\.yaml$` | Any k8s YAML with `-security` in the name |
+
+**Typical PEM patterns that trigger false positives in test files**:
+
+```
+-----BEGIN CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+-----BEGIN RSA PRIVATE KEY-----
+-----BEGIN EC PRIVATE KEY-----
+-----BEGIN CERTIFICATE REQUEST-----
+```
+
+These appear in TLS unit tests (`test_grpc_tls.cpp`, `test_tls_*.py`) and Kubernetes secret manifests
+that embed cert/key material as base64 or raw PEM for local dev environments.
+
+**Failed attempts for this pattern**:
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Delete the hook entirely | Remove `detect-private-key` from `.pre-commit-config.yaml` | Would miss real credential leaks in non-test paths — eliminates security value | Use `exclude:` to scope the hook, never remove it entirely |
+| Move test files to a different path | Rename `tests/unit/test_grpc_tls.cpp` to avoid detection | Disrupts test structure and doesn't scale for k8s manifests | Path-based `exclude:` is correct; don't relocate files to satisfy a hook |
+| Add `# noqa` or inline ignore comments | Tried per-line directives in C++ source | `detect-private-key` is a grep-based hook — inline suppressions not supported | Hook-level `exclude:` is the only supported suppression mechanism |
+
+### Go-Based Hook: Pre-Built Binary Download
+
+Use when a Go-based pre-commit hook (e.g., gitleaks) fails to build from source because the
+system Go version is too old for the hook's `go.mod` requirement.
+
+**Trigger conditions**:
+
+- A Go-based hook fails to build from source because system Go version is too old (e.g., system
+  Go 1.15 vs hook requirement Go 1.24.11).
+- pre-commit with `language: golang` reports "invalid go version" or Go compilation errors for a
+  hook that worked previously.
+
+**Fix**: Convert from `language: golang` (builds from source) to a `repo: local` hook that
+downloads the pre-built binary release:
+
+```yaml
+# AFTER (downloads pre-built binary):
+- repo: local
+  hooks:
+    - id: gitleaks
+      name: Gitleaks Secret Scan
+      entry: bash -c 'GITLEAKS_VERSION="8.30.1"; GITLEAKS_BIN="$HOME/.local/bin/gitleaks"; if [ ! -x "$GITLEAKS_BIN" ]; then mkdir -p "$HOME/.local/bin" && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C "$HOME/.local/bin" gitleaks; fi && "$GITLEAKS_BIN" protect --staged'
+      language: system
+      pass_filenames: false
+```
+
+**Key design decisions**:
+
+- Binary is cached at `$HOME/.local/bin/gitleaks` — only downloaded once
+- `curl -sSfL` fails fast on HTTP errors (`-f`) and follows redirects (`-L`)
+- `pass_filenames: false` because gitleaks scans the git diff, not individual files
+- Version is pinned inline — update the `GITLEAKS_VERSION` string when upgrading
+
+This pattern applies to any Go-based hook where the system Go is too old and upgrading Go is not
+feasible (e.g., constrained CI environments, conda-forge only providing old Go versions).
+
+#### lint + pre-commit dual failure: one `ruff format` clears both gates
+
+When `gh pr checks` shows EXACTLY two red checks — the required `lint` check and the
+`pre-commit` check — with everything else green, do NOT debug them as two independent
+failures. In a pixi-based repo (ProjectHephaestus) they share a single formatter root cause:
+
+- The `lint` job runs `pixi run --environment lint ruff format --check hephaestus scripts tests`.
+  Its log shows `Would reformat: <file>` for each file that would reflow.
+- The `pre-commit` job runs `pixi run --environment lint pre-commit run --all-files --show-diff-on-failure`.
+  Its `Ruff Format Python` hook fails with **"files were modified by this hook / N files
+  reformatted, M files left unchanged"** — the SAME files. Pre-commit fails any time a hook
+  *modifies* files, even when there are zero lint *violations*: formatters mutate-and-exit-0
+  locally, but in CI's check/diff mode the framework reports the modification as a failure.
+
+**Root cause is almost always a manual edit that bypassed the formatter** — e.g. a prior
+commit hand-wrapped a list/generator comprehension across multiple lines; `ruff format`
+collapses each onto a single line under the 100-col limit. The manual wrapping was never run
+through the formatter, so the formatter "wants" to reformat → both gates red.
+
+**One command fixes both** (run the formatter, then commit the pure-whitespace reflow):
+
+```bash
+# Reformat exactly the files the lint log named under "Would reformat:"
+pixi run --environment lint ruff format hephaestus/automation/ensure_state_labels.py \
+                                         hephaestus/automation/loop_runner.py
+# Result: "2 files reformatted" → e.g. 2 files changed, 2 insertions(+), 8 deletions(-)
+#         (pure line-wrap/whitespace — ZERO logic change)
+
+# Verify BOTH gates locally before committing:
+pixi run --environment lint ruff format --check hephaestus scripts tests   # lint gate
+pixi run --environment lint pre-commit run --all-files                      # pre-commit gate
+```
+
+The fix is mechanical (whitespace/line-wrap), never a logic change — review it as such.
+After any manual edit to Python, run `pixi run --environment lint ruff format <files>`
+(or just `pre-commit run --all-files`, which runs the same Ruff Format/Check hooks CI uses)
+BEFORE committing. Never hand-wrap an expression and assume it is fine.
+
+Verified by ProjectHephaestus PR #1058 (issue #814): `gh pr checks 1058` showed `lint` and
+`pre-commit` red on the same two-file `ruff format --check` diff; one `ruff format` run
+turned both green.
+
+#### Pre-commit scope before push: full PR diff, not the current edit
+
+`pre-commit run --files X Y Z` runs each hook on the LITERAL list `[X, Y, Z]`; the installed
+git hook runs only on STAGED files. So if a sub-agent committed file `A` and you commit file
+`B`, neither commit's hook saw the other under the current formatter baseline — two partial
+checks ≠ full coverage, and a sub-agent's `model.mojo` can pass its per-file pre-commit yet
+fail CI mojo-format after your fixup push. Canonical pre-push check (full PR diff at PR-diff
+cost): `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` (see Quick Reference).
+Prefer it over `--all-files` (slow → engineers fall back to `--files`) and over
+`--files <recent edits>` (misses sub-agent files). If hooks rewrite files, `git add` and
+make a NEW commit (never `--no-verify`/`--amend` on shared history); then `gh pr checks
+--watch` for CI-only validators.
+
+**Decision matrix:**
+
+| Scenario | Command |
+| ---------- | --------- |
+| During dev, after editing one file | `pre-commit run --files <file>` |
+| Before `git push` of a PR | `pre-commit run --from-ref origin/main --to-ref HEAD` |
+| After upgrading a formatter/hook version, or onboarding to a repo | `pre-commit run --all-files` (baseline changed) |
+
+If a sub-agent reports a `SKIP=hook-id` bypass (e.g. `SKIP=mojo-format` on older-GLIBC
+hosts), the orchestrator MUST re-run that hook against the full PR diff before pushing.
+
+Verified by ProjectOdyssey PR #5453 (sub-agent's `.mojo` files passed per-file pre-commit,
+failed CI mojo-format; full-diff scope fixed it).
+
+#### Adding `.editorconfig` for cross-editor consistency
+
+`.editorconfig` configures the editor *before* you type (indent, line endings, trailing
+whitespace, final newline) for ALL file types — complementary to ruff/black (which fix
+Python *after* save) and `.gitattributes` (which normalizes at the git layer). Add one
+when the repo lacks it or non-Python files (YAML, JSON, Markdown, shell, Makefile) have no
+formatting standard. Always set `root = true` (stops parent-dir search). Critically, set
+`trim_trailing_whitespace = false` for Markdown — two trailing spaces create a `<br>` line
+break. Makefiles MUST use tabs. Template in Results & Parameters.
+
+Verified by ProjectScylla PR #1556 (audit finding S13).
+
+#### Exempting toolchain-forced churn from PR-review scope/YAGNI rubrics
+
+When an automated PR-review agent enforces a scope/YAGNI rule ("flag scope creep,
+opportunistic refactors"), an unbounded "flag everything" rule fights the linter: it
+demands removal of CI-required edits (whitespace, import-sort, trailing-newline, mypy
+annotations) the toolchain *forced* to land the change. The carve-out is intent-based, not
+size-based — *who chose the change*:
+
+- **ACCEPTABLE (stay silent):** toolchain-FORCED churn — formatter/whitespace, import
+  sorting, trailing-newline, mypy-required annotations, lint/pre-commit auto-fixes — on
+  files the change already touches.
+- **STILL FLAG:** author-CHOSEN work — opportunistic refactors, unrelated rewrites,
+  "while we're here" features, dependency bumps that weren't asked for, config knobs
+  without a consumer.
+- **Key principle:** *"The test is intent, not size: churn the toolchain requires is fine;
+  churn the author chose is a finding."*
+
+A scope rule feeding multiple per-stage rubrics is almost always DUPLICATED (ProjectHephaestus:
+`_SEVEN_PRINCIPLES_DIMENSIONS` P2, `_PR_STRICT_RUBRIC_DIMENSIONS` D2, `_IMPL_LOOP_STRICT_RUBRIC`
+dim 6); a per-stage copy overrides the shared carve-out, so apply the SAME carve-out to all
+blocks. TDD both directions: assert carve-out language is present (anchor on stable substrings
+like `pre-commit`, `toolchain`, `opportunistic`) AND that scope-creep detection is retained.
+
+Verified by ProjectHephaestus PR #1019 (closes #1017; false positive originated from
+PR #1015 inline comment r3366637812).
+
+## Hook-Specific Patterns (Ruff Format Reference)
+
+### detect-private-key: False Positive Handling
+
+Use when `detect-private-key` fires on files that contain fake/test credentials (TLS unit tests,
+Kubernetes secret manifests, example certs). Do **not** delete the hook — that would miss real
+leaks. Use `exclude:` to scope it.
+
+**Trigger conditions**:
+
+- `detect-private-key` hook false-fires on test fixtures, TLS unit tests, or k8s secret manifests
+  containing fake/test PEM headers (`BEGIN CERTIFICATE`, `BEGIN PRIVATE KEY`, `BEGIN RSA PRIVATE KEY`,
+  `BEGIN EC PRIVATE KEY`, `BEGIN CERTIFICATE REQUEST`).
+
+**Quick Reference**:
+
+```yaml
+# .pre-commit-config.yaml — under detect-private-key hook entry:
+- id: detect-private-key
+  exclude: '^(k8s/metrics-security\.yaml|tests/unit/test_grpc_tls\.cpp)$'
+```
+
+For broader exclusions (test directories, example certs, k8s secret patterns):
+
+```yaml
+- id: detect-private-key
+  exclude: '^(tests/|fixtures/|examples/|k8s/.*-secret.*\.yaml|k8s/.*-security.*\.yaml)$'
+```
+
+**Step-by-step**:
+
+1. **Identify flagged files** — read CI log from the `detect-private-key` hook; it lists each triggering path.
+2. **Confirm they are test fixtures** — verify the file is a unit test, example cert, generated credential, or Kubernetes manifest. If it contains real credentials, fix that instead of excluding.
+3. **Locate the hook entry** in `.pre-commit-config.yaml` — find the `repo: https://github.com/pre-commit/pre-commit-hooks` block and `- id: detect-private-key`.
+4. **Add `exclude:` directly under the hook id** — value is a Python regex anchored with `^...$`.
+5. **Escape regex metacharacters**: forward slashes `/` do not need escaping; dots `.` in filenames must be escaped as `\.`.
+6. **Verify locally**: `pre-commit run detect-private-key --all-files` — excluded files should pass; all other paths still checked.
+7. **Commit** — `.pre-commit-config.yaml` is in version control; CI picks it up automatically.
+
+**Regex rules for the `exclude:` field**:
+
+| Pattern | Matches |
+| --------- | --------- |
+| `^path/to/file\.ext$` | Exact file |
+| `^(file1\.yaml\|file2\.cpp)$` | Either of two exact files |
+| `^tests/` | All files under `tests/` |
+| `^k8s/.*-secret.*\.yaml$` | Any k8s YAML with `-secret` in the name |
+| `^k8s/.*-security.*\.yaml$` | Any k8s YAML with `-security` in the name |
+
+**Typical PEM patterns that trigger false positives in test files**:
+
+```
+-----BEGIN CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+-----BEGIN RSA PRIVATE KEY-----
+-----BEGIN EC PRIVATE KEY-----
+-----BEGIN CERTIFICATE REQUEST-----
+```
+
+These appear in TLS unit tests (`test_grpc_tls.cpp`, `test_tls_*.py`) and Kubernetes secret manifests
+that embed cert/key material as base64 or raw PEM for local dev environments.
+
+**Failed attempts for this pattern**:
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Delete the hook entirely | Remove `detect-private-key` from `.pre-commit-config.yaml` | Would miss real credential leaks in non-test paths — eliminates security value | Use `exclude:` to scope the hook, never remove it entirely |
+| Move test files to a different path | Rename `tests/unit/test_grpc_tls.cpp` to avoid detection | Disrupts test structure and doesn't scale for k8s manifests | Path-based `exclude:` is correct; don't relocate files to satisfy a hook |
+| Add `# noqa` or inline ignore comments | Tried per-line directives in C++ source | `detect-private-key` is a grep-based hook — inline suppressions not supported | Hook-level `exclude:` is the only supported suppression mechanism |
+
+### Go-Based Hook: Pre-Built Binary Download
+
+Use when a Go-based pre-commit hook (e.g., gitleaks) fails to build from source because the
+system Go version is too old for the hook's `go.mod` requirement.
+
+**Trigger conditions**:
+
+- A Go-based hook fails to build from source because system Go version is too old (e.g., system
+  Go 1.15 vs hook requirement Go 1.24.11).
+- pre-commit with `language: golang` reports "invalid go version" or Go compilation errors for a
+  hook that worked previously.
+
+**Fix**: Convert from `language: golang` (builds from source) to a `repo: local` hook that
+downloads the pre-built binary release:
+
+```yaml
+# AFTER (downloads pre-built binary):
+- repo: local
+  hooks:
+    - id: gitleaks
+      name: Gitleaks Secret Scan
+      entry: bash -c 'GITLEAKS_VERSION="8.30.1"; GITLEAKS_BIN="$HOME/.local/bin/gitleaks"; if [ ! -x "$GITLEAKS_BIN" ]; then mkdir -p "$HOME/.local/bin" && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C "$HOME/.local/bin" gitleaks; fi && "$GITLEAKS_BIN" protect --staged'
+      language: system
+      pass_filenames: false
+```
+
+**Key design decisions**:
+
+- Binary is cached at `$HOME/.local/bin/gitleaks` — only downloaded once
+- `curl -sSfL` fails fast on HTTP errors (`-f`) and follows redirects (`-L`)
+- `pass_filenames: false` because gitleaks scans the git diff, not individual files
+- Version is pinned inline — update the `GITLEAKS_VERSION` string when upgrading
+
+This pattern applies to any Go-based hook where the system Go is too old and upgrading Go is not
+feasible (e.g., constrained CI environments, conda-forge only providing old Go versions).
+
+#### `lint` + `pre-commit` both red == one `ruff format` drift (diagnostic shortcut)
+
+When BOTH the required `lint` job and the required `pre-commit` job fail together on a Python
+PR, suspect a single `ruff format` drift BEFORE anything else — they are equivalent formatter
+gates and will both flag the same files. The `lint` job runs `ruff format --check hephaestus
+scripts tests` → `Would reformat: <file>` → exit 1. The `pre-commit` job runs the
+`ruff-format-python` hook with `--all-files` → `N files reformatted ... files were modified
+by this hook` → exit 1. Same formatter, same files, two red checks. Passing one locally
+guarantees the other (`ruff format --check` ≡ `ruff-format-python` hook), so you only need to
+clear one.
+
+**Most common cause — hand-wrapped code that fits on one line.** An editor or a prior
+automated edit splits a comprehension/call across lines, but it fits within `line-length`, so
+`ruff format` collapses it back:
+
+```python
+# Hand-wrapped (what the prior commit left) — ruff format WILL rewrite this:
+return sorted(
+    e["name"]
+    for e in entries
+    if not e.get("isArchived", False)
+    and not e.get("isFork", False)
+)
+
+# After `ruff format` (single line, fits the limit) — what CI expects:
+return sorted(
+    e["name"] for e in entries if not e.get("isArchived", False) and not e.get("isFork", False)
+)
+```
+
+**The mechanical fix (zero logic change):**
+
+```bash
+pixi run --environment lint ruff format <named files>   # e.g. the two files CI listed
+pixi run pre-commit run --all-files                      # confirm all hooks pass
+git commit -S -m "style(ruff): reflow hand-wrapped comprehensions"   # existing branch, signed
+```
+
+Net diff is pure whitespace/line-wrap (e.g. `2 files changed, 2 insertions(+), 8
+deletions(-)`). Never hand-wrap a comprehension or call that fits on one line — ruff will undo
+it. The CI ruff version is pinned (0.15.x via pixi), so the local `--environment lint` pixi env
+matches CI exactly; running it locally is authoritative.
+
+Verified-local by ProjectHephaestus PR #1058 (issue #814): `lint` + `pre-commit` both red from
+hand-wrapped comprehensions in `ensure_state_labels.py` and `loop_runner.py`; `ruff format` on
+the two files fixed both checks; `pre-commit run --all-files` green and full pytest (3521
+passed) green locally. CI re-validation pending push.
+
+#### Pre-commit scope before push: full PR diff, not the current edit
+
+`pre-commit run --files X Y Z` runs each hook on the LITERAL list `[X, Y, Z]`; the installed
+git hook runs only on STAGED files. So if a sub-agent committed file `A` and you commit file
+`B`, neither commit's hook saw the other under the current formatter baseline — two partial
+checks ≠ full coverage, and a sub-agent's `model.mojo` can pass its per-file pre-commit yet
+fail CI mojo-format after your fixup push. Canonical pre-push check (full PR diff at PR-diff
+cost): `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` (see Quick Reference).
+Prefer it over `--all-files` (slow → engineers fall back to `--files`) and over
+`--files <recent edits>` (misses sub-agent files). If hooks rewrite files, `git add` and
+make a NEW commit (never `--no-verify`/`--amend` on shared history); then `gh pr checks
+--watch` for CI-only validators.
+
+**Decision matrix:**
+
+| Scenario | Command |
+| ---------- | --------- |
+| During dev, after editing one file | `pre-commit run --files <file>` |
+| Before `git push` of a PR | `pre-commit run --from-ref origin/main --to-ref HEAD` |
+| After upgrading a formatter/hook version, or onboarding to a repo | `pre-commit run --all-files` (baseline changed) |
+
+If a sub-agent reports a `SKIP=hook-id` bypass (e.g. `SKIP=mojo-format` on older-GLIBC
+hosts), the orchestrator MUST re-run that hook against the full PR diff before pushing.
+
+Verified by ProjectOdyssey PR #5453 (sub-agent's `.mojo` files passed per-file pre-commit,
+failed CI mojo-format; full-diff scope fixed it).
+
+#### Adding `.editorconfig` for cross-editor consistency
+
+`.editorconfig` configures the editor *before* you type (indent, line endings, trailing
+whitespace, final newline) for ALL file types — complementary to ruff/black (which fix
+Python *after* save) and `.gitattributes` (which normalizes at the git layer). Add one
+when the repo lacks it or non-Python files (YAML, JSON, Markdown, shell, Makefile) have no
+formatting standard. Always set `root = true` (stops parent-dir search). Critically, set
+`trim_trailing_whitespace = false` for Markdown — two trailing spaces create a `<br>` line
+break. Makefiles MUST use tabs. Template in Results & Parameters.
+
+Verified by ProjectScylla PR #1556 (audit finding S13).
+
+#### Exempting toolchain-forced churn from PR-review scope/YAGNI rubrics
+
+When an automated PR-review agent enforces a scope/YAGNI rule ("flag scope creep,
+opportunistic refactors"), an unbounded "flag everything" rule fights the linter: it
+demands removal of CI-required edits (whitespace, import-sort, trailing-newline, mypy
+annotations) the toolchain *forced* to land the change. The carve-out is intent-based, not
+size-based — *who chose the change*:
+
+- **ACCEPTABLE (stay silent):** toolchain-FORCED churn — formatter/whitespace, import
+  sorting, trailing-newline, mypy-required annotations, lint/pre-commit auto-fixes — on
+  files the change already touches.
+- **STILL FLAG:** author-CHOSEN work — opportunistic refactors, unrelated rewrites,
+  "while we're here" features, dependency bumps that weren't asked for, config knobs
+  without a consumer.
+- **Key principle:** *"The test is intent, not size: churn the toolchain requires is fine;
+  churn the author chose is a finding."*
+
+A scope rule feeding multiple per-stage rubrics is almost always DUPLICATED (ProjectHephaestus:
+`_SEVEN_PRINCIPLES_DIMENSIONS` P2, `_PR_STRICT_RUBRIC_DIMENSIONS` D2, `_IMPL_LOOP_STRICT_RUBRIC`
+dim 6); a per-stage copy overrides the shared carve-out, so apply the SAME carve-out to all
+blocks. TDD both directions: assert carve-out language is present (anchor on stable substrings
+like `pre-commit`, `toolchain`, `opportunistic`) AND that scope-creep detection is retained.
+
+Verified by ProjectHephaestus PR #1019 (closes #1017; false positive originated from
+PR #1015 inline comment r3366637812).
+
+## Hook-Specific Patterns (Additional Reference)
+
+### detect-private-key: False Positive Handling
+
+Use when `detect-private-key` fires on files that contain fake/test credentials (TLS unit tests,
+Kubernetes secret manifests, example certs). Do **not** delete the hook — that would miss real
+leaks. Use `exclude:` to scope it.
+
+**Trigger conditions**:
+
+- `detect-private-key` hook false-fires on test fixtures, TLS unit tests, or k8s secret manifests
+  containing fake/test PEM headers (`BEGIN CERTIFICATE`, `BEGIN PRIVATE KEY`, `BEGIN RSA PRIVATE KEY`,
+  `BEGIN EC PRIVATE KEY`, `BEGIN CERTIFICATE REQUEST`).
+
+**Quick Reference**:
+
+```yaml
+# .pre-commit-config.yaml — under detect-private-key hook entry:
+- id: detect-private-key
+  exclude: '^(k8s/metrics-security\.yaml|tests/unit/test_grpc_tls\.cpp)$'
+```
+
+For broader exclusions (test directories, example certs, k8s secret patterns):
+
+```yaml
+- id: detect-private-key
+  exclude: '^(tests/|fixtures/|examples/|k8s/.*-secret.*\.yaml|k8s/.*-security.*\.yaml)$'
+```
+
+**Step-by-step**:
+
+1. **Identify flagged files** — read CI log from the `detect-private-key` hook; it lists each triggering path.
+2. **Confirm they are test fixtures** — verify the file is a unit test, example cert, generated credential, or Kubernetes manifest. If it contains real credentials, fix that instead of excluding.
+3. **Locate the hook entry** in `.pre-commit-config.yaml` — find the `repo: https://github.com/pre-commit/pre-commit-hooks` block and `- id: detect-private-key`.
+4. **Add `exclude:` directly under the hook id** — value is a Python regex anchored with `^...$`.
+5. **Escape regex metacharacters**: forward slashes `/` do not need escaping; dots `.` in filenames must be escaped as `\.`.
+6. **Verify locally**: `pre-commit run detect-private-key --all-files` — excluded files should pass; all other paths still checked.
+7. **Commit** — `.pre-commit-config.yaml` is in version control; CI picks it up automatically.
+
+**Regex rules for the `exclude:` field**:
+
+| Pattern | Matches |
+| --------- | --------- |
+| `^path/to/file\.ext$` | Exact file |
+| `^(file1\.yaml\|file2\.cpp)$` | Either of two exact files |
+| `^tests/` | All files under `tests/` |
+| `^k8s/.*-secret.*\.yaml$` | Any k8s YAML with `-secret` in the name |
+| `^k8s/.*-security.*\.yaml$` | Any k8s YAML with `-security` in the name |
+
+**Typical PEM patterns that trigger false positives in test files**:
+
+```
+-----BEGIN CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+-----BEGIN RSA PRIVATE KEY-----
+-----BEGIN EC PRIVATE KEY-----
+-----BEGIN CERTIFICATE REQUEST-----
+```
+
+These appear in TLS unit tests (`test_grpc_tls.cpp`, `test_tls_*.py`) and Kubernetes secret manifests
+that embed cert/key material as base64 or raw PEM for local dev environments.
+
+**Failed attempts for this pattern**:
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Delete the hook entirely | Remove `detect-private-key` from `.pre-commit-config.yaml` | Would miss real credential leaks in non-test paths — eliminates security value | Use `exclude:` to scope the hook, never remove it entirely |
+| Move test files to a different path | Rename `tests/unit/test_grpc_tls.cpp` to avoid detection | Disrupts test structure and doesn't scale for k8s manifests | Path-based `exclude:` is correct; don't relocate files to satisfy a hook |
+| Add `# noqa` or inline ignore comments | Tried per-line directives in C++ source | `detect-private-key` is a grep-based hook — inline suppressions not supported | Hook-level `exclude:` is the only supported suppression mechanism |
+
+### Go-Based Hook: Pre-Built Binary Download
+
+Use when a Go-based pre-commit hook (e.g., gitleaks) fails to build from source because the
+system Go version is too old for the hook's `go.mod` requirement.
+
+**Trigger conditions**:
+
+- A Go-based hook fails to build from source because system Go version is too old (e.g., system
+  Go 1.15 vs hook requirement Go 1.24.11).
+- pre-commit with `language: golang` reports "invalid go version" or Go compilation errors for a
+  hook that worked previously.
+
+**Fix**: Convert from `language: golang` (builds from source) to a `repo: local` hook that
+downloads the pre-built binary release:
+
+```yaml
+# AFTER (downloads pre-built binary):
+- repo: local
+  hooks:
+    - id: gitleaks
+      name: Gitleaks Secret Scan
+      entry: bash -c 'GITLEAKS_VERSION="8.30.1"; GITLEAKS_BIN="$HOME/.local/bin/gitleaks"; if [ ! -x "$GITLEAKS_BIN" ]; then mkdir -p "$HOME/.local/bin" && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C "$HOME/.local/bin" gitleaks; fi && "$GITLEAKS_BIN" protect --staged'
+      language: system
+      pass_filenames: false
+```
+
+**Key design decisions**:
+
+- Binary is cached at `$HOME/.local/bin/gitleaks` — only downloaded once
+- `curl -sSfL` fails fast on HTTP errors (`-f`) and follows redirects (`-L`)
+- `pass_filenames: false` because gitleaks scans the git diff, not individual files
+- Version is pinned inline — update the `GITLEAKS_VERSION` string when upgrading
+
+This pattern applies to any Go-based hook where the system Go is too old and upgrading Go is not
+feasible (e.g., constrained CI environments, conda-forge only providing old Go versions).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| `per-file-ignores` for generated files | Added `"path/_version.py" = ["ALL"]` to `[tool.ruff.lint.per-file-ignores]` | Silenced `ruff check` but `ruff format --check` still flagged -- `per-file-ignores` is scoped to lint rules only | Use `exclude = [...]` under `[tool.ruff]` for generated files to cover both check and format |
+| `.gitignore` prevents ruff scan | Assumed `.gitignore` entry stops ruff from scanning | `.gitignore` has no effect on ruff; ruff scans whatever files exist on disk | Generated files must be explicitly excluded in `pyproject.toml` |
+| `mirrors-mypy` without `additional_dependencies` | Standard hook config | "Library stubs not installed for yaml" | `mirrors-mypy` creates an isolated venv; stubs must be declared via `additional_dependencies` |
+| Semver range in `rev:` | Used `>=1.19.1` in `rev:` field | `rev:` only accepts exact git tags | Always use exact tag matching installed binary |
+| Guessing tag from pixi constraint | Assumed `v1.19.0` from constraint `>=1.19.1` | pixi resolves to latest satisfying version, not lower bound | Run `pixi run <tool> --version` rather than inferring from constraint |
+| `[[tool.mypy.overrides]]` in `pyproject.toml` | Added `ignore_errors = true` for test dirs | `mirrors-mypy` hook venv does not auto-load `pyproject.toml` | Use `mypy.ini` for overrides -- auto-discovered by mypy regardless of invocation context |
+| `--config-file pyproject.toml` in hook args | Force config loading | `pyproject.toml` has stricter settings that broke scripts (269 new errors) | Config files have stricter settings; mixing hook args with config files causes regressions |
+| Bulk mypy invocation on hyphenated dirs | Pass all `^examples/.*\.py$` files to single mypy run | "Duplicate module named 'download_cifar10'" -- hyphenated dir names are not valid Python packages | Per-file invocation via wrapper script is the only robust solution |
+| `namespace_packages = true` for hyphenated dirs | Configured mypy namespace support | Does not resolve duplicate-module conflict | The issue is a name collision, not a package discovery problem |
+| Module-path overrides for hyphenated dirs | `[mypy-tools.*]` override for `tools/paper-scaffold/prompts.py` | `paper-scaffold` has a hyphen -- mypy resolves module as top-level `prompts` | Fix the actual errors; do not rely on module-path overrides for hyphenated dirs |
+| mypy without `--explicit-package-bases` | `pixi run mypy scripts/` | "Source file found twice under different module names" | Always use `--explicit-package-bases` for directories without `__init__.py` |
+| mypy without `--python-version 3.10` | Default mypy python version | "X \| Y syntax for unions requires Python 3.10" | mypy defaults to older version even when runtime is 3.14 |
+| `ignore_errors = true` to suppress `call-overload` | Relied on overrides block for `tests.*` | In mypy 1.19, `ignore_errors = true` does NOT suppress `call-overload` from `Any`-typed dict access | Use targeted `# type: ignore[call-overload]` at each specific call site |
+| Per-dir mypy count without path filtering | Counted all output lines from `pixi run mypy scripts/` | Scripts import from other packages; mypy also checks them transitively, inflating count | Filter output lines by file path prefix before counting |
+| `markdownlint-cli2 --fix` for MD060 | Expected auto-fixer to resolve violations | Silent no-op -- MD060 has no auto-fix implementation | Write a custom Python script for MD060 bulk fixes |
+| Single-pass separator normalization | Ran only Pass 1 expecting all MD060 violations fixed | Header/data cells with wide padding still violated MD060 | Two passes required: Pass 1 normalizes separators, Pass 2 strips wide cell padding |
+| Eyeballed column alignment for MD060 | Counted dashes visually | Off-by-one dash count still failed MD060 | Use `len()` programmatically; exact match required for every column |
+| Suppressed MD060 entirely | Set `MD060: false` in `.markdownlint.yaml` | CI still required real fixes | Use `style: consistent` to accept existing style rather than disabling |
+| Wrong MD024 option | Used `allow_different_nesting: true` | Not a valid MD024 option -- silently ignored | The correct option is `siblings_only: true` |
+| markdownlint-cli2 npm version in pixi.toml | Added `">=0.12.1,<0.13"` to pixi.toml | conda-forge only has `>=0.13` builds; incomparable version series | JS tools use incomparable npm/conda version numbers -- exclude from drift tracking |
+| golangci-lint v1 config with v2 binary | Run v2 binary against v1 `.golangci.yml` | "Error: can't load config: unsupported version" | v2 requires explicit `version: "2"` and new schema layout |
+| Pin CI to `golangci-lint:latest-alpine` Docker image | Fixed alpine tag | Image built with Go 1.24 refuses Go 1.25 module | Use `golangci/golangci-lint-action@v6` with `version: latest` |
+| Suppress golangci-lint findings via `exclude-rules` | Ship v2 upgrade quickly without fixing findings | Left real resource leaks, concurrency bugs in production | Fix each finding; suppress defeats the purpose of the upgrade |
+| Treat `govet copylocks` as style nit | Added `//nolint:govet` on struct embedding sync.Mutex by value | Real concurrency bug -- each struct had its own copy of the mutex | `copylocks` always indicates a real concurrency bug; fix by using pointer embedding |
+| hadolint with `failure-threshold: warning` and `ignore:` list | Expected ignored rules to not cause CI failure | hadolint-action v3.1.0 can exit non-zero on threshold=warning even for ignored rules | Use `failure-threshold: error` when warning-level rules are in `ignore:` |
+| `language: pygrep` for exclusion logic | Used pygrep when need to exclude definition lines | pygrep cannot express exclusions (no grep -v) | Use `language: system` with `bash -c` entry for exclusion patterns |
+| Narrow `\|\|` regex `\|\|\s*true(\s*$\|\s+#)` | Only matched EOL and trailing `#` | Missed `$(cmd \|\| true)`, `cmd \|\| true; next` etc. | Widen to `^(?!\s*#).*\|\|\s*true(\s*$\|\s*[#);&\|])` with negative-lookahead for comment lines |
+| `\|\|\s*true\b` word boundary regex | Expected to match only `\|\| true` idiom | False-positives on documentation comments quoting idiom in backticks | Need explicit control-flow boundary chars `[#);&\|]` plus comment-line exemption |
+| Self-exempt lint guard exclusion missing | Added pygrep hook for pattern without exempting its definition | Hook fired on its own `name:`, `entry:`, error message strings | Self-exempt every lint guard via `exclude:` regex AND CI step `scan_files` array |
+| Advisory `::warning::` wrapper | Used `\|\| echo "::warning::"` to make steps advisory | Functional equivalent of `continue-on-error: true`; real findings invisible | v2.0.0: advisory `::warning::` wrappers also forbidden; use fail-fast mode |
+| Tool-level exit suppression | `bandit --exit-zero`, `trivy --exit-code 0`, `--no-fail` flags | Same suppression at tool layer; CI step passes despite real findings | Treat tool exit-suppression flags as equivalent to `continue-on-error: true` |
+| `continue-on-error` refactored to `if ! cmd; echo "::warning::..."` | Replaced per v1 Bucket E pattern | Functionally identical suppression -- step still passes when tool finds issues | v2.0.0 adds Bucket F; `::warning::` wrapper is also forbidden |
+| Lock file not staged before commit | `git add <other files>; git commit` with `pixi.lock` modified | pre-commit stashed working tree, auto-fixes staged, stash pop conflicted -> fixes rolled back | Always stage `pixi.lock` (or any large auto-generated file) before committing |
+| Cherry-pick instead of rebase for stale branch | Cherry-picked migration commit onto stale branch | Only applies diff of one commit; context conflicts without full history | Use `git rebase origin/main` -- replays entire history |
+| Formatter expected to fail commit | Assumed formatter would exit non-zero when rewriting | Formatters write changes and exit 0 -- they're fixers, not checkers | Distinguish fixer hooks (mutate-and-exit-0) from checker hooks (read-and-exit-nonzero) |
+| Trust `git commit` exit status after formatter | Assumed exit 0 means formatter output was committed | Exit 0 means hook succeeded; formatter writes to working tree, not index | A clean exit from a formatting hook says nothing about whether formatted content reached commit |
+| `git stash --keep-index` + re-apply for re-stage | Stashed unstaged tree, ran formatter, popped | Overcomplicated; formatter output not captured in stash bookkeeping | Do not use `stash` to solve re-stage; `git add` after formatter is the right primitive |
+| `pass_filenames: false` to scope formatter | Made hook scope smaller | Hook still mutated whatever it touched; just moved the bug | Scope reduction does not fix re-stage gap; only explicit `git add` does |
+| Checking only hook config for `pass_filenames` | Looked at `files:` and `entry:` only | Did not reveal whether script processes `sys.argv[1:]` | Must grep the script for argument handling code |
+| Check only `args` for bandit `--skip` flags | Looked for skip IDs in `hook["args"]` | Flags were in `entry: "pixi run bandit -ll --skip B310,B202"`, not in `args` | Always normalise flags from both `entry` and `args`; write `_all_flags()` helper |
+| Auto-discovery of `.bandit` at repo root | Expected bandit to find `.bandit` automatically | Bandit only searches within passed target directories, not at repo root | Always pass `--ini .bandit` explicitly in both hook and pixi task |
+| Add bandit without pre-scanning new dirs | Extended `files:` pattern directly | Violations in `examples/` would have broken CI | Always pre-scan new directories before extending hook scope |
+| CI-only actionlint step | actionlint ran in CI but not in pre-commit | Violations caught by CI but not locally before push | Add actionlint to pre-commit so violations are caught at commit time |
+| Divergent CI and pre-commit file patterns | Shellcheck on `*.sh` in CI while pre-commit also covered `*.bats` | Violations in `.bats` files passed CI but blocked pre-commit | Always make CI and pre-commit use identical file patterns |
+| `date +%s` for timing in hooks | Shell `date +%s` subtraction in YAML | Fragile across platforms; requires subshell | Use `$SECONDS` bash built-in -- always integer seconds, no subshell needed |
+| `if: failure()` on timing summary step | Wrote summary only on failure | Miss timing data for passing slow runs | Use `if: always()` |
+| Failing CI on slow hooks | Exit 1 from helper when threshold exceeded | Blocked legitimate CI runs on slow runners | Timing benchmarks must be non-blocking; use advisory `WARN:` to stdout |
+| PyYAML for version drift check | Import PyYAML in stdlib-only drift script | Requires pixi setup first -- defeats purpose of early gate | Use `re` regex; pre-commit config structure is regular enough for drift detection |
+| `sys.exit()` inside `main()` | Called `sys.exit(0/1)` directly in main function | pytest catches `SystemExit`, requiring `pytest.raises(SystemExit)` wrappers | Return `int` from `main()`, call `sys.exit(main())` in `if __name__ == "__main__"` |
+| `lstrip("v")` test for single-v strip | Test checked `normalize_rev("vv1.0") == "v1.0"` | `str.lstrip()` strips ALL leading matching chars | Test should expect `"1.0"` not `"v1.0"` |
+| pre-commit stage for signed-commit check | Checked `git config commit.gpgsign` at pre-commit stage | Pre-commit runs before commit is written -- signature has not happened yet | Use pre-push stage; verify each commit with `git log -1 --format='%G?'` |
+| Prepend directive above `---` YAML doc marker | Inserted config above `---` line | Created two YAML documents -- invalid for pre-commit framework | Detect leading `---` and insert directive AFTER it; validate with `yaml.safe_load()` |
+| `${REPO_ROOT}` for hook paths installed in `.git/hooks/` | `find "${REPO_ROOT}/agents"` where `REPO_ROOT="${SCRIPT_DIR}/.."` | When hook is `.git/hooks/pre-commit`, `REPO_ROOT` resolves to `.git/` not project root | Use `REPO_ROOT_HOOK="$(git rev-parse --show-toplevel)"` for all working-tree paths |
+| `just` inside hook without Justfile guard | `if command -v just; then just test; fi` | In bats temp repo, `just` finds real repo Justfile upstream and runs full test suite | Add `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` guard; set `SKIP_TESTS=1` in bats tests |
+| Short-circuit `&&` without `\|\| true` under `set -euo pipefail` | `[[ -n "$n" ]] && printf '%s\n' "$n"` | When condition is false, bash treats `&&` chain as exit 1, triggering `set -e` abort | Add `\|\| true`: `[[ -n "$n" ]] && printf '%s\n' "$n" \|\| true` |
+| Go-based tools via pixi/conda-forge | `pixi search gitleaks`, `pixi search go` | Not available or outdated (Go 1.15 only on conda-forge) | Go-based security tools: use pre-built GitHub release binaries |
+| pygrep alternation with `\|` syntax | Wrote `print.*NOTE\|print.*TODO` (grep syntax) | pygrep uses Python `re`; `\|` is a literal pipe character | Use `(NOTE\|TODO\|FIXME)` group syntax |
+| pygrep commented-out prints as negative test cases | Added `# print("NOTE: ...")` to NEGATIVE_CASES | pygrep matches raw line -- comment still contains `print.*NOTE` | Move commented-out prints to POSITIVE_CASES; pygrep does not understand comments |
+| Blanket `--skip B404,B603,B607` to silence bandit noise | Passed all three LOW-severity subprocess IDs to `--skip` | Skips injection-check IDs entirely, removing real signal for any future subprocess misuse | Use `--severity-level medium` instead -- filters by severity, not by check ID |
+| Fix MD033 by editing stray `.claude-prompt-NNN.md` to remove HTML tags | Tried to strip `<NONCE>` / `<LABEL>` tags from the file | File is an agent artifact with no source value; editing it is wasted effort and the file can recur | Always `git rm` accidental artifact files; add `.gitignore` pattern to prevent recurrence |
+| Delete a standalone `markdownlint` CI job assuming it is not a required check | Removed the job from `_required.yml` without checking branch-protection rulesets | If the job name is listed as a required status check, every subsequent PR is permanently BLOCKED (no context posted, never satisfies the rule) — `ci-driver-blocked-required-context-drift` pattern | ALWAYS run `gh api repos/{owner}/{repo}/rulesets` and the branch-protection required-checks endpoint BEFORE deleting any CI job; update the ruleset atomically with the deletion |
+| Widen markdownlint hook scope without pre-scanning new files | Extended `files:` pattern to include `docs/` assuming `--fix` would handle all violations | `markdownlint-cli2 --fix` is a silent no-op for several rules (MD060, MD013 long lines); unfixable violations break CI on the first push after the scope change | Pre-scan with `--fix` then re-run without `--fix` to confirm zero residual violations before merging |
+| Treat `.claude/` exclude in pre-commit hook as purely defensive | Assumed `.claude/` was untracked (gitignored) so the exclude was safe to drop | Two tracked `.md` files exist in ProjectHephaestus (`.claude/security/guidelines.md`, `.claude/workflows/development.md`); removing the exclusion would expose them to markdownlint and widen scope beyond what the old standalone job covered | Always run `git ls-files .claude/ \| grep '\.md$'` before removing the `.claude/` exclusion; if any results, the exclusion is load-bearing |
+| Delete CI job without updating docs that reference the job by name | Removed `markdownlint` job from `_required.yml` without searching for the job name in docs | `docs/DEFINITION_OF_DONE.md:31` cited "CI job \`markdownlint\`" and `.github/README.md:44` listed `markdownlint` in the aggregated-checks list; those became stale and misleading | After deleting any CI job, grep for the job name across all docs and update every reference; common locations: DoD, README, CONTRIBUTING.md |
+| `bandit --exit-zero` to pass CI while investigating | Added `--exit-zero` flag during bandit hook integration | All real findings invisible to CI; defeating the purpose of SAST | Never suppress exit codes; fix each MEDIUM+ finding properly |
+| Security hook blocking workflow file `Edit` | Used `Edit` tool on `.github/workflows/pre-commit.yml` | Project security hook fires on all Actions workflow edits | Use `python3 -c "..."` via Bash to write the file instead |
+| mypy fails on untracked test file referencing not-yet-committed methods | Created both test file and implementation file but only staged the implementation for commit 1 | mypy pre-commit hook runs on ALL `.py` files on disk, including untracked ones; sees `attr-defined` / `module-attribute` errors in the untracked test | Temporarily move the untracked test file to `/tmp` before commit 1; restore and stage it for commit 2. Only needed for strict multi-commit atomic ordering. |
+| Removing `$# -eq 0` guard from `report_unmanaged()` | Cleaned up what appeared redundant | Broke bats test -- guard is needed in `report_unmanaged()` specifically | Only remove the guard from `get_unmanaged_names()`; keep it in `report_unmanaged()` |
+| `sed -i` for trailing blank line in YAML | `sed -i '${/^$/d}' file.yml` | Fragile -- only deletes one blank line; fails on macOS sed | Use Python `content.rstrip() + '\n'` -- handles multiple trailing blank lines portably |
+| String splitting for YAML value parsing | `partition(':')` or `split(':', 1)` to parse values with colons | Splits inside quoted strings at wrong colon | Use a real YAML parser (`yaml.safe_load()`), not string splitting |
+| Removing conflict markers without checking trailing whitespace | Resolved git merge conflict in YAML file | Left trailing blank line introduced by conflict resolution | Always run yamllint after YAML conflict resolution |
+| `entry: pixi run <task>` without `--environment` | Wrote hook entry as `pixi run hephaestus-check-dep-sync` assuming pixi.toml task default env applies | Hook inherited whichever env pre-commit was launched from (e.g. `lint`); console script not installed there -> `command not found` | `pixi run` resolves the environment from current shell state, not from `pixi.toml`. Always write `pixi run --environment default <task>` for hooks that need a package entry point |
+| `pip install -e . --no-deps --no-build-isolation` in CI | Tried to skip build isolation to speed up the editable install | pip subprocess could not locate `hatchling` because `--no-build-isolation` requires the build backend be pre-installed in the same env | Drop `--no-build-isolation`; let pip do standard build isolation — pixi's env already has hatchling available to the pip child |
+| Skip `dev-install` and rely on `pixi install --environment default` | Assumed `pixi install` would install the host package along with its deps | `pixi install` installs declared deps only; once the self-reference is removed from `pyproject.toml` (to stop lockfile churn) it does not install the host package | After removing self-reference, an explicit `pip install -e . --no-deps` (via `pixi run dev-install`) is mandatory in CI before any hook that imports the package or calls a console script |
+| System-installed hephaestus shadows pixi default env version locally | `pixi run --environment default hephaestus-check-dep-sync` ran the binary from `~/.local/bin` (an older/newer system install) instead of the pixi env | When `hephaestus-check-dep-sync` resolves to `~/.local/bin` (user-level pip install), pixi `--environment default` doesn't shadow `$PATH`; the system binary has a different version of `dep_sync.py` with stricter checks that reject `[project.optional-dependencies]` — CI passes green because CI runs `pixi run dev-install` first, installing the local package into the pixi default env and making its console scripts take precedence | Always run `pixi run dev-install` in a fresh worktree before running pre-commit locally. The `~/.local/bin` system install is stale and will diverge from the in-tree version over time. After `dev-install` the local package's console scripts are installed into the pixi env and take priority over `~/.local/bin`. |
+| Inline imports inside test functions (ruff I001/RUF059) | Left `import sys` / `from module import func` inside test function bodies in newly-added test functions | ruff flags `I001` (import block unsorted/unformatted) for function-level imports and `RUF059` (unpacked variable never used) for tuple unpacking like `modified, fixes = obj.method()` where neither value is used | Move ALL imports to module top level; for unused tuple returns call the method directly: `obj.method()` rather than `_x, _y = obj.method()`. Pre-commit I001 fires even on test-function imports that are "logically local" — ruff treats them as mis-sorted module-level code. |
+| Ignore B904 `raise ... from` in `except ImportError` | Left bare `raise RuntimeError(...)` inside `except ImportError:` block | Ruff B904 fires: "Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None`" | Always use `raise RuntimeError("...") from err` to chain the cause; use `from None` only when deliberately suppressing the chain |
+| Leave `main()` at C901 complexity 17 | Added multiple `if/elif` branches inline in a single large `main()` function | Ruff `ruff-check-complexity` hook fires: "C901 `main` is too complex (17 > 10)" | Extract sub-operations into private helpers (e.g., `_check_module_floors()`, `_emit_json_report()`); each helper must have complexity ≤10 |
+| Trust `pixi run ruff check` alone before push | Ran lint, mypy, pytest; all green; pushed | `ruff check` does not exercise `ruff format`; CI's `ruff-format` hook then failed on multi-line signatures that should be single-line under the 100-col limit | `check` and `format` are TWO TOOLS sharing one binary; run both. Keep both hooks — they are not redundant |
+| Trust editor format-on-save for tooling edits | Assumed unformatted files caught on save | Worktree edits from Edit/codegen bypass the editor — no save event triggers the formatter | Run `ruff format` explicitly after tooling edits; `.editorconfig` does NOT drive ruff's column (it reads `pyproject.toml line-length`) |
+| `pre-commit run --files X Y Z` before push of a multi-author PR | Listed only the files the orchestrator personally edited | `--files` is a literal list; a sub-agent's earlier-committed file was skipped and failed CI formatter | Scope pre-push to the full PR diff: `pre-commit run --from-ref origin/main --to-ref HEAD` |
+| `pre-commit run --all-files` as the routine pre-push gate | Used the universal "safe" invocation every push | Multi-minute on large repos; engineers drop back to `--files` and the coverage gap reappears | Use `--from-ref/--to-ref` for routine pre-push; reserve `--all-files` for version bumps/onboarding. On a sub-agent `SKIP=`, re-run that hook against the full diff |
+| `trim_trailing_whitespace = true` for Markdown in `.editorconfig` | Applied the global whitespace-trim rule to `*.md` | Two trailing spaces in Markdown are a significant `<br>` line break; trimming silently breaks formatting | Set `trim_trailing_whitespace = false` under `[*.md]`; Makefiles must use `indent_style = tab` |
+| Flag every diff hunk not mapped to the issue (PR-review rubric) | Scope/YAGNI rule said "flag scope creep" with no exception | Punished lint-forced churn; the review agent demanded removal of CI-required whitespace/import-sort edits (false positive) | Carve out toolchain-FORCED churn explicitly (intent, not size); apply the SAME carve-out to every duplicated per-stage rubric block, and TDD that scope-creep detection is retained |
+
+| Triage `lint` and `pre-commit` both-red as two separate problems | Started debugging the `pre-commit` failure independently of the `lint` failure | Both jobs run the same formatter (`ruff format --check` vs `ruff-format-python --all-files`); a single drift surfaced as two red checks | When both go red on a Python PR, suspect ONE `ruff format` drift first; fix once and both clear |
+| Hand-wrap a comprehension/call that fits on one line | Editor/prior automated edit split a `sorted(... for ... if ...)` across multiple lines | `ruff format` collapses it back under `line-length`; `--check` reports "Would reformat" → exit 1 | Never hand-wrap code that fits the limit; run `pixi run --environment lint ruff format <files>` and let ruff own line-wrap |
+| Debug `lint` and `pre-commit` as two separate CI failures | Saw both red on a PR and opened two investigation threads | Wasted effort — both jobs run the SAME `ruff format` hook; `lint` runs `ruff format --check` (`Would reformat:`) and `pre-commit`'s `Ruff Format Python` hook reports "files were modified by this hook" on the identical files | When exactly `lint` + `pre-commit` are red, check `ruff format --check` FIRST; one `ruff format <files>` run clears both. A pre-commit job fails any time a hook *modifies* files, not only on lint *violations* |
+| Hand-wrap a comprehension after a manual edit and commit without re-running the formatter | A prior commit edited two comprehensions in `ensure_state_labels.py`/`loop_runner.py` and hand-wrapped them across lines, assuming the manual wrapping was acceptable | `ruff format` collapses each comprehension onto a single line under the 100-col limit; the formatter "wants" to reformat → `ruff format --check` (lint) and the pre-commit Ruff Format hook both fail with a pure-whitespace diff | After ANY manual edit to Python, run `pixi run --environment lint ruff format <files>` (or `pre-commit run --all-files`) BEFORE committing — never hand-wrap an expression and assume it is fine |
+| Inert commit-msg hook under plain `pre-commit install` (no `default_install_hook_types`) | Added `stages: [commit-msg]` hook to `.pre-commit-config.yaml` without setting `default_install_hook_types`; documented `pre-commit install` as the setup step | `pre-commit install` only wires the `pre-commit` stage by default; the commit-msg hook is never invoked — no error, no warning, just silent inaction for every contributor | Set `default_install_hook_types: [pre-commit, commit-msg]` at the top of `.pre-commit-config.yaml` so a plain `pre-commit install` wires both stages automatically |
+| Verified commit-msg hook with `--all-files` (shipped an untested/inert hook) | Ran `pre-commit run --all-files` after adding the commit-msg hook; it returned green; concluded the hook was working | `--all-files` skips any hook whose `stages` list does not include the current active stage; commit-msg hooks are entirely invisible to `--all-files` | Always verify commit-msg hooks via `pre-commit run --hook-stage commit-msg --commit-msg-filename <file>`; a green `--all-files` run proves nothing about commit-msg-stage hooks |
+| Ruff D301 — bare docstring with escaped `\n` in commit-msg validator | Wrote `"""Validate message.\n\nReturns True if valid."""` in the validator script | Ruff D301 fires: "Use `r\"\"\"` if any backslashes in a docstring" — the docstring contains a `\n` escape, which ruff treats as a reason to require a raw string | Use `r"""..."""` for any docstring that contains backslash sequences; raw strings suppress D301 without changing behaviour |
+| "Your pre-commit configuration is unstaged" abort during `--hook-stage` run | Modified `.pre-commit-config.yaml` to add `default_install_hook_types` then ran `pre-commit run --hook-stage commit-msg` before staging the file | pre-commit reads the config from the git index (staged version), not the working tree; an unstaged config change causes an immediate abort with an error message | Run `git add .pre-commit-config.yaml` before any `pre-commit run` invocation after modifying the config |
+| Assumed `core.hooksPath` blocking `pre-commit install` also blocks `--hook-stage` verification | In a repo with a custom `core.hooksPath`, skipped `--hook-stage` testing because `install` had failed | `pre-commit run --hook-stage` bypasses git hook installation entirely and invokes the pre-commit framework directly; it works regardless of `core.hooksPath` configuration | `core.hooksPath` affects `pre-commit install` (which writes `.git/hooks/`) but NOT direct framework invocations via `pre-commit run --hook-stage` |
+
+## Results & Parameters
+
+### Pre-commit Config Patterns
+
+```yaml
+# .pre-commit-config.yaml -- canonical structure
+repos:
+  # 1. Pinned to exact version matching pixi.toml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1  # must match: pixi run ruff --version
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # 2. mypy with pixi
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: pixi run mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+
+  # 3. mypy per-file for hyphenated dirs
+  - repo: local
+    hooks:
+      - id: mypy-examples
+        name: mypy (examples)
+        entry: pixi run python scripts/mypy-each-file.py --ignore-missing-imports --check-untyped-defs --python-version 3.10
+        language: system
+        files: ^examples/.*\.py$
+        pass_filenames: true
+
+  # 4. bandit
+  - repo: local
+    hooks:
+      - id: bandit
+        name: bandit
+        entry: pixi run bandit -r -ll --ini .bandit
+        language: system
+        files: ^(src|scripts)/.*\.py$
+        pass_filenames: false
+
+  # 5. language: system hook with exclusion
+  - repo: local
+    hooks:
+      - id: ban-pattern
+        name: Ban pattern
+        entry: bash -c 'grep -rnP "bad_pattern" "$@" | grep -v "exclusion" && exit 1 || exit 0' --
+        language: system
+        files: \.(py|mojo)$
+        pass_filenames: true
+```
+
+### golangci-lint v2 Config
+
+```yaml
+# .golangci.yml
+version: "2"
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+linters:
+  default: none
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - ineffassign
+    - unused
+    - gosec
+    - errorlint
+    - bodyclose
+  settings:
+    gosec:
+      excludes:
+        - G401  # weak crypto (document why)
+```
+
+### hadolint Config
+
+```yaml
+# .hadolint.yaml
+failure-threshold: error
+ignore:
+  - DL3008  # apt-get without version pinning (acceptable for dev images)
+```
+
+### ruff Config for Generated Files
+
+```toml
+# pyproject.toml
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+exclude = ["hephaestus/_version.py"]  # covers both check AND format
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "D102", "D107"]
+# Note: per-file-ignores is lint-only; use exclude for format suppression
+```
+
+### .editorconfig (cross-editor consistency)
+
+```ini
+# .editorconfig — root = true stops parent-dir search
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,toml,sh}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false   # two trailing spaces = significant <br>
+
+[Dockerfile*]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab                 # Make syntax requires tabs
+```
+
+### Expected Outputs
+
+- `pre-commit run --all-files` exits 0 with no diff output
+- `scripts/check_precommit_versions.py` prints `OK: all pre-commit hook versions are consistent`
+- `pixi run mypy <path>` prints `Success: no issues found`
+- `yamllint .github/workflows/ci.yml` prints no output (exit 0)
+- `bandit -r src/ -ll --ini .bandit` prints `No issues identified`
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Multiple HI repos | Synthesized from 53 skills across ProjectOdyssey, ProjectHephaestus, ProjectArgus, ProjectKeystone, AchaeanFleet, Myrmidons | [history file](pre-commit-hooks-and-linting-config.history) |
+| ProjectHephaestus | PRs #707, #913 (ruff-format trap), #1019 closes #1017 (review-rubric toolchain-churn carve-out) | [history file](pre-commit-hooks-and-linting-config.history) |
+| ProjectOdyssey | PR #5453 (full-PR-diff pre-commit scope fixed CI mojo-format on sub-agent files) | [history file](pre-commit-hooks-and-linting-config.history) |
+| ProjectScylla | PR #1556, audit finding S13 (.editorconfig cross-editor consistency) | [history file](pre-commit-hooks-and-linting-config.history) |
+| ProjectMnemosyne | Closed PR #2353 (commit-msg-stage hooks + `default_install_hook_types` learning) | [history file](pre-commit-hooks-and-linting-config.history) |
+
+## References
+
+- [pre-commit docs](https://pre-commit.com/)
+- [ruff docs](https://docs.astral.sh/ruff/)
+- [mypy docs](https://mypy.readthedocs.io/)
+- [golangci-lint v2 migration](https://golangci-lint.run/product/migration-guide/)
+- [History / superseded skills](pre-commit-hooks-and-linting-config.history)
+```
+
+---
+
 ## v2.2.0 (2026-06-13) -- Salvage commit-msg-stage hooks learning (closed PR #2353)
 
 **Source:** Closed PR #2353 (HomericIntelligence/ProjectMnemosyne) — commit-msg-stage hooks

--- a/skills/pre-commit-hooks-and-linting-config.md
+++ b/skills/pre-commit-hooks-and-linting-config.md
@@ -2,12 +2,12 @@
 name: pre-commit-hooks-and-linting-config
 description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes — system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed — the hook checks ALL .py files on disk including untracked ones, (9) CI ruff-format hook fails even though local `ruff check` passed — `ruff check` (lint) and `ruff format --check` (formatter) are SEPARATE tools sharing one binary and running only `check` never exercises the formatter, (10) running pre-commit against the full PR diff (every file changed since merge-base) with `--from-ref/--to-ref` not just `--files <current edit>` — a sub-agent's earlier commit can carry stale-formatter content that fails only in CI, (11) adding .editorconfig for cross-editor formatting consistency on non-Python files (YAML, JSON, Markdown, shell, Makefile), (12) an automated PR-reviewer flags lint/formatter/pre-commit-forced incidental churn as scope creep — toolchain-forced churn is exempt from YAGNI/scope review while author-chosen opportunistic work is still flagged, (13) removing a duplicate standalone markdownlint CI job when the lint job already runs pre-commit --all-files — MUST verify the job is NOT a required-check context in branch protection before deleting it, and MUST pre-scan the newly-in-scope files for violations that --fix cannot auto-fix, (14) the pre-commit hook exclude pattern for .claude/ may be LOAD-BEARING (not merely defensive) — confirm with git ls-files .claude/ before removing it; two tracked .md files (.claude/security/guidelines.md and .claude/workflows/development.md) exist in ProjectHephaestus and must remain excluded to match the standalone CI job's intent, (15) after removing a duplicate markdownlint CI job update every doc that names that job by its old CI name (e.g. docs/DEFINITION_OF_DONE.md and .github/README.md) or CI job name references become stale; (16) BOTH the required `lint` check AND the `pre-commit` check are red in a PR — they share the same `ruff format` hook, so a single `ruff format <files>` run clears both; do not debug as two separate problems; (17) adding a commit-msg-stage hook (e.g. conventional-commit validator) — must set `default_install_hook_types: [pre-commit, commit-msg]` in .pre-commit-config.yaml or plain `pre-commit install` silently omits the commit-msg stage and the hook is permanently inert for all contributors; (18) verifying that a commit-msg-stage hook actually fires — `pre-commit run --all-files` does NOT invoke commit-msg-stage hooks; drive them via `pre-commit run --hook-stage commit-msg --commit-msg-filename <file>` instead."
 category: tooling
-date: 2026-06-13
-version: "2.2.0"
+date: 2026-06-17
+version: "2.3.0"
 user-invocable: false
 verification: verified-ci
 history: pre-commit-hooks-and-linting-config.history
-tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionlint, hooks, pixi-environment, bandit, markdownlint, sast, ruff-format, editorconfig, pr-diff, ci-parity, pr-review, yagni, commit-msg, default-install-hook-types]
+tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionlint, hooks, pixi-environment, bandit, markdownlint, sast, ruff-format, editorconfig, pr-diff, ci-parity, pr-review, yagni, commit-msg, default-install-hook-types, check-toml, toml, uv-lock]
 ---
 
 # Pre-commit Hooks and Linting Configuration
@@ -16,9 +16,11 @@ tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionli
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-18 |
+| **Date** | 2026-06-17 |
 | **Objective** | Canonical single-entry-point for all pre-commit hook and linting advice across the HomericIntelligence ecosystem |
-| **Outcome** | Consolidated from 53 narrow skills; verified-local |
+| **Outcome** | Consolidated from 53 narrow skills; current TOML/Ruff hook parity amendment verified-ci |
+| **Verification** | verified-ci |
+| **History** | [changelog](./pre-commit-hooks-and-linting-config.history) |
 
 ## When to Use
 
@@ -27,6 +29,8 @@ tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionli
 - Deciding whether to fix or suppress a lint finding (ruff, mypy, bandit, hadolint, shellcheck)
 - Adding a new linter (golangci-lint, yamllint, actionlint, markdownlint-cli2) to a pipeline
 - Reconciling ruff/mypy config across repos (`pyproject.toml` vs `mypy.ini` vs hook args)
+- A Python repo fails CI before tests because `pyproject.toml` has invalid TOML or a duplicate table, and the team needs a local pre-commit gate
+- A repo uses `uv.lock` or another lockfile and needs `astral-sh/ruff-pre-commit` `rev:` kept in parity with the locked Ruff version
 - Investigating pre-commit timing / performance regressions
 - Migrating bandit, golangci-lint (v1->v2), or mypy hook to pixi environment
 - Fixing markdownlint MD060 table formatting issues in bulk
@@ -95,6 +99,13 @@ SKIP=mojo-format pixi run pre-commit run --all-files --show-diff-on-failure
 # --- VERSION DRIFT CHECK ---
 pixi run python scripts/check_precommit_versions.py
 # Expected: OK: all pre-commit hook versions are consistent with pixi.toml
+
+# --- PYTHON TOML + RUFF PRE-COMMIT PARITY (uv.lock repos) ---
+pre-commit run check-toml --all-files
+pre-commit run ruff --all-files
+pre-commit run ruff-format --all-files
+python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"
+PYTHON=.venv/bin/python just install-hooks
 
 # --- RUFF (check and format are SEPARATE tools, one binary) ---
 pixi run ruff format .          # FORMATTER: line-wrap/whitespace/quotes (rewrites in place)
@@ -186,6 +197,30 @@ git commit --amend --no-edit  # if not yet pushed
 2. Update `rev:` in `.pre-commit-config.yaml` to exact matching tag.
 3. Never use semver ranges in `rev:`; always exact git tags.
 4. For JS tools (markdownlint-cli2): npm and conda-forge version numbers differ -- exclude from drift tracking.
+
+#### Python TOML validity + locked Ruff hooks
+
+1. Add `check-toml` from `pre-commit/pre-commit-hooks` to `.pre-commit-config.yaml`.
+   Ruff does not validate duplicate TOML table structure.
+2. Keep `astral-sh/ruff-pre-commit` pinned to the exact locked Ruff version. For
+   uv projects, parse `uv.lock` and require `rev: v<locked ruff version>`; in the
+   Inference360 PR #157 fix this was `v0.15.17`.
+3. Keep both hook IDs:
+   - `ruff` catches lint/import/unused-code failures.
+   - `ruff-format` catches formatter drift. It is not covered by `ruff`.
+4. Remove the malformed or duplicate TOML table, then verify directly:
+   `python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"`.
+5. Add a regression test that parses `.pre-commit-config.yaml` and the lockfile,
+   then asserts the hook IDs include `check-toml`, `ruff`, and `ruff-format`, and
+   the Ruff hook `rev:` equals the locked Ruff version.
+6. Add a setup recipe such as `install-hooks` that calls
+   `${PYTHON:-python3} -m pre_commit install`, then document
+   `PYTHON=.venv/bin/python just install-hooks` when local `just` may resolve a
+   broken host Python.
+7. Verify all three hook surfaces independently:
+   `pre-commit run check-toml --all-files`,
+   `pre-commit run ruff --all-files`, and
+   `pre-commit run ruff-format --all-files`.
 
 #### Migrating bandit from pygrep to AST hook
 
@@ -442,6 +477,29 @@ reflow as a dedicated `style(ruff):` commit (never `--amend` once pushed). Never
 
 Verified by ProjectHephaestus PRs #707 and #913 (local `ruff check`/pytest/pre-push all
 green, CI `ruff-format` still failed).
+
+#### `check-toml` is required for duplicate TOML tables
+
+TOML parse failures can abort CI before tests or lint even start. In Inference360 PR
+#157, dependency setup failed because `pyproject.toml` had a duplicate
+`[tool.coverage.paths]` table. Ruff did not catch this because it operates on Python
+lint/format surfaces, not TOML table semantics. The correct pre-commit surface is
+`check-toml` from `pre-commit/pre-commit-hooks`, with a focused regression test that
+asserts the hook remains installed.
+
+When the same repo also uses Ruff, keep lockfile parity and both Ruff hook IDs in one
+test so future drift fails locally:
+
+```python
+def test_pre_commit_guards_toml_and_locked_ruff_version() -> None:
+    config = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+    hook_ids = {hook["id"] for repo in config["repos"] for hook in repo["hooks"]}
+    assert {"check-toml", "ruff", "ruff-format"} <= hook_ids
+    assert ruff_pre_commit_rev(config) == f"v{locked_ruff_version(Path('uv.lock'))}"
+```
+
+Treat `ruff` and `ruff-format` as separate required gates. `ruff` will not catch
+format drift, and `ruff-format` will not catch TOML structural errors.
 
 #### Pre-commit scope before push: full PR diff, not the current edit
 
@@ -1167,6 +1225,10 @@ feasible (e.g., constrained CI environments, conda-forge only providing old Go v
 | `.gitignore` prevents ruff scan | Assumed `.gitignore` entry stops ruff from scanning | `.gitignore` has no effect on ruff; ruff scans whatever files exist on disk | Generated files must be explicitly excluded in `pyproject.toml` |
 | `mirrors-mypy` without `additional_dependencies` | Standard hook config | "Library stubs not installed for yaml" | `mirrors-mypy` creates an isolated venv; stubs must be declared via `additional_dependencies` |
 | Semver range in `rev:` | Used `>=1.19.1` in `rev:` field | `rev:` only accepts exact git tags | Always use exact tag matching installed binary |
+| Ruff as TOML validator | Expected Ruff hooks to catch a duplicate `[tool.coverage.paths]` table in `pyproject.toml` | Ruff does not validate TOML table structure; CI failed before tests during TOML parsing | Add `check-toml` from `pre-commit/pre-commit-hooks` and keep a direct `tomllib` smoke check for `pyproject.toml` |
+| Only add `ruff` hook | Added or checked only the `ruff` hook after seeing Ruff-related failures | `ruff` lint and `ruff-format` formatting are separate hook IDs; format drift still reaches CI | Require both `ruff` and `ruff-format` in `.pre-commit-config.yaml` and in regression tests |
+| Let Ruff hook rev drift from `uv.lock` | Kept `astral-sh/ruff-pre-commit` at a different tag than the locked Ruff package | Local hook behavior no longer matched CI/dev dependencies | Parse `uv.lock` and assert the hook `rev:` equals `v<locked ruff version>` |
+| Run `just install-hooks` with host Python | Relied on this host's default `just`/Python resolution | Local `just` can point at a broken Miniconda Python entry point | Implement the recipe through a `PYTHON` variable and document `PYTHON=.venv/bin/python just install-hooks` |
 | Guessing tag from pixi constraint | Assumed `v1.19.0` from constraint `>=1.19.1` | pixi resolves to latest satisfying version, not lower bound | Run `pixi run <tool> --version` rather than inferring from constraint |
 | `[[tool.mypy.overrides]]` in `pyproject.toml` | Added `ignore_errors = true` for test dirs | `mirrors-mypy` hook venv does not auto-load `pyproject.toml` | Use `mypy.ini` for overrides -- auto-discovered by mypy regardless of invocation context |
 | `--config-file pyproject.toml` in hook args | Force config loading | `pyproject.toml` has stricter settings that broke scripts (269 new errors) | Config files have stricter settings; mixing hook args with config files causes regressions |
@@ -1265,15 +1327,21 @@ feasible (e.g., constrained CI environments, conda-forge only providing old Go v
 ```yaml
 # .pre-commit-config.yaml -- canonical structure
 repos:
-  # 1. Pinned to exact version matching pixi.toml
+  # 1. Generic file syntax checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+
+  # 2. Pinned to exact version matching pixi.toml / uv.lock
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1  # must match: pixi run ruff --version
+    rev: v0.15.17  # must match: pixi/uv locked Ruff version
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
-  # 2. mypy with pixi
+  # 3. mypy with pixi
   - repo: local
     hooks:
       - id: mypy
@@ -1283,7 +1351,7 @@ repos:
         types: [python]
         pass_filenames: false
 
-  # 3. mypy per-file for hyphenated dirs
+  # 4. mypy per-file for hyphenated dirs
   - repo: local
     hooks:
       - id: mypy-examples
@@ -1312,6 +1380,34 @@ repos:
         language: system
         files: \.(py|mojo)$
         pass_filenames: true
+```
+
+### Python uv.lock + TOML Guard Pattern
+
+For uv-based Python repos, add a regression test that treats the pre-commit config and
+lockfile as a contract:
+
+```python
+def test_pre_commit_guards_toml_and_locked_ruff_version() -> None:
+    config = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+    hook_ids = {hook["id"] for repo in config["repos"] for hook in repo["hooks"]}
+
+    assert "check-toml" in hook_ids
+    assert "ruff" in hook_ids
+    assert "ruff-format" in hook_ids
+    assert ruff_pre_commit_rev(config) == f"v{locked_ruff_version(Path('uv.lock'))}"
+```
+
+Verification commands from Inference360 PR #157:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_quality_gate_scripts.py::test_pre_commit_guards_toml_and_locked_ruff_version
+.venv/bin/python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"
+.venv/bin/pre-commit run check-toml --all-files
+.venv/bin/pre-commit run ruff --all-files
+.venv/bin/pre-commit run ruff-format --all-files
+PYTHON=.venv/bin/python just --dry-run install-hooks
+git diff --check
 ```
 
 ### golangci-lint v2 Config
@@ -1407,6 +1503,7 @@ indent_style = tab                 # Make syntax requires tabs
 | --------- | --------- | --------- |
 | Multiple HI repos | Synthesized from 53 skills across ProjectOdyssey, ProjectHephaestus, ProjectArgus, ProjectKeystone, AchaeanFleet, Myrmidons | [history file](pre-commit-hooks-and-linting-config.history) |
 | ProjectHephaestus | PRs #707, #913 (ruff-format trap), #1019 closes #1017 (review-rubric toolchain-churn carve-out) | [history file](pre-commit-hooks-and-linting-config.history) |
+| Inference360 | PR #157 (TOML duplicate-key guard, Ruff hook lockfile parity, hook install docs; checks passed and PR merged) | [history file](pre-commit-hooks-and-linting-config.history) |
 | ProjectOdyssey | PR #5453 (full-PR-diff pre-commit scope fixed CI mojo-format on sub-agent files) | [history file](pre-commit-hooks-and-linting-config.history) |
 | ProjectScylla | PR #1556, audit finding S13 (.editorconfig cross-editor consistency) | [history file](pre-commit-hooks-and-linting-config.history) |
 | ProjectMnemosyne | Closed PR #2353 (commit-msg-stage hooks + `default_install_hook_types` learning) | [history file](pre-commit-hooks-and-linting-config.history) |

--- a/skills/pre-commit-hooks-and-linting-config.md
+++ b/skills/pre-commit-hooks-and-linting-config.md
@@ -480,8 +480,8 @@ green, CI `ruff-format` still failed).
 
 #### `check-toml` is required for duplicate TOML tables
 
-TOML parse failures can abort CI before tests or lint even start. In Inference360 PR
-#157, dependency setup failed because `pyproject.toml` had a duplicate
+TOML parse failures can abort CI before tests or lint even start. In Inference360
+PR #157, dependency setup failed because `pyproject.toml` had a duplicate
 `[tool.coverage.paths]` table. Ruff did not catch this because it operates on Python
 lint/format surfaces, not TOML table semantics. The correct pre-commit surface is
 `check-toml` from `pre-commit/pre-commit-hooks`, with a focused regression test that


### PR DESCRIPTION
## Summary

Amends `pre-commit-hooks-and-linting-config` from v2.2.0 to v2.3.0.

Documents the Inference360 PR #157 learning:

- use `check-toml` to catch duplicate or malformed TOML tables before CI setup fails
- keep `astral-sh/ruff-pre-commit` `rev:` synced to the locked Ruff version
- require both `ruff` and `ruff-format` hook IDs
- add a regression test for the pre-commit/lockfile contract
- document `PYTHON=.venv/bin/python just install-hooks` for hook installation on hosts with broken default Python resolution

## Verification Level

**verified-ci**

Inference360 PR #157 checks passed and the PR merged. This amendment also passed local ProjectMnemosyne validation.

## Key Findings

**What Worked**:

- Gate TOML syntax with `check-toml`; Ruff does not validate TOML table structure.
- Treat `ruff` and `ruff-format` as separate required hook surfaces.
- Assert Ruff pre-commit `rev:` equals `v<locked ruff version>` from `uv.lock`.

**What Failed**:

- Expecting Ruff to catch a duplicate `[tool.coverage.paths]` table failed because Ruff is not a TOML structural validator.
- Checking only `ruff` missed formatter drift covered by `ruff-format`.

## Test Plan

- [x] `python3 scripts/validate_plugins.py`
- [x] `git diff --check`
- [x] Confirmed only `skills/pre-commit-hooks-and-linting-config.md` and `.history` changed
