### PR TITLE
feat: amend Radiance Dependabot CI skills

### DIFF
--- a/skills/ci-transient-flake-and-environment-failures.history
+++ b/skills/ci-transient-flake-and-environment-failures.history
@@ -1,3 +1,310 @@
+## v1.1.0 (2026-06-17)
+
+**Changed by:** Radiance GitHub Actions dependency-install hang session (#897/#904)
+**Verification:** verified-ci
+
+### What changed
+- Added dependency-install hang triage for jobs stuck before tests run.
+- Documented Playwright --with-deps hanging in CI and the durable browser-install simplification.
+- Documented cancel-and-rerun handling for Python dependency install hangs after proving the same path passes elsewhere.
+- Added Radiance verification rows and failed-attempt lessons.
+
+### Why
+Radiance CI had jobs stuck in dependency installation with no live logs: Playwright Chromium installation with --with-deps, and later Python backend dependency installs. API step-state polling showed tests had not run. The Playwright path needed a small workflow fix; the Python install hangs cleared on a fresh runner attempt. The transferable lesson is to distinguish pre-test runner/install hangs from code failures before editing tests.
+
+### Previous version snapshot
+
+~~~markdown
+---
+name: ci-transient-flake-and-environment-failures
+description: "Use when: (1) a CI job fails non-deterministically and re-running resolves it (e.g. Trivy install.sh curl-pipe exit-1, lychee link-check 403/connection-reset from bot-blocking sites), (2) CI passes locally 100% but fails in GitHub Actions and you need a reproduction strategy that covers cold pixi cache + UID mismatch + no-TTY simultaneously, (3) a CI job is failing because a doctor/health-check script validates developer-local resources absent in GitHub Actions runners."
+category: ci-cd
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: ci-transient-flake-and-environment-failures.history
+tags:
+  - ci
+  - github-actions
+  - transient
+  - flake
+  - trivy
+  - lychee
+  - link-check
+  - lycheeignore
+  - reproduction
+  - podman
+  - pixi
+  - uid
+  - tty
+  - doctor
+  - git-hooks
+  - ci-guard
+  - environment-detection
+---
+
+# CI Transient Flake and Environment Failures
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-07 |
+| **Objective** | Diagnose and resolve CI failures that are transient network flakes (Trivy install, lychee link-check) or environment-only (passes locally, fails in GHA) — without reaching for banned suppressions. |
+| **Outcome** | Verified across ProjectAgamemnon (#368), ProjectOdyssey (#5347), ProjectOdyssey local repro, and ProjectMyrmidons (#350). |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A GitHub Actions job fails non-deterministically and a fresh run (rerun or new push) resolves it with zero code change. Common signatures:
+  - **Trivy install flake**: `aquasecurity/trivy info found version: X.Y.Z` immediately followed by `##[error]Process completed with exit code 1.`, with the prior `pip-audit` (or equivalent) step clean.
+  - **Lychee link-check flake**: HTTP 403 on `claude.ai` / `platform.claude.com` / `code.claude.com` (bot-blocking), or `os error 104` (connection reset) on `contributor-covenant.org` and similar community sites.
+- Tests pass locally 100% but fail consistently in CI, and you need to replicate the three CI conditions (cold pixi cache + UID mismatch + no-TTY) simultaneously.
+- A doctor / health-check / preflight script (`scripts/doctor.sh`, `just doctor`) exits 1 in CI because it validates developer-local resources (`.git/hooks/`, SSH keys, local config) absent on GHA runners.
+- You are tempted to add `|| true` or `continue-on-error: true` to silence a flake — STOP, those are policy-banned.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# --- Transient flake: rerun first, no code change ---
+unset GITHUB_TOKEN GH_TOKEN                       # let gh use runner auth chain
+gh run rerun <RUN_ID> --repo "$ORG/$REPO" --failed
+# Fallback: empty commit retriggers a fresh run
+git commit --allow-empty -m "ci: retrigger CI to clear transient flake" && git push
+
+# --- Lychee bot-403 / reset: add regex patterns to .lycheeignore ---
+cat >> .lycheeignore << 'EOF'
+claude\.ai
+platform\.claude\.com
+code\.claude\.com
+contributor-covenant\.org
+EOF
+
+# --- Reproduce CI-only failure locally: all 3 conditions at once ---
+podman compose down -v                            # cold pixi cache
+USER_ID=1001 GROUP_ID=1001 podman compose up -d   # CI runner UID (image build UID is 1000)
+USER_ID=1001 GROUP_ID=1001 podman compose exec -T <service> bash -c \
+  "cd /workspace && <test command>"               # -T = no TTY
+
+# --- Doctor script: guard developer-local checks in CI ---
+if [[ "${CI:-}" == "true" ]]; then
+    warn "<check name> skipped in CI" "<reason: dev-local only>"
+    return
+fi
+```
+
+### Detailed Steps
+
+#### A. Transient Trivy install.sh exit-1
+
+1. **Match the signature exactly.** The trivy install step's log MUST end with the `found version` line (no download bar, no checksum, no tar-extraction error) followed within ~0.4s by the runner error:
+
+   ```text
+   ##[group]Run TRIVY_VERSION=0.58.1
+   TRIVY_VERSION=0.58.1
+   curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+     | sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
+   trivy --version
+   shell: /usr/bin/bash -e {0}
+   ##[endgroup]
+   aquasecurity/trivy info checking GitHub for tag 'v0.58.1'
+   aquasecurity/trivy info found version: 0.58.1 for v0.58.1/Linux/64bit
+   ##[error]Process completed with exit code 1.
+   ```
+
+   If the log includes a progress bar, checksum-mismatch, or extraction error, this is NOT the same flake — investigate normally.
+2. **Confirm the prior step passed.** A clean `pip-audit` immediately before rules out a job-wide environment issue.
+3. **Rerun the failed jobs.** `gh run rerun <RUN_ID> --failed`. Unset `GITHUB_TOKEN`/`GH_TOKEN` if your shell has a PAT lacking `actions:write`.
+4. **If rerun isn't possible** (workflow changed since the run), push an empty commit to retrigger.
+5. **Only investigate if multiple reruns fail.** A repeat after two clean reruns implies a real problem (GitHub raw-content outage, version yank).
+6. **Durable follow-up (separate issue, don't block the PR):** replace curl-pipe-to-sh with the official action, which has retry semantics:
+
+   ```yaml
+   - name: Run Trivy
+     uses: aquasecurity/trivy-action@v<X>
+     with:
+       scan-type: fs
+       format: sarif
+       output: trivy-results.sarif
+   ```
+
+#### B. Lychee link-check bot-403 / connection reset
+
+1. **Identify the failing URLs** in the CI log:
+
+   ```text
+   [ERROR] https://claude.ai/code — Status 403 (Forbidden)
+   [ERROR] https://contributor-covenant.org/... — Connection reset (os error 104)
+   ```
+
+2. **Classify each failure**:
+
+   | Failure Type | URL Pattern | Root Cause | Action |
+   |-------------|-------------|------------|--------|
+   | HTTP 403 | `claude.ai`, `platform.claude.com`, `code.claude.com` | Anthropic URLs return 403 to automated bots (lychee user-agent) | Add to `.lycheeignore` |
+   | Connection reset (os error 104) | `contributor-covenant.org` | Intermittent server reset; site valid but unreliable from CI | Add to `.lycheeignore` |
+
+3. **Add regex patterns to `.lycheeignore`** (project root). Patterns are regular expressions, not globs; escape literal dots with `\.`; a pattern matches any URL containing the substring; `#` starts a comment:
+
+   ```text
+   # Ignore Claude/Anthropic URLs that return 403 to bots (valid URLs)
+   claude\.ai
+   platform\.claude\.com
+   code\.claude\.com
+
+   # Ignore external sites that intermittently reset connections (os error 104)
+   contributor-covenant\.org
+   ```
+
+4. **Verify** — push to trigger CI, or run locally:
+
+   ```bash
+   lychee --config .lychee.toml "**/*.md" --exclude-path .pixi
+   # or: pixi run lychee "**/*.md"
+   ```
+
+   `.lycheeignore` is read automatically by lychee — no explicit `.lychee.toml` reference needed.
+
+#### C. Reproduce CI-only test failures locally
+
+1. **Identify the three CI-specific conditions** that differ from local:
+   - **Cold pixi cache**: CI creates fresh named volumes every run; locally volumes persist.
+   - **UID mismatch**: CI runner typically uses UID 1001; container image is built with UID 1000.
+   - **No TTY**: CI uses `podman compose exec -T` (the `-T` flag disables TTY).
+2. **Confirm exact values from your CI config:**
+
+   ```bash
+   grep -r "USER_ID\|GROUP_ID\|uid\|user:" .github/workflows/
+   grep -r "exec -T\|compose exec" .github/workflows/ justfile
+   ```
+
+3. **Delete all named volumes** (`podman compose down -v`), **start with CI UID** (`USER_ID=1001 GROUP_ID=1001 podman compose up -d`), then **run the failing test with `-T`**.
+4. **If still not reproducing**, add CI env vars (`CI=true GITHUB_ACTIONS=true`) and check runner resource limits / filesystem (overlay vs native).
+5. **Read the FULL stack trace**, not just the summary. `execution crashed` is a symptom; the real cause (permission error from UID mismatch, missing cache dir, segfault) is in the trace. `fortify_fail_abort` / `__fortify_fail` points to a buffer overflow or permission violation.
+
+#### D. Doctor/health-check script CI guard
+
+1. **Identify the failing `check_*()` function** referencing developer-local artifacts (`.git/hooks/`, `~/.ssh/`, pre-commit install state).
+2. **Understand the CI context.** GitHub Actions sets `CI=true` on all runners. `${CI:-}` safely handles set and unset cases under `set -u`.
+3. **Add the guard at the TOP of the check function**, before any file-existence tests:
+
+   ```bash
+   check_hooks() {
+       section "Check N: Git hooks"
+
+       local hook_src="${REPO_ROOT}/hooks/pre-commit"
+       local hook_dst="${REPO_ROOT}/.git/hooks/pre-commit"
+
+       if [[ ! -f "$hook_src" ]]; then
+           warn "hooks/pre-commit source not found in repo"
+           return
+       fi
+
+       # In CI there is no .git/hooks directory; skip this check.
+       if [[ "${CI:-}" == "true" ]]; then
+           warn "pre-commit hook check skipped in CI" "hooks are installed by developers locally"
+           return
+       fi
+
+       if [[ ! -f "$hook_dst" ]]; then
+           fail "pre-commit hook not installed" "Run: just install-hooks"
+       elif [[ ! -x "$hook_dst" ]]; then
+           fail "pre-commit hook not executable" "Run: chmod +x .git/hooks/pre-commit"
+       else
+           pass "pre-commit hook installed and executable"
+       fi
+   }
+   ```
+
+4. **Use `warn` not `pass`** for the skip message so CI logs show the check was intentionally skipped.
+5. **Test locally** that the guard doesn't suppress the check in a normal shell, then **verify in CI** the job exits 0.
+
+   Categories of checks needing CI guards: git hooks, SSH infrastructure, local config files, pre-commit install state, GPG signing setup, editor/IDE config.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Add `\|\| true` / `continue-on-error: true` to silence a flake | Suppress the failing Trivy or link-check step | Org-wide `forbid-suppressions` / `forbid-continue-on-error` guards reject the diff at lint time | Suppressions are policy-banned; never reach for them to mask a flake |
+| Pin Trivy to a different version (thinking it was yanked) | Changed `0.58.1` → `0.57.x` | The same install.sh exit-1 reproduces on a fresh run; reverting then succeeds on rerun | The curl-pipe-to-sh transport is the variable, not the version. Don't churn version numbers. |
+| Read `install.sh` source to find the failure path | Source-dived the upstream script | It writes nothing to stderr before exit 1; no log evidence to investigate | Without log evidence, source-diving is speculative — rerun first, investigate only if reruns reproduce |
+| `--exclude-all-private` lychee flag | Tried excluding private/localhost URLs | Only skips private IP ranges and localhost, not bot-blocked external URLs | Use targeted `.lycheeignore` regex for external 403s |
+| `accept = [403]` in `.lychee.toml` | Globally accept 403 status | Too broad — would hide real broken links returning 403 | Prefer `.lycheeignore` for targeted exclusion; reserve `--accept` for codes you globally trust |
+| Wait for intermittent resets to clear | Assumed `contributor-covenant.org` resets were transient | Resets consistently enough in CI to block every run | Add unreliable external gates to `.lycheeignore`; don't rely on their availability |
+| Declare crash "non-reproducible locally" with warm cache + UID 1000 | 10 parallel agents ran the test locally; all passed | Warm cache + matching UID + TTY don't replicate CI | Never declare "passes locally" without identical conditions; replicate ALL three at once |
+| Fix one CI condition at a time | Tried only cold cache, or only UID mismatch | Each condition alone may not trigger the crash; all three together are required | Replicate cold cache + UID mismatch + no-TTY simultaneously |
+| Conclude "non-deterministic JIT flakiness" from the summary line | Read only `execution crashed`, not the full trace | The real cause (permission error) was in the stack trace | Always read the complete stack trace before forming a hypothesis |
+
+## Results & Parameters
+
+### Trivy flake — resolution commands
+
+```bash
+unset GITHUB_TOKEN GH_TOKEN
+gh run rerun <RUN_ID> --repo "$ORG/$REPO" --failed
+# fallback
+git commit --allow-empty -m "ci: retrigger CI to clear trivy install flake" && git push
+```
+
+Signature features: job shell is `bash -e`; the `found version` line is the last informational line; the `##[error]` appears <0.4s later; no trivy/curl/sh error message; the prior dep-scanner step exited 0.
+
+### Lychee — `.lycheeignore` entries
+
+```text
+claude\.ai
+platform\.claude\.com
+code\.claude\.com
+contributor-covenant\.org
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `claude\.ai` | Any URL containing `claude.ai` |
+| `platform\.claude\.com` | `https://platform.claude.com/...` |
+| `contributor-covenant\.org` | Any `contributor-covenant.org` URL |
+
+### CI environment conditions (Podman + pixi)
+
+```bash
+USER_ID=1001   # CI runner UID (image build UID is 1000)
+GROUP_ID=1001  # CI runner GID
+# Named pixi-cache volumes are fresh each run; compose exec uses -T (no TTY)
+```
+
+| Condition | Local Default | CI Default | Replicate Locally |
+|-----------|--------------|-----------|-------------------|
+| Pixi cache | Warm (persistent) | Cold (fresh) | `podman compose down -v` |
+| Container UID | 1000 | 1001 | `USER_ID=1001 GROUP_ID=1001 podman compose up -d` |
+| TTY | Present | None (`-T`) | `podman compose exec -T` |
+| CI env vars | Unset | `CI=true`, `GITHUB_ACTIONS=true` | Add to exec command |
+
+Expected: a previously "non-reproducible" crash reproduces 100% deterministically; the full trace reveals the real root cause.
+
+### Doctor CI guard — environment reference
+
+```bash
+CI=true            # set automatically on all GitHub Actions runners
+${CI:-}            # empty string if unset (safe under set -u)
+if [[ "${CI:-}" == "true" ]]; then ...  # skip developer-local checks
+```
+
+`.git/hooks/` is absent on: GitHub Actions runners (all OS), GitLab shallow clones, any `git clone --depth=1` / `actions/checkout`, Docker-copied repos. It IS present after `pre-commit install`, on full clones, or in CI jobs that explicitly run `pre-commit install`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectAgamemnon | 2026-05-11 — PR #368 final fix-up cycle | Trivy depscan install exit-1 unblocked by a fresh rerun / push; no code change to the install step |
+| ProjectOdyssey | 2026-05-03 — PR #5347/#5348 link-check session | `claude.ai` (403) and `contributor-covenant.org` (os error 104) fixed by `.lycheeignore` entries |
+| ProjectOdyssey | Reproducing `fortify_fail_abort` crash declared non-reproducible in `jit-fortify-buffer-overflow.md` | Cold cache + UID 1001 + `-T` flag combined triggered the crash 100% deterministically |
+| ProjectMyrmidons | PR #350 | `scripts/doctor.sh` Check 4 failed `just doctor --skip-connectivity` in CI; `${CI:-}` guard fixed it |
+
+~~~
+
+---
+
 <!-- markdownlint-disable MD024 -->
 
 # History: ci-transient-flake-and-environment-failures

--- a/skills/ci-transient-flake-and-environment-failures.md
+++ b/skills/ci-transient-flake-and-environment-failures.md
@@ -1,11 +1,12 @@
 ---
 name: ci-transient-flake-and-environment-failures
-description: "Use when: (1) a CI job fails non-deterministically and re-running resolves it (e.g. Trivy install.sh curl-pipe exit-1, lychee link-check 403/connection-reset from bot-blocking sites), (2) CI passes locally 100% but fails in GitHub Actions and you need a reproduction strategy that covers cold pixi cache + UID mismatch + no-TTY simultaneously, (3) a CI job is failing because a doctor/health-check script validates developer-local resources absent in GitHub Actions runners."
+description: "Use when: (1) a CI job fails non-deterministically and re-running resolves it (e.g. Trivy install.sh curl-pipe exit-1, lychee link-check 403/connection-reset from bot-blocking sites), (2) CI passes locally 100% but fails in GitHub Actions and you need a reproduction strategy that covers cold pixi cache + UID mismatch + no-TTY simultaneously, (3) a CI job is failing because a doctor/health-check script validates developer-local resources absent in GitHub Actions runners, (4) a dependency-install step stays in_progress far beyond the repo's baseline before tests start, such as Playwright browser install or Python package install hangs."
 category: ci-cd
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-17
+version: "1.1.0"
 user-invocable: false
 history: ci-transient-flake-and-environment-failures.history
+verification: verified-ci
 tags:
   - ci
   - github-actions
@@ -24,6 +25,11 @@ tags:
   - git-hooks
   - ci-guard
   - environment-detection
+  - playwright
+  - pip-install
+  - dependency-install
+  - runner-hang
+  - gh-run-rerun
 ---
 
 # CI Transient Flake and Environment Failures
@@ -32,10 +38,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-07 |
-| **Objective** | Diagnose and resolve CI failures that are transient network flakes (Trivy install, lychee link-check) or environment-only (passes locally, fails in GHA) — without reaching for banned suppressions. |
-| **Outcome** | Verified across ProjectAgamemnon (#368), ProjectOdyssey (#5347), ProjectOdyssey local repro, and ProjectMyrmidons (#350). |
+| **Date** | 2026-06-17 |
+| **Objective** | Diagnose and resolve CI failures that are transient network flakes, environment-only, developer-local health checks, or dependency-install hangs before tests start - without reaching for banned suppressions. |
+| **Outcome** | Verified across ProjectAgamemnon (#368), ProjectOdyssey (#5347), ProjectOdyssey local repro, ProjectMyrmidons (#350), and Radiance (#897/#904). |
 | **Verification** | verified-ci |
+| **History** | Previous v1.0.0 snapshot archived in `ci-transient-flake-and-environment-failures.history` |
 
 ## When to Use
 
@@ -44,6 +51,7 @@ tags:
   - **Lychee link-check flake**: HTTP 403 on `claude.ai` / `platform.claude.com` / `code.claude.com` (bot-blocking), or `os error 104` (connection reset) on `contributor-covenant.org` and similar community sites.
 - Tests pass locally 100% but fail consistently in CI, and you need to replicate the three CI conditions (cold pixi cache + UID mismatch + no-TTY) simultaneously.
 - A doctor / health-check / preflight script (`scripts/doctor.sh`, `just doctor`) exits 1 in CI because it validates developer-local resources (`.git/hooks/`, SSH keys, local config) absent on GHA runners.
+- A GitHub job API response shows a dependency-install step such as `Install Playwright Chromium for browser smoke tests`, `Install backend coverage dependencies`, `Install backend runtime and test dependencies`, or `Install focused regression dependencies` remains `in_progress` far beyond the latest green baseline while the test step is still pending.
 - You are tempted to add `|| true` or `continue-on-error: true` to silence a flake — STOP, those are policy-banned.
 
 ## Verified Workflow
@@ -76,6 +84,21 @@ if [[ "${CI:-}" == "true" ]]; then
     warn "<check name> skipped in CI" "<reason: dev-local only>"
     return
 fi
+
+# --- Dependency-install hang before tests start ---
+gh api repos/<owner>/<repo>/actions/jobs/<job_id> \
+  --jq '{status:.status,steps:[.steps[]|{name,status,started_at,completed_at}]}'
+
+# Compare against a latest green main/PR job before deciding whether to wait.
+gh api repos/<owner>/<repo>/actions/runs/<main_run_id>/jobs \
+  --jq '.jobs[] | select(.name=="tests-frontend") | {status,conclusion,started_at,completed_at,steps}'
+
+# If the install path invokes optional OS package work but the runner already has deps:
+npx --no-install playwright install chromium
+
+# If the same install path passed elsewhere and this run is stuck:
+gh run cancel <run_id> --repo <owner/repo>
+gh run rerun <run_id> --repo <owner/repo>
 ```
 
 ### Detailed Steps
@@ -206,6 +229,32 @@ fi
 
    Categories of checks needing CI guards: git hooks, SSH infrastructure, local config files, pre-commit install state, GPG signing setup, editor/IDE config.
 
+#### E. Dependency-install step hangs before tests start
+
+1. **Use the job API, not just logs.** In-progress jobs may return unavailable log
+   blobs, but `gh api repos/<owner>/<repo>/actions/jobs/<job_id>` still reports
+   each step's `status`, `started_at`, and `completed_at`. If the test step is
+   pending, do not debug the tests yet.
+
+2. **Compare against a recent green baseline.** Pull the same job from the latest
+   green main or sibling PR run. A dependency-install step running for 10-15 minutes
+   when the baseline is seconds is a runner/install hang, not slow tests.
+
+3. **Simplify optional install work when the command is the variable.** For
+   Playwright, `playwright install --with-deps chromium` can enter an apt/system
+   dependency path that is not needed when the runner image already has system
+   dependencies. Prefer `playwright install chromium` (or `npx --no-install
+   playwright install chromium`) only after verifying the browser smoke tests still
+   pass in fresh CI.
+
+4. **Cancel and rerun proven transient install hangs.** If identical dependency
+   install paths passed on main, sibling jobs, or a subsequent PR attempt, cancel the
+   stuck run and rerun it on a fresh runner instead of waiting indefinitely.
+
+5. **Only edit code/tests after reproduction.** If the rerun reaches the test step
+   and fails deterministically with logs, treat that as a real code/test failure.
+   Until then, classify the problem as pre-test infrastructure.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -219,6 +268,10 @@ fi
 | Declare crash "non-reproducible locally" with warm cache + UID 1000 | 10 parallel agents ran the test locally; all passed | Warm cache + matching UID + TTY don't replicate CI | Never declare "passes locally" without identical conditions; replicate ALL three at once |
 | Fix one CI condition at a time | Tried only cold cache, or only UID mismatch | Each condition alone may not trigger the crash; all three together are required | Replicate cold cache + UID mismatch + no-TTY simultaneously |
 | Conclude "non-deterministic JIT flakiness" from the summary line | Read only `execution crashed`, not the full trace | The real cause (permission error) was in the stack trace | Always read the complete stack trace before forming a hypothesis |
+| Fetch live logs for an in-progress install step | Tried to read logs while the job was still running | GitHub returned unavailable log blobs; the test step had not started | Use the job API step list to identify the stuck in-progress step and pending test steps |
+| Debug tests before dependency install completed | Treated the failing check as a test failure | The test command never ran, so editing tests or assertions could not affect the failure | Classify pre-test dependency-install hangs separately from deterministic test failures |
+| Keep `playwright install --with-deps chromium` after a long CI hang | Waited on the apt/system dependency path even though the runner baseline installed browsers in seconds | The optional `--with-deps` path was the variable and could hang before browser smoke tests started | If runner system deps are already adequate, install the pinned browser only and verify fresh CI |
+| Wait indefinitely on Python dependency install hangs | Assumed enough time would eventually produce logs | The same install path passed on a fresh runner attempt; the stuck attempt consumed CI time without new evidence | After proving a pre-test install hang is transient, cancel and rerun on a fresh runner |
 
 ## Results & Parameters
 
@@ -275,6 +328,16 @@ if [[ "${CI:-}" == "true" ]]; then ...  # skip developer-local checks
 
 `.git/hooks/` is absent on: GitHub Actions runners (all OS), GitLab shallow clones, any `git clone --depth=1` / `actions/checkout`, Docker-copied repos. It IS present after `pre-commit install`, on full clones, or in CI jobs that explicitly run `pre-commit install`.
 
+### Dependency-install hang - Radiance facts
+
+| Fact | Detail |
+|------|--------|
+| Playwright install hang | PR #897 first CI attempt had `Install Playwright Chromium for browser smoke tests` stuck for 15+ minutes while the latest green `master` baseline completed the same job in seconds |
+| Durable frontend fix | Replaced `playwright install --with-deps chromium` with `playwright install chromium`; fresh CI installed in about 12 seconds and browser smoke passed |
+| Python coverage install hang | Original Dependabot PR #890 had coverage dependency install hang before tests; canceling and rerunning produced a green second attempt |
+| Backend dependency install hangs | PR #904 attempt 1 had backend dependency-install jobs stuck before tests; canceling and rerunning produced a green second attempt |
+| Classification rule | When the stuck step is dependency installation and test steps are pending, do not edit tests until a fresh run reaches the test command and fails deterministically |
+
 ## Verified On
 
 | Project | Context | Details |
@@ -283,3 +346,4 @@ if [[ "${CI:-}" == "true" ]]; then ...  # skip developer-local checks
 | ProjectOdyssey | 2026-05-03 — PR #5347/#5348 link-check session | `claude.ai` (403) and `contributor-covenant.org` (os error 104) fixed by `.lycheeignore` entries |
 | ProjectOdyssey | Reproducing `fortify_fail_abort` crash declared non-reproducible in `jit-fortify-buffer-overflow.md` | Cold cache + UID 1001 + `-T` flag combined triggered the crash 100% deterministically |
 | ProjectMyrmidons | PR #350 | `scripts/doctor.sh` Check 4 failed `just doctor --skip-connectivity` in CI; `${CI:-}` guard fixed it |
+| Radiance | PRs #897/#904, 2026-06-17 | Playwright `--with-deps` install hang resolved by browser-only install; Python dependency-install hangs cleared by cancel/rerun after API step-state polling showed tests had not started |

--- a/skills/lockfile-and-release-pipeline-management.history
+++ b/skills/lockfile-and-release-pipeline-management.history
@@ -1,5 +1,496 @@
 # lockfile-and-release-pipeline-management — History
 
+## v1.2.0 (2026-06-17)
+
+**Changed by:** Radiance Dependabot CI stabilization session (#896/#897, #903/#904)
+**Verification:** verified-ci
+
+### What changed
+- Added lockfile-backed Dependabot CI contract guidance from Radiance.
+- Added grouped Angular exact-peer dependency update workflow.
+- Added narrow expiring pip-audit allowlist guidance for no-fixed-version advisories.
+- Added failed-attempt lessons against deleting or weakening tests for deterministic dependency contract failures.
+
+### Why
+Radiance had 10 open failing Dependabot PRs. The root causes were deterministic: hardcoded dependency-version contract tests, exact-peer Angular package updates opened as separate PRs, and a torch advisory with no fixed version. Keeping the tests and making them lockfile-aware produced green CI; blindly deleting flaky-looking tests would have hidden real dependency-contract drift.
+
+### Previous version snapshot
+
+~~~markdown
+---
+name: lockfile-and-release-pipeline-management
+description: "Recover drifted lockfiles, resync dependency lockfiles after manifest edits, fix silent release recipe failures, enforce version single-source-of-truth, and configure Renovate for multi-ecosystem repos. Use when: (1) CI rejects a generated lockfile (pixi.lock, Cargo.lock, package-lock.json) and the source manifest is unchanged vs main, (2) editing package.json without regenerating package-lock.json causes npm ci EUSAGE failures, (3) `just release X.Y.Z` exits non-zero with 'nothing to commit' because pyprojects already have the target version, (4) project version is declared in multiple files that can drift and you need a single-source-of-truth strategy with pre-commit guards, (5) adding automated dependency updates (Renovate) to a C++20 repo with Conan, FetchContent, pixi, GHA, and Dockerfiles, (6) `pixi install` fails with `No candidates were found for <pkg> ==<version>` because a pinned nightly/dev-build artifact was garbage-collected from the channel."
+category: ci-cd
+date: 2026-05-19
+version: "1.1.0"
+user-invocable: false
+history: lockfile-and-release-pipeline-management.history
+tags:
+  - lockfile
+  - pixi-lock
+  - cargo-lock
+  - package-lock
+  - drift-recovery
+  - npm-ci
+  - eusage
+  - release
+  - just
+  - bump-version
+  - git-tag
+  - versioning
+  - importlib-metadata
+  - pre-commit
+  - renovate
+  - conan
+  - fetchcontent
+  - tool-version-skew
+  - nightly-build
+  - artifact-gc
+  - unsolvable-pin
+  - mojo
+  - pixi-install
+---
+
+# Lockfile and Release Pipeline Management
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-19 |
+| **Objective** | Canonical skill covering the full gap between "dependency declared" and "lockfile/version consistent in CI": verbatim lockfile restoration from main, npm lockfile resync, release recipe no-op diagnosis, version single-source-of-truth enforcement, Renovate setup for heterogeneous C++ repos, and recovery from a pinned nightly/dev-build artifact garbage-collected from its channel |
+| **Outcome** | Merged from 5 verified skills; patterns confirmed across ProjectAgamemnon, ProjectProteus, ProjectScylla; v1.1.0 adds the GC'd-nightly failure mode (predictive-coding research project) |
+| **Verification** | verified-ci (lockfile restore, npm resync); verified-local (release recipe, versioning, GC'd-nightly recovery); unverified (Renovate — app install in progress) |
+
+## When to Use
+
+- A generated lockfile (`pixi.lock`, `Cargo.lock`, `poetry.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `go.sum`) is rejected by CI and the matching source manifest is **identical** to `origin/main`
+- You've already tried local regeneration once and CI still rejects the result (tool-version skew between dev machine and CI runner)
+- A `package.json` edit was committed without regenerating its sibling `package-lock.json`; CI fails with `npm error code EUSAGE`
+- `just release X.Y.Z` ends with "nothing added to commit" / "Recipe `release` failed with exit code 1" even though no real problem exists
+- Project declares `__version__` or version strings in multiple files (`pyproject.toml`, `pixi.toml`, `__init__.py`, CLI) that can drift
+- CHANGELOG references phantom future versions that don't exist yet as tags
+- Adding Renovate bot to a C++20 repo using Conan, CMake FetchContent, pixi, GitHub Actions, and Dockerfiles
+- A pinned nightly or dev-build dependency (`==X.Y.Zb2.devYYYYMMDD`-style) can no longer be resolved because the artifact was GC'd from the package channel; you need to repin and lock
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# ── A. Verbatim lockfile restore from main ──────────────────────────────────
+# Confirm source manifest matches main (empty output = safe to copy)
+git diff origin/main..HEAD -- <path/to/manifest>
+
+# Confirm main is GREEN on the same source SHA
+gh run list --workflow=<workflow>.yml --branch=main --limit=3 \
+  --json conclusion,headSha,displayTitle
+
+# Restore generated file verbatim
+git checkout origin/main -- <path/to/lockfile>
+
+# Verify zero diff vs main on the restored file
+git diff origin/main -- <path/to/lockfile> | wc -l   # must be 0
+
+# Commit — DO NOT run install tools locally afterward
+pre-commit run --files <path/to/lockfile>
+git commit -S -m "fix(ci): align <lockfile> with main verbatim"
+git push --force-with-lease
+
+# ── B. npm lockfile resync after package.json edit ───────────────────────────
+cd <pkg-dir>                   # MUST be same directory as the edited package.json
+npm install                    # rewrites package-lock.json
+git add package-lock.json
+rm -rf node_modules && npm ci  # verify same command CI runs
+git commit -m "chore(<pkg-dir>): regenerate package-lock.json after <dep> change"
+
+# ── C. Release recipe no-op recovery ─────────────────────────────────────────
+# Diagnose: git status clean + all pyprojects already at target version
+git status
+grep -H '^version = ' clients/python/pyproject.toml agamemnon/pyproject.toml
+git log --oneline -5
+git tag --list 'v*' --sort=-v:refname | head -5
+
+# Manual recovery: skip the broken recipe, tag directly
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+git tag --verify vX.Y.Z
+gh run list --workflow=<release-workflow>.yml --limit=2
+
+# ── D. Version single-source-of-truth setup ──────────────────────────────────
+# In package/__init__.py — read version from installed metadata
+# from importlib.metadata import PackageNotFoundError, version as _get_version
+# try:
+#     __version__: str = _get_version("mypackage")
+# except PackageNotFoundError:
+#     __version__ = "0.0.0"
+
+# Run consistency check
+python3 scripts/check_package_version_consistency.py --verbose
+
+# ── E. Renovate setup for C++20 repo ─────────────────────────────────────────
+# Create renovate.json in repo root (see Results & Parameters)
+# Install Renovate GitHub App at https://github.com/apps/renovate
+
+# ── F. Pinned nightly artifact garbage-collected ─────────────────────────────
+# Diagnosis: pixi install fails with
+#   × failed to solve the conda requirements of 'default' 'linux-64'
+#   ╰─▶ Cannot solve the request because of:
+#       No candidates were found for <pkg> ==<exact-version>.
+# Confirm the artifact is GC'd (pinned version absent from search results):
+pixi search <pkg> -c <channel>          # e.g. -c https://conda.modular.com/max
+# NOTE: pixi (<= 0.39.x) has NO `pixi lock` subcommand — the lock is a side
+# effect of `pixi install`. `pixi lock` errors: unrecognized subcommand 'lock'.
+# Recovery: repin manifest to the newest still-available build, then lock:
+#   edit pixi.toml  →  <pkg> = "==<newest-available-build>"
+pixi install                            # generates pixi.lock against the new pin
+git add pixi.toml pixi.lock
+git commit -S -m "fix(deps): repin <pkg> to <build> after nightly GC; commit pixi.lock"
+```
+
+### Detailed Steps
+
+#### A — Verbatim Lockfile Restore
+
+1. **Confirm source manifests match main.** If `pixi.toml`/`Cargo.toml`/`package.json` differs, this approach does NOT apply — regenerate properly.
+
+   ```bash
+   git fetch origin
+   git diff origin/main..HEAD -- <path/to/manifest>
+   # Empty output = source files match; generated file is the only drift
+   ```
+
+2. **Confirm main is GREEN** on this source-file SHA. Check the latest CI run on main via `gh run list`.
+
+3. **Restore the generated file verbatim:**
+
+   ```bash
+   git checkout origin/main -- <path/to/lockfile>
+   # Multiple files at once if needed:
+   git checkout origin/main -- clients/python/pixi.lock clients/python/tests/test_bump_version.py
+   ```
+
+4. **Verify zero diff vs main:**
+
+   ```bash
+   git diff origin/main -- <path/to/lockfile> | wc -l   # must be 0
+   ```
+
+5. **Commit and push — CRITICAL: do NOT run `pixi install` / `cargo update` / `npm install` locally afterward.** Local tool invocations re-write the lock based on the local binary version, undoing the alignment.
+
+   ```bash
+   pre-commit run --files <path/to/lockfile>
+   git commit -S -m "fix(ci): align <lockfile> with main verbatim"
+   git push --force-with-lease
+   ```
+
+**When this approach is WRONG:** The generated file SHOULD differ from main because your PR adds/removes/changes dependencies; the source manifest has changes not yet propagated to the lock; main itself is RED (copying its lock propagates the bug).
+
+#### B — npm Lockfile Resync
+
+1. **Identify the directory owning the edited `package.json`.** Running `npm install` from repo root regenerates the WRONG lockfile or none at all.
+
+2. **Confirm a lockfile exists** before assuming it's absent:
+
+   ```bash
+   ls <pkg-dir>/package-lock.json <pkg-dir>/npm-shrinkwrap.json 2>/dev/null
+   ```
+
+3. **Run `npm install` in that directory.** This rewrites `package-lock.json` to match the new `package.json` and creates `node_modules/` (which must NOT be committed — verify `.gitignore`).
+
+4. **Stage ONLY the lockfile** and verify with CI's exact command:
+
+   ```bash
+   git add <pkg-dir>/package-lock.json
+   cd <pkg-dir> && rm -rf node_modules && npm ci   # must succeed with no EUSAGE
+   ```
+
+5. **Both `package.json` and `package-lock.json` MUST land in the same PR.** Never split them across two PRs.
+
+**Sub-agent dispatch template addition** — append to any brief touching `package.json`:
+
+```text
+If you edit any package.json:
+  1. cd into the SAME directory as that package.json.
+  2. Run `npm install` to regenerate package-lock.json.
+  3. Run `rm -rf node_modules && npm ci` to verify the lockfile is in sync.
+  4. Stage and commit ONLY package.json AND package-lock.json (NOT node_modules/).
+  5. Both files MUST land in the same PR.
+```
+
+#### C — Release Recipe No-op Recovery
+
+1. **Confirm this is the no-op trap, not a real failure.** `git status` should be clean. Grep every source-of-truth pyproject file for the target version. If they all already show `version = "X.Y.Z"`, the recipe failed because `bump-version.py` had nothing to do.
+
+2. **Skip the recipe; tag manually:**
+
+   ```bash
+   git tag -s vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z   # NOT --follow-tags (no commit alongside it)
+   ```
+
+3. **Verify the tag is signed** and the release workflow fired (most trigger on `push.tags: ["v*"]`, not PR merge).
+
+4. **File a follow-up PR** applying the justfile fix in Results & Parameters so future release runs aren't fragile.
+
+#### D — Version Single-Source-of-Truth
+
+1. **Switch `__init__.py` to `importlib.metadata`** so `pyproject.toml` is the only declaration site.
+
+2. **Eliminate hardcoded CLI version** — import `__version__` from the package's `__init__.py`.
+
+3. **Create a pre-commit consistency checker** using `tomllib` (not regex) that validates `pixi.toml`, `pyproject.toml`, `__init__.py`, and `CHANGELOG.md`.
+
+4. **Fix CHANGELOG phantom versions** — replace aspirational version references with `[Unreleased]` or "a future major version."
+
+5. **Release workflow**: trigger on `push.tags: ["v*"]`; validate tag version matches `pyproject.toml`; use `gh release create --generate-notes`.
+
+#### E — Renovate for C++20 Repos
+
+1. Create `renovate.json` in each repo root (see config in Results & Parameters).
+2. Install the Renovate GitHub App at `https://github.com/apps/renovate` for the org.
+3. For meta-repos with submodules, use `ignorePaths` in the root config; each submodule gets its own `renovate.json`.
+4. CMake FetchContent `GIT_TAG` has no native Renovate manager — use the custom `regex` manager.
+
+#### F — Pinned Nightly Artifact Garbage-Collected
+
+This is a **distinct, higher-severity failure** from lockfile drift (section A). In
+section A the dependency is still solvable — only the *generated* lockfile is out of
+sync. Here the **pinned dependency itself is unsolvable** because its artifact no
+longer exists on the package channel. Nightly / dev / dated-snapshot builds are
+**garbage-collected** from channels on a rolling window (often weeks). A pin to a
+version like `==1.0.0b2.dev2026050805` will eventually become unsolvable.
+
+1. **Recognize the diagnosis signature.** `pixi install` fails with:
+
+   ```text
+   × failed to solve the conda requirements of 'default' 'linux-64'
+   ╰─▶ Cannot solve the request because of: No candidates were found for mojo
+       ==1.0.0b2.dev2026050805.
+   ```
+
+   `No candidates were found for <pkg> ==<exact-version>` means the **artifact is
+   unavailable**, NOT that the manifest drifted. This is distinct from the
+   lockfile-drift failures in section A (where CI rejects a *generated* file but the
+   dependency is still solvable).
+
+2. **Confirm the artifact is GC'd** — search the channel for what remains:
+
+   ```bash
+   pixi search mojo -c https://conda.modular.com/max
+   ```
+
+   If the pinned version is **absent from the search results**, the artifact is gone.
+   The channel typically retains only the release build and a few older stable
+   versions; dated nightlies are not retained.
+
+3. **Note: `pixi` (≤ 0.39.x) has no standalone `pixi lock` subcommand.** The lockfile
+   is generated only as a side effect of `pixi install`. Verified: `pixi 0.39.5`
+   responds to `pixi lock` with `unrecognized subcommand 'lock'`.
+
+4. **Recover by repinning to the newest still-available build.** Pick the newest
+   version from the `pixi search` output (prefer a release build over another
+   nightly), edit the manifest, regenerate the lock, and **commit `pixi.lock`
+   immediately** — while the artifact still exists:
+
+   ```bash
+   # edit pixi.toml: mojo = "==1.0.0b1"   (newest still-available build)
+   pixi install
+   git add pixi.toml pixi.lock
+   git commit -S -m "fix(deps): repin mojo to 1.0.0b1 after nightly GC; commit pixi.lock"
+   ```
+
+5. **If a transitive/upstream dependency also pins the GC'd version**, the repin is a
+   **deliberate divergence** from upstream — bumping to match upstream is not an
+   option because upstream is equally broken. Document the divergence in the project's
+   dependency notes / failure-cascade matrix, and flag downstream code for
+   re-verification against the new toolchain version.
+
+**Prevention (the load-bearing lesson):** Generate and commit the lockfile the moment
+a dependency is pinned — especially for nightly/dev builds. The lockfile is the only
+durable record of the resolved artifact. Once the nightly is GC'd, a committed
+`pixi.lock` may still let `pixi install --locked` succeed (the lock references the
+artifact by content hash + URL); with no lockfile, the pin is unrecoverable. The
+window to lock is "while the artifact still exists" — "lock it later" is not a plan.
+Prefer pinning a release build over a dated nightly when reproducibility matters.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Install pixi v0.39.5 locally (matching CI pin) and regenerate lock | Pinned developer pixi to CI's version, regenerated `pixi.lock` from branch | Produced another divergent format: "lock-file not up-to-date with the project". OS/glibc/conda channel cache differences still cause drift | Pinning dev pixi to CI's version is necessary but not sufficient — use verbatim copy from main when source manifest is unchanged |
+| Regenerate with dev pixi v0.67.2 and accept format drift | Ran newer local pixi, committed output | Newer pixi writes a lock format the older CI pixi rejects; v0.39.5 vs v0.67.2 binary skew | Newer-to-older pixi lockfile compatibility is NOT guaranteed |
+| Copy verbatim then run `pixi install` locally to "sync" environment | `git checkout origin/main -- pixi.lock` then ran `pixi install` | `pixi install` immediately re-wrote the lock based on the local binary, reintroducing exact drift | Once you copy verbatim, do NOT touch the file with any install tool |
+| Easy-issue sweep agent edited `package.json`, claimed no lockfile present | Ran `find . -name package-lock.json` from repo root with wrong CWD depth, missed `dagger/package-lock.json` | CI failed with `npm error code EUSAGE`: `Invalid: lock file's @types/node@25.6.2 does not satisfy @types/node@20.19.40` | Always run `ls <pkg-dir>/package-lock.json` from the same directory as the edited file; never trust a `find` result as proof of absence |
+| Edit `package.json` and push without `npm install` | Hoped local `node_modules/` was fresh enough | Local builds use `npm install` masking the problem; CI uses `npm ci` (strict) and refuses any mismatch | Use the same command CI uses: `npm ci` after `rm -rf node_modules` |
+| Run `npm install` from repo root when `package.json` is nested | Assumed npm would auto-discover the nested package | npm only operates on CWD's `package.json`; from repo root with no root `package.json` the command errors | Always `cd <pkg-dir>` first |
+| Re-run `just release X.Y.Z` after seeing "nothing to commit" error | Assumed transient issue | `bump-version.py` is still a no-op; re-running cannot escape the trap — recipe is deterministic | Recipe failure is deterministic when bump is a no-op; recover the tag manually instead |
+| `git commit --allow-empty` before re-running the release recipe | Tried to satisfy the commit step | Doesn't fix the recipe-flow problem and pollutes history with a meaningless empty commit | Don't paper over recipe bugs with manual side-commits |
+| Edit pyprojects down to `0.0.1` then run `just release X.Y.Z` | Forced bump-version to have work to do | Adds a useless version-down-then-up cycle to git history; reviewers will question it | Manipulating source files to satisfy a broken recipe pollutes history |
+| Release recipe stages only one of N pyproject files | Pre-existing justfile only `git add`s `clients/python/pyproject.toml` | Silently drops bump to `agamemnon/pyproject.toml` — ships with one file bumped, other dangling in working tree | Whenever `bump-version.py` writes to N files, `git add` must list all N |
+| Test file at `tests/unit/test_version_consistency.py` | Placed test directly under `tests/unit/` | Pre-commit hook `check-unit-test-structure` requires tests in sub-packages | Check project test structure conventions before placing new test files |
+| Regex-based TOML parsing in consistency script | Used `re.match(r'^version\s*=\s*"([^"]+)"')` | Fragile: breaks on inline comments, multi-line strings, non-standard formatting | Use `tomllib` (stdlib since Python 3.11) for reliable TOML parsing |
+| Dependabot for Conan \| pixi \| FetchContent | Considered GitHub Dependabot as Renovate alternative | Dependabot has no native Conan, pixi, or FetchContent support | Renovate is the correct choice for C++ ecosystems |
+| Single Renovate config at meta-repo root covering all submodules | One `renovate.json` at Odysseus root | Submodules are separate git repos — Renovate needs a config per repo to open PRs | Use `ignorePaths` in the meta-repo config; put individual configs in each submodule |
+| Pinned a Mojo nightly (`==1.0.0b2.dev2026050805`) and deferred generating the lockfile | Left `pixi.lock` ungenerated for weeks after pinning the nightly toolchain build | The nightly was garbage-collected from `conda.modular.com/max`; `pixi install` then failed with `No candidates were found`. With no committed lockfile, the pin was unrecoverable — had to repin to a different build | Nightly/dev-build artifacts are GC'd from channels. Generate and commit the lockfile the moment the dependency is pinned, while the artifact still exists. Prefer pinning a release build over a dated nightly when reproducibility matters |
+
+## Results & Parameters
+
+### A. Lockfile Restore — Decision Flowchart
+
+```
+Generated file CI failure on feature branch
+  │
+  ├─ Source manifest differs from main?  ──► Regenerate (different skill)
+  ├─ Branch adds new deps to source?     ──► Regenerate (different skill)
+  ├─ main is RED on same source SHA?     ──► Fix main first (different skill)
+  └─ Source matches main, main is GREEN, no new deps
+        └─► THIS SKILL: git checkout origin/main -- <generated-file>
+                         commit, push, DO NOT run install tool locally
+```
+
+Applies to: `pixi.lock`, `Cargo.lock`, `poetry.lock`, `package-lock.json`, `yarn.lock`,
+`pnpm-lock.yaml`, `go.sum`, `requirements.txt` (pip-compile), vendored JSON/YAML.
+
+### B. npm Resync — Sub-Agent Brief Expansion
+
+When an easy-issue brief says "change `<dep>`'s version in `package.json`", expand to:
+
+> "Change `<dep>`'s version in `<pkg-dir>/package.json` AND regenerate `<pkg-dir>/package-lock.json`
+> by running `npm install` in `<pkg-dir>/`. Commit both files in the same PR."
+
+### C. Justfile Fix for No-op Bump Trap
+
+```diff
+ release VERSION push='true':
+   #!/usr/bin/env bash
+   set -euo pipefail
+   python3 scripts/bump-version.py "{{VERSION}}"
+-  git add clients/python/pyproject.toml
+-  git commit -S -m "chore: bump version to v{{VERSION}}"
++  git add clients/python/pyproject.toml agamemnon/pyproject.toml
++  if ! git diff --cached --quiet; then
++    git commit -S -m "chore: bump version to v{{VERSION}}"
++  else
++    echo "Version already at {{VERSION}}; skipping no-op bump commit"
++  fi
+   git tag -s "v{{VERSION}}" -m "v{{VERSION}}"
+   if [ "{{push}}" = "true" ]; then
+     git push --follow-tags
+   fi
+```
+
+Two required changes: (1) stage ALL source-of-truth pyproject files; (2) gate the commit on
+`git diff --cached --quiet` so no-op bumps don't abort the recipe before tagging.
+
+### D. importlib.metadata Pattern
+
+```python
+# package/__init__.py — read version from installed metadata
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _get_version
+
+try:
+    __version__: str = _get_version("mypackage")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback when package is not installed
+```
+
+```python
+# Consistency script — use tomllib, not regex
+import tomllib  # Python 3.11+; use tomli as fallback for 3.10
+
+def get_pyproject_version(path: Path) -> str:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["version"]
+
+def check_init_uses_importlib(path: Path) -> bool:
+    content = path.read_text()
+    return not re.search(r'^__version__\s*=\s*["\'][\d.]+["\']', content, re.MULTILINE)
+```
+
+```yaml
+# Pre-commit hook registration
+- id: check-package-version-consistency
+  name: Check Package Version Consistency
+  entry: pixi run python scripts/check_package_version_consistency.py
+  language: system
+  files: ^(pyproject\.toml|pixi\.toml|package/__init__\.py|CHANGELOG\.md)$
+  pass_filenames: false
+```
+
+### E. Renovate Config for C++20 Repo
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 5am on Monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["CMakeLists\\.txt$"],
+      "matchStrings": [
+        "FetchContent_Declare\\([\\s\\S]*?GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^/]+/[^.]+)\\.git\\s+GIT_TAG\\s+(?<currentValue>v?[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    { "matchManagers": ["conan"], "groupName": "C++ Conan dependencies" },
+    { "matchManagers": ["pixi"], "groupName": "pixi build tools",
+      "schedule": ["before 5am on the first day of the month"] },
+    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions", "automerge": true }
+  ]
+}
+```
+
+Meta-repo config (root with submodules): add `"ignorePaths": ["control/**", "testing/**", ...]`
+to prevent scanning submodule directories — each submodule owns its own `renovate.json`.
+
+| Ecosystem | Renovate Manager | Native? |
+|-----------|-----------------|---------|
+| Conan 2.x (`conanfile.py`) | `conan` | Yes |
+| pixi.toml (conda-forge) | `pixi` | Yes |
+| CMake FetchContent (`GIT_TAG`) | `regex` (custom) | No |
+| GitHub Actions (`uses:`) | `github-actions` | Yes |
+| Dockerfile (`FROM`) | `dockerfile` | Yes |
+| Python (`pyproject.toml`) | `pep621` | Yes |
+
+### F. Pinned Nightly Artifact GC — Verified Facts
+
+| Fact | Detail |
+|------|--------|
+| No `pixi lock` subcommand | `pixi` (≤ 0.39.x) has no standalone `pixi lock` — verified: `pixi 0.39.5` → `pixi lock` errors with `unrecognized subcommand 'lock'`. The lockfile is generated only as a side effect of `pixi install` |
+| GC diagnosis signature | `pixi install` failing with `No candidates were found for <pkg> ==<exact-version>` means the *artifact* is unavailable, NOT that the manifest drifted (distinct from section A lockfile drift) |
+| Confirmation command | `pixi search <pkg> -c <channel>` — if the pinned version is absent from the search results, the artifact has been GC'd from the channel |
+| Recovery | Repin the manifest to the newest still-available build from `pixi search`, run `pixi install` to regenerate `pixi.lock`, commit the lockfile immediately |
+
+**Prevention rule:** generate and commit the lockfile the moment a dependency is
+pinned — especially for nightly/dev builds. The lockfile is the only durable record
+of the resolved artifact; once the nightly is GC'd, "lock it later" is no longer
+possible. Prefer pinning a release build over a dated nightly when reproducibility
+matters.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectAgamemnon | PR #400 — `clients/python/pixi.lock` verbatim restore, 2026-05-18; 3 failed regeneration attempts; v0.1.0 tag cut shortly after | See `git log --grep="align clients/python/pixi.lock with main verbatim"` in ProjectAgamemnon |
+| ProjectAgamemnon | Phase F-6 v0.1.0 release cut, 2026-05-18 — `just release 0.1.0` no-op trap; manual `git tag -s v0.1.0 && git push origin v0.1.0` triggered `python-client-release.yml` | Both `clients/python/pyproject.toml` and `agamemnon/pyproject.toml` already at 0.1.0 |
+| ProjectProteus | PR #135 (regression) — `@types/node` downgraded in `dagger/package.json` only; `npm ci` EUSAGE failure | Easy-issue sweep agent missed `dagger/package-lock.json` |
+| ProjectProteus | PR #136 (fix) — regenerated `dagger/package-lock.json` via `npm install` in `dagger/`, CI green | Validates the regen-and-commit pattern end-to-end |
+| ProjectScylla | Issue #1527 (PR #1557) — versioning remediation; 35 tests passing, all pre-commit hooks green | `importlib.metadata` + `tomllib` consistency checker |
+| ProjectScylla | Issue #1535 (PR #1562) — reconcile CHANGELOG aspirational versions; 4808 total tests passing | Phantom version refs replaced with `[Unreleased]` convention |
+| Odysseus / ProjectAgamemnon / ProjectNestor / ProjectCharybdis | Renovate multi-ecosystem C++20 config — Conan + FetchContent regex + pixi + GHA + Dockerfile | Unverified: app installation in progress |
+| predictive-coding research project | Mojo nightly `1.0.0b2.dev2026050805` GC'd from `conda.modular.com/max`; repinned to `1.0.0b1` and locked, 2026-05-19 | First `pixi install` failed with `No candidates were found`; no `pixi.lock` had ever been committed. Upstream dep (pinned git SHA) also pinned the GC'd nightly — repin was a documented deliberate divergence |
+
+~~~
+
+---
+
 ## v1.1.0 (2026-05-19)
 
 **Changed by:** 2026-05-19 session — a pinned Mojo nightly was GC'd from the conda channel

--- a/skills/lockfile-and-release-pipeline-management.md
+++ b/skills/lockfile-and-release-pipeline-management.md
@@ -1,11 +1,12 @@
 ---
 name: lockfile-and-release-pipeline-management
-description: "Recover drifted lockfiles, resync dependency lockfiles after manifest edits, fix silent release recipe failures, enforce version single-source-of-truth, and configure Renovate for multi-ecosystem repos. Use when: (1) CI rejects a generated lockfile (pixi.lock, Cargo.lock, package-lock.json) and the source manifest is unchanged vs main, (2) editing package.json without regenerating package-lock.json causes npm ci EUSAGE failures, (3) `just release X.Y.Z` exits non-zero with 'nothing to commit' because pyprojects already have the target version, (4) project version is declared in multiple files that can drift and you need a single-source-of-truth strategy with pre-commit guards, (5) adding automated dependency updates (Renovate) to a C++20 repo with Conan, FetchContent, pixi, GHA, and Dockerfiles, (6) `pixi install` fails with `No candidates were found for <pkg> ==<version>` because a pinned nightly/dev-build artifact was garbage-collected from the channel."
+description: "Recover drifted lockfiles, resync dependency lockfiles after manifest edits, fix silent release recipe failures, enforce version single-source-of-truth, configure Renovate for multi-ecosystem repos, and stabilize lockfile-backed Dependabot CI gates without deleting tests. Use when: (1) CI rejects a generated lockfile (pixi.lock, Cargo.lock, package-lock.json) and the source manifest is unchanged vs main, (2) editing package.json without regenerating package-lock.json causes npm ci EUSAGE failures, (3) `just release X.Y.Z` exits non-zero with 'nothing to commit' because pyprojects already have the target version, (4) project version is declared in multiple files that can drift and you need a single-source-of-truth strategy with pre-commit guards, (5) adding automated dependency updates (Renovate) to a C++20 repo with Conan, FetchContent, pixi, GHA, and Dockerfiles, (6) `pixi install` fails with `No candidates were found for <pkg> ==<version>` because a pinned nightly/dev-build artifact was garbage-collected from the channel, (7) multiple Dependabot PRs fail because CI contract tests hardcode exact dependency versions or split exact-peer dependency families across separate PRs."
 category: ci-cd
-date: 2026-05-19
-version: "1.1.0"
+date: 2026-06-17
+version: "1.2.0"
 user-invocable: false
 history: lockfile-and-release-pipeline-management.history
+verification: verified-ci
 tags:
   - lockfile
   - pixi-lock
@@ -30,6 +31,12 @@ tags:
   - unsolvable-pin
   - mojo
   - pixi-install
+  - dependabot
+  - angular
+  - peer-dependencies
+  - pip-audit
+  - contract-tests
+  - vulnerability-allowlist
 ---
 
 # Lockfile and Release Pipeline Management
@@ -38,10 +45,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-19 |
-| **Objective** | Canonical skill covering the full gap between "dependency declared" and "lockfile/version consistent in CI": verbatim lockfile restoration from main, npm lockfile resync, release recipe no-op diagnosis, version single-source-of-truth enforcement, Renovate setup for heterogeneous C++ repos, and recovery from a pinned nightly/dev-build artifact garbage-collected from its channel |
-| **Outcome** | Merged from 5 verified skills; patterns confirmed across ProjectAgamemnon, ProjectProteus, ProjectScylla; v1.1.0 adds the GC'd-nightly failure mode (predictive-coding research project) |
-| **Verification** | verified-ci (lockfile restore, npm resync); verified-local (release recipe, versioning, GC'd-nightly recovery); unverified (Renovate — app install in progress) |
+| **Date** | 2026-06-17 |
+| **Objective** | Canonical skill covering the full gap between "dependency declared" and "lockfile/version consistent in CI": verbatim lockfile restoration from main, npm lockfile resync, release recipe no-op diagnosis, version single-source-of-truth enforcement, Renovate setup for heterogeneous C++ repos, recovery from pinned nightly/dev-build artifact GC, and lockfile-backed Dependabot CI contract stabilization |
+| **Outcome** | Merged from 5 verified skills; patterns confirmed across ProjectAgamemnon, ProjectProteus, ProjectScylla; v1.1.0 added the GC'd-nightly failure mode; v1.2.0 adds the Radiance Dependabot contract case |
+| **Verification** | verified-ci (lockfile restore, npm resync, Radiance Dependabot contract stabilization); verified-local (release recipe, versioning, GC'd-nightly recovery); unverified (Renovate - app install in progress) |
+| **History** | Previous v1.1.0 snapshot archived in `lockfile-and-release-pipeline-management.history` |
 
 ## When to Use
 
@@ -53,6 +61,9 @@ tags:
 - CHANGELOG references phantom future versions that don't exist yet as tags
 - Adding Renovate bot to a C++20 repo using Conan, CMake FetchContent, pixi, GitHub Actions, and Dockerfiles
 - A pinned nightly or dev-build dependency (`==X.Y.Zb2.devYYYYMMDD`-style) can no longer be resolved because the artifact was GC'd from the package channel; you need to repin and lock
+- Multiple Dependabot PRs fail because a contract test hardcodes exact dependency versions instead of checking that manifest and lockfile entries remain pinned and internally consistent
+- Single-package frontend PRs fail `npm ci` because the ecosystem has exact peer dependencies (for example Angular packages) and the bot opened each peer-package bump separately
+- A dependency-audit gate blocks on a vulnerability with no fixed version and the correct action is a narrow, expiring allowlist with tests, not disabling the audit or deleting tests
 
 ## Verified Workflow
 
@@ -127,6 +138,25 @@ pixi search <pkg> -c <channel>          # e.g. -c https://conda.modular.com/max
 pixi install                            # generates pixi.lock against the new pin
 git add pixi.toml pixi.lock
 git commit -S -m "fix(deps): repin <pkg> to <build> after nightly GC; commit pixi.lock"
+
+# ── G. Lockfile-backed Dependabot CI contract stabilization ─────────────────
+# Enumerate failing bot PRs and group by failure signature.
+gh pr list --state open --author app/dependabot --json number,title,statusCheckRollup
+gh pr checks <PR> --repo <owner/repo>
+
+# Prefer structural contract checks over current-version literals:
+# - manifest requires an exact pin where policy demands one
+# - lockfile root/package entries match the manifest
+# - related package entries remain internally consistent
+
+# Exact-peer families must usually move together, then the lockfile is regenerated.
+cd vendor/model_explorer/src/ui
+npm install --package-lock-only
+npm ci
+
+# After the stabilization PR lands, update still-open Dependabot PR branches.
+gh api -X PUT repos/<owner>/<repo>/pulls/<PR>/update-branch \
+  -f expected_head_sha=<current-head-sha>
 ```
 
 ### Detailed Steps
@@ -295,6 +325,40 @@ artifact by content hash + URL); with no lockfile, the pin is unrecoverable. The
 window to lock is "while the artifact still exists" — "lock it later" is not a plan.
 Prefer pinning a release build over a dated nightly when reproducibility matters.
 
+#### G - Lockfile-backed Dependabot CI Contract Stabilization
+
+1. **Enumerate failing bot PRs and group by failure signature.** Use the PR check
+   rollups and logs to separate deterministic contract failures from runner flakes.
+   Multiple PRs failing the same test usually means the contract is too literal, not
+   that every PR is independently broken.
+
+2. **Replace hardcoded current versions with structural checks.** If a test asserts
+   "dev extra X must equal version Y" or "lockfile package Z must equal version Y",
+   check the invariant instead: exact pins where policy requires them, manifest and
+   lockfile agreement, and internal consistency across related lockfile entries.
+   Do not delete the test; make it express the dependency contract that survives a
+   legitimate Dependabot bump.
+
+3. **Group exact-peer dependency families.** For ecosystems with exact peer ranges
+   (Angular is the common case), a one-package Dependabot PR can be impossible to
+   install. Move the exact-peer family together in one stabilization PR, regenerate
+   the lockfile from the package directory, and let superseded bot PRs close.
+
+4. **Use narrow allowlists for no-fixed-version advisories.** If an audit gate fails
+   on an advisory with no fixed versions, allow exactly the affected package,
+   version, and advisory, with an expiry and a condition that fixed versions remain
+   empty. Add tests that fail when the advisory becomes fixable or the allowlist
+   expires.
+
+5. **Verify the same gates that failed.** Run focused contract tests, `npm ci`,
+   package/build validation, and the security policy script locally where feasible,
+   then require a fresh CI pass on the stabilization PR.
+
+6. **Update original bot PR branches after the stabilization lands.** For still-open
+   Dependabot PRs, call the update-branch API with the current head SHA so the bot
+   branch picks up the generalized tests. Let branches that are now no-ops close
+   naturally rather than hand-editing every bot branch.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -314,6 +378,9 @@ Prefer pinning a release build over a dated nightly when reproducibility matters
 | Dependabot for Conan \| pixi \| FetchContent | Considered GitHub Dependabot as Renovate alternative | Dependabot has no native Conan, pixi, or FetchContent support | Renovate is the correct choice for C++ ecosystems |
 | Single Renovate config at meta-repo root covering all submodules | One `renovate.json` at Odysseus root | Submodules are separate git repos — Renovate needs a config per repo to open PRs | Use `ignorePaths` in the meta-repo config; put individual configs in each submodule |
 | Pinned a Mojo nightly (`==1.0.0b2.dev2026050805`) and deferred generating the lockfile | Left `pixi.lock` ungenerated for weeks after pinning the nightly toolchain build | The nightly was garbage-collected from `conda.modular.com/max`; `pixi install` then failed with `No candidates were found`. With no committed lockfile, the pin was unrecoverable — had to repin to a different build | Nightly/dev-build artifacts are GC'd from channels. Generate and commit the lockfile the moment the dependency is pinned, while the artifact still exists. Prefer pinning a release build over a dated nightly when reproducibility matters |
+| Delete or relax flaky-looking dependency contract tests | Removed hardcoded version assertions from the failing path | The failures were deterministic contract drift, not flaky tests; deleting them would hide future manifest/lockfile mismatches | Keep the tests and generalize them to structural invariants: exact pins, manifest/lockfile agreement, and internal consistency |
+| Let single Angular package PRs update independently | Trusted Dependabot's one-package bumps for an exact-peer Angular family | `npm ci` could not resolve the split exact-peer set because related Angular packages must move together | Group exact-peer packages in one PR and regenerate the lockfile from the owning package directory |
+| Add an empty or broad `pip-audit` allowlist | Suppressed the audit failure without package/version/advisory scope or expiry | A broad allowlist would hide unrelated vulnerabilities or remain after a fixed version became available | Scope allowlists to package, version, advisory, expiry, and "no fixed versions"; test stale and now-fixable behavior |
 
 ## Results & Parameters
 
@@ -455,6 +522,16 @@ of the resolved artifact; once the nightly is GC'd, "lock it later" is no longer
 possible. Prefer pinning a release build over a dated nightly when reproducibility
 matters.
 
+### G. Radiance Dependabot Contract Stabilization - Verified Facts
+
+| Fact | Detail |
+|------|--------|
+| Original scope | 10 failing Dependabot PRs (#886-#895) across Python and frontend dependency updates |
+| Contract fix | Replaced a concrete dev-extra version expectation with exact-pin checks; later generalized the frontend Playwright lock contract so expected versions are derived from `package.json` and validated across `package-lock.json` root, `node_modules/playwright`, `playwright` -> `playwright-core`, and `node_modules/playwright-core` |
+| Security fix | Added a narrow, expiring allowlist for `torch==2.11.0` / `CVE-2025-3000`, limited to the advisory's no-fixed-version state, with tests for expiry and fixable-advisory behavior |
+| Frontend fix | Grouped exact-peer Angular package updates, regenerated `vendor/model_explorer/src/ui/package-lock.json`, and left unsupported semver-major `@angular-devkit/*` updates out of scope |
+| Verification | Stabilization PR #897 reached green CI and merged; follow-up PR #904 reached green CI and merged; original Python Dependabot PRs #886-#890 passed after branch updates; #902 passed after #904; superseded Angular PRs #891-#895 closed automatically |
+
 ## Verified On
 
 | Project | Context | Details |
@@ -467,3 +544,4 @@ matters.
 | ProjectScylla | Issue #1535 (PR #1562) — reconcile CHANGELOG aspirational versions; 4808 total tests passing | Phantom version refs replaced with `[Unreleased]` convention |
 | Odysseus / ProjectAgamemnon / ProjectNestor / ProjectCharybdis | Renovate multi-ecosystem C++20 config — Conan + FetchContent regex + pixi + GHA + Dockerfile | Unverified: app installation in progress |
 | predictive-coding research project | Mojo nightly `1.0.0b2.dev2026050805` GC'd from `conda.modular.com/max`; repinned to `1.0.0b1` and locked, 2026-05-19 | First `pixi install` failed with `No candidates were found`; no `pixi.lock` had ever been committed. Upstream dep (pinned git SHA) also pinned the GC'd nightly — repin was a documented deliberate divergence |
+| Radiance | Issues #896/#903, PRs #897/#904, 2026-06-17 | Generalized lockfile-backed Dependabot contract tests, grouped exact-peer Angular updates, added a narrow no-fixed-version `pip-audit` allowlist, and updated original bot PRs until CI passed |


### PR DESCRIPTION
## Summary
- amend lockfile-and-release-pipeline-management with Radiance Dependabot contract stabilization lessons
- amend ci-transient-flake-and-environment-failures with dependency-install hang triage lessons
- archive previous skill versions in history files

## Verification
- python3 scripts/validate_plugins.py (via local venv with requirements.txt)
- pre-push pytest hook: 219 passed
