### PR TITLE
feat: amend Radiance duplicate cleanup skills

### DIFF
--- a/skills/dry-refactoring-workflow.history
+++ b/skills/dry-refactoring-workflow.history
@@ -1,6 +1,823 @@
 <!-- markdownlint-disable MD024 -->
 # dry-refactoring-workflow — History
 
+## v1.6.0 (2026-06-18)
+
+**Changed by:** Radiance PR #908 duplicate-code cleanup
+**Verification:** verified-local
+
+### What changed
+- Added Phase 11 for behavior-preserving duplicate cleanup across server route tests, layout-only metric kernels, validation wrappers, and stale tool deletion.
+- Added focused search commands and verification gates used in Radiance.
+- Added failed-attempt rows for over-sharing validation wrappers, flattening route fake variants, and reusing a branch whose old PR was already merged.
+- Updated verification metadata to verified-local because PR CI was pending when captured.
+
+### Why
+Radiance cleanup showed a practical DRY pattern: centralize only identical mechanics while preserving public exports, local wrapper contracts, and test assertion shapes. The work was verified locally and by the repository pre-push hook, but GitHub CI was still pending at capture time.
+
+### Previous version (v1.5.0) snapshot
+
+````markdown
+---
+name: dry-refactoring-workflow
+description: "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Use when: (1) extracting duplicated helper methods into a shared module using TDD (write a failing test against the canonical, delete the duplicate, run green); (2) creating a private leaf module with leading-underscore naming to centralize a repeated internal call (e.g. importlib.metadata version resolution, path construction) and prevent re-introduction across modules; (3) centralizing hardcoded path constants into a single module to prevent drift when directory structure changes (incl. phase-routed in_progress/completed splits); (4) deduplicating LLM JSON extraction, parser logic, or any call-site pattern copy-pasted across several files; (5) test structure must mirror source structure when extracting helpers; (6) running a full DRY consolidation pass (discovery via grep, classifying true duplicates vs intentional variants, dict-structure consolidation) and refactoring to a single canonical source; (7) extract-method / SRP decomposition of over-long functions (50-LOC) and methods (100-LOC), including converting a mutating closure into a method via a small mutable box; (8) extracting repeated cached lookups into an @lru_cache helper (and clearing the cache so unittest.mock.patch works); (9) removing stale scripts / deprecated stubs (grep callers first) and replacing hardcoded file lists with dynamic Path.rglob discovery; (10) PLANNING a consolidation of two OVERLAPPING but not-identical constant collections (frozensets / keyword lists / error-pattern tuples) — classify true-duplicate vs intentional-variant first, then extract only the shared CORE into one canonical immutable constant and have each consumer compose CORE | its-own-extras, proving anti-drift with CORE.issubset(consumer) parity tests, instead of a flat merge that would violate a deliberate behavioral contract. Also covers cryptographic commit signing requirements in PR workflows."
+category: architecture
+date: 2026-06-12
+version: 1.5.0
+user-invocable: false
+verification: verified-ci
+history: dry-refactoring-workflow.history
+---
+# DRY Refactoring Workflow
+
+Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods.
+
+## Overview
+
+| Attribute | Details |
+| ----------- | --------- |
+| **Date** | 2026-06-04 |
+| **Objective** | TDD-driven extraction of duplicated code into reusable helper modules, with emphasis on private module placement, test structure mirroring, and cryptographic commit signing |
+| **Outcome** | ✅ v1.0.0 (Feb 2026): Eliminated token aggregation duplication. v1.1.0 (Jun 2026): Extended with private module patterns, test mirroring enforcement, signing requirements. v1.3.0 (Jun 2026): Absorbed centralized path constants, LLM JSON extraction dedup, full DRY consolidation discovery/classify pass, and canonical-source refactor patterns (Pydantic type hierarchy, dict-structure consolidation, orphan relocation). v1.4.0 (Jun 2026): Restored SRP/extract-method (mutable-box closure), @lru_cache detection util (mock.patch/cache_clear gotcha), stale-script/stub cleanup, and dynamic Path.rglob discovery patterns from the nuance audit. ⚠️ v1.5.0 (Jun 2026, **planning-only / unverified**): Added Phase 10 — planning a consolidation of OVERLAPPING constant collections via the core/extras split (CORE \| consumer-extras) with subset parity anti-drift tests, classifying intentional-variant-with-overlap separately from "do not consolidate". Captured from ProjectHephaestus #1205 planning; NOT executed end-to-end. |
+| **Primary Issues** | #642 (original), #739 (private module extraction), #917 (pr-policy signing), #503 (LLM JSON dedup) |
+| **Primary PRs** | #714 (original), #900+ (refactoring), #137/#1738 (path constants), #505 (JSON dedup), #201 (DRY consolidation) |
+| **History** | [changelog](./dry-refactoring-workflow.history) |
+
+## When to Use This Skill
+
+Use this workflow when you encounter:
+
+- **Code duplication**: Same logic appears in 2+ methods
+- **DRY violations**: Identical patterns that should be abstracted
+- **Refactoring tasks**: Need to improve code maintainability
+- **Follow-up issues**: Code review identified duplication to fix
+
+**Trigger phrases**:
+
+- "Extract duplicate [X] logic"
+- "Consolidate [X] code"
+- "DRY violation in [method names]"
+- "Create helper method for [pattern]"
+- "Extract duplicated function calls into a helper module"
+- "Private helper module placement — where should `_helper.py` go?"
+- "How to structure tests for root-level private modules?"
+- "Duplicated `importlib.metadata.version()` calls — consolidate into helper"
+- "Centralize hardcoded path strings into a single `paths.py`"
+- "Same JSON/LLM-response extraction logic copy-pasted across files"
+- "Run a full DRY consolidation pass — find and classify duplicates"
+- "Consolidate duplicate Pydantic models / type aliases into a base hierarchy"
+- "Same dict structure built in multiple call sites — extract a shared helper"
+- "This function/method is too long — extract methods / decompose by responsibility"
+- "Convert a mutating closure into a standalone method"
+- "Extract repeated cached lookups into an `@lru_cache` helper"
+- "`@lru_cache` is breaking my `mock.patch` test — how to clear the cache?"
+- "Remove stale scripts / deprecated stubs as part of consolidation"
+- "Replace a hardcoded file list with dynamic `Path.rglob` discovery"
+- "Two error-pattern / keyword lists overlap — should I merge them into one frozenset?"
+- "Consolidate `TRANSIENT_ERROR_PATTERNS` and `NETWORK_ERROR_KEYWORDS` / two near-duplicate constant collections"
+- "These two constant lists are 80% the same but one has extras — DRY them up"
+- "Plan a DRY merge of overlapping constants without changing either matcher's behavior"
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# --- DISCOVERY: find duplicate symbols / hardcoded strings ---
+grep -rh "^def [a-z_]"  src/ --include="*.py" | sed 's/(.*//' | sort | uniq -c | sort -rn | head -30
+grep -rh "^class [A-Z]" src/ --include="*.py" | sed 's/(.*//;s/://' | sort | uniq -c | sort -rn | head -30
+grep -rn '"agent"\|"judge"\|"result\.json"' src/ --include="*.py" | grep -v "^[[:space:]]*#"
+
+# --- PATH-CONSTANT BYPASS AUDIT (run before merging dir-structure changes) ---
+grep -rn "experiment_dir / \|experiment_dir/" src/ scripts/ | grep -v "paths.py" | grep -v __pycache__
+
+# --- VERIFY no orphaned refs after migration (must be empty) ---
+grep -rn "old_module\.\|_old_function_name" src/ tests/ --include="*.py"
+
+# --- TDD loop: write failing test, implement helper, go green ---
+<package-manager> run pytest tests/unit/<module>/test_<file>.py -v   # RED then GREEN
+<package-manager> run pytest tests/ -q                              # no regressions
+pre-commit run --files <changed-files>
+git commit -S -m "refactor(scope): consolidate <X> into canonical helper"  # -S if pr-policy gate
+```
+
+Core loop: **discover → classify (true duplicate vs intentional variant) → write failing test → extract canonical → migrate call sites one at a time → verify green → signed commit + auto-merge PR.**
+
+### Phase 1: Analysis & Planning
+
+1. **Identify duplication** - Find exact duplicate code blocks
+
+   ```bash
+   # Search for the pattern
+   grep -n "pattern" path/to/file.py
+   ```
+
+2. **Verify identical logic** - Confirm both instances do the same thing
+   - Check for any subtle differences
+   - Note any conditional variations
+
+3. **Choose placement** - Place helper near related private methods
+   - After similar helper methods
+   - Before the methods that will use it
+   - Maintain logical grouping
+
+### Phase 2: Test-Driven Development
+
+**IMPORTANT**: Always write tests BEFORE implementing the helper method.
+
+1. **Create test file** if it doesn't exist
+
+   ```python
+   # tests/unit/<module>/test_<class>.py
+   from pathlib import Path
+   from unittest.mock import MagicMock
+   import pytest
+
+   @pytest.fixture
+   def mock_config() -> ConfigClass:
+       """Create mock config for testing."""
+       return ConfigClass(
+           required_field="value",
+           # Add all required fields
+       )
+   ```
+
+2. **Write comprehensive tests**
+   - Empty/None input case
+   - Single item case
+   - Multiple items case
+   - Edge cases (zeros, special values)
+
+3. **Run tests to verify they fail**
+
+   ```bash
+   pixi run python -m pytest tests/unit/<module>/test_<class>.py -v
+   ```
+
+   - Confirm `AttributeError: object has no attribute '<method>'`
+
+### Phase 3: Implementation
+
+1. **Extract helper method**
+
+   ```python
+   def _helper_method(self, input_data: dict[K, V]) -> Result:
+       """Brief description of what this does.
+
+       Args:
+           input_data: Description of the input
+
+       Returns:
+           Description of the return value. Explain edge case behavior
+           (e.g., "Returns empty Result if input_data is empty").
+       """
+       from functools import reduce  # Import at function level if needed
+
+       if not input_data:
+           return Result()  # Handle empty case
+
+       return reduce(
+           lambda a, b: a + b,
+           [v.attribute for v in input_data.values()],
+           Result(),  # Identity element
+       )
+   ```
+
+2. **Run tests to verify implementation**
+
+   ```bash
+   pixi run python -m pytest tests/unit/<module>/test_<class>.py -v
+   ```
+
+   - All new tests should pass
+
+### Phase 4: Refactoring
+
+1. **Update first call site**
+
+   ```python
+   # Before:
+   from functools import reduce
+   result = reduce(
+       lambda a, b: a + b,
+       [v.attribute for v in data.values()],
+       Result(),
+   ) if data else Result()
+
+   # After:
+   result = self._helper_method(data)
+   ```
+
+2. **Update second call site** - Same transformation
+
+3. **Run full test suite**
+
+   ```bash
+   pixi run python -m pytest tests/unit/<module>/ -v --tb=short -x
+   ```
+
+   - Verify no regressions
+
+### Phase 5: Quality Checks
+
+1. **Run pre-commit hooks**
+
+   ```bash
+   pre-commit run --files path/to/modified/files
+   ```
+
+   - Fix any formatting issues
+   - Address type checking errors
+
+2. **Verify all checks pass**
+
+   ```bash
+   pre-commit run --files path/to/modified/files
+   ```
+
+### Phase 6: Commit & PR
+
+1. **Stage changes**
+
+   ```bash
+   git add path/to/implementation.py tests/unit/path/test_file.py
+   ```
+
+2. **Create descriptive commit**
+
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   refactor(module): Extract duplicate [X] logic
+
+   Extract duplicate [description] from method1() and method2()
+   into a new helper method _helper_name().
+
+   This refactoring:
+   - Eliminates code duplication (DRY principle)
+   - Improves maintainability
+   - Provides comprehensive test coverage
+   - Maintains identical functionality
+
+   Changes:
+   - Add _helper_name() helper method in file.py:LINE1-LINE2
+   - Refactor method1() to use new helper (line N)
+   - Refactor method2() to use new helper (line M)
+   - Add comprehensive unit tests in test_file.py
+
+   All X tests pass with no regressions.
+
+   Closes #ISSUE
+
+   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+3. **Push and create PR**
+
+   ```bash
+   git push -u origin BRANCH-NAME
+
+   gh pr create \
+     --title "refactor(module): Extract duplicate [X] logic" \
+     --body "PR_BODY" \
+     --label "refactoring"
+
+   gh pr merge --auto --rebase PR_NUMBER
+   ```
+
+### Phase 7: Private Module Extraction (NEW in v1.1.0)
+
+When extracting duplicates spans multiple modules, create a **private helper module** with leading-underscore naming:
+
+1. **Place as a leaf module at package root** to avoid circular imports:
+
+   ```text
+   hephaestus/
+   ├── __init__.py
+   ├── _version_lookup.py          # Private helper — leaf module, not a package
+   ├── agents/
+   ├── utils/
+   └── ...
+   ```
+
+   **Why not a package?** Private packages (`_internal/`) with `__init__.py` can trigger circular imports if imported from multiple sibling modules that also depend on the package.
+   Leaf modules (`_version_lookup.py`) avoid this by having no sub-modules.
+
+2. **Store module-level constants in the helper** — especially PyPI distribution names that must NOT be guessed or normalized:
+
+   ```python
+   # hephaestus/_version_lookup.py
+   """Internal helper for version resolution via importlib.metadata."""
+
+   from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+   # CRITICAL: This is the literal [project].name from pyproject.toml
+   # importlib.metadata does NOT normalize between distribution and import names
+   _DIST_NAME = "HomericIntelligence-Hephaestus"
+
+   def lookup_version() -> str:
+       """Resolve package version from installed metadata.
+
+       Returns:
+           Version string from most recent git tag, or "unknown" if not found.
+       """
+       try:
+           return _pkg_version(_DIST_NAME)
+       except PackageNotFoundError:
+           return "unknown"
+   ```
+
+3. **Test structure mirroring** — Root-level private modules must have tests in a logical sub-package:
+
+   ```text
+   tests/unit/
+   ├── version/
+   │   ├── __init__.py
+   │   └── test_version_lookup.py    # Test for hephaestus/_version_lookup.py
+   └── ...
+   ```
+
+   **Pre-commit enforcement:** `test_*.py` files CANNOT live directly under `tests/unit/`. They must be in sub-directories that mirror the package structure. This enforces organization and catches orphaned test files.
+
+4. **Cryptographic commit signing requirement** — All commits in PRs must be signed:
+
+   ```bash
+   # Commit with mandatory -S flag
+   git commit -S -m "refactor: consolidate duplicate version resolution
+
+   Extract duplicated importlib.metadata.version() calls into
+   _version_lookup helper module.
+
+   Key learnings:
+   - Private modules use leading underscore (_module.py)
+   - Store PyPI dist name as module constant (not guessed at runtime)
+   - Root-level helpers go in tests/unit/category/ for test organization
+   - All commits must be cryptographically signed (-S)
+   - pr-policy CI gate validates every commit at GraphQL layer
+
+   Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>"
+
+   # Verify commit was actually signed
+   git log -1 --pretty=format:'%G?'   # Must print 'G', not 'N' or 'B'
+   ```
+
+   **CI validation:** The `pr-policy` required-check gate validates commit signatures at the GraphQL layer before allowing merge. Unsigned commits block auto-merge even if all other checks pass.
+
+### Phase 8: Specific Consolidation Patterns (NEW in v1.3.0)
+
+These are concrete instances of the workflow above, absorbed from dedicated skills.
+
+#### 8a. Centralized Path Constants
+
+Eliminate hardcoded path strings by routing every path through one `paths.py` module. Critical when a directory structure has phases (e.g. `in_progress/` vs `completed/`) — routing must live at a single point or bypass violations appear at every construction site.
+
+```python
+# paths.py — single source of truth
+from pathlib import Path
+import shutil
+
+IN_PROGRESS_DIR = "in_progress"
+COMPLETED_DIR = "completed"
+AGENT_DIR = "agent"
+RESULT_FILE = "result.json"
+
+def get_agent_dir(run_dir: Path) -> Path:
+    return run_dir / AGENT_DIR
+
+# Phase-routed: keyword-only completed= keeps active-work callers unchanged
+def get_tier_dir(experiment_dir: Path, tier_id: str, *, completed: bool = False) -> Path:
+    phase = COMPLETED_DIR if completed else IN_PROGRESS_DIR
+    return experiment_dir / phase / tier_id
+
+def promote_run_to_completed(experiment_dir, tier_id, subtest_id, run_num) -> Path:
+    src = get_run_dir(experiment_dir, tier_id, subtest_id, run_num, completed=False)
+    dst = get_run_dir(experiment_dir, tier_id, subtest_id, run_num, completed=True)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
+    # copy (NOT move) shared baseline so sibling runs can also be promoted
+    baseline = src.parent / "pipeline_baseline.json"
+    if baseline.exists():
+        shutil.copy2(str(baseline), str(dst.parent / "pipeline_baseline.json"))
+    return dst
+```
+
+**Pre-merge bypass audit** (run before merging any directory-structure change — must return zero hits):
+
+```bash
+grep -rn "experiment_dir / \|experiment_dir/" src/ scripts/ \
+  | grep -v "paths.py" | grep -v "# noqa" | grep -v "__pycache__" | grep -v ".pyc"
+```
+
+`completed=` routing decision: `False` for in-flight execution; `True` for judging, reporting, rehydration/resume, aggregation; pass both only for repair/reconcile commands. In one ProjectScylla split, skipping this audit left 17 silent wrong-dir reads post-merge — the grep would have found them in 5 seconds.
+
+#### 8b. Deduplicate LLM JSON Extraction
+
+When the same JSON-extraction-from-LLM-output logic is copy-pasted across 3+ files (and a bug lives in only one copy), extract the **most robust** copy into a shared utility rather than fixing one place and creating a 4th variant.
+
+```python
+# <module>/utils.py — keep the version that handles the most formats
+def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
+    r"""Extract a JSON object from LLM output.
+
+    Handles raw JSON, ```json``` / ``` code blocks, XML-tag-wrapped JSON with
+    preamble, and JSON surrounded by explanatory text via brace-matching.
+
+    Returns parsed dict, or None if no valid JSON object found.
+    """
+    ...  # paste the most robust brace-matching implementation
+```
+
+Selection criteria for the canonical copy: most robust (handles most edge cases) > best tested > most recent > clearest. Export it from `<module>/__init__.py`, then replace every duplicate with a one-line delegation. Add a regression test for the originally-failing input (e.g. XML-wrapped JSON with preamble). Use `r"""` for docstrings containing backslashes (ruff `D301`). Verify any "new" full-suite failures pre-exist on `main` via `git stash` before blaming your change.
+
+#### 8c. Full DRY Consolidation Discovery + Classification Pass
+
+For a whole-codebase cleanup, discover systematically then classify before touching anything.
+
+```bash
+# Discovery
+find src/ -type f \( -name "*.py" -o -name "*.mojo" \) -exec md5sum {} + \
+  | awk '{print $1}' | sort | uniq -c | sort -rn | head -20          # identical files
+grep -rh "^def [a-z_]"  src/ --include="*.py" | sed 's/(.*//' | sort | uniq -c | sort -rn  # dup funcs
+grep -rh "^class [A-Z]" src/ --include="*.py" | sed 's/(.*//;s/://' | sort | uniq -c | sort -rn  # dup classes
+```
+
+| Type | Criteria | Action |
+| ------ | --------- | ------- |
+| **True duplicate** | Identical/near-identical logic, same purpose | Create/extend canonical module; delete copies; update callers |
+| **Intentional variant** | Different fields/domain/pipeline stage | Add cross-reference docstrings (`see: other/module.py:Name`); do NOT consolidate |
+| **Weaker vs stronger** | Same intent, one validates content, one only checks existence | Keep stronger; update callers and test fixtures |
+
+Search team knowledge first (`/advise`), read both implementations in full before acting, verify imports with the project package manager, and run the full suite before/after.
+
+#### 8d. Pydantic Type-Alias Hierarchy Consolidation
+
+Unify duplicate Pydantic models into a base + domain subtypes, keeping a backward-compat alias so old imports keep working:
+
+```python
+class ExecutionInfoBase(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    exit_code: int = Field(...)
+    duration_seconds: float = Field(default=0.0)   # default, not required
+
+class ExecutorExecutionInfo(ExecutionInfoBase):
+    container_id: str = Field(...)
+
+ExecutionInfo = ExecutorExecutionInfo               # old imports still work
+result = result.model_copy(update={"duration_seconds": elapsed})  # frozen → model_copy, not assignment
+```
+
+#### 8e. Dict-Structure Consolidation (Shared Payload)
+
+When the same dict shape is built in multiple call sites (format function + CLI output), extract one private helper so the shape can't drift:
+
+```python
+def _serializable_stats(stats: dict[str, Any]) -> dict[str, Any]:
+    """Canonical JSON-serializable shape for agent stats."""
+    return {
+        "agent_type": stats.get("agent_type"),
+        "total_delegations": stats.get("total_delegations", 0),
+        "skill_refs": stats.get("skill_refs", []),
+        "timestamp": stats.get("timestamp"),
+    }
+
+def format_stats_json(stats): return json.dumps(_serializable_stats(stats))
+def main(): cli_output = json.dumps(_serializable_stats(stats))
+```
+
+Add a regression test asserting shape parity between the call sites so future fields stay in sync.
+
+#### 8f. Orphan Module Relocation (Preserve History)
+
+```bash
+cp package/orphan.py package/subpackage/orphan.py          # prefer existing sub-package (KISS)
+grep -rn "from package\.orphan\|import package\.orphan" --include="*.py" .  # find consumers
+<package-manager> run python -c "from package.subpackage.orphan import Class; print('OK')"
+git rm package/orphan.py                                    # git rm (not rm) → records a rename
+grep -rn "from package\.orphan" .                           # must be empty before commit
+```
+
+### Phase 9: Additional DRY-Consolidation Patterns (NEW in v1.4.0)
+
+Further consolidation patterns restored from `dry-consolidate-to-canonical-refactor`.
+
+#### Detailed Steps
+
+**9a. Extract-method / SRP decomposition.** Long functions/methods both violate Single Responsibility and hide duplication. Treat size as a smell trigger, not a hard rule: **functions > ~50 LOC** and **methods > ~100 LOC** are extraction candidates. Pull each distinct responsibility into its own named helper.
+
+A common snag: a closure that mutates a variable captured from the enclosing scope cannot be lifted into a standalone method as-is (Python rebinding makes the captured name local). Wrap the mutable state in a small **mutable box** — a one-field dataclass or a single-element `list` cell — and pass it in:
+
+```python
+# Before: closure mutates captured `total` — can't be extracted cleanly
+def process(items):
+    total = 0
+    def add(x):            # `nonlocal` ties this to the enclosing frame
+        nonlocal total
+        total += x
+    for i in items:
+        add(i)
+    return total
+
+# After: mutable box makes the helper a free-standing, testable method
+from dataclasses import dataclass
+
+@dataclass
+class _Accumulator:
+    total: int = 0
+
+def _add(box: _Accumulator, x: int) -> None:
+    box.total += x          # mutates the box's field, not a captured local
+
+def process(items: list[int]) -> int:
+    box = _Accumulator()
+    for i in items:
+        _add(box, i)
+    return box.total
+# (a single-element list `box = [0]` / `box[0] += x` works too for trivial cases)
+```
+
+**9b. LRU-cache detection util.** When the same expensive lookup is recomputed at many call sites (config resolution, path discovery, metadata reads), extract it into one `@lru_cache`-decorated helper so it is computed once:
+
+```python
+from functools import lru_cache
+
+@lru_cache(maxsize=None)
+def resolve_root() -> Path:
+    """Locate project root once; cached for the process lifetime."""
+    ...  # expensive walk / import
+```
+
+**Gotcha — `@lru_cache` conflicts with `unittest.mock.patch`.** The cache holds the value computed *before* the patch was applied, so the mock is never seen. Call `helper.cache_clear()` in the test (and between successive patches):
+
+```python
+def test_resolve_root(monkeypatch):
+    resolve_root.cache_clear()           # drop any pre-patch cached value
+    monkeypatch.setattr(module, "_walk", fake_walk)
+    resolve_root.cache_clear()           # ensure the patched impl is used
+    assert resolve_root() == expected
+```
+
+Prefer a `cache_clear()` in setup/teardown (or an autouse fixture) for any module exposing `@lru_cache` helpers.
+
+**9c. Stale-script removal & deprecated-stub cleanup.** Consolidation leaves behind stale scripts and deprecated stubs — remove them as part of the pass, but **grep for callers first**; a deletion is only safe once nothing references it:
+
+```bash
+grep -rn "stale_script\.py\|deprecated_stub\|old_entrypoint" \
+  --include="*.py" --include="*.md" --include="*.yaml" --include="*.yml" --include="*.sh" .
+```
+
+If a file you are keeping holds a **stale back-reference** to something being deleted, rewrite that file to be **self-contained first** (inline the still-needed logic / update the docstring), commit and verify, and only then delete the stale target. Deleting first leaves a dangling reference that breaks imports or docs.
+
+**9d. Dynamic discovery via `Path.rglob`.** Replace hardcoded file lists (which silently rot as files are added/removed) with dynamic discovery so the set is always current:
+
+```python
+# Before: hardcoded list drifts out of sync with the tree
+SKILL_FILES = ["a.md", "b.md", "c.md"]
+
+# After: discovered at runtime — new/removed files are picked up automatically
+from pathlib import Path
+skill_files = sorted(Path("skills").rglob("*.md"))
+```
+
+Sort the result for deterministic ordering and filter excludes explicitly (e.g. skip `*.notes.md` / `__pycache__`) rather than re-introducing a hardcoded allowlist.
+
+### Phase 10: Overlapping Constant Collections — Core/Extras Split (NEW in v1.5.0, PLANNING-ONLY)
+
+> **Warning:** This phase is a **proposed workflow** captured from PLANNING ProjectHephaestus
+> issue #1205. It was **NOT validated end-to-end** — no code was written, no tests were run,
+> and no CI confirmed it. Treat every step below as a hypothesis until CI confirms it on a
+> real PR. The rest of this skill is `verified-ci`; this phase alone is unverified.
+
+**The trap this phase exists to avoid:** when two duplicate-*looking* constant collections
+(frozensets, keyword lists, error-pattern tuples) are flagged for DRY consolidation, the
+naive move is a flat merge into one shared frozenset. But "looks duplicated" is not
+"is duplicated." Two collections can overlap heavily yet carry **deliberate,
+behavior-bearing differences** — an *intentional variant with overlap*. A flat merge
+silently violates one consumer's contract or breaks one consumer's test.
+
+This is a **refinement of the Phase 8c classification table.** Phase 8c offered two
+end-states for an intentional variant: "do NOT consolidate" (cross-reference docstrings)
+vs full consolidation. Phase 10 adds a **third, middle path** for the overlapping case:
+consolidate *only the shared CORE*, keep each consumer's extras local.
+
+#### Quick Reference
+
+```text
+discover two duplicate-looking collections
+  └─ CLASSIFY: true-duplicate (same intent) ── or ── intentional-variant (deliberate diffs)?
+       ├─ true duplicate            → flat-merge into one canonical constant (Phase 8c)
+       ├─ variant, NO overlap       → do NOT consolidate; cross-reference docstrings (Phase 8c)
+       └─ variant WITH overlap      → CORE/EXTRAS split (THIS phase):
+             1. extract genuinely-shared CORE into ONE canonical immutable frozenset
+             2. each consumer = CORE | <its own layer-specific extras>
+             3. add parity tests: CORE.issubset(consumer_A) AND CORE.issubset(consumer_B)
+             4. keep PUBLIC NAMES + iterable types; recompose only their VALUES
+             5. real acceptance gate = the EXISTING behavioral suites stay green
+```
+
+#### The #1205 worked example
+
+`TRANSIENT_ERROR_PATTERNS` (resilience layer) and `NETWORK_ERROR_KEYWORDS` (retry layer)
+overlapped on transient-failure substrings. But `NETWORK_ERROR_KEYWORDS` *additionally*
+held `"rate limit"` / `"throttle"`, which the resilience layer **deliberately omits** —
+its documented contract is *"rate limit error passthrough (not retried)"*. A naive shared
+frozenset would either (a) make the resilience layer retry rate-limit errors (contract
+violation) or (b) drop rate-limit/throttle from the network tagger (breaks an existing
+test). Neither is acceptable. The core/extras split preserves both contracts.
+
+#### Detailed Steps
+
+1. **Discover, then CLASSIFY before touching anything.** Read BOTH collections and their
+   surrounding docstrings/tests in full. Ask: is every element shared by *intent*, or does
+   one collection carry elements the other *deliberately excludes*? A module docstring
+   contract line ("rate limit error passthrough — not retried") or an existing test that
+   asserts an exclusion is your signal that you are looking at an intentional variant, not
+   drift. **If you cannot confirm the difference is deliberate, stop and confirm it** —
+   the whole split is mis-scoped if the "intentional" difference is actually stale.
+
+2. **Extract only the genuinely-shared CORE** into one canonical immutable constant. Use a
+   `frozenset` (immutable, set-algebra-friendly). Put it in a **leaf module both consumers
+   can import with no cycle, respecting the architecture boundary** — in Hephaestus this was
+   the pre-existing `hephaestus/constants.py` (stdlib-only, already holds shared frozensets).
+   **Never** place it in the product/automation layer (the library may not import automation),
+   and avoid sub-package `__init__.py` (circular-import risk).
+
+   ```python
+   # hephaestus/constants.py  (leaf, stdlib-only, no cycle)
+   # Shared CORE of transient-failure substrings used by BOTH the resilience
+   # retry matcher and the network-error tagger. Lowercase; matched as substrings.
+   TRANSIENT_ERROR_CORE: frozenset[str] = frozenset({
+       "timeout", "timed out", "connection", "network", "temporarily",
+       "unavailable", "reset by peer", "broken pipe",
+   })
+   ```
+
+3. **Each consumer composes its full collection as `CORE | <its own extras>`** —
+   keeping the **public names and existing iterable types** so call sites that iterate
+   them (`any(p in err for p in NAME)`) and exported-symbol consumers keep working. Only
+   the *values* are recomposed from the core.
+
+   ```python
+   # resilience layer — intentionally does NOT include rate-limit/throttle
+   from hephaestus.constants import TRANSIENT_ERROR_CORE
+   # exact phrases kept as explicit extras (see trap #2 below)
+   _RESILIENCE_EXTRAS = frozenset({"connection refused", "connection reset"})
+   TRANSIENT_ERROR_PATTERNS = tuple(sorted(TRANSIENT_ERROR_CORE | _RESILIENCE_EXTRAS))
+
+   # retry/network layer — ADDS rate-limit/throttle by deliberate contract
+   from hephaestus.constants import TRANSIENT_ERROR_CORE
+   _NETWORK_EXTRAS = frozenset({"rate limit", "throttle"})
+   NETWORK_ERROR_KEYWORDS = tuple(sorted(TRANSIENT_ERROR_CORE | _NETWORK_EXTRAS))
+   ```
+
+4. **Add subset parity (anti-drift) tests** so the shared signals can never silently drift
+   out of either consumer — this is what makes the plan *reviewable*:
+
+   ```python
+   from hephaestus.constants import TRANSIENT_ERROR_CORE
+   from hephaestus.resilience import TRANSIENT_ERROR_PATTERNS
+   from hephaestus.retry import NETWORK_ERROR_KEYWORDS
+
+   def test_core_present_in_both_consumers():
+       assert TRANSIENT_ERROR_CORE.issubset(set(TRANSIENT_ERROR_PATTERNS))
+       assert TRANSIENT_ERROR_CORE.issubset(set(NETWORK_ERROR_KEYWORDS))
+   ```
+
+   Plus standard constants-module tests (see the `testing-python-constants-module` skill):
+   `isinstance(CORE, frozenset)`, all-lowercase, immutability (`AttributeError` on `.add()`),
+   and parametrized membership of each expected substring.
+
+5. **TDD RED → GREEN.** The parity + constants tests fail first with `ImportError`
+   (`TRANSIENT_ERROR_CORE` does not exist yet); create the constant to go green.
+
+6. **Grep ALL file types for orphaned refs** to the old literals after recomposing.
+
+7. **The REAL acceptance gate is the EXISTING behavioral suites, not the new constant
+   tests.** Run `test_retry.py`, `test_subprocess_resilience.py`, etc. — every behavioral
+   matcher test must stay green. New constant tests proving structure are necessary but
+   insufficient; behavior is the contract.
+
+8. Signed commit + auto-merge per the standard PR workflow above.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Place private helper in a sub-package (`_internal/__init__.py`) | Created `hephaestus/_internal/_version_lookup.py` to group private modules | Triggers circular imports when multiple sibling modules try to import from `_internal`, each bringing their own transitive dependencies that refer back to `_internal` | Use **leaf modules** for private helpers: `_version_lookup.py` (no sub-modules). Packages add layers that create circular paths. |
+| Guess PyPI distribution name at runtime from `__name__` or import path | Tried `_dist_name = __name__.split(".")[0]` or `__package__.replace("_", "-").title()` | `importlib.metadata` does NOT normalize distribution names. The name must match the literal `[project].name` value from pyproject.toml exactly. Guessing produced `KeyError` or `PackageNotFoundError`. | Store the PyPI distribution name as a module-level constant in the helper. Do not derive it; it is arbitrary and may differ from the import path. Document the dependency: "Update this constant if [project].name changes in pyproject.toml". |
+| Place test for `_version_lookup.py` directly under `tests/unit/` | Created `tests/unit/test_version_lookup.py` | Pre-commit hook `test-file-placement` rejected it — `test_*.py` files cannot live directly under `tests/unit/`. They must be in logical sub-directories that mirror the package structure. | Create `tests/unit/version/` sub-directory and place the test there. This enforces test organization and makes it clear which part of the codebase the test covers. |
+| Omit the `-S` flag when committing in a sub-agent dispatch | Ran `git commit -m "..."` without `-S` in a sub-agent shell | The pr-policy CI gate validates commit signatures at the GraphQL layer (via GitHub's `/graphql` API). Commits without valid signatures are flagged as `verification.reason: "unsigned"`, which blocks auto-merge even if all other checks pass. | **Always** use `git commit -S` when creating commits that will be pushed to a PR. The pr-policy gate is non-negotiable for ProjectHephaestus and similar repos. Pre-warm GPG by signing a test commit before agent dispatch if needed. |
+| Compare version strings across files to assert "single source" | Wrote drift-check that compared `pyproject.toml` version to `__init__.py` version as strings | After hatch-vcs, `pyproject.toml` no longer has a static `[project].version` field — it declares `dynamic = ["version"]`. String comparisons fail because the field doesn't exist. | Validate the **invariant** (hatch-vcs is configured correctly), not string equality. Check: `dynamic = ["version"]` is present, `[tool.hatch.version].source == "vcs"`. See `hatch-vcs-pyproject-auto-versioning-setup.md` skill. |
+| Phase-split directory structure without auditing callers | Added `in_progress`/`completed` split but didn't grep for direct path construction | 17 files still used `experiment_dir / tier_id` directly — silent wrong-dir reads post-merge | ALWAYS run the pre-merge bypass-audit grep before merging any directory-structure change |
+| `shutil.move` for a baseline file shared across sibling runs | Moved `pipeline_baseline.json` with the first run during promotion | The second run in the same subtest could no longer find the baseline — it had been moved away | Use `shutil.copy2` for files shared across siblings; only `move` the run directory itself |
+| Fix only the broken copy of duplicated JSON-extraction logic | Considered copying the brace-matching fix into the one buggy file | Would have created a 4th duplicate; future bugs need fixing in 4 places | When a bug surfaces duplication, deduplicate to a shared utility FIRST, then the fix lives in one place |
+| Plain `"""` docstring containing backslash examples (`\n`) | Wrote extraction-utility docstring with literal backslashes | ruff `D301` failed: "Use r\"\"\" if any backslashes in a docstring" | Use `r"""` for any docstring containing backslashes, even in examples |
+| Make `Field(...)` required for an optional-by-usage Pydantic field | Marked `duration_seconds` required in the consolidated base model | Broke existing callers that constructed the object without it | Provide `Field(default=X)` for fields not universally supplied by all callers |
+| Mutate a frozen Pydantic model directly | `info.started_at = value` on a `frozen=True` model | Raised `FrozenInstanceError` | Use `model_copy(update={...})` for all field updates on frozen models |
+| Rename a class globally without a backward-compat alias | One-pass global rename | Broke external consumers importing the old name | Add `OldName = NewName` alias; old imports keep working |
+| Grep only source files for references before deleting/relocating | `--include="*.py"` only | Missed references in `CLAUDE.md`, `docs/`, `scripts/*.py`, `*.yaml` | Grep ALL file types (`.py`, `.mojo`, `.md`, `.yaml`, `.yml`) and use `git rm` to preserve history |
+| Leave the same dict structure built in multiple call sites | Kept identical dict construction in a format function and `main()` | Shapes drift independently when new fields are added later | Extract a `_serializable_*()` helper; add a regression test pinning shape parity |
+| Lift a mutating closure into a standalone method unchanged | Cut a `nonlocal`-mutating inner function out into a module-level helper as-is | The captured variable became a plain local in the new scope; the caller's value was never updated | Wrap the mutated state in a small mutable box (one-field dataclass or single-element `list` cell) and pass it into the extracted helper |
+| Mock a value behind an `@lru_cache` helper without clearing the cache | `unittest.mock.patch` / `monkeypatch.setattr` on the underlying function, then called the cached helper | The cache held the pre-patch value, so the mock was never exercised and the test asserted stale data | Call `helper.cache_clear()` in the test before (and between) patches — ideally via setup/teardown or an autouse fixture |
+| Delete a stale script before checking for callers | `git rm old_entrypoint.py` as part of consolidation without grepping first | A kept file still imported / documented it → broken import and dangling doc reference post-merge | Grep all file types for callers FIRST; if a kept file back-references the target, rewrite it self-contained and verify before deleting |
+| Keep a hardcoded file list after consolidating the tree | Left `SKILL_FILES = [...]` enumerating discovered files by hand | The list silently rotted as files were added/removed — discovery missed new files and pointed at deleted ones | Discover dynamically with `sorted(Path(...).rglob("*.ext"))` and filter excludes explicitly instead of maintaining an allowlist |
+| (PLANNING #1205) Assume two duplicate-*looking* constant lists are pure duplicates and flat-merge them | Planned a single shared frozenset for `TRANSIENT_ERROR_PATTERNS` + `NETWORK_ERROR_KEYWORDS` | The resilience layer's documented contract DELIBERATELY omits `"rate limit"`/`"throttle"` ("rate limit error passthrough — not retried"). A flat merge would make it retry rate-limit errors (contract violation) OR drop them from the network tagger (breaks an existing test) | CLASSIFY first: true-duplicate vs intentional-variant-WITH-overlap. For overlap, extract only the shared CORE into one frozenset and have each consumer compose `CORE \| its-own-extras`. Confirm the "intentional" difference is a real, current contract (docstring + test), not stale drift, before scoping the split |
+| (PLANNING #1205) Drop exact phrases "because a broad substring in CORE already covers them" | Considered removing `"connection refused"`/`"connection reset"` from the resilience extras since CORE held the broader `"connection"` | `"connection"` MATCHES `"connection refused"` at runtime, but the resilience test `test_essential_patterns_present` asserts EXACT MEMBERSHIP of the phrase `"connection refused"` — matching-equivalence is NOT membership-equivalence. Dropping the phrase passes behavior but fails the membership assertion | Keep the exact phrases as explicit per-consumer extras even when a broad CORE substring would match them. A flat dedupe that elides "covered" phrases silently breaks membership tests |
+| (PLANNING #1205) Change a list literal to `sorted(frozenset \| frozenset)` without checking how callers use it | Planned to recompose `TRANSIENT_ERROR_PATTERNS`/`NETWORK_ERROR_KEYWORDS` as `sorted(CORE \| extras)` | That changes element ORDER and the source TYPE. Any caller relying on original ordering, on `.append()`/mutation, or on index access would break; and the looser `is_network_error` substrings (`"connection"`,`"timeout"`,`"network"`) must not be accidentally tightened/loosened | Before recomposing, grep callers to confirm ONLY iteration is used (no mutation, no indexing, no order dependence). Keep public names + iterable types; treat each behavioral matcher suite (`test_retry.py`, `test_subprocess_resilience.py`) as the real acceptance gate, not the new constant tests |
+## Results & Parameters
+
+### Code Changes
+
+**Files Modified**: 2
+
+- `scylla/e2e/runner.py` - Implementation
+- `tests/unit/e2e/test_runner.py` - Tests
+
+**Lines Changed**: +173 / -18
+
+### Test Coverage
+
+**New Tests**: 4 unit tests
+
+- `test_empty_tier_results()` - Empty dict handling
+- `test_single_tier_result()` - Single item aggregation
+- `test_multiple_tier_results()` - Multi-item aggregation
+- `test_zero_token_stats()` - Zero value handling
+
+**Regression Tests**: 467 E2E tests passed
+
+### Helper Method Pattern
+
+```python
+def _aggregate_token_stats(self, tier_results: dict[TierID, TierResult]) -> TokenStats:
+    """Aggregate token statistics from all tier results.
+
+    Args:
+        tier_results: Dictionary mapping tier IDs to their results
+
+    Returns:
+        Aggregated token statistics across all tiers. Returns empty
+        TokenStats if tier_results is empty.
+    """
+    from functools import reduce
+
+    if not tier_results:
+        return TokenStats()
+
+    return reduce(
+        lambda a, b: a + b,
+        [t.token_stats for t in tier_results.values()],
+        TokenStats(),
+    )
+```
+
+### Key Implementation Details
+
+1. **Import placement**: `from functools import reduce` inside method
+2. **Empty handling**: Explicit check with early return
+3. **Identity element**: Empty `TokenStats()` as third parameter to `reduce`
+4. **Type hints**: Complete signature with proper types
+5. **Docstring**: Clear description with Args and Returns sections
+
+## Success Metrics
+
+| Metric | Value |
+| -------- | ------- |
+| Duplication eliminated | 2 instances → 1 helper |
+| Lines saved | ~15 lines per call site |
+| Test coverage | 4 comprehensive tests |
+| Regression tests | 467 tests pass |
+| Pre-commit checks | All pass |
+| Time to implement | ~30 minutes |
+
+## Verified On
+
+| Project | Issue/PR | Scope | Verification |
+| --------- | ---------- | ------- | -------------- |
+| ProjectHephaestus | #739 | Private module extraction | verified-ci |
+| ProjectScylla | dir-structure split | Path-constant bypass audit | verified-ci |
+| ProjectHephaestus | #1205 | Phase 10 core/extras split for overlapping `TRANSIENT_ERROR_PATTERNS` / `NETWORK_ERROR_KEYWORDS` | ⚠️ **unverified — planning only, NOT executed** (no code, no tests, no CI) |
+
+## Related Skills
+
+- `token-stats-aggregation` (evaluation) - Token aggregation pattern
+- `codebase-consolidation` (architecture) - Finding duplicates
+- `testing-python-constants-module` (testing) - frozenset/immutability/membership tests referenced by Phase 10
+
+## Tags
+
+`refactoring`, `dry-principle`, `helper-methods`, `tdd`, `code-quality`, `python`, `pytest`, `private-modules`, `test-structure`, `git-signing`, `importlib-metadata`, `srp`, `extract-method`, `lru-cache`, `mock-patch`, `rglob`, `dead-code-removal`, `constants`, `frozenset`, `drift`, `intentional-variant`, `core-extras-split`, `planning`
+
+## Version History
+
+- **v1.5.0** (2026-06-12): Added Phase 10 (PLANNING-ONLY, **unverified**) — the core/extras split for consolidating OVERLAPPING constant collections that are intentional-variants-with-overlap, not pure duplicates. Refines the Phase 8c classification table with a third middle path: extract only the shared CORE into one immutable frozenset, compose each consumer as `CORE | extras`, and prove anti-drift with `CORE.issubset(consumer)` parity tests while keeping public names/types. Added 3 Failed Attempts rows (flat-merge-violates-contract, drop-phrases-because-broad-substring-covers-them, recompose-changes-order/type) and a `## Verified On` table. Captured from planning ProjectHephaestus issue #1205; NOT executed end-to-end (no code, no tests, no CI). Prior v1.4.0 snapshot archived to history.
+- **v1.4.0** (2026-06-07): Restored SRP/LRU-cache/stale-script DRY patterns lost in the v1.3.0 absorption (nuance audit). Added Phase 9 + `### Detailed Steps`: extract-method/SRP decomposition with mutable-box closure conversion, `@lru_cache` detection util with the `mock.patch`/`cache_clear()` gotcha, stale-script/deprecated-stub cleanup (grep callers first, rewrite back-references self-contained), and dynamic `Path.rglob` discovery. Added 4 Failed Attempts rows.
+- **v1.3.0** (2026-06-07): Absorbed 5 skills — `centralized-path-constants`, `private-module-extraction-helper-pattern`, `deduplicate-llm-json-extraction`, `dry-consolidation-workflow`, `dry-consolidate-to-canonical-refactor`. Added Quick Reference h3 and Phase 8 (path constants, LLM JSON dedup, discovery/classify pass, Pydantic type hierarchy, dict-structure consolidation, orphan relocation). Extended description and Failed Attempts. Full originals preserved in history.
+- **v1.1.0** (2026-06-04): Added Phase 7 covering private module extraction patterns, test structure mirroring enforcement, cryptographic commit signing, PyPI distribution name handling. Verified via ProjectHephaestus issue #739.
+- **v1.0.0** (2026-02-15): Initial release covering token aggregation extraction with TDD workflow.
+````
+
+---
 ## v1.1.0 (2026-06-04)
 
 **Changed by:** ProjectHephaestus issue #739 - DRY refactoring for version resolution

--- a/skills/dry-refactoring-workflow.md
+++ b/skills/dry-refactoring-workflow.md
@@ -1,11 +1,11 @@
 ---
 name: dry-refactoring-workflow
-description: "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Use when: (1) extracting duplicated helper methods into a shared module using TDD (write a failing test against the canonical, delete the duplicate, run green); (2) creating a private leaf module with leading-underscore naming to centralize a repeated internal call (e.g. importlib.metadata version resolution, path construction) and prevent re-introduction across modules; (3) centralizing hardcoded path constants into a single module to prevent drift when directory structure changes (incl. phase-routed in_progress/completed splits); (4) deduplicating LLM JSON extraction, parser logic, or any call-site pattern copy-pasted across several files; (5) test structure must mirror source structure when extracting helpers; (6) running a full DRY consolidation pass (discovery via grep, classifying true duplicates vs intentional variants, dict-structure consolidation) and refactoring to a single canonical source; (7) extract-method / SRP decomposition of over-long functions (50-LOC) and methods (100-LOC), including converting a mutating closure into a method via a small mutable box; (8) extracting repeated cached lookups into an @lru_cache helper (and clearing the cache so unittest.mock.patch works); (9) removing stale scripts / deprecated stubs (grep callers first) and replacing hardcoded file lists with dynamic Path.rglob discovery; (10) PLANNING a consolidation of two OVERLAPPING but not-identical constant collections (frozensets / keyword lists / error-pattern tuples) — classify true-duplicate vs intentional-variant first, then extract only the shared CORE into one canonical immutable constant and have each consumer compose CORE | its-own-extras, proving anti-drift with CORE.issubset(consumer) parity tests, instead of a flat merge that would violate a deliberate behavioral contract. Also covers cryptographic commit signing requirements in PR workflows."
+description: "Complete TDD-driven workflow for identifying and eliminating code duplication by extracting reusable helper methods. Use when: (1) extracting duplicated helper methods into a shared module using TDD (write a failing test against the canonical, delete the duplicate, run green); (2) creating a private leaf module with leading-underscore naming to centralize a repeated internal call (e.g. importlib.metadata version resolution, path construction) and prevent re-introduction across modules; (3) centralizing hardcoded path constants into a single module to prevent drift when directory structure changes (incl. phase-routed in_progress/completed splits); (4) deduplicating LLM JSON extraction, parser logic, or any call-site pattern copy-pasted across several files; (5) test structure must mirror source structure when extracting helpers; (6) running a full DRY consolidation pass (discovery via grep, classifying true duplicates vs intentional variants, dict-structure consolidation) and refactoring to a single canonical source; (7) extract-method / SRP decomposition of over-long functions (50-LOC) and methods (100-LOC), including converting a mutating closure into a method via a small mutable box; (8) extracting repeated cached lookups into an @lru_cache helper (and clearing the cache so unittest.mock.patch works); (9) removing stale scripts / deprecated stubs (grep callers first) and replacing hardcoded file lists with dynamic Path.rglob discovery; (10) PLANNING a consolidation of two OVERLAPPING but not-identical constant collections (frozensets / keyword lists / error-pattern tuples) — classify true-duplicate vs intentional-variant first, then extract only the shared CORE into one canonical immutable constant and have each consumer compose CORE | its-own-extras, proving anti-drift with CORE.issubset(consumer) parity tests, instead of a flat merge that would violate a deliberate behavioral contract. (11) behavior-preserving duplicate cleanup across test fakes, tiny strategy/kernel modules, and validation wrappers: keep public module exports stable, centralize only identical mechanics, preserve local wrapper names/error messages, and verify with focused + full suites before opening a PR. Also covers cryptographic commit signing requirements in PR workflows."
 category: architecture
-date: 2026-06-12
-version: 1.5.0
+date: 2026-06-18
+version: "1.6.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 history: dry-refactoring-workflow.history
 ---
 # DRY Refactoring Workflow
@@ -16,9 +16,9 @@ Complete TDD-driven workflow for identifying and eliminating code duplication by
 
 | Attribute | Details |
 | ----------- | --------- |
-| **Date** | 2026-06-04 |
+| **Date** | 2026-06-18 |
 | **Objective** | TDD-driven extraction of duplicated code into reusable helper modules, with emphasis on private module placement, test structure mirroring, and cryptographic commit signing |
-| **Outcome** | ✅ v1.0.0 (Feb 2026): Eliminated token aggregation duplication. v1.1.0 (Jun 2026): Extended with private module patterns, test mirroring enforcement, signing requirements. v1.3.0 (Jun 2026): Absorbed centralized path constants, LLM JSON extraction dedup, full DRY consolidation discovery/classify pass, and canonical-source refactor patterns (Pydantic type hierarchy, dict-structure consolidation, orphan relocation). v1.4.0 (Jun 2026): Restored SRP/extract-method (mutable-box closure), @lru_cache detection util (mock.patch/cache_clear gotcha), stale-script/stub cleanup, and dynamic Path.rglob discovery patterns from the nuance audit. ⚠️ v1.5.0 (Jun 2026, **planning-only / unverified**): Added Phase 10 — planning a consolidation of OVERLAPPING constant collections via the core/extras split (CORE \| consumer-extras) with subset parity anti-drift tests, classifying intentional-variant-with-overlap separately from "do not consolidate". Captured from ProjectHephaestus #1205 planning; NOT executed end-to-end. |
+| **Outcome** | ✅ v1.0.0 (Feb 2026): Eliminated token aggregation duplication. v1.1.0 (Jun 2026): Extended with private module patterns, test mirroring enforcement, signing requirements. v1.3.0 (Jun 2026): Absorbed centralized path constants, LLM JSON extraction dedup, full DRY consolidation discovery/classify pass, and canonical-source refactor patterns (Pydantic type hierarchy, dict-structure consolidation, orphan relocation). v1.4.0 (Jun 2026): Restored SRP/extract-method (mutable-box closure), @lru_cache detection util (mock.patch/cache_clear gotcha), stale-script/stub cleanup, and dynamic Path.rglob discovery patterns from the nuance audit. ⚠️ v1.5.0 (Jun 2026, **planning-only / unverified**): Added Phase 10 — planning a consolidation of OVERLAPPING constant collections via the core/extras split (CORE \| consumer-extras) with subset parity anti-drift tests, classifying intentional-variant-with-overlap separately from "do not consolidate". v1.6.0 (Jun 2026): Added Radiance behavior-preserving duplicate cleanup pattern for route-test fakes, layout-only metric kernels, validation field wrappers, and stale tool deletion; verified locally with Ruff, full pytest, compileall, diff check, and pre-push pytest; PR CI pending. |
 | **Primary Issues** | #642 (original), #739 (private module extraction), #917 (pr-policy signing), #503 (LLM JSON dedup) |
 | **Primary PRs** | #714 (original), #900+ (refactoring), #137/#1738 (path constants), #505 (JSON dedup), #201 (DRY consolidation) |
 | **History** | [changelog](./dry-refactoring-workflow.history) |
@@ -57,6 +57,10 @@ Use this workflow when you encounter:
 - "Consolidate `TRANSIENT_ERROR_PATTERNS` and `NETWORK_ERROR_KEYWORDS` / two near-duplicate constant collections"
 - "These two constant lists are 80% the same but one has extras — DRY them up"
 - "Plan a DRY merge of overlapping constants without changing either matcher's behavior"
+- "Consolidate duplicated server test fake apps / fake requests without changing route assertions"
+- "Replace repeated tiny metric/operator kernel classes with one parameterized kernel while keeping module-level `KERNEL` exports stable"
+- "Share validation type checks but preserve each module's exception class, wrapper function names, and error message text"
+- "Remove an obsolete script and its Ruff exception after `rg` proves no first-party callers remain"
 
 ## Verified Workflow
 
@@ -73,6 +77,13 @@ grep -rn "experiment_dir / \|experiment_dir/" src/ scripts/ | grep -v "paths.py"
 
 # --- VERIFY no orphaned refs after migration (must be empty) ---
 grep -rn "old_module\.\|_old_function_name" src/ tests/ --include="*.py"
+
+# --- RADIANCE-STYLE behavior-preserving duplicate cleanup ---
+rg -n "class _FakeRequest|class _FakeApp|def route\(" tests/radiance/server tests/project/release -g "*.py"
+rg -n "class (Flatten|Reshape|Permute|Transpose|View)Kernel|estimate_layout_reindex" radiance/metrics/ops -g "*.py"
+rg -n "def _required_mapping|def _required_list|def _required_string|def _as_mapping" radiance/*validation.py
+./.venv/bin/python -m ruff check radiance scripts tests --no-cache
+./.venv/bin/pytest -q
 
 # --- TDD loop: write failing test, implement helper, go green ---
 <package-manager> run pytest tests/unit/<module>/test_<file>.py -v   # RED then GREEN
@@ -679,6 +690,56 @@ test). Neither is acceptable. The core/extras split preserves both contracts.
 
 8. Signed commit + auto-merge per the standard PR workflow above.
 
+
+### Phase 11: Behavior-Preserving Duplicate Cleanup Across Tests, Kernels, and Validation Wrappers (NEW in v1.6.0)
+
+Use this when an audit finds several low-risk duplicate surfaces in one Python repository, but
+runtime behavior must remain stable.
+
+#### Quick Reference
+
+```bash
+# Find repeated fake app/request route scaffolding.
+rg -n "class _FakeRequest|class _FakeApp|def route\(" tests/radiance/server tests/project/release -g "*.py"
+
+# Find repeated tiny kernel classes delegating to the same estimator.
+rg -n "class (Flatten|Reshape|Permute|Transpose|View)Kernel|estimate_layout_reindex" radiance/metrics/ops -g "*.py"
+
+# Find repeated validation field wrappers.
+rg -n "def _required_mapping|def _required_list|def _required_string|def _as_mapping" radiance/*validation.py
+
+# Behavior-preserving verification gate.
+./.venv/bin/python -m ruff check radiance scripts tests --no-cache
+./.venv/bin/pytest -q
+./.venv/bin/python -m compileall radiance scripts tests
+git diff --check
+```
+
+#### Detailed Steps
+
+1. **Centralize test-only HTTP fakes in tests, not production.** If several route tests define
+   `_FakeRequest`, `_FakeApp`, and identical `route()` decorators, create a local test support
+   module. Keep variants explicit by storage shape: rule -> handler, rule -> list[handler],
+   `(rule, method) -> handler`, `(method, rule) -> handler`, or registration-order list.
+   This removes decorator duplication without making assertions harder to read.
+2. **Extract only the invariant mechanics.** For fake route apps, share the decorator and route
+   method normalization once, then let tiny subclasses/adapters record routes in the shape each
+   test already expects. Do not force every test into one awkward route index.
+3. **Replace repeated tiny strategy classes with one parameterized instance.** If modules differ
+   only by `supported_ops` and call the same estimator, keep each module's public `KERNEL` export
+   but construct it from the shared class, e.g. `KERNEL = LayoutReindexKernel(("flatten", ...))`.
+   This preserves provider registration behavior while deleting boilerplate classes.
+4. **Preserve validation API/error contracts with local wrappers.** When modules use different
+   exception classes or message wording, do not import one module's helper into another. Instead,
+   create generic low-level checks that accept `error_type` and exact message strings, then keep
+   the existing `_required_mapping` / `_required_string` wrappers in each module.
+5. **Delete stale large scripts only after a caller audit.** Run `rg` for the filename, import
+   name, CLI reference, docs, and CI exception. Remove the file and remove only the specific lint
+   exception/test expectation tied to it.
+6. **Run focused tests first, then full gates.** Execute the touched server tests, touched
+   validation tests, metric alias tests, then full Ruff/pytest/compileall/diff-check. If the repo
+   has a pre-push hook, treat its full pytest rerun as an additional local signal, not CI.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -704,7 +765,20 @@ test). Neither is acceptable. The core/extras split preserves both contracts.
 | (PLANNING #1205) Assume two duplicate-*looking* constant lists are pure duplicates and flat-merge them | Planned a single shared frozenset for `TRANSIENT_ERROR_PATTERNS` + `NETWORK_ERROR_KEYWORDS` | The resilience layer's documented contract DELIBERATELY omits `"rate limit"`/`"throttle"` ("rate limit error passthrough — not retried"). A flat merge would make it retry rate-limit errors (contract violation) OR drop them from the network tagger (breaks an existing test) | CLASSIFY first: true-duplicate vs intentional-variant-WITH-overlap. For overlap, extract only the shared CORE into one frozenset and have each consumer compose `CORE \| its-own-extras`. Confirm the "intentional" difference is a real, current contract (docstring + test), not stale drift, before scoping the split |
 | (PLANNING #1205) Drop exact phrases "because a broad substring in CORE already covers them" | Considered removing `"connection refused"`/`"connection reset"` from the resilience extras since CORE held the broader `"connection"` | `"connection"` MATCHES `"connection refused"` at runtime, but the resilience test `test_essential_patterns_present` asserts EXACT MEMBERSHIP of the phrase `"connection refused"` — matching-equivalence is NOT membership-equivalence. Dropping the phrase passes behavior but fails the membership assertion | Keep the exact phrases as explicit per-consumer extras even when a broad CORE substring would match them. A flat dedupe that elides "covered" phrases silently breaks membership tests |
 | (PLANNING #1205) Change a list literal to `sorted(frozenset \| frozenset)` without checking how callers use it | Planned to recompose `TRANSIENT_ERROR_PATTERNS`/`NETWORK_ERROR_KEYWORDS` as `sorted(CORE \| extras)` | That changes element ORDER and the source TYPE. Any caller relying on original ordering, on `.append()`/mutation, or on index access would break; and the looser `is_network_error` substrings (`"connection"`,`"timeout"`,`"network"`) must not be accidentally tightened/loosened | Before recomposing, grep callers to confirm ONLY iteration is used (no mutation, no indexing, no order dependence). Keep public names + iterable types; treat each behavioral matcher suite (`test_retry.py`, `test_subprocess_resilience.py`) as the real acceptance gate, not the new constant tests |
+| Replacing repeated validation wrappers directly with one module-specific helper | Considered importing one validation module's `_required_*` helpers into the others | Each validation module has its own exception class and message wording; sharing a wrapper would leak the wrong exception/message contract | Share only the primitive type checks and keep local wrappers that pass `error_type` plus exact message text |
+| Forcing all fake route apps into one route dictionary shape | A single fake app abstraction looked attractive for all server route tests | Tests intentionally index registered routes differently: by rule, by ordered list, by `(rule, method)`, or by `(method, rule)` | Share the decorator mechanics in a base helper, then keep explicit small storage adapters so test assertions remain clear |
+| Reusing a merged feature branch for a follow-up cleanup PR | Current branch already had a merged PR, so committing on it would have produced a confusing branch/PR relationship | GitHub reported the branch's prior PR as `MERGED`; a new PR needed a new branch from current trunk | Stash uncommitted work, fetch current trunk, create a fresh branch from `origin/<trunk>`, pop the stash, re-verify, sign, push, and open the new PR |
 ## Results & Parameters
+
+### Radiance v1.6.0 Local Verification
+
+| Check | Result |
+| ----- | ------ |
+| Ruff | `./.venv/bin/python -m ruff check radiance scripts tests --no-cache` passed |
+| Full pytest | `1249 passed, 6 skipped` locally and again in the pre-push hook |
+| Compileall | `./.venv/bin/python -m compileall radiance scripts tests` passed |
+| Diff hygiene | `git diff --check` passed |
+| PR | LLM360/Radiance PR #908 opened; CI pending at capture time |
 
 ### Code Changes
 
@@ -777,6 +851,7 @@ def _aggregate_token_stats(self, tier_results: dict[TierID, TierResult]) -> Toke
 | ProjectHephaestus | #739 | Private module extraction | verified-ci |
 | ProjectScylla | dir-structure split | Path-constant bypass audit | verified-ci |
 | ProjectHephaestus | #1205 | Phase 10 core/extras split for overlapping `TRANSIENT_ERROR_PATTERNS` / `NETWORK_ERROR_KEYWORDS` | ⚠️ **unverified — planning only, NOT executed** (no code, no tests, no CI) |
+| LLM360/Radiance | PR #908 | Consolidated route-test fakes, layout-only metric kernels, validation field checks, and removed stale `hf_checkpoint_architecture_html.py` | verified-local — full local/pre-push test suite passed; PR CI pending at capture time |
 
 ## Related Skills
 
@@ -786,10 +861,11 @@ def _aggregate_token_stats(self, tier_results: dict[TierID, TierResult]) -> Toke
 
 ## Tags
 
-`refactoring`, `dry-principle`, `helper-methods`, `tdd`, `code-quality`, `python`, `pytest`, `private-modules`, `test-structure`, `git-signing`, `importlib-metadata`, `srp`, `extract-method`, `lru-cache`, `mock-patch`, `rglob`, `dead-code-removal`, `constants`, `frozenset`, `drift`, `intentional-variant`, `core-extras-split`, `planning`
+`refactoring`, `dry-principle`, `helper-methods`, `radiance`, `test-fakes`, `validation-wrappers`, `layout-kernels`, `tdd`, `code-quality`, `python`, `pytest`, `private-modules`, `test-structure`, `git-signing`, `importlib-metadata`, `srp`, `extract-method`, `lru-cache`, `mock-patch`, `rglob`, `dead-code-removal`, `constants`, `frozenset`, `drift`, `intentional-variant`, `core-extras-split`, `planning`
 
 ## Version History
 
+- **v1.6.0** (2026-06-18): Added Phase 11, a locally verified Radiance behavior-preserving duplicate cleanup workflow. Captures shared server route test fakes, parameterized layout-only metric kernels via `LayoutReindexKernel`, shared primitive validation field checks with local wrappers preserving exception/message contracts, stale script deletion after caller audit, and the fresh-branch PR workflow when the current branch's old PR is already merged. Verification was local/pre-push only; PR #908 CI was pending at capture time. Prior v1.5.0 snapshot archived to history.
 - **v1.5.0** (2026-06-12): Added Phase 10 (PLANNING-ONLY, **unverified**) — the core/extras split for consolidating OVERLAPPING constant collections that are intentional-variants-with-overlap, not pure duplicates. Refines the Phase 8c classification table with a third middle path: extract only the shared CORE into one immutable frozenset, compose each consumer as `CORE | extras`, and prove anti-drift with `CORE.issubset(consumer)` parity tests while keeping public names/types. Added 3 Failed Attempts rows (flat-merge-violates-contract, drop-phrases-because-broad-substring-covers-them, recompose-changes-order/type) and a `## Verified On` table. Captured from planning ProjectHephaestus issue #1205; NOT executed end-to-end (no code, no tests, no CI). Prior v1.4.0 snapshot archived to history.
 - **v1.4.0** (2026-06-07): Restored SRP/LRU-cache/stale-script DRY patterns lost in the v1.3.0 absorption (nuance audit). Added Phase 9 + `### Detailed Steps`: extract-method/SRP decomposition with mutable-box closure conversion, `@lru_cache` detection util with the `mock.patch`/`cache_clear()` gotcha, stale-script/deprecated-stub cleanup (grep callers first, rewrite back-references self-contained), and dynamic `Path.rglob` discovery. Added 4 Failed Attempts rows.
 - **v1.3.0** (2026-06-07): Absorbed 5 skills — `centralized-path-constants`, `private-module-extraction-helper-pattern`, `deduplicate-llm-json-extraction`, `dry-consolidation-workflow`, `dry-consolidate-to-canonical-refactor`. Added Quick Reference h3 and Phase 8 (path constants, LLM JSON dedup, discovery/classify pass, Pydantic type hierarchy, dict-structure consolidation, orphan relocation). Extended description and Failed Attempts. Full originals preserved in history.

--- a/skills/git-branch-state-triage-and-recovery.history
+++ b/skills/git-branch-state-triage-and-recovery.history
@@ -2,6 +2,561 @@
 
 # History: git-branch-state-triage-and-recovery
 
+## v1.4.0 (2026-06-18)
+
+**Changed by:** Radiance PR #908 fresh branch from already-merged current branch
+**Verification:** verified-local
+
+### What changed
+- Added State E for uncommitted follow-up work on a branch whose previous PR is already merged.
+- Documented the stash -> fetch trunk -> fresh branch -> stash pop -> re-verify -> signed commit -> issue-linked PR workflow.
+- Added failed-attempt and results entries from the Radiance duplicate-code cleanup PR creation.
+- Updated verification metadata to verified-local because PR #908 CI was pending when captured.
+
+### Why
+Radiance exposed a distinct branch-state case from the existing binary-patch follow-up workflow: the follow-up work was an uncommitted worktree diff on a branch whose old PR was already merged. The clean recovery was to preserve the diff with a stash and move it to a fresh branch from current trunk before committing and opening a new PR.
+
+### Previous version (v1.3.1) snapshot
+
+````markdown
+---
+name: git-branch-state-triage-and-recovery
+description: >-
+  Diagnose and recover branches that have entered an invalid or obsolete state. Use when:
+  (1) a branch is many commits behind main and its remote tracking ref is gone,
+  (2) a branch has no common ancestor with main and needs content extraction,
+  (3) stacked or diverged PR fixes must be cherry-picked onto the correct tip,
+  (4) a branch has many HEAD-only files after main-side consolidation,
+  (5) a squash-merged branch looks unmerged because git cherry/ahead counts lie,
+  (6) an auto-merge PR already merged, its remote head ref is gone or stale, and a
+  validated local amended commit must be converted into a clean follow-up branch from
+  current trunk using git diff --binary plus git apply --index.
+category: tooling
+date: 2026-06-18
+version: "1.3.1"
+user-invocable: false
+verification: verified-ci
+history: git-branch-state-triage-and-recovery.history
+tags: [git, branch, triage, recovery, stale, superseded, orphan, diverged, merge-base, cherry-pick, fork-point, diff-filter, unrelated-histories, non-fast-forward, consolidation, three-way-diff, count-diff, hard-reset, stash, auto-merge, follow-up-branch, force-with-lease, git-apply]
+---
+
+# Git Branch State Triage and Recovery
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-18 |
+| **Objective** | Diagnose what state a branch is in (stale/superseded, orphaned/unrelated history, or diverged from remote) and recover it cleanly |
+| **Outcome** | Success — unified triage tree: confirm-and-discard superseded branches, extract+recreate orphan branches, reset+cherry-pick diverged branches, and convert validated local amended commits from already-merged PRs into clean follow-up branches |
+| **Verification** | verified-ci |
+
+## When to Use
+
+Use this skill whenever a branch is in an unexpected or unmergeable state. The root question
+is always: **what state is this branch in, and how do I recover it?** Four distinct states:
+
+**State A — Stale / superseded by main:**
+- A branch is many commits behind main **and** its remote tracking ref is gone (`[gone]` in `git branch -vv`)
+- The task is "get all open PRs merged" — check `gh pr list --state open` first; if zero open PRs the premise has changed
+- A `git diff origin/main...HEAD` shows a large file count difference but you suspect most of it is merge noise
+- Staged files with AD status in `git status --short` (added in index, deleted from working dir)
+- Hundreds or thousands of HEAD-only files exist vs main, and main has commit messages like "consolidate N skills into X" or "absorb C086" — this is a **corpus consolidation** divergence, not unique unmerged work
+- A branch **looks unmerged but is actually subsumed by a squash-merge**: `git cherry origin/main <branch>` shows every commit with a `+` prefix, `git rev-list --count origin/main..<branch>` reports commits "ahead", and an auto-rebase onto main **conflicts** — yet the branch's PR was already squash-merged. Squash gives the merged work a brand-new patch-id, so `git cherry` never matches and these signals are **false positives**. Disambiguate with message-search on main, **not** git cherry / ahead-counts (see "Squash-merge false positive" below). A worktree showing "uncommitted modified files" can be the same false alarm — verify with a 0-unique-lines diff against main
+
+**State B — Orphan / unrelated history:**
+- `git merge-base` returns nothing between branch and main
+- Error: "fatal: refusing to merge unrelated histories"
+- Branch appears to have a completely different commit history (suspect: pushed from wrong repo)
+- PR shows massive unexpected file changes
+
+**State C — Diverged from remote:**
+- `git push` fails with "non-fast-forward" on a feature branch
+- `git status` shows "Your branch and 'origin/<branch>' have diverged"
+- A fix commit exists locally but the remote has accumulated additional commits (e.g. after a rebase or stacked-PR retarget)
+- A fix plan assumed the remote was behind, but it actually has more commits than local
+
+**State D — Already-merged PR; old head ref stale/gone; local amended commit has follow-up work:**
+- `git push --force-with-lease origin <branch>` rejects as stale after auto-merge had been enabled
+- `git fetch origin <branch>` fails with "couldn't find remote ref" because the PR head branch was deleted after merge
+- `gh pr view <pr>` shows `state: MERGED` and an old `headRefOid`, while current trunk contains the merged work under a new squash/rebase commit SHA
+- You have a local amended commit that was already validated, but the old PR branch is no longer the correct target
+- The right recovery is to diff current trunk to the validated local commit, apply that binary patch on a fresh branch from trunk, prove the new tree matches the validated commit, then open a follow-up PR
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# === Triage: which state am I in? ===
+git branch -vv | grep "$(git rev-parse --abbrev-ref HEAD)"   # [gone] = remote ref deleted
+git merge-base HEAD origin/main || echo "ORPHAN: no common ancestor"  # empty = State B
+git status                                                    # "diverged" = State C
+
+# === State A: stale / superseded by main ===
+gh pr list --state open                          # check premise FIRST
+FORK=$(git merge-base HEAD origin/main)           # fork point
+git ls-tree --name-only -r HEAD skills/ | sort > /tmp/head.txt
+git ls-tree --name-only -r origin/main skills/ | sort > /tmp/main.txt
+comm -23 /tmp/head.txt /tmp/main.txt              # HEAD-only files (maybe new, maybe old)
+git log --diff-filter=D --oneline origin/main -- <path> | head -1  # how main disposed of it
+# staged-index no-op check:
+git ls-files --stage | awk '{print $1, $4}' | sort > /tmp/staged.txt
+git ls-tree -r origin/main | awk '{print $3, $4}' | sort > /tmp/mainh.txt
+comm -23 /tmp/staged.txt /tmp/mainh.txt           # staged files NOT on main = true new work
+
+# === State A: squash-merge FALSE POSITIVE — do NOT trust git cherry / ahead-counts ===
+# These LIE on squash repos (squash = new patch-id, cherry never matches):
+git cherry origin/main <branch>                   # every commit shows '+' even when subsumed
+git rev-list --count origin/main..<branch>        # >0 "ahead" even when subsumed
+# Reliable disambiguator — message-search on main for the squash commit (PR number / subject):
+git log origin/main --oneline | grep -iE '<distinctive phrase or (#PRnum)>'
+# found on main  => branch is SUBSUMED: safe to discard, no rebase/PR. Cross-check PR state:
+gh pr list --head <branch> --state all --json number,state   # MERGED/CLOSED corroborates
+# rebase conflicts on a subsumed branch are EXPECTED (squash content on main collides with the
+# original un-squashed commits). Report "subsumed" and STOP — do not resolve, do not auto-delete.
+
+# === State A: worktree "uncommitted modified files" 0-unique-lines redundancy check ===
+# A modified working-tree file can be byte-for-byte already on main (it shipped via a merged PR):
+diff <(git show origin/main:<path>) <(cat <worktree>/<path>) | grep -c '^>'  # 0 = no unique lines
+# 0 unique lines on ALL modified files => the "uncommitted work" already merged; safe to discard.
+
+# === State A (large-scale): three-way count diff for consolidation divergence ===
+MERGE_BASE=$(git merge-base HEAD origin/main)
+git ls-tree -r --name-only "$MERGE_BASE" skills/ | grep '\.md$' | sort > /tmp/base.txt
+git ls-tree -r --name-only HEAD skills/ | grep '\.md$' | sort > /tmp/branch.txt
+git ls-tree -r --name-only origin/main skills/ | grep '\.md$' | sort > /tmp/main2.txt
+wc -l /tmp/base.txt /tmp/branch.txt /tmp/main2.txt  # counts: base→branch grew? base→main shrank?
+comm -23 /tmp/branch.txt /tmp/main2.txt | wc -l     # branch-only (pre-consolidation originals?)
+comm -13 /tmp/branch.txt /tmp/main2.txt | wc -l     # main-only (new canonical merged skills?)
+# if main shrank (consolidation) and branch-only are old originals absorbed by main:
+git log --oneline origin/main | grep -iE 'consolidat|absorb|merge.*skill|cluster' | head -10
+# safety: stash before any hard-reset (recoverable snapshot)
+git stash push -u -m "pre-reset snapshot $(date +%Y%m%d)"
+git log --oneline origin/main..HEAD                  # confirm only superseded commits
+
+# === State B: orphan / unrelated history ===
+git fetch origin <branch>
+git merge-base origin/main origin/<branch>        # empty = orphan
+git log --oneline origin/<branch> | tail -10      # oldest commits reveal origin repo
+git ls-tree --name-only origin/<branch> | head    # unexpected files = wrong repo
+git show origin/<branch>:<path> > /tmp/extracted   # extract before deleting
+git log --oneline origin/main -- <path>           # CHECK: already merged on main?
+git push origin --delete <branch>                 # delete broken branch
+
+# === State C: diverged from remote ===
+git log --oneline origin/<branch>..HEAD           # local-only commits
+git log --oneline HEAD..origin/<branch>           # remote-only commits (often forgotten!)
+git merge-base HEAD origin/<branch>               # common ancestor
+git reset --hard origin/<branch>                  # absorb remote, AFTER confirming fix applies
+git cherry-pick <fix-sha>                         # apply only the targeted fix
+
+# === State D: old PR merged; remote branch deleted; preserve validated local delta ===
+# Use the repository's real trunk: origin/main for most repos, origin/master for Inference360.
+TRUNK=origin/master
+VALIDATED_SHA=<validated-local-amended-sha>
+PATCH=/tmp/<topic>-followup.patch
+git fetch origin master
+gh pr view <old-pr> --json state,headRefName,headRefOid,autoMergeRequest,mergeCommit
+git fetch origin <old-branch>                     # expected failure if the branch was deleted
+git diff --stat "$TRUNK" "$VALIDATED_SHA"         # inspect the intended incremental delta
+git diff --binary "$TRUNK" "$VALIDATED_SHA" --output="$PATCH"
+git switch -c <followup-branch> "$TRUNK"
+git apply --index "$PATCH"
+git diff --quiet "$VALIDATED_SHA" -- .            # proves worktree matches validated commit
+git commit -m "<follow-up message>"
+git push -u origin <followup-branch>
+```
+
+### Detailed Steps
+
+#### State A — Stale-branch-superseded-by-main diagnosis
+
+1. **Check the premise**: run `gh pr list --state open` before any branch archaeology. If
+   there are zero open PRs, the task "get all PRs merged" is already done — report and stop.
+2. **Find the fork point**: `git merge-base HEAD origin/main` gives the SHA where the branch
+   diverged. All analysis is relative to this point.
+3. **Three-way file inventory**: compare `git ls-tree` outputs for HEAD and origin/main on
+   the relevant directories, piped through `sort` then `comm` → three sets: HEAD-only,
+   main-only, both.
+4. **For each HEAD-only file**: run `git log --diff-filter=D --oneline origin/main -- <path>`.
+   A commit message containing "consolidate", "merge", or "absorb" means main intentionally
+   deleted it via a consolidation PR. An empty result means the file genuinely never reached
+   main (rare for an old branch).
+5. **For each file in both**: compare `version:` frontmatter. If main's version number is
+   strictly greater, main has the newer copy and the branch's change is stale.
+6. **Staged index check**: if `git status --short` shows many AD-status files (added in index,
+   deleted in working tree), hash-compare `git ls-files --stage` against `git ls-tree
+   origin/main`. If every staged hash matches a main hash, the staged index is a no-op.
+7. **Apply the three-condition test** — a branch is fully superseded when **all three** hold:
+   - Its deletions are already absent from main, AND
+   - Its modified files have lower version numbers than main's, AND
+   - Its "new" files are already present on main.
+
+   When all three hold the branch has zero net contribution and can be discarded.
+
+#### State A (squash-merge) — `git cherry` false positive, message-search disambiguator
+
+On repos where PRs are **squash-merged** (the default on many repos), the commit-level
+"is this on main?" tools cannot be trusted:
+
+- `git cherry origin/main <branch>` shows **every** branch commit with a `+` prefix (its
+  meaning is "this patch is not on main"), so a fully-merged branch looks entirely unmerged.
+- `git rev-list --count origin/main..<branch>` reports the branch is N commits **ahead**.
+
+Both are **false positives**. The reason: squash-merge collapses the branch's commits into a
+single brand-new commit on main with a **different patch-id**. `git cherry`'s patch-id
+matching never matches the branch's original commits, and the original commits are genuinely
+not reachable from main, so the ahead-count is non-zero. **Neither signal means the work is
+unmerged.**
+
+The reliable disambiguator is **message-search on main**. Take a distinctive phrase from the
+branch's commit subject (or the PR title), and grep main's history:
+
+```bash
+git log origin/main --oneline | grep -iE '<distinctive phrase or (#PRnum)>'
+```
+
+If the squash commit is found on main, the branch is **subsumed** — safe to discard, no
+rebase and no PR required. Cross-check the PR state to corroborate:
+
+```bash
+gh pr list --head <branch> --state all --json number,state   # MERGED / CLOSED corroborates
+```
+
+Important consequence: when you try to auto-rebase a subsumed branch onto main it will
+**conflict**, *precisely because* the same changes already exist on main as a squash commit
+and the branch's original un-squashed commits collide with them. **A rebase conflict on a
+subsumed branch is expected and is NOT evidence of unmerged work.** Correct action:
+
+- Report "subsumed" and **stop**. Do **not** spawn a conflict-resolution swarm — every
+  resolution would be "take main's side" on every file, producing an empty branch with zero
+  net benefit.
+- Do **not** auto-delete the branch. Branch deletion is left to the user / gh-tidy's own
+  y/N prompts (and is Safety-Net-blocked anyway — see below).
+
+**Worktree-redundancy variant.** A worktree reporting "uncommitted modified files" can be the
+same false alarm. Diff each working-tree file against `origin/main` and count unique lines:
+
+```bash
+diff <(git show origin/main:<path>) <(cat <worktree>/<path>) | grep -c '^>'
+```
+
+`0` unique lines on **all** modified files means the "uncommitted work" is byte-for-byte
+already on main (it shipped via a merged PR); the worktree is safe to discard. Real example:
+worktree `agent-a7fe2df2b7f6e658b` had 3 modified files all showing 0 unique lines vs main —
+the `log_on_error` changes had already merged via PR #1372.
+
+**Destructive ops are Safety-Net-blocked — hand them to the user.** Once safety is proven
+(subsumed / 0-unique-lines), the *recovery* commands are blocked by the CC Safety Net hook
+even with in-conversation user approval; the assistant cannot override the hook and must print
+the exact command for the **user** to run manually:
+
+- `git checkout -- <file>` (discards tracked changes) — "use `git stash` first", then hand to user
+- `git worktree remove --force <path>` (can discard uncommitted work) — hand to user
+- `git tag -d <tag>` (deletes tags) — hand to user
+- `git branch -D <branch>` — branch deletion is gh-tidy's job anyway
+- `git stash drop` and `rm -rf .worktrees/` are likewise blocked
+
+Workflow shape: **prove** safety (subsumed / 0-unique-lines), **then print** the precise
+`--force` / `-d` / `checkout --` command for the user to execute.
+
+#### State A (large-scale) — Three-way count diff for corpus-consolidation divergence
+
+When a branch has **hundreds or thousands** of HEAD-only files vs main AND main shows
+consolidation commit messages, spot-checking a few file versions is not sufficient — the
+branch and main may have diverged in *opposite* directions simultaneously.
+
+1. **Find the merge-base**: `MERGE_BASE=$(git merge-base HEAD origin/main)`. All counts are
+   relative to this ancestor.
+2. **Count artifacts at all three points**:
+   ```bash
+   git ls-tree -r --name-only "$MERGE_BASE" skills/ | grep '\.md$' | sort > /tmp/base.txt
+   git ls-tree -r --name-only HEAD            skills/ | grep '\.md$' | sort > /tmp/branch.txt
+   git ls-tree -r --name-only origin/main     skills/ | grep '\.md$' | sort > /tmp/main2.txt
+   wc -l /tmp/base.txt /tmp/branch.txt /tmp/main2.txt
+   ```
+   Interpret: if `base→branch` grew (new skills added on branch) but `base→main` shrank
+   (consolidation on main), the branch has old originals that main absorbed into canonical
+   merged skills. The branch-only files are the **pre-consolidation originals**, not new work.
+3. **Compute three comm sets**:
+   - `comm -23 branch main` (branch-only): would be deleted by reset — are these old originals or new skills?
+   - `comm -13 branch main` (main-only): canonical merged skills the branch is missing.
+   - `comm -12 branch main` (intersection): files present in both — compare versions.
+4. **Confirm consolidation on main**: `git log --oneline origin/main | grep -iE 'consolidat|absorb|cluster' | head -10`.
+   Messages like "consolidate 50-cluster 516->291" confirm main ran systematic consolidation
+   after the branch diverged. Branch-only files matching the pre-consolidation count at
+   merge-base are the absorbed originals, not unique work.
+5. **Safety: stash before any destructive reset**:
+   ```bash
+   git stash push -u -m "pre-reset snapshot $(date +%Y%m%d)"
+   ```
+   The stash is a recoverable snapshot. Confirm `git log --oneline origin/main..HEAD` contains
+   only commits superseded by main's consolidation PRs before running `git reset --hard origin/main`.
+6. **Surface the finding to the human** when branch-only file count is large (e.g. >500).
+   The decision to hard-reset is irreversible without the stash — it's the human's data and
+   they should confirm the conclusion explicitly.
+
+#### State B — Orphan-branch recovery (no common ancestor)
+
+1. **Diagnose**: `git fetch origin <branch>` then `git merge-base origin/main
+   origin/<branch>`. No output (exit 1) = no common ancestor.
+2. **Understand the divergence**: `git log --oneline origin/main..origin/<branch>` (commits
+   on branch not in main) and the reverse. Then `git log --oneline origin/<branch> | tail -10`
+   — unfamiliar "Initial commit" lines reveal the branch was created from a different repo.
+3. **Inspect contents**: `git ls-tree --name-only origin/<branch> | head` — unexpected files
+   (e.g. `.mojo-version` in a Python project) confirm a wrong-repo push.
+4. **Extract valuable content** before any deletion:
+   ```bash
+   git show origin/<branch>:plugins/cat/name/SKILL.md > /tmp/SKILL.md
+   ```
+5. **Check if already merged**: `git log --oneline origin/main -- <path>`. Often the real
+   content already landed via a correct PR and the orphan is just a stale duplicate — then no
+   recreation is needed, just delete.
+6. **Delete and (if needed) recreate**:
+   ```bash
+   git push origin --delete <branch>
+   git checkout main && git pull origin main
+   git checkout -b <branch>
+   cp /tmp/extracted <path>/ && git add . && git commit -m "feat: recreated from broken branch"
+   git push -u origin <branch>
+   ```
+
+   **Root cause / prevention**: orphan branches typically come from running `/learn` (or any
+   commit-and-push flow) from one project's working directory while pushing to another's
+   remote. Always verify `git remote -v` matches the expected repository before pushing.
+
+#### State C — Diverged-branch cherry-pick fix
+
+1. **Diagnose the divergence**: `git status` shows "diverged, N and M different commits". Run
+   both `git log --oneline origin/<branch>..HEAD` (local-only) AND `git log --oneline
+   HEAD..origin/<branch>` (remote-only). The remote-only side is the one usually forgotten —
+   a fix plan may claim "just push" while the remote has accumulated commits since.
+2. **Understand each side**: `git show origin/<branch>:path/to/file` to see the remote's
+   current version; `git show <fix-sha> --stat` to see exactly what the local fix touches.
+   Confirm the fix applies cleanly on top of the remote tip.
+3. **Reset local to remote tip** (only after confirming the fix applies):
+   `git reset --hard origin/<branch>`.
+4. **Cherry-pick the minimal fix**: `git cherry-pick <fix-sha>`. Resolve any conflicts, then
+   `git cherry-pick --continue`. Cherry-pick the targeted fix only — never the full local
+   commit stack, which may duplicate an equivalent commit already on the remote.
+5. **Verify**: `git status` should show "ahead by 1 commit"; `git show HEAD --stat` confirms
+   the fix is present. Then push (fast-forward now succeeds).
+
+   This same pattern recovers stacked-PR fix commits: when a stacked PR is retargeted and
+   lint/CI fix commits made after the retarget become orphaned from the prerequisite, reset to
+   the correct remote tip and cherry-pick the orphaned fix commits onto it.
+
+#### State D — Already-merged PR with deleted head ref; recover follow-up delta
+
+Use this when the PR merged before you could update it, the remote PR branch is gone or stale,
+and you have a local amended commit that contains exactly the validated follow-up work. Do not
+try to keep force-pushing the old branch; after merge, the correct target is current trunk.
+
+1. **Confirm the old PR is no longer writable as a PR update target.** A stale lease rejection
+   plus a missing remote ref means this is not a normal rebase push:
+   ```bash
+   git push --force-with-lease origin <old-branch>  # rejected as stale
+   git fetch origin <old-branch>                    # fatal: couldn't find remote ref
+   gh pr view <old-pr> --json state,headRefName,headRefOid,autoMergeRequest,mergeCommit
+   ```
+   If `state` is `MERGED`, stop targeting `<old-branch>`. The PR content is already on trunk,
+   usually as a new squash/rebase commit SHA that does not equal the old PR head SHA.
+2. **Refresh trunk and compare the validated local tree to trunk.** Use the repo's real trunk
+   branch (`origin/master` for Inference360, `origin/main` for most HomericIntelligence repos):
+   ```bash
+   git fetch origin master
+   TRUNK=origin/master
+   VALIDATED_SHA=<validated-local-amended-sha>
+   git diff --stat "$TRUNK" "$VALIDATED_SHA"
+   ```
+   The diff must show only the intended follow-up changes. If it includes the already-merged PR
+   body again, your trunk ref is stale or you picked the wrong validated SHA.
+3. **Save a binary patch from trunk to the validated local commit.** Binary mode preserves
+   renames, mode bits, and binary files:
+   ```bash
+   PATCH=/tmp/<repo>-<topic>-followup.patch
+   git diff --binary "$TRUNK" "$VALIDATED_SHA" --output="$PATCH"
+   ```
+4. **Create the follow-up branch from current trunk and apply the patch into the index.**
+   ```bash
+   git switch -c <followup-branch> "$TRUNK"
+   git apply --index "$PATCH"
+   ```
+5. **Prove the new branch tree matches the already-validated local commit.**
+   ```bash
+   git diff --quiet "$VALIDATED_SHA" -- .
+   ```
+   This is the key guardrail: it proves the patch-applied branch has the same tree as the
+   local commit you already validated. If this diff is non-empty, fix the mismatch before
+   committing.
+6. **Commit, push, and open a normal follow-up PR.** Enable auto-merge on the new PR; the old
+   merged PR should remain untouched.
+   ```bash
+   git commit -m "<follow-up message>"
+   git push -u origin <followup-branch>
+   gh pr create --base <trunk-branch> --head <followup-branch> --title "<title>" --body "<body>"
+   gh pr merge <new-pr> --auto --squash --repo <owner/repo>
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Judging staleness by spot-checking a few file `version:` fields | Compared version numbers in ~5 files on branch vs main to determine which side was "newer" | Branch and main had diverged in opposite directions: branch grew (new skills added), main shrank (consolidation). A handful of version comparisons gave a misleading picture of the whole | Run a three-way file-count diff (branch vs main vs merge-base) before drawing any conclusion when hundreds of files are involved |
+| Assuming "branch's PR already merged ⇒ all branch work is on main" | Saw that an early PR (#1572) was merged and concluded the branch had no remaining contribution | An early PR merged but the bulk of the branch's subsequent commits (hundreds of new skills added after the merge) never reached main — they were simply abandoned before the branch was last touched | PR-merge history answers only "did this PR's content land?" not "has every commit on this branch landed?" — check `git log --oneline origin/main..HEAD` for the full picture |
+| Committing the large working-tree deletions | Working tree showed hundreds of deleted files; first instinct was to commit them as "cleanup" | The deletions were not intentional cleanup — they were the working tree reflecting pre-consolidation originals that the index still tracked but disk did not have. Committing would have reverted ~360 skills and downgraded canonicals main had since improved | Never commit large file-count deletions without first running the three-way count diff; if `comm -23 branch main` shows thousands of "branch-only" files that map to the pre-consolidation count at merge-base, the deletions are stale state, not new work |
+| Treating HEAD-only files as unmerged value | Assumed "file present in HEAD but not in main" = "work not yet on main" | Most HEAD-only files were OLD files that main subsequently deleted or consolidated through later PRs after the branch diverged | Always check HOW a file left main (`--diff-filter=D`) before assuming it was never there |
+| Using plain `git log` to find deletions | `git log --oneline origin/main -- <path>` showed nothing | Plain log only shows commits that touched the file; it does not surface the deletion commit reliably | `--diff-filter=D` is required to find the commit that removed a file |
+| Treating AD status as uncommitted work | `git status --short` showed hundreds of AD lines and looked like staged changes needing attention | AD status is normal for branches created in worktrees not fully restored to disk — files exist in the index but not on disk | AD means "added in index, deleted from working dir"; verify hashes match main before treating as new work |
+| Direct push after local commits (diverged) | Assumed local was ahead of remote and pushed | Branches had diverged; remote had 13 additional commits not present locally | Always check `HEAD..origin/<branch>` not just `origin/<branch>..HEAD` before pushing |
+| Treating a fix plan at face value | Plan said "2 commits ahead, just push" | Plan was written before the remote accumulated additional commits | Re-diagnose actual remote state with `git log --oneline HEAD..origin/<branch>` before acting |
+| Keeping local commits and merging (diverged) | Would merge the local cleanup commit with the remote's equivalent | Remote already had an equivalent cleanup commit; merge would create a duplicate | Cherry-pick the minimal fix only, not the full local commit stack |
+| Deleting an orphan branch before extraction | Tempted to just `git push --delete` the broken branch | Risked losing valid skill content that lived only on the branch tip | Extract content (and check whether it is already on main) before deleting |
+| Relied on `git cherry origin/main <branch>` to detect unmerged work | All commits showed `+` so branches looked unmerged | Squash-merge gives every original commit a new patch-id; cherry never matches | Use message-search (`git log origin/main --oneline \| grep '(#PR)'`) + `gh pr list --state all`, not git cherry, for squash repos |
+| Considered spawning a rebase-conflict-resolution swarm for 7 conflicting branches | Conflicts existed only because the squash content already on main collides with original commits | Resolution would be "take main's side" everywhere → empty branch | Confirm subsumed first; report subsumed and stop — don't resolve, don't delete |
+| Assistant tried `git worktree remove --force` / `git tag -d` / `git checkout --` | Blocked by CC Safety Net hook | Cannot override the hook even with user approval in-chat | Prove safety, then print the exact destructive command for the user to run manually |
+| Force-pushed a follow-up amendment to an auto-merged PR's old branch | `git push --force-with-lease origin feat/simplify-control-interface` after PR #160 had auto-merge enabled | The PR had already merged and the lease was stale; the old branch was no longer the live PR update target | Check `gh pr view <pr> --json state,headRefOid,autoMergeRequest` before pushing follow-up amendments to an auto-merge PR |
+| Fetched the old PR branch after merge | `git fetch origin feat/simplify-control-interface` | GitHub had deleted the merged PR head branch, so fetch failed with "couldn't find remote ref" | Treat missing remote ref plus `state: MERGED` as a signal to create a new follow-up branch from current trunk |
+| Treated the local amended commit as a branch update after merge | Local commit `530bd3114d4ae62c01d4ac11729ff4a86fab6706` was validated, so the instinct was to force-push it to PR #160 | `origin/master` already contained the original simplification under new commit `61304b9`; the old PR head SHA was `858e302`, so the branch identity was obsolete | Diff current trunk to the validated commit, apply that patch on a fresh branch, and prove the resulting tree matches the validated commit before opening a follow-up PR |
+
+## Results & Parameters
+
+### State A — Superseded decision matrix
+
+| Condition | Check Command | "Stale" Verdict |
+| --------- | ------------- | --------------- |
+| Deletions already absent from main | `comm -23 head.txt main.txt` → each: `git log --diff-filter=D origin/main -- <path>` | consolidation commit found for all |
+| Modified files have lower version | `grep "^version:" skills/<f>.md` vs `git show origin/main:skills/<f>.md \| grep "^version:"` | branch version < main version |
+| "New" files already on main | `comm -23 staged_hashes.txt main_hashes.txt \| wc -l` | result = 0 |
+
+Expected output for a fully superseded branch:
+
+```text
+# gh pr list --state open
+No pull requests match your search
+# comm -23 /tmp/head.txt /tmp/main.txt | wc -l
+1193    ← looks alarming, but all are old deletions
+# git log --diff-filter=D --oneline origin/main -- skills/old-skill.md | head -1
+a3f2b1c feat(skill-merge): consolidate 12 skills into automation-bundle (C086)
+# comm -23 staged_hashes.txt main_hashes.txt | wc -l
+0       ← zero true new files; staged index is a no-op
+```
+
+### State A (large-scale) — Three-way count diff interpretation table
+
+| Pattern | merge-base count | branch count | main count | Diagnosis |
+| ------- | ---------------- | ------------ | ---------- | --------- |
+| Branch grew, main shrank | 1661 | 1849 | 333 | main ran corpus consolidation post-diverge; branch-only files are pre-consolidation originals |
+| Branch shrank, main grew | N | N-k | N+m | branch deleted files; check if intentional or if branch is behind main |
+| Both grew from base | N | N+a | N+b | two independent workstreams; inspect `comm -23` and `comm -13` carefully |
+| Branch == main count | N | N | N | files differ by content, not count; use hash comparison or version comparison |
+
+**Confirmation command sequence** for the "branch grew, main shrank" pattern:
+
+```bash
+# 1. Get counts at all three points
+MERGE_BASE=$(git merge-base HEAD origin/main)
+git ls-tree -r --name-only "$MERGE_BASE" skills/ | grep '\.md$' | wc -l   # e.g. 1661
+git ls-tree -r --name-only HEAD            skills/ | grep '\.md$' | wc -l   # e.g. 1849
+git ls-tree -r --name-only origin/main     skills/ | grep '\.md$' | wc -l   # e.g. 333
+
+# 2. Verify main ran consolidation
+git log --oneline origin/main | grep -iE 'consolidat|absorb|cluster' | head -5
+# Expected: "chore(triage): second-pass addendum (21 new clusters, 5 merges, C060-C080)"
+
+# 3. Confirm branch-only count matches expected pre-consolidation originals
+comm -23 /tmp/branch.txt /tmp/main2.txt | wc -l  # e.g. 970 (pre-consolidation originals)
+comm -13 /tmp/branch.txt /tmp/main2.txt | wc -l  # e.g. 76 (canonical merged skills branch lacks)
+
+# 4. Safety stash and confirm superseded commits
+git stash push -u -m "pre-reset snapshot $(date +%Y%m%d)"
+git log --oneline origin/main..HEAD | head -10  # should show only adds/updates now on main
+
+# 5. Only then hard-reset
+git reset --hard origin/main
+```
+
+### State B — Orphan signs and recovery checklist
+
+Signs of a wrong-repo push: unfamiliar "Initial commit" at `git log <branch> | tail`;
+unexpected files at `git ls-tree --name-only <branch>`; massive ahead/behind counts; commit
+messages referencing a different project.
+
+- [ ] Verify branch has no merge-base with main
+- [ ] Identify valuable content on branch tip
+- [ ] Check whether content is already on main (`git log origin/main -- <path>`)
+- [ ] Extract files before deletion
+- [ ] Delete remote branch
+- [ ] Recreate from main only if content not already merged
+
+### State C — Reset + cherry-pick recipe
+
+```bash
+git log --oneline origin/<branch>..HEAD       # local-only commits
+git log --oneline HEAD..origin/<branch>       # remote-only commits
+git merge-base HEAD origin/<branch>           # common ancestor SHA
+git reset --hard origin/<branch>              # absorb all remote commits
+git cherry-pick <fix-sha>                     # apply only the targeted fix
+git log --oneline -3                          # fix should be single HEAD commit
+git status                                    # "ahead by 1 commit"
+```
+
+Cherry-picks of small, focused single-file fixes rarely conflict, even on heavily diverged
+branches, because they touch a narrow region the remote version differs in only slightly.
+
+### State D — Follow-up branch from validated local amendment
+
+Generic verified parameter map from the follow-up branch recovery:
+
+| Parameter | Value |
+| --------- | ----- |
+| Old PR | `<repo> PR <old-pr-number>` |
+| Old branch | `<old-branch>` |
+| Local validated amended commit | `<validated-commit-sha>` |
+| Old PR head SHA reported by GitHub | `<old-pr-head-sha>` |
+| Trunk commit containing the merged work | `<trunk-commit-sha>` on `origin/<trunk>` |
+| Patch file | `/tmp/<followup-topic>.patch` |
+| Follow-up branch | `<followup-branch>` |
+| Follow-up PR | `<repo> PR <followup-pr-number>` |
+| Verification | `verified-ci` after follow-up PR checks passed |
+
+Copy-paste sequence used:
+
+```bash
+TRUNK="master"
+VALIDATED_COMMIT="<validated-commit-sha>"
+FOLLOWUP_BRANCH="<followup-branch>"
+PATCH_FILE="/tmp/<followup-topic>.patch"
+
+git fetch origin "$TRUNK"
+git diff --stat "origin/$TRUNK" "$VALIDATED_COMMIT"
+git diff --binary "origin/$TRUNK" "$VALIDATED_COMMIT" --output="$PATCH_FILE"
+git switch -c "$FOLLOWUP_BRANCH" "origin/$TRUNK"
+git apply --index "$PATCH_FILE"
+git diff --quiet "$VALIDATED_COMMIT" -- .
+git commit -m "refactor: apply follow-up change"
+git push -u origin "$FOLLOWUP_BRANCH"
+```
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectMnemosyne | Branch `feature/myrmidon-merge-triage` (32 ahead, 730 behind, remote gone) — three-way count diff: merge-base=1661 skills, branch=1849 (grew), main=333 (shrank via consolidation). 970 branch-only files were pre-consolidation originals. Hard-reset to origin/main confirmed correct after stash. 107 PRs subsequently merged on main. | State A — large-scale corpus consolidation |
+| ProjectMnemosyne | Branch `feature/myrmidon-merge-triage` (32 ahead, 525 behind, remote gone) — confirmed fully superseded; no PRs opened | State A |
+| ProjectMnemosyne | Branch `skill/debugging/fixme-todo-cleanup-v2` pushed from ProjectOdyssey's history — no merge-base; content already on main; deleted | State B |
+| ProjectOdyssey | PR #3197, issue #3088 — BF16 test skip; reset to remote (13 remote-only commits) + cherry-pick fix | State C |
+| ProjectHephaestus | 7 local branches all failed auto-rebase with conflicts; `git cherry` showed every commit `+`. Message-search proved all subsumed: `999-fix-pr-thread-reply-mutation`→`187720a … (#1041)`, `fix-1282-work`→`22fc435 … (#1282)`, `rc2-conflict-gate`→`d3701b8 … (#1335)`. Reported subsumed; no swarm, no delete | State A — squash-merge false positive |
+| ProjectHephaestus | Worktree `agent-a7fe2df2b7f6e658b` — 3 "uncommitted modified" files all 0 unique lines vs main (`log_on_error` changes already merged via PR #1372); safe to discard | State A — worktree 0-unique-lines |
+| LLM360/Inference360 | An auto-merged PR merged before follow-up changes could be force-pushed; the old remote branch was gone, and a validated local amended commit was converted into a clean follow-up branch from current trunk; the follow-up PR auto-merged after CI passed | State D — already-merged PR follow-up branch |
+
+## References
+
+- [git-branch-state-triage-and-recovery.history](git-branch-state-triage-and-recovery.history) — superseded source skills (verbatim)
+````
+
+---
 ## v1.3.1 (2026-06-18)
 
 **Changed by:** Generic wording cleanup for already-merged PR follow-up branch recovery

--- a/skills/git-branch-state-triage-and-recovery.md
+++ b/skills/git-branch-state-triage-and-recovery.md
@@ -9,14 +9,14 @@ description: >-
   (5) a squash-merged branch looks unmerged because git cherry/ahead counts lie,
   (6) an auto-merge PR already merged, its remote head ref is gone or stale, and a
   validated local amended commit must be converted into a clean follow-up branch from
-  current trunk using git diff --binary plus git apply --index.
+  current trunk using git diff --binary plus git apply --index, or (7) the current branch has an already-merged PR but contains uncommitted follow-up work, so stash it, create a fresh branch from current trunk, pop the stash, re-verify, sign, push, and open a new linked PR.
 category: tooling
 date: 2026-06-18
-version: "1.3.1"
+version: "1.4.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 history: git-branch-state-triage-and-recovery.history
-tags: [git, branch, triage, recovery, stale, superseded, orphan, diverged, merge-base, cherry-pick, fork-point, diff-filter, unrelated-histories, non-fast-forward, consolidation, three-way-diff, count-diff, hard-reset, stash, auto-merge, follow-up-branch, force-with-lease, git-apply]
+tags: [git, branch, triage, recovery, stale, superseded, orphan, diverged, merge-base, cherry-pick, fork-point, diff-filter, unrelated-histories, non-fast-forward, consolidation, three-way-diff, count-diff, hard-reset, stash, auto-merge, follow-up-branch, force-with-lease, git-apply, current-branch, merged-pr, uncommitted-follow-up, signed-commit]
 ---
 
 # Git Branch State Triage and Recovery
@@ -27,13 +27,13 @@ tags: [git, branch, triage, recovery, stale, superseded, orphan, diverged, merge
 | ------- | ------- |
 | **Date** | 2026-06-18 |
 | **Objective** | Diagnose what state a branch is in (stale/superseded, orphaned/unrelated history, or diverged from remote) and recover it cleanly |
-| **Outcome** | Success — unified triage tree: confirm-and-discard superseded branches, extract+recreate orphan branches, reset+cherry-pick diverged branches, and convert validated local amended commits from already-merged PRs into clean follow-up branches |
-| **Verification** | verified-ci |
+| **Outcome** | Success — unified triage tree: confirm-and-discard superseded branches, extract+recreate orphan branches, reset+cherry-pick diverged branches, convert validated local amended commits from already-merged PRs into clean follow-up branches, and move uncommitted follow-up work off a branch whose prior PR is already merged |
+| **Verification** | verified-local |
 
 ## When to Use
 
 Use this skill whenever a branch is in an unexpected or unmergeable state. The root question
-is always: **what state is this branch in, and how do I recover it?** Four distinct states:
+is always: **what state is this branch in, and how do I recover it?** Five distinct states:
 
 **State A — Stale / superseded by main:**
 - A branch is many commits behind main **and** its remote tracking ref is gone (`[gone]` in `git branch -vv`)
@@ -61,6 +61,14 @@ is always: **what state is this branch in, and how do I recover it?** Four disti
 - `gh pr view <pr>` shows `state: MERGED` and an old `headRefOid`, while current trunk contains the merged work under a new squash/rebase commit SHA
 - You have a local amended commit that was already validated, but the old PR branch is no longer the correct target
 - The right recovery is to diff current trunk to the validated local commit, apply that binary patch on a fresh branch from trunk, prove the new tree matches the validated commit, then open a follow-up PR
+
+
+
+**State E — Current branch's old PR is already merged, but the worktree has uncommitted follow-up work:**
+- `gh pr view` for the current branch reports `state: MERGED`.
+- The branch may still exist on origin, but its PR identity is spent; pushing more commits to it will not update an open PR.
+- `git status --short` shows real uncommitted follow-up work that should become a new PR.
+- The correct recovery is: stash including untracked files, fetch current trunk, create a fresh branch from `origin/<trunk>`, pop the stash, re-run verification, sign a new commit, push, and create a new issue-linked PR.
 
 ## Verified Workflow
 
@@ -146,6 +154,23 @@ git diff --quiet "$VALIDATED_SHA" -- .            # proves worktree matches vali
 git commit -m "<follow-up message>"
 git push -u origin <followup-branch>
 ```
+
+
+# === State E: current branch PR is MERGED but uncommitted follow-up work exists ===
+gh pr view --json number,state,title,url,headRefName,baseRefName
+# If state == MERGED, do not commit/push more work to that branch for a new PR.
+git stash push -u -m <topic>-before-fresh-pr
+git fetch origin <trunk>
+git checkout -b <fresh-branch> origin/<trunk>
+git stash pop
+./.venv/bin/python -m ruff check radiance scripts tests --no-cache
+./.venv/bin/pytest -q
+git add -A
+git commit -S -m "<message>"
+git log --show-signature -1 --oneline
+git push -u origin <fresh-branch>
+gh issue create --title "<tracking issue>" --body "<kickoff/scope>"
+gh pr create --base <trunk> --head <fresh-branch> --title "<title>" --body "Closes #<issue>"
 
 ### Detailed Steps
 
@@ -378,6 +403,55 @@ try to keep force-pushing the old branch; after merge, the correct target is cur
    gh pr merge <new-pr> --auto --squash --repo <owner/repo>
    ```
 
+
+#### State E — Current branch's previous PR is merged; move uncommitted follow-up work to a fresh PR branch
+
+Use this when `gh pr view` on the current branch points to a merged PR, but `git status` shows
+new uncommitted work that should become its own review. This is different from State D: the
+follow-up exists as a worktree/staged diff, not as a validated local commit that needs a binary
+patch.
+
+1. **Confirm the current branch's PR is already merged.**
+   ```bash
+   git status --short --branch
+   gh pr view --json number,state,title,url,headRefName,baseRefName
+   ```
+   If `state` is `MERGED`, treat the current branch name as historical. Do not create a new PR
+   from that same branch, because GitHub will associate it with the closed/merged PR context.
+2. **Stash the follow-up diff, including untracked files.**
+   ```bash
+   git stash push -u -m <topic>-before-fresh-pr
+   ```
+3. **Refresh the real trunk and create a fresh branch from it.** Use the repo's actual default
+   branch (`master` for Radiance in June 2026; `main` for most repos).
+   ```bash
+   git fetch origin <trunk>
+   git checkout -b <fresh-branch> origin/<trunk>
+   ```
+4. **Restore the diff and resolve any base drift immediately.**
+   ```bash
+   git stash pop
+   git status --short
+   ```
+   If conflicts appear, resolve them against current trunk before committing. If it applies
+   cleanly, still re-run the relevant focused tests because the base changed.
+5. **Re-run local verification on the fresh branch, then sign the commit.**
+   ```bash
+   ./.venv/bin/python -m ruff check radiance scripts tests --no-cache
+   ./.venv/bin/pytest -q
+   git add -A
+   git commit -S -m "refactor: reduce duplicate code"
+   git log --show-signature -1 --oneline
+   ```
+6. **Push the fresh branch and create a new linked PR.** If the repository requires one issue per
+   PR, create the tracking issue before the PR and include `Closes #<issue>` in the body.
+   ```bash
+   git push -u origin <fresh-branch>
+   gh issue create --title "<issue title>" --body "<scope and validation>"
+   gh pr create --base <trunk> --head <fresh-branch> --title "<title>" --body "Closes #<issue>"
+   gh pr checks <new-pr>
+   ```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -399,7 +473,41 @@ try to keep force-pushing the old branch; after merge, the correct target is cur
 | Fetched the old PR branch after merge | `git fetch origin feat/simplify-control-interface` | GitHub had deleted the merged PR head branch, so fetch failed with "couldn't find remote ref" | Treat missing remote ref plus `state: MERGED` as a signal to create a new follow-up branch from current trunk |
 | Treated the local amended commit as a branch update after merge | Local commit `530bd3114d4ae62c01d4ac11729ff4a86fab6706` was validated, so the instinct was to force-push it to PR #160 | `origin/master` already contained the original simplification under new commit `61304b9`; the old PR head SHA was `858e302`, so the branch identity was obsolete | Diff current trunk to the validated commit, apply that patch on a fresh branch, and prove the resulting tree matches the validated commit before opening a follow-up PR |
 
+| Reused the current branch after discovering its PR was already merged | `gh pr view` on `codex/test-architecture-layout` showed PR #906 as `MERGED`, but the worktree contained new cleanup changes | A merged PR branch is historical; pushing more commits there would not create the intended fresh review and would confuse branch/PR state | Stash the uncommitted work, fetch current trunk, create a fresh branch from `origin/<trunk>`, pop the stash, re-verify, sign, push, and create a new linked PR |
 ## Results & Parameters
+
+
+### State E — Fresh PR branch from merged current branch with uncommitted work
+
+| Parameter | Value |
+| --------- | ----- |
+| Current branch | Branch whose `gh pr view` reports `state: MERGED` |
+| Follow-up work state | Uncommitted/staged/untracked diff in the worktree |
+| Preservation command | `git stash push -u -m <topic>-before-fresh-pr` |
+| Fresh base | `origin/<trunk>` after `git fetch origin <trunk>` |
+| Fresh branch | New branch name that has not already been tied to a merged PR |
+| Required verification | Re-run focused/full local tests after `git stash pop`; prior tests on old base do not count |
+| Commit requirement | Signed commit (`git commit -S`) and signature verification with `git log --show-signature -1` |
+| PR requirement | New issue-linked PR; include `Closes #<issue>` when repo policy requires it |
+| Verification level | `verified-local` until GitHub checks pass |
+
+Radiance example commands used:
+
+```bash
+gh pr view --json number,url,state,title,headRefName,baseRefName
+git stash push -u -m codex-duplicate-cleanup-before-pr
+git fetch origin master
+git checkout -b codex/reduce-duplicate-code origin/master
+git stash pop
+./.venv/bin/python -m ruff check radiance scripts tests --no-cache
+./.venv/bin/pytest -q
+git add -A
+git commit -S -m "refactor: reduce duplicate code"
+git log --show-signature -1 --oneline
+git push -u origin codex/reduce-duplicate-code
+gh issue create --title "Reduce duplicate code in Radiance helpers" --body "..."
+gh pr create --base master --head codex/reduce-duplicate-code --title "refactor: reduce duplicate helper code" --body "Closes #907"
+```
 
 ### State A — Superseded decision matrix
 
@@ -529,6 +637,7 @@ git push -u origin "$FOLLOWUP_BRANCH"
 | ProjectHephaestus | 7 local branches all failed auto-rebase with conflicts; `git cherry` showed every commit `+`. Message-search proved all subsumed: `999-fix-pr-thread-reply-mutation`→`187720a … (#1041)`, `fix-1282-work`→`22fc435 … (#1282)`, `rc2-conflict-gate`→`d3701b8 … (#1335)`. Reported subsumed; no swarm, no delete | State A — squash-merge false positive |
 | ProjectHephaestus | Worktree `agent-a7fe2df2b7f6e658b` — 3 "uncommitted modified" files all 0 unique lines vs main (`log_on_error` changes already merged via PR #1372); safe to discard | State A — worktree 0-unique-lines |
 | LLM360/Inference360 | An auto-merged PR merged before follow-up changes could be force-pushed; the old remote branch was gone, and a validated local amended commit was converted into a clean follow-up branch from current trunk; the follow-up PR auto-merged after CI passed | State D — already-merged PR follow-up branch |
+| LLM360/Radiance | Current branch `codex/test-architecture-layout` had merged PR #906 but contained uncommitted duplicate-code cleanup work. Stashed, fetched `origin/master`, created `codex/reduce-duplicate-code`, popped, re-verified locally, signed commit `e772d982`, pushed, created issue #907 and PR #908. GitHub checks were pending at capture time. | State E — merged current branch with uncommitted follow-up work, verified-local |
 
 ## References
 


### PR DESCRIPTION
## Summary

Amends existing skills with learnings from the Radiance duplicate-code cleanup and PR creation flow.

- Updates dry-refactoring-workflow to v1.6.0 with a behavior-preserving duplicate cleanup pattern for server route test fakes, layout-only metric kernels, validation field wrappers, and stale tool deletion.
- Updates git-branch-state-triage-and-recovery to v1.4.0 with State E: move uncommitted follow-up work off a branch whose prior PR is already merged.
- Archives previous versions in the corresponding history files.

## Verification Level

**verified-local**

Radiance PR #908 CI was pending when captured. The workflows were verified locally with Ruff/full pytest/compileall/diff-check for Radiance, and this ProjectMnemosyne branch passed local validation and pre-push tests.

## Key Findings

**What Worked**:
- Centralize identical mechanics while preserving public exports, local wrapper names, exception classes, and test assertion shapes.
- When the current branch already has a merged PR, stash uncommitted follow-up work and move it to a fresh branch from current trunk before committing.
- Use history snapshots when amending skills so the prior recommendations remain auditable.

**What Failed**:
- Treating the merged current branch as a valid new PR branch would confuse PR state and review linkage.
- Importing one validation module's helper into another would leak exception/message contracts.

## Test Plan

- [x] Validate with `pixi run validate`
- [x] Pre-push pytest: `219 passed`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Codex <noreply@openai.com>