### PR TITLE
feat: amend CodeQL PR CI triage skills

### DIFF
--- a/skills/gha-security-scanning-supply-chain.history
+++ b/skills/gha-security-scanning-supply-chain.history
@@ -1,7 +1,575 @@
-<!-- markdownlint-disable MD024 -->
+<!-- markdownlint-disable MD012 MD024 -->
 
 # History: gha-security-scanning-supply-chain
 
+## v1.3.0 (2026-06-19)
+
+**Changed by:** Sanitized session context: post-rebase PR CodeQL and validate remediation
+**Verification:** verified-ci
+
+### What changed
+- Added CodeQL PR alert triage commands for check-run ids, annotations, and code-scanning alerts.
+- Documented weak-sensitive-data-hashing remediation for salted non-secret identifiers: replace MD5 with SHA-256 and regression-test deterministic 64-character digests.
+- Documented command-line-injection remediation for subprocess wrappers: select executables from a hard-coded allowlist, reject NUL bytes, reconstruct safe argv, and test unsupported commands before subprocess.run.
+- Added PR gate reminder that CodeQL fixed/pass and validate pass are separate gates.
+
+### Why
+The prior skill covered setting up and hardening scanners, but did not capture the GitHub Advanced Security gotcha where gh pr checks reports a check-run id instead of a workflow run id, nor the reusable CodeQL remediation patterns from the session.
+
+### Previous version (v1.2.0) snapshot
+
+
+``````markdown
+---
+name: gha-security-scanning-supply-chain
+description: "Use when: (1) adding CodeQL SAST to TypeScript/JavaScript workflows or Semgrep/Gitleaks to any PR pipeline, (2) CI security scans only trigger on push to main — not PRs — and need promotion to PR gates, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) enforcing pinned SHA-based action versions instead of mutable tags, (5) auditing or porting curl|bash installers with SHA-256 verification, (6) a GHA job fails at 'Set up job' due to unresolved transitive action dependency, (7) adding Bandit SAST as a required CI check for Python/pixi projects."
+category: ci-cd
+date: 2026-06-19
+version: "1.2.0"
+user-invocable: false
+history: gha-security-scanning-supply-chain.history
+tags:
+  - codeql
+  - semgrep
+  - gitleaks
+  - sarif
+  - sast
+  - secrets-scanning
+  - dependency-scanning
+  - pip-audit
+  - npm-audit
+  - dependabot
+  - supply-chain
+  - sha-pinning
+  - curl-bash
+  - installer
+  - sha256-verification
+  - github-actions
+  - trivy
+  - pixi
+  - dockerfile
+  - bandit
+  - python-sast
+  - nosec
+---
+
+# GitHub Actions Security Scanning and Supply-Chain Hardening
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-06-19 |
+| Objective | Set up security scanning (CodeQL/Semgrep/Gitleaks SAST + secrets + Bandit Python SAST), harden CI supply-chain (action SHA pinning, dependency scanning), and pin/verify curl\|bash installers with SHA-256 |
+| Outcome | Consolidated guidance for security gate setup, scan-trigger gaps, SARIF parsing fixes, action SHA pinning, transitive-pin diagnosis, installer trust-model hardening, and Bandit SAST integration for Python/pixi projects |
+| Verification | verified-local |
+
+## When to Use
+
+- Setting up CodeQL SAST for the first time in a TypeScript/JavaScript project, or adding Semgrep/Gitleaks to a PR pipeline
+- Security scans only trigger on `push: branches: [main]` — not on PRs (pre-merge gates are missing)
+- `continue-on-error: true` on a Semgrep or Gitleaks scan step masks real failures
+- Gitleaks SARIF parsing uses POSIX `grep` instead of `jq`, causing a required check to always fail
+- A `security-report` required check never passes, blocking all PR auto-merges
+- GitHub Actions `uses:` references use mutable tags (`@v8`, `@v0.9.4`) instead of pinned commit SHAs
+- A Dockerfile/workflow installs tools via unverifiable `curl|sh`, npm, or pixi without a version pin
+- A GHA job fails at "Set up job" with `Unable to resolve action` for a transitive dependency you do not reference
+- Adding `curl|bash` installers, or porting/hardening existing ones with SHA-256 verification and multi-platform support
+- Adding automated dependency vulnerability scanning (pip-audit/npm audit + Dependabot)
+- Isolating `security-events: write` permission from base required checks
+- Adding Bandit SAST as a required CI check for Python/pixi projects (medium+ severity, JSON report artifact)
+- Performing a security code review where static-analysis output is noisy with false positives
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Audit unpinned action refs (search ALL of .github/, not just workflows/)
+grep -rn "uses:.*@v[0-9]" .github/
+
+# Resolve action tag to commit SHA (handle lightweight + annotated tags)
+RESULT=$(gh api repos/OWNER/REPO/git/ref/tags/vX.Y.Z --jq '.object | {sha,type}')
+TYPE=$(echo "$RESULT" | jq -r '.type'); SHA=$(echo "$RESULT" | jq -r '.sha')
+[ "$TYPE" = "tag" ] && SHA=$(gh api repos/OWNER/REPO/git/tags/$SHA --jq '.object.sha')
+
+# Fix Gitleaks SARIF parser (replace fragile grep with jq)
+jq '[.runs[].results[]] | length == 0' results.sarif | grep -q true
+
+# Find curl|sh / wget|sh installers
+grep -rn "curl\|wget" .github/workflows/*.yml | grep "|.*sh\b\|bash\b"
+
+# Validate workflow YAML
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))" && echo OK
+```
+
+### Detailed Steps
+
+#### A. Security scanning setup (CodeQL SAST + npm audit + Gitleaks gate)
+
+**CodeQL — isolate `security-events: write` in its own workflow** (least privilege; one failing job
+must not block all security checks). File `.github/workflows/codeql.yml`:
+
+```yaml
+name: CodeQL
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+  schedule:
+    - cron: "27 3 * * 2"   # weekly, off-peak
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["typescript"]
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c7467395007f7e897ffd472b1c  # v4.1.6
+      - uses: github/codeql-action/init@4e828ff8a76ab34a99dd1f01ba9ca34eb10ebddad  # v3.27.5
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+      - uses: github/codeql-action/autobuild@4e828ff8a76ab34a99dd1f01ba9ca34eb10ebddad  # v3.27.5
+      - uses: github/codeql-action/analyze@4e828ff8a76ab34a99dd1f01ba9ca34eb10ebddad  # v3.27.5
+        with:
+          category: "/language:typescript"
+```
+
+**npm audit — production-only, advisory job** in the base required-checks workflow:
+
+```yaml
+  security-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c7467395007f7e897ffd472b1c  # v4.1.6
+      - uses: actions/setup-node@60edb5dd545a775178fac7f3a11fc4209779e326  # v4.0.2
+        with: { node-version: "20", cache: "npm" }
+      - run: npm ci
+      - run: npm audit --omit=dev --audit-level=high
+```
+
+`--omit=dev` drops dev-only CVEs (typescript, ts-node); `--audit-level=high` cuts low/moderate noise.
+Keep it a separate job so pre-existing transitive CVEs (e.g. `@dagger.io/dagger` → protobufjs/uuid)
+are observable without blocking the pipeline.
+
+**Gitleaks — PR-gated, main advisory** (direct binary install for conditional `--exit-code`):
+
+```yaml
+  security-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c7467395007f7e897ffd472b1c  # v4.1.6
+        with: { fetch-depth: 0 }   # full history for git-log scanning
+      - name: Run Gitleaks scan
+        run: |
+          set -euo pipefail
+          VERSION="v8.30.1"
+          wget -q "https://github.com/gitleaks/gitleaks/releases/download/${VERSION}/gitleaks_${VERSION#v}_linux_x64.tar.gz"
+          echo "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e  gitleaks_${VERSION#v}_linux_x64.tar.gz" | sha256sum --check
+          tar -xzf "gitleaks_${VERSION#v}_linux_x64.tar.gz"
+          # PR gates (exit 1); main is advisory (exit 0). Keep this comment so the
+          # conditional is not removed by future maintainers.
+          EXIT_CODE=0
+          [ "${{ github.event_name }}" == "pull_request" ] && EXIT_CODE=1
+          ./gitleaks detect --source=. --verbose --exit-code="$EXIT_CODE"
+```
+
+The `gitleaks/gitleaks-action` wrapper does NOT expose conditional `--exit-code`; use the direct
+binary. Always SHA-256-verify the download. Omit `--no-git` so the full branch history is scanned.
+
+#### B. Close scan-trigger / masking gaps in existing workflows
+
+**Add a PR trigger** so security runs pre-merge, not only after:
+
+```yaml
+on:
+  pull_request:
+  push: { branches: [main] }
+  workflow_dispatch:
+```
+
+**Remove `continue-on-error` from scan steps only** — keep it on SARIF upload/artifact/reporting
+steps. Removing it from upload steps silently breaks reporting.
+
+#### C. Fix Gitleaks SARIF false-positive blocking a required check
+
+Two bugs make `security-report` always fail:
+
+```bash
+# Bug 1 — POSIX grep \s is literal backslash-s, never matches even an empty array.
+# WRONG:  grep -q '"results":\s*\[\]' results.sarif
+# RIGHT:  jq '[.runs[].results[]] | length == 0' results.sarif | grep -q true
+
+# Bug 2 — a bare ❌ gate catches false positives from Bug 1.
+# WRONG:  grep -q "❌" report.md
+# RIGHT:  ! grep -qE "^- ❌ Secret Scanning:|^- ❌ Docker Image Scanning:" report.md
+```
+
+Fix `.gitleaks.toml` for v8 — single-bracket `[allowlist]` (a map), not `[[rules.allowlist]]`
+(array-of-tables = slice → crash `'Rules[0].AllowList' expected a map, got 'slice'`):
+
+```toml
+[allowlist]
+description = "Documentation and example files"
+paths = ['''k8s/secrets.yaml''', '''docs/KUBERNETES_DEPLOYMENT.md''', '''tests/.*''']
+```
+
+Fix the parser first to see real findings, then add the allowlist — both in the same PR.
+
+### Detailed Steps: scanner version bumps and pin discovery
+
+#### Bumping a pinned scanner version
+
+When you bump a pinned scanner binary (e.g. Gitleaks) in a security workflow, the version string,
+download URL, and SHA-256 in the YAML are NOT the only places that pin lives. The test suite that
+asserts the workflow is correctly pinned holds its own copy of those constants, and tests will then
+silently point at the *old* hash if you forget to update them.
+
+```bash
+# 1. Find the latest stable release
+gh release list --repo gitleaks/gitleaks --limit 5
+
+# 2. Fetch the official SHA-256 (linux x64) from the release checksums file
+VERSION="v8.30.1"; VER="${VERSION#v}"
+curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/${VERSION}/gitleaks_${VER}_checksums.txt" \
+  | grep "linux_x64.tar.gz"
+
+# 3. Apply version + SHA update in the workflow (use sed, not Edit — pre-commit hook
+#    blocks the Edit tool on .github/workflows/*.yml)
+OLD="8.18.0"; NEW="8.30.1"
+OLD_SHA="6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb"
+NEW_SHA="79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
+sed -i \
+  "s/v${OLD}/v${NEW}/g; s/gitleaks_${OLD}/gitleaks_${NEW}/g; s/${OLD_SHA}/${NEW_SHA}/g" \
+  .github/workflows/security.yml
+
+# 4. CRITICAL — also update the test constants, or the tests still assert the OLD hash:
+#    GITLEAKS_VERSION, GITLEAKS_TARBALL, EXPECTED_SHA256
+#    in tests/workflows/test_security_workflow.py
+
+# 5. Verify no old strings remain anywhere (workflow AND tests)
+grep -rn "${OLD}\|${OLD_SHA}" .github/workflows/security.yml tests/workflows/test_security_workflow.py
+```
+
+The version bump is only complete when both the workflow and `tests/workflows/test_security_workflow.py`
+reference the new version, tarball name, and SHA-256. Step 5 must come back empty.
+
+#### Discovering the correct pin via git history
+
+When you need to pin a `--tag`/`--version` flag (e.g. switching a Dockerfile from
+`cargo install <tool>` to `curl ... | bash -s -- --tag <ver>`) but do not know which version the
+project was previously building, recover it from git history instead of guessing:
+
+```bash
+# 1. List every commit that touched the Dockerfile (--all covers branches/tags)
+git log --oneline --all -- Dockerfile
+
+# 2. Inspect the Dockerfile at the relevant commit and read the version off the
+#    prior cargo install (or pip/npm) invocation
+git show <commit>:Dockerfile | grep cargo
+```
+
+Use the version recovered from `cargo install` as the `--tag` pin so behavior is unchanged across
+the migration. Do NOT pin to "latest" — that reintroduces the floating-version supply-chain risk.
+
+#### D. Pin GitHub Actions to commit SHAs
+
+Search ALL of `.github/` (composite actions under `.github/actions/*/action.yml` are frequently
+missed). Resolve tags with the lightweight/annotated handling from Quick Reference, then:
+
+```yaml
+# BEFORE
+uses: prefix-dev/setup-pixi@v0.9.4
+# AFTER
+uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e  # v0.9.4
+```
+
+Use `sed -i` (not the Edit tool) for workflow edits — pre-commit security hooks block interactive
+edits of `.github/workflows/*.yml`.
+
+#### E. Diagnose transitive action-pin failures
+
+When a job fails at "Set up job" with `Unable to resolve action <action>@<ver>` and that action is
+NOT in your workflows, the pin lives inside a wrapper/composite action:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/aquasecurity/trivy-action/v0.30.0/action.yml" | grep -nE 'uses:'
+```
+
+**Two-strikes-and-drop:** try the latest wrapper release; if still failing, inspect that release's
+`action.yml`; after 2 failures drop the step, open a tracking issue, move on. Do NOT mask with
+`continue-on-error: true`.
+
+#### F. Add dependency scanning (pip-audit + Dependabot, pixi projects)
+
+```yaml
+# .github/dependabot.yml  (zero CI-minutes; runs on GitHub infra)
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule: { interval: weekly }
+```
+
+```toml
+# pixi.toml — pip-audit is PyPI-only, so use pypi-dependencies NOT dependencies
+[feature.lint.pypi-dependencies]
+pip-audit = ">=2.7"
+```
+
+Use a `pixi-lint-*` cache key so lint and dev caches do not collide.
+
+#### G. Pin and verify curl|bash installers (SHA-256, multi-platform)
+
+Reference implementation — pin versions + verify SHA-256 + portable platform/sha detection:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+readonly PIXI_VERSION="0.34.0"
+readonly PIXI_SHA256_LINUX_X86_64="fbdec98dff8b522c4ceb12d76e3fdc177b55620a33451b350c94eae37b3803c8"
+readonly PIXI_SHA256_LINUX_AARCH64="037f2513419127a3c19c129c9396973a146beee1231404f4f0d4699d2e3101d1"
+readonly PIXI_SHA256_DARWIN_X86_64="fa44bc52aa20350cefcd00938ea2269d172c00a0de9a0159d7d80e75b3495a73"
+readonly PIXI_SHA256_DARWIN_AARCH64="dc4b686d97d095687e6ef7ac0107863d1ae8a2d4d15374db9540971133f1c07d"
+
+_sha256_cmd() {                      # Linux: sha256sum; macOS: shasum -a 256
+    if command -v sha256sum >/dev/null 2>&1; then echo "sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then echo "shasum -a 256"
+    else return 1; fi
+}
+
+_detect_platform() {                 # NOTE: Darwin reports arm64; normalize to aarch64
+    case "$(uname -s):$(uname -m)" in
+        Linux:x86_64)  echo "linux-x86_64"   ;;
+        Linux:aarch64) echo "linux-aarch64"  ;;
+        Darwin:x86_64) echo "darwin-x86_64"  ;;
+        Darwin:arm64)  echo "darwin-aarch64" ;;
+        *) return 1 ;;
+    esac
+}
+
+download_and_verify() {              # args: expected_sha url out
+    local expected_sha="$1" url="$2" out="$3" sha_cmd actual
+    sha_cmd="$(_sha256_cmd)" || { echo "ERROR: no sha256 available" >&2; return 2; }
+    curl --proto '=https' --tlsv1.2 -fsSL -o "$out" "$url" || return 1
+    actual="$($sha_cmd "$out" | awk '{print $1}')"   # string-compare, not --check (portable)
+    if [ "$actual" != "$expected_sha" ]; then
+        echo "ERROR: SHA-256 mismatch for $out" >&2; rm -f "$out"; return 1
+    fi
+}
+
+# Replace `curl https://get.pixi.sh | bash` with:
+download_and_verify "$PIXI_SHA256_LINUX_X86_64" \
+  "https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/pixi-${PIXI_VERSION}-linux-x86_64.tar.gz" \
+  /tmp/pixi.tar.gz
+tar -xzf /tmp/pixi.tar.gz -C /opt/pixi && rm -f /tmp/pixi.tar.gz
+```
+
+For tools that cannot be pinned without breaking usability, document a TRUST MODEL inline (tool +
+issue ref + built-in integrity mechanism + trust root):
+
+```bash
+# TRUST MODEL — npm/claude-code: npm verifies SHA-512 on every install.
+# Trust root: registry.npmjs.org TLS + npm signed metadata.
+npm install -g --save-exact @anthropic-ai/claude-code@2.1.42
+```
+
+Fail fast (print manual URL + `exit 1`) on unsupported distros instead of silently falling back to
+`curl|sh`. For tools with a version flag, pin it: `just` → `--tag 1.14.0`; Dockerfile npm →
+`npm install -g <pkg>@X.Y.Z`. Test the security property functionally: call `download_and_verify`
+with a wrong hash and assert non-zero exit + file cleanup.
+
+#### I. Add Bandit SAST as a required CI check (Python/pixi projects)
+
+Bandit writes the JSON report **before** exiting non-zero on findings. The exit propagates to the
+step (failing the job), while the artifact remains on disk. Use a single invocation — no `|| true`,
+no duplicate scan.
+
+```yaml
+security-sast-scan:
+  name: security/sast-scan
+  runs-on: ubuntu-24.04
+  steps:
+    - uses: actions/checkout@<SHA>  # v4
+    - uses: prefix-dev/setup-pixi@<SHA>  # v0.9.x
+      with:
+        pixi-version: v0.67.2
+        cache: true
+    - name: Run Bandit SAST scan (medium+ severity, emit JSON report)
+      run: pixi run python -m bandit -ll --ini .bandit -r src/<pkg> -f json -o bandit.json
+    - name: Upload Bandit JSON report
+      if: always() && hashFiles('bandit.json') != ''
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
+      with:
+        name: bandit-report
+        path: bandit.json
+        retention-days: 90
+```
+
+Key decisions:
+
+- **`if: always() && hashFiles('bandit.json') != ''`** — preserves triage data on both pass and fail.
+- **`pixi run python -m bandit`** — invoke via `python -m bandit` rather than `pixi run bandit` when
+  adding flags beyond what the pixi task embeds (see Failed Attempts).
+- **`actions/upload-artifact@v5.0.0`** — pin to full SHA. `@v7` does not exist on GitHub.com.
+  Verify any tag with: `gh api repos/actions/upload-artifact/git/refs/tags/v5.0.0 -q '.object.sha'`
+- **`.bandit` INI** — start with no `skips` list. Only add skips when a real finding requires it
+  (YAGNI). Do NOT pre-emptively skip B101 (assert_used).
+- **Inline `# nosec`** for real false positives — prefer site-specific suppression over widening
+  the global `skips` list. Include the rule ID and one-line rationale:
+  ```python
+  working_dir: str = "/tmp"  # nosec B108 — ephemeral agent working directory
+  ```
+
+When adding a new package under `src/<name>/`, also update the `-r` target in the `bandit` task in
+`pixi.toml` and the `files:` regex in `.pre-commit-config.yaml`.
+
+#### H. Security code review with false-positive filtering
+
+Two-phase agents: Phase 1 (single agent) lists candidates with confidence 1-10, surfacing only ≥7
+and excluding DoS/secrets-on-disk/rate-limiting/memory-safety/test-only/regex-injection. Phase 2
+(one agent per finding) validates real exploitability from untrusted input. Report only confidence
+≥8 AND TRUE POSITIVE; otherwise output `No security vulnerabilities identified above the confidence
+threshold.`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Combined all scanners in one workflow | CodeQL + npm audit + Gitleaks in a single workflow | One failing job blocks all checks; `security-events:write` leaks to other steps | Isolate CodeQL (privileged) in its own workflow; per-job scope the rest |
+| Single-workflow grep for unpinned tags | Searched only `.github/workflows/` | Missed composite actions under `.github/actions/` | Scope grep to ALL of `.github/` |
+| Removed all `continue-on-error` | Stripped it from every security step | SARIF upload/artifact steps legitimately need it; reporting breaks | Only remove it from scan steps, never from upload/reporting |
+| POSIX grep on SARIF | `grep -q '"results":\s*\[\]'` | `\s` is literal backslash-s; never matches | Use `jq` for JSON/SARIF; never POSIX grep on structured data |
+| Bare ❌ failure gate | `grep -q "❌" report.md` | Any ❌ anywhere (incl. parser false positives) fails the check | Gate on specific line prefixes `^- ❌ Secret Scanning:` |
+| Parser fix without allowlist | Fixed SARIF parser but no `.gitleaks.toml` allowlist | Parser then correctly reports findings in docs/k8s placeholders | Fix parser first to see real findings, then add allowlist in same PR |
+| `[[rules.allowlist]]` in gitleaks v8 | Double-bracket TOML | Array-of-tables = slice; v8 expects a map → crash | Use single `[allowlist]` at top level |
+| Edit tool on workflow YAML | Edited `.github/workflows/*.yml` | Pre-commit security hook blocks the Edit tool | Use `sed -i` for workflow edits |
+| Gitleaks `--exit-code 1` on all branches | Gated main pushes too | Violates #86 runbook; pre-commit already covers local | Conditional exit code: gate PRs, keep main advisory |
+| `gitleaks/gitleaks-action` wrapper | Used the action wrapper | Does not support conditional `--exit-code` | Use direct binary install for full flag control |
+| `--no-git` / `--log-opts=HEAD~1..HEAD` | Limited Gitleaks to working dir / PR diff | Misses secrets in prior branch commits | Default full git-log mode with `fetch-depth: 0` |
+| npm audit without `--omit=dev` | Default scope | Dev-only transitive CVEs fail PRs; not code-quality issues | `--omit=dev --audit-level=high` for production-only, actionable risk |
+| `[feature.lint.dependencies]` for pip-audit | Put PyPI-only pkg in conda deps | pip-audit is PyPI-only | Use `[feature.ENV.pypi-dependencies]` |
+| Re-pinning `trivy-action` 3 times | Repeatedly re-pinned a broken transitive | Internal setup-trivy missing; wrong tag format; downstream OOM | Two-strikes-and-drop: drop step + file tracking issue |
+| Placeholder SHA hashes | Shipped `<fill from GitHub>` placeholders | Blocks review; unresolved at impl time | Fetch real hashes first; regression-test `^[0-9a-f]{64}$` |
+| Hardcoded `sha256sum` | No fallback | macOS lacks GNU coreutils (uses `shasum`) | Runtime-detect via `_sha256_cmd()` |
+| `sha256sum --check` reliance | Used `--check` flag | Output spacing varies across tools | Extract with `awk '{print $1}'` and string-compare |
+| Unnormalized uname platform | Used raw `uname -m` | Apple Silicon returns `arm64`, not `aarch64`; lookup fails | Normalize `arm64`→`aarch64` at detection |
+| Silent curl\|sh distro fallback | Fell back to curl\|sh on unsupported distro | Silent security downgrade with no signal | Fail fast: print manual URL + exit 1 |
+| String-only security tests | Tested for `download_and_verify` text only | Function never validated end-to-end | Functional test: call with bad hash, assert non-zero exit + cleanup |
+| NATS as verification reference | Modeled after NATS installer | NATS pins versions but does NOT verify SHA-256 | gitleaks CI step is the real reference (download + verify + run) |
+| Single-agent identify+filter review | One agent does both phases | Anchors on its own Phase 1 output | Separate identification from validation with independent agents |
+| Bumped Gitleaks version in workflow only | Updated version/URL/SHA in `security.yml` but not the tests | `test_security_workflow.py` still asserted the OLD `EXPECTED_SHA256`, so tests pointed at the stale hash | On a scanner version bump also update `GITLEAKS_VERSION`, `GITLEAKS_TARBALL`, `EXPECTED_SHA256` in `tests/workflows/test_security_workflow.py` |
+| Guessed the `--tag` pin version | Picked a plausible recent version when migrating Dockerfile off `cargo install` | Wrong version changed tool behavior across the migration | Recover the exact prior version from git history: `git log --oneline --all -- Dockerfile` then `git show COMMIT:Dockerfile \| grep cargo` |
+| Pixi task with embedded args + extra CLI args | `bandit = "bandit -ll --ini .bandit -r src/telemachy"` invoked as `pixi run bandit -f json -o bandit.json` | Arg doubling: `bandit: error: unrecognized arguments: src/telemachy` | Use `pixi run python -m bandit -ll --ini .bandit -r src/<pkg>` for invocations that need extra flags; keep pixi task as a bare entry point or omit extra flags at call site |
+| Pre-emptive skip of B101 in `.bandit` | Added `skips = B101` before any asserts existed in `src/` | YAGNI — adds a suppression rule with zero benefit; flagged in review | Start `.bandit` with no `skips`; only add suppressions when an actual finding requires it |
+| `actions/upload-artifact@v7` | Pinned upload artifact action to `@v7` | Tag `v7` does not exist on GitHub.com (latest is v4/v5); workflow fails at "Set up job" | Pin to full SHA for v5.0.0: `actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0`; verify tags with `gh api repos/actions/upload-artifact/git/refs/tags/v5.0.0 -q '.object.sha'` |
+| Global `.bandit` skip for false positive | Widened `skips = B108` for a single hardcoded `/tmp` default | Suppresses B108 globally across all files; any future real hardcoded path would be silently missed | Use inline `# nosec B108 — ephemeral agent working directory` at the specific site only |
+
+## Results & Parameters
+
+### Gitleaks version reference
+
+| Field | Value |
+|-------|-------|
+| Version (latest stable) | v8.30.1 (2026-06-03) / v8.30.0 (2026-03-15) |
+| linux_x64 SHA256 | `79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e` |
+| Checksums URL | `https://github.com/gitleaks/gitleaks/releases/download/<VER>/gitleaks_<ver>_checksums.txt` |
+| Exit code (PR / main) | 1 (gate) / 0 (advisory) |
+| Scan mode | full git history (`fetch-depth: 0`, no `--no-git`) |
+
+### Action SHA reference
+
+| Action | Version | Commit SHA |
+|--------|---------|------------|
+| `actions/checkout` | v4.1.6 | `a5ac7e51b41094c7467395007f7e897ffd472b1c` |
+| `actions/setup-node` | v4.0.2 | `60edb5dd545a775178fac7f3a11fc4209779e326` |
+| `github/codeql-action/*` | v3.27.5 | `4e828ff8a76ab34a99dd1f01ba9ca34eb10ebddad` |
+| `prefix-dev/setup-pixi` | v0.9.4 | `a0af7a228712d6121d37aba47adf55c1332c9c2e` |
+| `actions/github-script` | v8 | `ed597411d8f924073f98dfc5c65a23a2325f34cd` |
+| `actions/upload-artifact` | v5.0.0 | `330a01c490aca151604b8cf639adc76d48f6c5d4` |
+
+### CodeQL / npm audit configuration
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| CodeQL queries | `security-extended,security-and-quality` | Security + quality coverage |
+| CodeQL workflow | isolated `codeql.yml` | Scope `security-events: write` |
+| npm audit flags | `--omit=dev --audit-level=high` | Production-only, actionable CVEs |
+| Node install | `npm ci` (v20) | Locked, reproducible |
+
+### Installer SHA-256 values (verified from GitHub releases)
+
+```
+pixi   v0.34.0 linux-x86_64:   fbdec98dff8b522c4ceb12d76e3fdc177b55620a33451b350c94eae37b3803c8
+pixi   v0.34.0 darwin-aarch64: dc4b686d97d095687e6ef7ac0107863d1ae8a2d4d15374db9540971133f1c07d
+dagger v0.13.3 linux-x86_64:   787307925b10c0b9b04c0fd814716abe339c53b6aa250a8ba25321a934d14a67
+just   v1.36.0 linux-x86_64:   bc7c9f377944f8de9cd0418b11d2955adebfa25a488c0b5e3dd2d2c0e9d732da
+```
+
+### Installer version flags by tool
+
+| Tool | Version flag | Example |
+|------|-------------|---------|
+| `just` | `--tag` | `--tag 1.14.0` |
+| `pixi` | env `PIXI_VERSION` | `PIXI_VERSION=0.65.0 curl ... \| bash` |
+| `rustup` | `--default-toolchain` | `--default-toolchain 1.75.0` |
+
+### Bandit configuration reference
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| Severity threshold | `-ll` (medium+) | Low-severity findings are noise in most projects |
+| Report format (CI) | `-f json -o bandit.json` | Machine-readable; upload as artifact; parseable on pass AND fail |
+| INI file | `--ini .bandit` | Centralizes config; scoped to project `targets` + `skips` |
+| Initial `skips` list | _(empty)_ | YAGNI — only add when a real finding requires suppression |
+| False-positive suppression | `# nosec B<ID>  # <rationale>` inline | Site-specific; auditable; `.bandit` skips stay clean |
+| Pixi invocation (bare task) | `pixi run bandit` | Only when the pixi task embeds all needed flags |
+| Pixi invocation (extra flags) | `pixi run python -m bandit -ll --ini .bandit -r src/<pkg>` | Use when adding `-f`, `-o`, or other flags beyond the task default |
+| Artifact upload condition | `if: always() && hashFiles('bandit.json') != ''` | Preserves triage data on both pass and fail |
+| Artifact retention | `retention-days: 90` | Sufficient for triage; keeps storage low |
+
+### jq command reference (SARIF)
+
+```bash
+jq '[.runs[].results[]] | length == 0' results.sarif   # zero results?
+jq '[.runs[].results[]] | length' results.sarif        # count findings
+jq '[.runs[].results[].ruleId] | unique' results.sarif # rule IDs
+```
+
+### Transitive pin reference
+
+| Pinned version | Result |
+|----------------|--------|
+| `aquasecurity/trivy-action@v0.30.0` | Fails: internal setup-trivy@v0.2.2 missing |
+| `aquasecurity/trivy-action@0.19.0` | Fails: tag missing (no leading v) |
+| Drop step + open tracking issue | Unblocked; correct call |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectProteus | Issue #23 — CodeQL + npm audit + PR-gated Gitleaks | merged 2026-06-03, auto-merge |
+| ProjectHephaestus | Issue #744, PR #935 — installer SHA-256 pinning (pixi/dagger/just) | 13 regression + 47 shell tests passing |
+| ProjectOdyssey | Issue #3143, PR #3315 — security scan gap fixes | scan triggers + masking |
+| ProjectOdyssey | Issue #3939, PR #4835 — Gitleaks version upgrade | version + SHA |
+| ProjectOdyssey | Issue #3342, PR #3971 — composite action SHA pinning | full `.github/` scope |
+| ProjectOdyssey | Issue #3941, PR #4837 — curl\|sh → pixi replacement | supply-chain |
+| ProjectScylla | Issue #650, PR #717 — npm Dockerfile pinning | exact-version pins |
+| ProjectKeystone | PR #451 — Gitleaks SARIF false-positive fix | jq parser |
+| ProjectOdyssey | Issue #755, PR #869 — pip-audit + Dependabot | dependency scanning |
+| ProjectAgamemnon | PR #400 — transitive trivy pin failure | two-strikes-and-drop |
+| ProjectTelemachy | Issue #157 — Bandit SAST as required CI check (pixi project, `_required.yml`) | verified-local (2026-06-19) |
+``````
+
+---
 ## v1.2.0 (2026-06-19)
 
 Bandit SAST integration for Python/pixi projects (ProjectTelemachy issue #157)

--- a/skills/gha-security-scanning-supply-chain.md
+++ b/skills/gha-security-scanning-supply-chain.md
@@ -1,13 +1,15 @@
 ---
 name: gha-security-scanning-supply-chain
-description: "Use when: (1) adding CodeQL SAST to TypeScript/JavaScript workflows or Semgrep/Gitleaks to any PR pipeline, (2) CI security scans only trigger on push to main — not PRs — and need promotion to PR gates, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) enforcing pinned SHA-based action versions instead of mutable tags, (5) auditing or porting curl|bash installers with SHA-256 verification, (6) a GHA job fails at 'Set up job' due to unresolved transitive action dependency, (7) adding Bandit SAST as a required CI check for Python/pixi projects."
+description: "Use when: (1) adding CodeQL SAST to TypeScript/JavaScript workflows or Semgrep/Gitleaks to any PR pipeline, (2) CI security scans only trigger on push to main — not PRs — and need promotion to PR gates, (3) Gitleaks SARIF parsing uses grep instead of jq causing always-fail required checks, (4) enforcing pinned SHA-based action versions instead of mutable tags, (5) auditing or porting curl|bash installers with SHA-256 verification, (6) a GHA job fails at 'Set up job' due to unresolved transitive action dependency, (7) adding Bandit SAST as a required CI check for Python/pixi projects, (8) triaging and remediating CodeQL PR alerts when gh reports a check-run id instead of a workflow run id."
 category: ci-cd
 date: 2026-06-19
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 history: gha-security-scanning-supply-chain.history
+verification: verified-local
 tags:
   - codeql
+  - code-scanning
   - semgrep
   - gitleaks
   - sarif
@@ -29,6 +31,8 @@ tags:
   - bandit
   - python-sast
   - nosec
+  - weak-hashing
+  - command-injection
 ---
 
 # GitHub Actions Security Scanning and Supply-Chain Hardening
@@ -39,7 +43,7 @@ tags:
 |-------|-------|
 | Date | 2026-06-19 |
 | Objective | Set up security scanning (CodeQL/Semgrep/Gitleaks SAST + secrets + Bandit Python SAST), harden CI supply-chain (action SHA pinning, dependency scanning), and pin/verify curl\|bash installers with SHA-256 |
-| Outcome | Consolidated guidance for security gate setup, scan-trigger gaps, SARIF parsing fixes, action SHA pinning, transitive-pin diagnosis, installer trust-model hardening, and Bandit SAST integration for Python/pixi projects |
+| Outcome | Consolidated guidance for security gate setup, scan-trigger gaps, SARIF parsing fixes, action SHA pinning, transitive-pin diagnosis, installer trust-model hardening, Bandit SAST integration for Python/pixi projects, and CodeQL PR alert remediation |
 | Verification | verified-local |
 
 ## When to Use
@@ -56,6 +60,10 @@ tags:
 - Adding automated dependency vulnerability scanning (pip-audit/npm audit + Dependabot)
 - Isolating `security-events: write` permission from base required checks
 - Adding Bandit SAST as a required CI check for Python/pixi projects (medium+ severity, JSON report artifact)
+- `gh pr checks` shows a failing CodeQL identifier but `gh run view` cannot find it because the
+  identifier is a check-run id, not a workflow run id
+- CodeQL flags weak sensitive-data hashing, command-line injection, or similar findings that need
+  code fixes plus targeted regression tests
 - Performing a security code review where static-analysis output is noisy with false positives
 
 ## Verified Workflow
@@ -79,6 +87,12 @@ grep -rn "curl\|wget" .github/workflows/*.yml | grep "|.*sh\b\|bash\b"
 
 # Validate workflow YAML
 python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))" && echo OK
+
+# Inspect a failing CodeQL check-run id from gh pr checks
+gh api "repos/<owner>/<repo>/check-runs/<check_run_id>" \
+  --jq '{name,conclusion,details_url,html_url}'
+gh api "repos/<owner>/<repo>/check-runs/<check_run_id>/annotations" --paginate
+gh api "repos/<owner>/<repo>/code-scanning/alerts?pr=<pr>&tool_name=CodeQL" --paginate
 ```
 
 ### Detailed Steps
@@ -200,6 +214,45 @@ paths = ['''k8s/secrets.yaml''', '''docs/KUBERNETES_DEPLOYMENT.md''', '''tests/.
 ```
 
 Fix the parser first to see real findings, then add the allowlist — both in the same PR.
+
+#### CodeQL PR alert triage and remediation
+
+When `gh pr checks` reports a failing CodeQL identifier, do not assume it is a workflow run id.
+GitHub can show a **check-run id** in the PR checks table; `gh run view <id>` will fail or inspect
+the wrong object. Query the check-run and CodeQL alerts directly:
+
+```bash
+gh api "repos/<owner>/<repo>/check-runs/<check_run_id>" \
+  --jq '{name,status,conclusion,started_at,completed_at,details_url,html_url}'
+gh api "repos/<owner>/<repo>/check-runs/<check_run_id>/annotations" --paginate
+gh api "repos/<owner>/<repo>/code-scanning/alerts?pr=<pr>&tool_name=CodeQL" --paginate
+```
+
+Read the rule id, path, line, state, and most recent instance before editing. The alerts API also
+shows when older alerts are fixed while newer alerts remain open, which prevents declaring the
+security gate done after only the first finding disappears.
+
+For `py/weak-sensitive-data-hashing` on user/login identifiers:
+
+- Replace MD5 with SHA-256 when the value is a non-secret salted tracking identifier and policy
+  requires SHA-2.
+- Add regression tests proving deterministic output for the same salt/input pair and a 64-character
+  hexadecimal digest.
+- Do **not** use bare SHA-256 for low-entropy secrets or passwords. Use a password hashing or KDF
+  primitive such as Argon2, bcrypt, scrypt, or PBKDF2 according to the project's policy.
+
+For `py/command-line-injection` around a generic subprocess wrapper:
+
+- Reject an empty command before any subprocess call.
+- Convert arguments to strings and reject any argument containing a NUL byte.
+- Select executables from hard-coded literals, for example an `if`/`elif` ladder or dict allowlist
+  of scheduler commands; do not pass through arbitrary `argv[0]`.
+- Reconstruct the safe argv from the selected literal executable plus validated arguments, then call
+  `subprocess.run`.
+- Add tests proving unsupported executables are rejected before `subprocess.run` is called.
+
+After pushing the fix, treat CodeQL and the normal validate/test job as separate gates: CodeQL can
+be fixed while validate still fails for an unrelated CI-environment difference.
 
 ### Detailed Steps: scanner version bumps and pin discovery
 
@@ -450,6 +503,9 @@ threshold.`
 | Pre-emptive skip of B101 in `.bandit` | Added `skips = B101` before any asserts existed in `src/` | YAGNI — adds a suppression rule with zero benefit; flagged in review | Start `.bandit` with no `skips`; only add suppressions when an actual finding requires it |
 | `actions/upload-artifact@v7` | Pinned upload artifact action to `@v7` | Tag `v7` does not exist on GitHub.com (latest is v4/v5); workflow fails at "Set up job" | Pin to full SHA for v5.0.0: `actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0`; verify tags with `gh api repos/actions/upload-artifact/git/refs/tags/v5.0.0 -q '.object.sha'` |
 | Global `.bandit` skip for false positive | Widened `skips = B108` for a single hardcoded `/tmp` default | Suppresses B108 globally across all files; any future real hardcoded path would be silently missed | Use inline `# nosec B108 — ephemeral agent working directory` at the specific site only |
+| Treating a CodeQL check-run id as a workflow run id | Ran `gh run view <check_run_id>` from the value shown by `gh pr checks` | The id belonged to a check-run, so the workflow-run API did not expose the alert details | Use `gh api repos/<owner>/<repo>/check-runs/<check_run_id>` and the matching annotations/alerts APIs |
+| Hash replacement without data classification | Replaced MD5 mechanically without deciding whether the material was a tracking id or a password/secret | SHA-256 is acceptable for non-secret salted IDs under SHA-2 policy, but not for low-entropy secrets | Classify the data first: SHA-256 for salted non-secret identifiers, password hashing/KDF for secrets |
+| Sanitizing a generic subprocess wrapper after command selection | Validated argument strings but still accepted arbitrary executables | CodeQL still had a path from caller-controlled command names to `subprocess.run` | Choose the executable from a hard-coded allowlist before reconstructing argv |
 
 ## Results & Parameters
 
@@ -483,6 +539,15 @@ threshold.`
 | npm audit flags | `--omit=dev --audit-level=high` | Production-only, actionable CVEs |
 | Node install | `npm ci` (v20) | Locked, reproducible |
 
+### CodeQL PR remediation reference
+
+| Finding | Preferred pattern | Regression test |
+|---------|-------------------|-----------------|
+| Check-run id from `gh pr checks` | Query `check-runs/<check_run_id>`, `check-runs/<check_run_id>/annotations`, and `code-scanning/alerts?pr=<pr>&tool_name=CodeQL` | Confirm rule id, path, line, and open/fixed state before editing |
+| Weak hashing for non-secret salted IDs | Replace MD5 with SHA-256 when policy requires SHA-2 | Same salt/input is deterministic; digest length is 64 hex characters |
+| Low-entropy secret/password hashing | Use a password hashing/KDF primitive, not bare SHA-256 | Verify project-approved parameters and migration behavior |
+| Command-line injection in subprocess wrapper | Select executable from a hard-coded allowlist, validate args, reject NUL bytes, reconstruct argv | Unsupported executable is rejected before `subprocess.run` is called |
+
 ### Installer SHA-256 values (verified from GitHub releases)
 
 ```
@@ -507,7 +572,7 @@ just   v1.36.0 linux-x86_64:   bc7c9f377944f8de9cd0418b11d2955adebfa25a488c0b5e3
 | Severity threshold | `-ll` (medium+) | Low-severity findings are noise in most projects |
 | Report format (CI) | `-f json -o bandit.json` | Machine-readable; upload as artifact; parseable on pass AND fail |
 | INI file | `--ini .bandit` | Centralizes config; scoped to project `targets` + `skips` |
-| Initial `skips` list | _(empty)_ | YAGNI — only add when a real finding requires suppression |
+| Initial `skips` list | *(empty)* | YAGNI — only add when a real finding requires suppression |
 | False-positive suppression | `# nosec B<ID>  # <rationale>` inline | Site-specific; auditable; `.bandit` skips stay clean |
 | Pixi invocation (bare task) | `pixi run bandit` | Only when the pixi task embeds all needed flags |
 | Pixi invocation (extra flags) | `pixi run python -m bandit -ll --ini .bandit -r src/<pkg>` | Use when adding `-f`, `-o`, or other flags beyond the task default |
@@ -545,3 +610,4 @@ jq '[.runs[].results[].ruleId] | unique' results.sarif # rule IDs
 | ProjectOdyssey | Issue #755, PR #869 — pip-audit + Dependabot | dependency scanning |
 | ProjectAgamemnon | PR #400 — transitive trivy pin failure | two-strikes-and-drop |
 | ProjectTelemachy | Issue #157 — Bandit SAST as required CI check (pixi project, `_required.yml`) | verified-local (2026-06-19) |
+| Sanitized PR session | CodeQL weak hashing + command injection remediation after a rebase | verified-ci (2026-06-19): CodeQL and validate gates green |

--- a/skills/pr-ci-failure-triage-preexisting-vs-introduced.history
+++ b/skills/pr-ci-failure-triage-preexisting-vs-introduced.history
@@ -1,6 +1,383 @@
-<!-- markdownlint-disable MD024 -->
+<!-- markdownlint-disable MD012 MD024 -->
+
 # pr-ci-failure-triage-preexisting-vs-introduced — History
 
+## v1.1.0 (2026-06-19)
+
+**Changed by:** Sanitized session context: post-rebase PR CI recovery
+**Verification:** verified-ci
+
+### What changed
+- Added a post-rebase recovery pattern for PRs with independent security and validate gates.
+- Added noninteractive rebase continuation with git -c core.editor=true rebase --continue for automation.
+- Added CI-only validate failure guidance for host-specific filesystem auto-detection: patch probes or pass explicit CLI config in tests instead of relying on ambient hosts or forbidden env config.
+- Added final polling and mergeability confirmation with mergeStateStatus, mergeable, headRefOid, and URL.
+
+### Why
+The prior skill classified PR failures and rollup artifacts, but did not spell out the complete after-rebase remediation loop when CodeQL and validate fail for different reasons on the same PR.
+
+### Previous version (v1.0.0) snapshot
+
+
+``````markdown
+---
+name: pr-ci-failure-triage-preexisting-vs-introduced
+description: "Use when: (1) a PR has unexpected CI failures and you need to determine if they are PR-introduced or pre-existing main-branch rot before bisecting, reverting, or retriggering, (2) CI fails after a force-push and cancelled runs from the old SHA appear as failures in the PR status rollup, (3) a required CI check fails on a PR whose diff is unrelated to the failing job, (4) CI failures look like flakes (Mojo JIT crash, SIGABRT) and need to be classified before a rerun, (5) stale CI warnings need to be surfaced in PR comments rather than stderr only, (6) CI coverage gate fails because it measures the merge-preview tree rather than the branch alone, (7) a stacked rebased PR has stale CI runs and needs fresh triggering without code changes, (8) sanitizer or compilation jobs fail identically on a PR because stale duplicate commits from another branch are present on the PR branch, (9) deciding whether to fix in-scope, admin-merge, or file a follow-up issue for a blocking failure"
+category: ci-cd
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: pr-ci-failure-triage-preexisting-vs-introduced.history
+tags:
+  - ci-failure
+  - triage
+  - preexisting
+  - pr-introduced
+  - check-runs-api
+  - force-push
+  - cancelled-runs
+  - concurrency-supersession
+  - mojo-jit
+  - flaky
+  - stale-cache
+  - admin-merge
+  - tracking-issue
+  - stale-duplicate-commit
+---
+
+# PR CI Failure Triage: Pre-Existing vs. PR-Introduced
+
+Classify why CI is red on a pull request — PR-introduced, pre-existing main-branch rot,
+flaky, or a status-rollup artifact (cancelled / superseded / stale-cache) — **before**
+bisecting, reverting, retriggering, or expanding scope.
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-07 |
+| **Objective** | Determine, per failing check, whether a red PR is the PR's fault or a systemic/flaky/artifact failure, then pick the right resolution (fix-in-scope, admin-merge, tracking issue, retrigger, or no-op) |
+| **Outcome** | Consolidated from 11 triage skills; authoritative classification via `gh api .../check-runs` on main HEAD; rollup-artifact detection for force-push/concurrency cancellations; flaky-vs-real signatures; stale duplicate-commit detection |
+| **Verification** | verified-ci |
+| **History** | [changelog](./pr-ci-failure-triage-preexisting-vs-introduced.history) |
+
+## When to Use
+
+- A PR is `BLOCKED` by failing required checks and you must decide fix / admin-merge / issue
+- A reviewer labeled failures `PREEXISTING_CI_NOISE` (re-verify — wrong ~2/3 of the time)
+- CI is red but the PR diff is unrelated to the failing job (docs-only, config-only, agent-only)
+- Failures look like Mojo JIT crashes (`execution crashed`, `SIGABRT`, `libKGENCompilerRTShared.so`)
+- A PR shows many red checks right after a rebase / force-push, or right after `gh run rerun`
+- `gh pr checks` reports "N fail" but `mergeable=MERGEABLE` and `mergeStateStatus=BLOCKED`
+- A required check fails identically across multiple unrelated branches (incl. main)
+- All sanitizers fail identically on a PR; the branch carries extra/stale commits
+- A stacked PR series is behind main with failures from missing files / stale digests / renamed APIs
+- Stale CI pattern warnings exist but only print to stderr, never to the PR comment
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 0. Always unset shadowing tokens first
+unset GITHUB_TOKEN GH_TOKEN
+
+# --- AUTHORITATIVE TEST: does each failing check pass on main HEAD? ---
+ORG=HomericIntelligence; REPO=ProjectOdyssey; PR=368
+gh pr view "$PR" --repo "$ORG/$REPO" --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion == "FAILURE") | .name'
+MAIN_SHA=$(gh api "repos/$ORG/$REPO/branches/main" --jq '.commit.sha')
+for chk in "<failing-check>"; do
+  s=$(gh api "repos/$ORG/$REPO/commits/$MAIN_SHA/check-runs" \
+       --jq ".check_runs[] | select(.name==\"$chk\") | .conclusion" | head -1)
+  printf "%-30s main=%s\n" "$chk" "${s:-not-run}"
+done
+# success -> PR-INTRODUCED | failure -> PRE-EXISTING | not-run -> NEW-CHECK
+
+# --- ROLLUP ARTIFACT: real FAILURE vs cancelled/superseded ---
+gh pr view "$PR" --json statusCheckRollup --jq '{
+  real_failures: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name],
+  cancelled: ([.statusCheckRollup[] | select(.conclusion=="CANCELLED")] | length)}'
+
+# --- MAIN HISTORY: is the workflow systemically red? ---
+gh run list --branch main --workflow "<Workflow>" --limit 10 \
+  --json conclusion,createdAt,headSha \
+  --jq '.[] | "\(.createdAt)\t\(.conclusion)\t\(.headSha[0:8])"'
+
+# --- gh pr checks valid --json fields (narrow schema!) ---
+gh pr checks "$PR" --json name,workflow,state,bucket   # NO status/conclusion/required
+
+# --- Retrigger ONLY failed jobs (after classifying as flake) ---
+gh run rerun <run-id> --failed
+```
+
+### Detailed Steps
+
+#### 1. Authoritative classification via the check-runs API (do this first)
+
+The fastest, most authoritative test is whether each failing **check name** (not workflow
+name) passes on main HEAD. A ~5-second `check-runs` query overrides any reviewer label.
+
+- Use the EXACT `name` from `statusCheckRollup` — that is the required-status-check context
+  branch protection enforces. A workflow can show FAILURE while its required sub-job PASSED.
+- `success` on main → **PR-INTRODUCED** (fix in this PR). `failure` → **PRE-EXISTING**
+  (use the resolution ladder; do NOT expand scope). `not-run` → **NEW-CHECK** (added by the
+  branch; investigate).
+- ALWAYS re-verify reviewer `PREEXISTING_CI_NOISE` labels — empirically wrong 2 of 3 times
+  (Agamemnon #368 markdownlint+trivy and Hermes #614 urllib3 CVE were actually PR-introduced).
+- File-overlap (failing test not in the diff) is a hint, not proof — a check can fail from
+  env/config drift unrelated to file paths. The check-runs API is the only authoritative test.
+
+Full diagnostic script:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+unset GITHUB_TOKEN GH_TOKEN
+ORG="${1:?}" REPO="${2:?}" PR="${3:?}"
+mapfile -t FAILING < <(gh pr view "$PR" --repo "$ORG/$REPO" --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion == "FAILURE") | .name')
+[ "${#FAILING[@]}" -eq 0 ] && { echo "No failing required checks."; exit 0; }
+MAIN_SHA=$(gh api "repos/$ORG/$REPO/branches/main" --jq '.commit.sha')
+for chk in "${FAILING[@]}"; do
+  s=$(gh api "repos/$ORG/$REPO/commits/$MAIN_SHA/check-runs" \
+       --jq ".check_runs[] | select(.name == \"$chk\") | .conclusion" | head -1)
+  case "${s:-not-run}" in
+    success) v="PR-INTRODUCED (fix here)";;
+    failure) v="PRE-EXISTING (admin-merge + issue ladder)";;
+    *)       v="NEW-CHECK (branch-added; investigate)";;
+  esac
+  printf "%-40s main=%-10s -> %s\n" "$chk" "${s:-not-run}" "$v"
+done
+```
+
+#### 2. Rule out status-rollup artifacts (cancelled / superseded / stale-cache)
+
+A red rollup is often NOT a real failure. The rollup mixes runs from ALL of the PR's commits.
+
+**Force-push cancelled runs (Trigger 1).** After `git push --force-with-lease` (e.g. post-rebase),
+GHA marks in-flight runs on the prior SHA `CANCELLED`; they render red next to the new SHA's
+runs. On Odyssey PR #5380, all 50+ "failures" were `CANCELLED` from the rebased-out SHA;
+the tip had zero `FAILURE`. Filter by tip SHA:
+
+```bash
+TIP=$(gh pr view <PR> --json headRefOid --jq .headRefOid)
+gh run list --branch <branch> --limit 60 --json conclusion,headSha \
+  | jq --arg s "$TIP" '[.[]|select(.headSha==$s)]|group_by(.conclusion//"queued")
+       |map({key:(.[0].conclusion//"queued"),count:length})'
+```
+
+After a force-push, GHA auto-schedules fresh runs on the new SHA — no manual rerun needed.
+
+**Concurrency supersession (Trigger 2, verified-ci).** Without any force-push, a higher-priority
+queued run cancels an in-flight rerun. On Hephaestus PR #1073, `gh pr checks` summarized "4 fail"
+after `gh run rerun --failed`; all four were CANCELLED mid-run with
+`Canceling since a higher priority waiting request for required-Required Checks-<branch> exists`
+/ `The operation was canceled.`, with zero `FAILED`. Verify against the LATEST run:
+
+```bash
+gh run list --branch <branch> --limit 3                       # newest is authoritative
+gh run view --log --job=<jobid> | grep -c 'FAILED'            # 0 => supersession artifact
+gh run view --log --job=<jobid> | tail -n5                    # ends "The operation was canceled."
+```
+
+**Stale CI cache (verified-ci).** A required check (e.g. `security/dependency-scan`) failing
+*identically across multiple unrelated branches incl. main* with a clean diff = repo-wide infra,
+not your code. Fingerprint: the gate log *installs* the fixed version while pip-audit *reports*
+the old vulnerable one (poisoned `.pixi`/setup-pixi cache). Trust a LOCAL run over stale CI:
+
+```bash
+grep -n "urllib3" pixi.lock | head        # lockfile already pins the fix (2.7.0)
+pixi run -e lint pip-audit                 # -> "No known vulnerabilities found"
+git log origin/main --oneline | grep -iE "unblock CI|cache poison|\.pixi cache"
+gh pr update-branch <N>                    # pull the cache-invalidation fix from main (no diff change)
+gh api repos/$ORG/$REPO/commits/<merge-sha> --jq '.commit.verification.verified'  # true => signed-gate ok
+```
+
+Heuristic table:
+
+| Indicator | Meaning |
+|---|---|
+| `mergeable: MERGEABLE` + `BLOCKED` + `real_failures: []` | Healthy; blocked only on queued/in-progress |
+| `mergeable: CONFLICTING` + `DIRTY` | Real conflict — rebase needed |
+| `mergeable: MERGEABLE` + `BLOCKED` + `real_failures: [...]` | Real failures — investigate |
+| Many `CANCELLED` on a non-tip SHA | Stale from force-push — ignore |
+
+#### 3. Check main-branch history (systemic vs PR)
+
+For each failing workflow, read recent main conclusions:
+
+```bash
+gh run list --branch main --limit 10 --workflow "<Workflow>" \
+  --json conclusion,createdAt,headSha \
+  --jq '.[] | "\(.createdAt)\t\(.conclusion)\t\(.headSha[0:8])"'
+```
+
+3+ consecutive `failure` on main → **SYSTEMIC** (stop bisecting). Mixed → flaky pre-existing
+if the failing files are unrelated to the diff. All `success` → potentially PR-introduced.
+Do this per distinct workflow — they can be in different states. On Odyssey PR #5381, the
+`execution crashed` failure had 7+ consecutive main failures → addressed in a separate
+workaround PR #5382, not the surface PR.
+
+#### 4. Classify flaky / infra signatures (before any rerun)
+
+| Signature in log | Classification | Action |
+| --- | --- | --- |
+| `HTTP 5xx` on `git fetch` / `actions/checkout` / `upload-artifact` | GitHub infra flake | Leave; next push re-runs. Do NOT `gh run rerun`. |
+| `mojo: error: execution crashed` + `libKGENCompilerRTShared.so`, no Mojo frame | libKGEN JIT crash (modular#6413) | Reference upstream; do NOT revert the Mojo bump; workaround in a separate PR |
+| `SIGABRT` in a test file NOT in the PR diff, passes on main | Pre-existing Mojo flake | Confirm via main history; do not fix in PR |
+| `Cannot connect to podman socket` | Container setup race | Leave / file infra issue |
+| `fortify_fail_abort` only inside a docstring / commit body | grep text-match noise | Ignore — not a real abort |
+| `error: compilation failed` / test-specific assert in a file the PR touched | PR-introduced regression | Fix the PR |
+
+ProjectOdyssey hard policy: NEVER `gh run rerun` to dismiss a failure as a flake; NEVER
+revert/pin-back a Mojo version bump; ALWAYS file/reference a Modular issue for runtime crashes
+and fix forward. Note `gh pr checks --json` has a narrow schema — valid fields are
+`bucket,completedAt,description,event,link,name,startedAt,state,workflow`; there is NO
+`status`/`conclusion`/`required`. Requesting a bad field makes gh exit non-zero on EVERY call;
+classify such deterministic CLI-arg errors as fail-fast (one wrong field once tripped a
+`gh_cli` circuit breaker and bricked a 10-item batch).
+
+#### 5. Stale duplicate-commit detection (all sanitizers fail identically)
+
+When asan+tsan+ubsan+lsan (or every compilation job) fail the SAME test identically, suspect a
+logical error from a stale parallel-attempt commit, not a data race (races show under TSan only):
+
+```bash
+git fetch origin
+git log --oneline origin/main..origin/<branch>          # MORE commits than the PR claims?
+gh pr list --state all --search "<symbol from suspicious commit>"   # already merged elsewhere?
+# Rebuild with only the real payload (do NOT amend — that edits the wrong commit):
+git checkout -B <branch> origin/main
+git cherry-pick <real-payload-sha>
+git push --force-with-lease origin <branch>             # bare --force is blocked by Safety Net
+```
+
+On Keystone PR #436, stale commit `984fef0` duplicated a fix already on main via PR #435;
+rebuilding with only the real payload restored green. C++ pitfall in such stale fixes:
+`return const std::vector<T>&` under a `lock_guard` is always wrong (lock released at return →
+dangling ref); return by value.
+
+#### 6. Stacked / rebased PR series
+
+When earlier PRs in a stack merged but later ones are behind main, rebase first, then map logs:
+
+| Log Output | Root Cause | Fix |
+| --- | --- | --- |
+| `stat .../Containerfile: no such file` | Predecessor not merged | Rebase onto main |
+| `[org] is an organization. License key is required` | `gitleaks-action@v2` needs paid license | Replace with gitleaks CLI |
+| `failed to resolve source metadata ... not found` | Stale pinned image digest | Pull fresh linux/amd64 digest |
+| `Expected exactly N FROM lines ... found N+1` | Test asserts old Dockerfile structure | Update stage-count test |
+| `AttributeError: module ... has no attribute 'old_name'` | Test patches a function the PR renamed | `@patch` the NEW inner function |
+
+Resolve YAML conflicts (composite action vs inline steps) with Python `str.replace()`, never
+sed/heredoc — `${{ }}` expressions corrupt under shell interpolation. Verify fix commit reached
+remote (`git log --oneline origin/<branch>...<branch>`); a force-push may have dropped it.
+
+#### 7. Surface stale-pattern / coverage warnings in the PR comment
+
+Diagnostic CI output buried in stderr never reaches reviewers. To surface stale CI-group
+warnings, add `stale_patterns: Optional[List[str]] = None` to `generate_report()`, append a
+`### Stale CI Patterns` section when non-empty (after both uncovered/covered branches, before
+`return`), and widen the post guard to `if post_pr and (uncovered or stale_patterns):` —
+**parenthesize**, since `and` binds tighter than `or`. For the coverage gate, note it can
+measure the merge-preview tree rather than the branch alone, producing a discrepancy that is
+not a PR regression — diagnose with main history before "fixing".
+
+#### 8. Resolve
+
+- **PR-INTRODUCED** → fix in this PR (your responsibility).
+- **PRE-EXISTING** → ladder, in order: (A) quick fix only if ≤10 min and no scope creep;
+  (B) admin-merge `gh pr merge <PR> --repo <org/repo> --squash --admin` (needs admin scope;
+  if absent, auto-merge stays armed for a human); (C) ALWAYS file a tracking issue (even with
+  A/B). Never expand PR scope to fix unrelated rot.
+- **Systemic / infra flake / cache** → leave the surface PR; link the tracking PR/issue,
+  `gh pr update-branch` if main is already fixed; do not rerun/revert.
+- **No-op** → if all failures are confirmed pre-existing, enable auto-merge
+  (`gh pr merge <PR> --auto --rebase`) and STOP. Do NOT create empty commits, manufacture
+  changes, run passing tests locally, or commit `.claude-review-fix-*.md` artifacts.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Trusting a reviewer's `PREEXISTING_CI_NOISE` label | Took the classification at face value (Agamemnon #368, Hermes #614) | `check-runs` API showed those checks PASSED on main HEAD — failures were PR-introduced | ALWAYS re-verify with `check-runs` on main HEAD; ~5 sec vs ~10 min wasted per false trust |
+| Comparing the workflow's overall conclusion | Used the workflow `conclusion` instead of the individual required-check `name` | A workflow can show FAILURE while its required sub-job PASSED | Key the `check-runs` query on the EXACT `name` from `statusCheckRollup` |
+| File-overlap heuristic alone | Assumed zero diff-overlap means pre-existing | A check can fail from env/config drift unrelated to file paths | File overlap is a hint; the check-runs API on main HEAD is the only authoritative test |
+| Reading "50+ failed checks" in the UI as real | Assumed real test failures post-rebase | Most entries were `CANCELLED` from the force-pushed-away SHA, not `FAILURE` | The rollup mixes runs from ALL of the PR's commits; filter by tip SHA |
+| Reading `gh pr checks` "N fail" as real after a rerun | Treated 4 "fail" as failures (Hephaestus #1073) | Jobs were CANCELLED by concurrency supersession; 0 `FAILED`, latest run succeeded | A "fail" in `gh pr checks` can be a superseded run; verify against the latest run + grep log for `FAILED` |
+| Bisecting the PR diff before checking main | Started bisecting a red workflow | 7+ consecutive main runs had the same failure — it was systemic | Run `gh run list --branch main` FIRST; 3+ consecutive failures = systemic, stop |
+| `gh run rerun --failed` to "see if it's a flake" | Considered rerunning crashed Mojo jobs | Violates the no-CI-retries policy; masks systemic upstream bugs, no diagnostic value | Root-cause the signature (libKGEN→modular#6413), reference upstream, workaround in a separate PR |
+| Proposing to revert the Mojo version bump | JIT crash appeared after the bump | Reverting hides the bug upstream and traps the repo on an old toolchain | Fix forward: file/reference the Modular issue, add a CI-side workaround, keep the bump |
+| Treating an all-sanitizer failure as a data race | Wrote a fresh TSan synchronization fix | Identical failures across asan/tsan/ubsan/lsan = logical UB; the fix already landed on main | `gh pr list --state all --search "<symbol>"` before writing a fix; cherry-pick only the real payload |
+| `git commit --amend` on the stale commit | Tried to correct it in place | Edits the wrong commit and rewrites history confusingly | Rebuild from fresh `origin/main` and cherry-pick only the real payload — cleaner, auditable |
+| Trying to fix urllib3 in the blocked PR | Bumped/pinned to satisfy pip-audit | `pixi.lock` already pinned the fix and local pip-audit passed — it was a stale CI cache | Trust a local run over stale CI; install-vs-report version contradiction = cache poisoning; rebase via `gh pr update-branch` |
+| Creating an empty/trivial commit | `git commit --allow-empty` to satisfy "implement all fixes" | Pollutes history; the plan said no action needed | Never manufacture work; if confirmed pre-existing, enable auto-merge and stop |
+| Combined guard `if post_pr and uncovered or stale_patterns:` | Relied on default precedence | `and` binds tighter than `or`, so the stale arm ran unconditionally | Parenthesize mixed `and`/`or`: `if post_pr and (uncovered or stale_patterns):` |
+| `gh pr checks --json name,status,conclusion,...` | Requested fields that don't exist on that subcommand | gh rejected the whole call (`Unknown JSON field: "status"`) non-zero; retried as transient, tripped a circuit breaker | Valid fields are `bucket,...,state,workflow`; classify deterministic CLI-arg errors fail-fast, never retry |
+
+## Results & Parameters
+
+### Signature → classification map
+
+| Log signature | Tag | Tracking |
+| --- | --- | --- |
+| `HTTP 5xx` on fetch/checkout | infra-flake | GitHub status |
+| `mojo: error: execution crashed` + `libKGENCompilerRTShared.so` | mojo-jit | modular/modular#6413 |
+| Podman socket connect refused | container-setup | repo infra |
+| `fortify_fail_abort` in narrative text | noise | ignore |
+| Same check red on multiple unrelated branches, install≠report version | stale-cache | cache invalidation on main |
+| Test file outside diff, reproducible on main | systemic | link main run / tracking issue |
+| Test file inside diff, reproducible locally | pr-regression | fix the PR |
+
+### Decision rule (one-liner)
+
+> If `gh run list --branch main` shows 3+ consecutive `failure` for the same workflow, OR the
+> same required check is red on unrelated branches, the failure is NOT the PR's — do not blame,
+> rerun, revert, or bisect; use the admin-merge + tracking-issue ladder or `gh pr update-branch`.
+
+### Tracking issue body template
+
+```markdown
+## Failing check
+`<exact check name from statusCheckRollup>`
+## Status on main
+- Main HEAD SHA: <sha>  | Conclusion: failure | First observed: <date/run URL>
+## Log excerpt
+<root-cause lines>
+## Suspected root cause
+<one paragraph>
+## Action checklist
+- [ ] Reproduce on main  - [ ] Identify regressing commit  - [ ] Open fix PR  - [ ] Close when green
+```
+
+### Empirical re-classification rate (2026-05-11 sweep)
+
+3 of 3 lingering BLOCKED PRs needed this triage; 2 of 3 reviewer `PREEXISTING_CI_NOISE` labels
+were wrong. Diagnose with the check-runs API every time before fixing or admin-merging.
+
+### Retrigger flaky CI (only after classifying as flake)
+
+```bash
+gh pr diff <pr> --name-only          # confirm failing files are NOT in the diff
+gh run rerun <run-id> --failed       # --failed: only failed jobs, not the whole workflow
+```
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| ProjectOdyssey | PR #5380 post-rebase showed 50+ "failures" — all `CANCELLED` from the prior SHA (force-push, Trigger 1) | Filtering by tip SHA avoided a wasteful rerun (verified-local) |
+| ProjectOdyssey | PR #5381 `execution crashed` had 7+ consecutive main failures (modular#6413) | Addressed in separate workaround PR #5382, not the surface PR (verified-ci) |
+| ProjectHephaestus | PR #1073 `gh pr checks` "4 fail" after `gh run rerun --failed` | All four CANCELLED by concurrency supersession; latest run succeeded (verified-ci) |
+| ProjectHephaestus | PRs #1019/#1022/#1024 `security/dependency-scan` red on every branch (urllib3 stale `.pixi` cache) | Lockfile already pinned 2.7.0; unblocked via `gh pr update-branch` after #1021 cache fix (verified-ci) |
+| ProjectAgamemnon | PR #368 markdownlint MD031 + trivy mislabeled `PREEXISTING_CI_NOISE` | check-runs API showed PR-introduced — fixed in PR (verified-ci) |
+| ProjectHermes | PR #614 urllib3 CVE mislabeled `PREEXISTING_CI_NOISE` | check-runs API showed PR-introduced — upgraded urllib3 (verified-ci) |
+| ProjectKeystone | PR #552 `coverage` truly pre-existing (`BackpressureConcurrentTrigger` aborts on main) | Admin-merged + tracking issue #553 (verified-ci) |
+| ProjectKeystone | PR #436 all 4 sanitizers failing `AsyncAgentsConcurrentProcessing` identically | Stale duplicate commit `984fef0` (fix already on main via #435); rebuilt with real payload only (verified-local) |
+``````
+
+---
 ## v1.0.0 (2026-06-07)
 
 Initial canonical, consolidated from 11 absorbed skills:

--- a/skills/pr-ci-failure-triage-preexisting-vs-introduced.md
+++ b/skills/pr-ci-failure-triage-preexisting-vs-introduced.md
@@ -1,11 +1,12 @@
 ---
 name: pr-ci-failure-triage-preexisting-vs-introduced
-description: "Use when: (1) a PR has unexpected CI failures and you need to determine if they are PR-introduced or pre-existing main-branch rot before bisecting, reverting, or retriggering, (2) CI fails after a force-push and cancelled runs from the old SHA appear as failures in the PR status rollup, (3) a required CI check fails on a PR whose diff is unrelated to the failing job, (4) CI failures look like flakes (Mojo JIT crash, SIGABRT) and need to be classified before a rerun, (5) stale CI warnings need to be surfaced in PR comments rather than stderr only, (6) CI coverage gate fails because it measures the merge-preview tree rather than the branch alone, (7) a stacked rebased PR has stale CI runs and needs fresh triggering without code changes, (8) sanitizer or compilation jobs fail identically on a PR because stale duplicate commits from another branch are present on the PR branch, (9) deciding whether to fix in-scope, admin-merge, or file a follow-up issue for a blocking failure"
+description: "Use when: (1) a PR has unexpected CI failures and you need to determine if they are PR-introduced or pre-existing main-branch rot before bisecting, reverting, or retriggering, (2) CI fails after a force-push and cancelled runs from the old SHA appear as failures in the PR status rollup, (3) a required CI check fails on a PR whose diff is unrelated to the failing job, (4) CI failures look like flakes (Mojo JIT crash, SIGABRT) and need to be classified before a rerun, (5) stale CI warnings need to be surfaced in PR comments rather than stderr only, (6) CI coverage gate fails because it measures the merge-preview tree rather than the branch alone, (7) a stacked rebased PR has stale CI runs and needs fresh triggering without code changes, (8) sanitizer or compilation jobs fail identically on a PR because stale duplicate commits from another branch are present on the PR branch, (9) deciding whether to fix in-scope, admin-merge, or file a follow-up issue for a blocking failure, (10) a rebased PR has independent CodeQL and validate failures, (11) validate fails only in CI because tests depend on host-specific filesystem auto-detection."
 category: ci-cd
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-19
+version: "1.1.0"
 user-invocable: false
 history: pr-ci-failure-triage-preexisting-vs-introduced.history
+verification: verified-ci
 tags:
   - ci-failure
   - triage
@@ -21,6 +22,10 @@ tags:
   - admin-merge
   - tracking-issue
   - stale-duplicate-commit
+  - post-rebase
+  - validate
+  - ci-env-drift
+  - codeql
 ---
 
 # PR CI Failure Triage: Pre-Existing vs. PR-Introduced
@@ -33,9 +38,9 @@ bisecting, reverting, retriggering, or expanding scope.
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-07 |
+| **Date** | 2026-06-19 |
 | **Objective** | Determine, per failing check, whether a red PR is the PR's fault or a systemic/flaky/artifact failure, then pick the right resolution (fix-in-scope, admin-merge, tracking issue, retrigger, or no-op) |
-| **Outcome** | Consolidated from 11 triage skills; authoritative classification via `gh api .../check-runs` on main HEAD; rollup-artifact detection for force-push/concurrency cancellations; flaky-vs-real signatures; stale duplicate-commit detection |
+| **Outcome** | Consolidated from 11 triage skills; authoritative classification via `gh api .../check-runs` on main HEAD; rollup-artifact detection for force-push/concurrency cancellations; flaky-vs-real signatures; stale duplicate-commit detection; post-rebase CodeQL plus validate recovery |
 | **Verification** | verified-ci |
 | **History** | [changelog](./pr-ci-failure-triage-preexisting-vs-introduced.history) |
 
@@ -51,6 +56,9 @@ bisecting, reverting, retriggering, or expanding scope.
 - All sanitizers fail identically on a PR; the branch carries extra/stale commits
 - A stacked PR series is behind main with failures from missing files / stale digests / renamed APIs
 - Stale CI pattern warnings exist but only print to stderr, never to the PR comment
+- A branch was rebased and now has both security/code-scanning failures and validate-job failures
+- Local tests pass but CI validate fails because a test depends on host-specific filesystem
+  auto-detection or ambient cluster/container state
 
 ## Verified Workflow
 
@@ -84,6 +92,12 @@ gh run list --branch main --workflow "<Workflow>" --limit 10 \
 
 # --- gh pr checks valid --json fields (narrow schema!) ---
 gh pr checks "$PR" --json name,workflow,state,bucket   # NO status/conclusion/required
+
+# --- Post-rebase recovery / final state confirmation ---
+git -c core.editor=true rebase --continue
+gh pr checks "<pr>" --repo "<owner>/<repo>"
+gh pr view "<pr>" --repo "<owner>/<repo>" \
+  --json mergeStateStatus,mergeable,headRefOid,url
 
 # --- Retrigger ONLY failed jobs (after classifying as flake) ---
 gh run rerun <run-id> --failed
@@ -262,7 +276,40 @@ warnings, add `stale_patterns: Optional[List[str]] = None` to `generate_report()
 measure the merge-preview tree rather than the branch alone, producing a discrepancy that is
 not a PR regression — diagnose with main history before "fixing".
 
-#### 8. Resolve
+#### 8. Post-rebase recovery when CodeQL and validate fail independently
+
+After a feature branch is rebased onto the default branch, treat each red gate as an independent
+failure until proven otherwise. A CodeQL fix does not imply validate is fixed, and a local pytest
+pass does not prove CI validate will pass if tests depend on CI-only filesystem state.
+
+1. Resolve rebase conflicts, then continue noninteractively in automation if Git opens an editor:
+
+   ```bash
+   git -c core.editor=true rebase --continue
+   ```
+
+2. Push the rebased branch and collect the current PR state:
+
+   ```bash
+   gh pr checks "<pr>" --repo "<owner>/<repo>"
+   gh pr view "<pr>" --repo "<owner>/<repo>" \
+     --json mergeStateStatus,mergeable,headRefOid,url
+   ```
+
+3. For CodeQL/GitHub Advanced Security failures, remember that the identifier from `gh pr checks`
+   may be a check-run id, not a workflow run id. Use the check-runs and code-scanning APIs to read
+   the rule id, path, line, and alert state.
+
+4. For validate failures where local tests pass, inspect whether tests are touching host-specific
+   filesystem probes, auto-discovered cluster/container paths, or other ambient CI state. Make tests
+   deterministic by patching the probe or passing explicit CLI configuration in the test. Do not add
+   environment-variable runtime config solely to make tests pass when the product direction forbids
+   env-based configuration.
+
+5. After each fix, push and poll `gh pr checks`. The final gate is: CodeQL green, validate green,
+   security/SCA green, branch clean, and `gh pr view` reports mergeable/current `headRefOid`.
+
+#### 9. Resolve
 
 - **PR-INTRODUCED** → fix in this PR (your responsibility).
 - **PRE-EXISTING** → ladder, in order: (A) quick fix only if ≤10 min and no scope creep;
@@ -293,6 +340,10 @@ not a PR regression — diagnose with main history before "fixing".
 | Creating an empty/trivial commit | `git commit --allow-empty` to satisfy "implement all fixes" | Pollutes history; the plan said no action needed | Never manufacture work; if confirmed pre-existing, enable auto-merge and stop |
 | Combined guard `if post_pr and uncovered or stale_patterns:` | Relied on default precedence | `and` binds tighter than `or`, so the stale arm ran unconditionally | Parenthesize mixed `and`/`or`: `if post_pr and (uncovered or stale_patterns):` |
 | `gh pr checks --json name,status,conclusion,...` | Requested fields that don't exist on that subcommand | gh rejected the whole call (`Unknown JSON field: "status"`) non-zero; retried as transient, tripped a circuit breaker | Valid fields are `bucket,...,state,workflow`; classify deterministic CLI-arg errors fail-fast, never retry |
+| Letting rebase continue open an editor in automation | Ran plain `git rebase --continue` after resolving conflicts | Git tried to launch an editor for the commit message and blocked the automated session | Use `git -c core.editor=true rebase --continue` |
+| Treating local pytest pass as enough for validate | Fixed tests locally and assumed CI validate would match | CI had different filesystem auto-detection inputs, so the validate job still failed | Patch probes or pass explicit CLI config in tests so CI and local runs exercise deterministic inputs |
+| Using environment variables to hide auto-detection drift | Proposed env-based runtime configuration just for tests | The product contract forbade env-based runtime config, and envs would mask the real deterministic-test gap | Keep runtime config explicit; tests should patch filesystem probes or pass CLI options |
+| Treating CodeQL green as PR-ready | Fixed security alerts and stopped polling | Validate was an independent gate and still red | Poll all required gates after each push and confirm mergeability/head SHA before declaring ready |
 
 ## Results & Parameters
 
@@ -341,6 +392,18 @@ gh pr diff <pr> --name-only          # confirm failing files are NOT in the diff
 gh run rerun <run-id> --failed       # --failed: only failed jobs, not the whole workflow
 ```
 
+### Post-rebase gate checklist
+
+```bash
+gh pr checks "<pr>" --repo "<owner>/<repo>"
+gh pr view "<pr>" --repo "<owner>/<repo>" \
+  --json mergeStateStatus,mergeable,headRefOid,url
+git status --short
+```
+
+Expected final state: CodeQL passes, validate passes, dependency/security analysis passes, branch
+has no local changes, `mergeable` is clean, and `headRefOid` matches the pushed fix commit.
+
 ## Verified On
 
 | Project | Context | Details |
@@ -353,3 +416,4 @@ gh run rerun <run-id> --failed       # --failed: only failed jobs, not the whole
 | ProjectHermes | PR #614 urllib3 CVE mislabeled `PREEXISTING_CI_NOISE` | check-runs API showed PR-introduced — upgraded urllib3 (verified-ci) |
 | ProjectKeystone | PR #552 `coverage` truly pre-existing (`BackpressureConcurrentTrigger` aborts on main) | Admin-merged + tracking issue #553 (verified-ci) |
 | ProjectKeystone | PR #436 all 4 sanitizers failing `AsyncAgentsConcurrentProcessing` identically | Stale duplicate commit `984fef0` (fix already on main via #435); rebuilt with real payload only (verified-local) |
+| Sanitized PR session | Post-rebase CodeQL and validate remediation | CodeQL, validate, security/SCA, and analysis gates green; branch clean and mergeable (verified-ci, 2026-06-19) |


### PR DESCRIPTION
## Summary

Amends two existing skills with sanitized learning from a post-rebase PR remediation session.

- gha-security-scanning-supply-chain: v1.2.0 -> v1.3.0
- pr-ci-failure-triage-preexisting-vs-introduced: v1.0.0 -> v1.1.0

Documents:

- CodeQL check-run and code-scanning API triage when gh pr checks reports a check-run id
- weak hashing and command-line injection remediation patterns
- deterministic validate tests for host-specific filesystem auto-detection
- final gate polling and mergeability confirmation after each push

## Verification Level

verified-ci for the captured source session; local ProjectMnemosyne validation passed on this branch.

## Test Plan

- [x] python3 scripts/validate_plugins.py
- [x] npx --yes markdownlint-cli2 --config .markdownlint.yaml on changed files
- [x] git diff --check
- [ ] Verify PR required checks on GitHub
