### PR TITLE
feat: add cluster endpoint incident reproducer validation skill

### DIFF
--- a/skills/cluster-endpoint-incident-reproducer-validation.md
+++ b/skills/cluster-endpoint-incident-reproducer-validation.md
@@ -1,0 +1,118 @@
+---
+name: cluster-endpoint-incident-reproducer-validation
+description: "Build and harden cluster endpoint incident reproducer PRs after strict review. Use when: (1) a model-serving/HPC incident needs a checkout-to-validation reproducer, (2) a shell reproducer allocates Slurm or similar cluster resources, (3) artifacts may contain private prompts, responses, tokens, endpoint metadata, or control-plane evidence, (4) a strict PR review produced blockers around security, cleanup, reproducibility, tests, typing, docs, or CI."
+category: debugging
+date: 2026-06-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - incident-reproducer
+  - cluster
+  - hpc
+  - slurm
+  - endpoint
+  - artifact-security
+  - cleanup
+  - dry-run
+  - strict-review
+  - validation
+---
+
+# Cluster Endpoint Incident Reproducer Validation
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-25 |
+| **Objective** | Turn a strict PR review of a cluster endpoint incident reproducer into a concrete fix list and a reusable validation contract. |
+| **Outcome** | A checkout-to-validation reproducer was hardened for private artifacts, non-launching testability, allocation-safe cleanup, reproducibility evidence, typed helper scripts, docs, and CI. |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A PR adds or changes a reproducer for a model-serving, endpoint, parser, corruption, or semantic-behavior incident on an HPC or Slurm-style cluster.
+- The reproducer can allocate nodes, register/start an endpoint, query HTTP APIs, or write prompts/responses/control metadata to artifacts.
+- A strict review reports blockers across security/privacy, cleanup safety, reproducibility metadata, test coverage, typing, docs, or CI, and you need to convert them into implementation work.
+- You need a testable prepare/dry-run path that proves manifests, configs, command logs, and artifact metadata without allocating GPUs or binding a live control socket.
+- Cleanup correctness depends on allocated node IDs, Slurm job IDs, or endpoint registration state, and failures may occur between allocation and startup.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Static shell validation for reproducer scripts.
+bash -n scripts/<incident-reproducer>.sh
+
+# Focused tests before full validation.
+pytest tests/<focused-reproducer-tests>.py -q
+pytest tests/<focused-http-or-parser-tests>.py -q
+
+# Python tooling only on Python files; shell files need shell-specific checks.
+ruff format scripts/<helper>.py tests/<focused-python-tests>.py
+ruff check scripts/<helper>.py tests/<focused-python-tests>.py
+mypy scripts/<helper>.py scripts/<incident-helper>.py
+
+# Repo-level gates after focused checks.
+git diff --check
+pre-commit run --files <staged-files>
+scripts/validate.sh
+
+# GitHub final state.
+gh pr checks <pr-number> --repo <owner>/<repo>
+gh pr view <pr-number> --repo <owner>/<repo> --json mergeStateStatus,mergeable,statusCheckRollup
+```
+
+### Detailed Steps
+
+1. **Translate strict review into a fix list.** Treat the review as concrete work, not commentary. Use the review categories as implementation buckets: security/privacy, cleanup safety, reproducibility metadata, test coverage, typing, docs, and CI.
+2. **Add a non-launching prepare/dry-run mode.** The reproducer should be able to generate manifests, configs, replay metadata, and artifact README files without allocating GPUs, registering endpoints, starting services, binding control sockets, or sending live HTTP requests. This makes the shell contract testable in restricted sandboxes and CI.
+3. **Make private artifact handling explicit.** Set `umask 077`, create shared log/artifact directories with mode `700`, and write token-bearing or prompt/response-bearing files with mode `600`. Add an artifact README warning that full prompts, responses, endpoint metadata, and control-plane evidence are private incident evidence.
+4. **Keep live tokens out of replay logs.** Do not print control tokens or token-bearing environment values into command logs. Write replay metadata using shell-safe quoting (`printf '%q'`) or a structured serialization format. Validate required environment variables and ports before interpolating them into shell commands, YAML, manifests, or HTTP URLs.
+5. **Capture allocation metadata immediately.** Record allocated node IDs and Slurm job IDs immediately after allocation, before endpoint registration or startup. Failures can occur after allocation but before the endpoint has a started node ID, so cleanup cannot rely only on "started endpoint" metadata.
+6. **Make cleanup release allocated resources, not just started endpoints.** Cleanup should release based on the allocation metadata captured in step 5. Do not clear allocated node IDs unless release succeeds; failed release attempts are evidence and must remain visible for follow-up cleanup.
+7. **Preserve reproducibility and evidence.** Keep endpoint metadata, launch command, parser/serving flags when relevant, control registry path, allocated node IDs, Slurm job IDs, and best-effort `squeue`/`sacct` snapshots before and after cleanup. Treat these as audit evidence, not optional logs.
+8. **Test the shell reproducer contract directly.** Add tests for bash syntax, private file modes, shell-safe replay logs, allocation cleanup behavior, Slurm evidence capture, and prepare-only artifact generation. Use fake control commands or temp fixtures so tests do not need a live cluster.
+9. **Add focused coverage for nearby Python behavior.** If review identified HTTP error logging gaps or parser edge cases, add targeted tests for those paths rather than relying on the reproducer integration path to exercise them indirectly.
+10. **Verify in layers.** Run focused pytest first, then `bash -n`, `git diff --check`, Ruff format/check only on touched Python files, direct mypy for touched Python scripts, pre-commit on staged files, full repo validation, and finally GitHub PR checks plus mergeability.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Formatting shell with Python tooling | Ran Ruff over a Bash reproducer script | Ruff cannot parse shell, so the check fails before validating anything useful | Use `bash -n` and shell-specific tests for shell scripts; limit Ruff to Python files |
+| Dry-run tests used an ephemeral local socket | Prepare-mode tests still tried to bind or probe a local control port | Restricted sandboxes can reject socket binding or networking, making non-network tests flaky | Make the control port overrideable and provide a prepare-only mode that does not bind sockets |
+| Cleanup keyed only off started endpoint node ID | Release logic looked for node IDs only after endpoint startup | A failure after allocation but before startup leaves allocated nodes unreleased | Capture allocated node IDs immediately and use them as the cleanup source of truth |
+| Clearing allocation metadata too early | Cleanup erased allocated node IDs even when release failed | The evidence needed for manual cleanup disappeared | Clear allocation metadata only after release succeeds |
+| Raw environment interpolation in generated commands | Shell/YAML snippets interpolated raw env values directly | Tokens can leak, quoting can break, and replay artifacts become malformed or unreproducible | Validate inputs first; quote with `printf '%q'` or serialize structurally |
+| Treating command logs as safe by default | Replay logs included live control-token context | Command logs persist and are often shared during incident review | Keep tokens out of logs; store private control metadata in mode-600 evidence files |
+
+## Results & Parameters
+
+### Reproducer Contract Checklist
+
+| Area | Required Contract |
+|------|-------------------|
+| Prepare mode | Generates manifests/configs/replay metadata/artifact README without GPU allocation, endpoint startup, network calls, or socket binding |
+| Artifact permissions | `umask 077`; directories mode `700`; prompt/response/token/control files mode `600` |
+| Replay metadata | Shell-safe or structured; no live tokens in command logs; validated env vars and ports before interpolation |
+| Allocation metadata | Captured immediately after allocation; includes node IDs and job IDs before register/start |
+| Cleanup | Releases allocated node IDs; preserves node IDs if release fails; records before/after `squeue` and `sacct` snapshots best-effort |
+| Evidence files | Endpoint metadata, launch command, parser/serving flags when relevant, control registry path, node IDs, job IDs, cleanup snapshots |
+| Static tests | Bash syntax, file modes, command-log quoting, allocation cleanup contract, Slurm evidence contract, prepare-only generation |
+| Focused Python tests | HTTP error logging and parser edge cases when touched by the incident reproducer PR |
+| Validation | Focused pytest, `bash -n`, `git diff --check`, Ruff on Python files only, mypy on touched Python scripts, pre-commit on staged files, full validation, GitHub checks and mergeability |
+
+### Verification Evidence
+
+Verified in LLM360/Inference360 PR #262 on 2026-06-25 at commit `48c2e1f` with sanitized context only:
+
+- Local validation passed with the repo's explicit virtualenv command: `PYTHON=.venv/bin/python INFERENCE360=.venv/bin/inference360 scripts/validate.sh`.
+- Test result: 791 passed, 8 skipped, coverage 82.22%.
+- Pre-commit on staged files passed.
+- Direct mypy passed for the touched endpoint/status and incident-trial Python helpers.
+- GitHub PR checks were green; `mergeStateStatus` was `CLEAN`; `mergeable` was `MERGEABLE`.
+
+Do not copy raw prompts, responses, model/checkpoint names, internal hostnames, tokens, or corrupted output snippets into a durable skill or shared PR body. Keep this skill generic; cite the PR only as the verified workflow context.


### PR DESCRIPTION
## Summary

Adds a new ProjectMnemosyne skill:

- `skills/cluster-endpoint-incident-reproducer-validation.md`

Documents a reusable workflow for hardening cluster endpoint incident reproducers after strict PR review:

- non-launching prepare/dry-run mode for shell reproducers
- private artifact and replay metadata handling
- allocation-first cleanup contracts for Slurm/HPC endpoints
- static, focused, and full validation layering

## Verification Level

**verified-ci**

The source workflow was verified in LLM360/Inference360 PR #262 on 2026-06-25 at commit `48c2e1f`. The skill records only sanitized, generic context.

## Key Findings

**What Worked**:

- Convert strict review findings into implementation buckets: security/privacy, cleanup, reproducibility, tests, typing, docs, and CI.
- Add prepare-only generation so artifacts can be tested without allocating GPUs or binding local sockets.
- Capture allocation metadata immediately and release from allocation state, not only started endpoint state.

**What Failed**:

- Running Ruff over Bash scripts fails; use `bash -n` and shell-specific tests.
- Socket-binding dry runs are fragile in restricted sandboxes; prepare mode should be non-network.
- Clearing allocated node IDs after failed release hides cleanup evidence.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Run `git diff --check`
- [x] Scan the new skill for forbidden/sensitive identifiers
