### PR TITLE
fix: repair stale plan markdown heading

### DIFF
--- a/skills/stale-plan-already-resolved.md
+++ b/skills/stale-plan-already-resolved.md
@@ -112,8 +112,8 @@ gh api graphql -f query='query{...inlined ${owner}...}'   # → reproduces the U
 ```
 
 Only the findings that still reproduce on current main warrant a fix. In the 2026-06-14
-session, 2 of 4 log-found bugs were already fixed (the `UNKNOWN_CHAR` GraphQL crash by PR
-#1148; the planner-learnings 120s timeout replaced by `learn_claude_timeout()` = 7200s), so
+session, 2 of 4 log-found bugs were already fixed (the `UNKNOWN_CHAR` GraphQL crash by
+PR #1148; the planner-learnings 120s timeout replaced by `learn_claude_timeout()` = 7200s), so
 their fixes were scoped down to the durable hardening only. The other 2 (armed-DIRTY
 swallowed, green-BLOCKED threads not addressed) were confirmed still present before implementing.
 


### PR DESCRIPTION
## Summary
- fixes the markdownlint MD018 failure introduced by #2532 on `main`
- rewrites the line-start issue reference as prose (`PR #1148`) so it is not parsed as an ATX heading

## Local verification
- `markdownlint-cli2 skills/stale-plan-already-resolved.md --config .markdownlint.yaml`
- `markdownlint-cli2 "**/*.md" "!.claude/**" --config .markdownlint.yaml`
- `python scripts/validate_plugins.py`
- `python scripts/check_pii.py`
- pre-push `pytest -q`
