### PR TITLE
feat: add inference360 slurm control allocation debugging skill

### DIFF
--- a/skills/inference360-slurm-control-node-allocation-debugging.md
+++ b/skills/inference360-slurm-control-node-allocation-debugging.md
@@ -1,0 +1,171 @@
+---
+name: inference360-slurm-control-node-allocation-debugging
+description: "Debug pending Inference360 Slurm control-node allocations and correct control defaults. Use when: (1) `inference360 control up` is pending on a CPU control job, (2) `cpuonly`, account, QOS, or `cpus_per_task` settings are suspected, (3) interactive `srun --gres=gpu:0` behavior disagrees with control sbatch behavior."
+category: debugging
+date: 2026-06-26
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - inference360
+  - slurm
+  - control
+  - cpuonly
+  - account
+  - qos
+  - cpus-per-task
+  - allocation-debugging
+---
+
+# Inference360 Slurm Control-Node Allocation Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-26 |
+| **Objective** | Explain why `uv run inference360 control up` was pending for a CPU control-node allocation and update the Inference360 control-node Slurm defaults. |
+| **Outcome** | Successful. LLM360/Inference360 PR #286 fixed issue #285 and merged on 2026-06-26 after CI passed. |
+| **Verification** | verified-ci. PR #286 passed `validate`, `secrets`, `sast`, `python-sca`, and CodeQL before auto-merge. Local host fallback validation also passed with 852 passed and 8 skipped; plain `just validate` was blocked locally only because rootless Podman was unavailable. |
+
+## When to Use
+
+- `uv run inference360 control up` submits a Slurm control-node job that stays pending with `Reason=Priority`.
+- The control job is CPU-only or `--gres=gpu:0`, but partition, account, QOS, or CPU request behavior is unclear.
+- An interactive `srun` appears to start quickly, but the Inference360 control sbatch waits in a different Slurm scheduling lane.
+- You need to verify that Inference360 manifest defaults for `slurm.control` produce the expected sbatch command.
+- Existing pending Slurm jobs may have stale attributes after a manifest edit and need cancel/re-submit.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Inspect live queue state for the control job.
+squeue -j <job> -o '%i|%T|%R|%P|%q|%b|%D|%C|%m|%l|%S|%u|%j'
+
+# Inspect the full Slurm job record.
+scontrol show job <job>
+
+# Compare the candidate partitions directly.
+scontrol show partition cpuonly
+scontrol show partition main
+
+# Compare an interactive user allocation with the Inference360 control sbatch.
+srun -n 1 --cpus-per-task=32 --gres=gpu:0 --pty bash
+```
+
+### Detailed Steps
+
+1. Capture the live pending job with:
+
+   ```bash
+   squeue -j <job> -o '%i|%T|%R|%P|%q|%b|%D|%C|%m|%l|%S|%u|%j'
+   ```
+
+   Record the partition, QOS, GRES, node count, CPU count, memory, time limit, start time, user, job name, and pending reason.
+
+2. Inspect the full job record with:
+
+   ```bash
+   scontrol show job <job>
+   ```
+
+   Do not rely on this alone to reveal the submitted wrap command. For the observed pending sbatch, `Command=(null)` was possible.
+
+3. Compare the relevant Slurm partitions directly:
+
+   ```bash
+   scontrol show partition cpuonly
+   scontrol show partition main
+   ```
+
+   Confirm relative size, priority, and policy instead of assuming that a GPU-free request picks a CPU partition.
+
+4. Run or inspect a comparable interactive command:
+
+   ```bash
+   srun -n 1 --cpus-per-task=32 --gres=gpu:0 --pty bash
+   ```
+
+   The key observation from issue #285 was that `--gres=gpu:0` did not select `cpuonly`. Without an explicit `--partition`, the interactive job landed on the default `main` partition, which had more capacity and a higher-priority scheduling path than `cpuonly`.
+
+5. Compare that with the Inference360 manifest-driven sbatch. In the failing state, `manifests/clusters/m2.yaml` explicitly set `slurm.control.partition: cpuonly`, used account/QOS `k2m`, and had no explicit `slurm.control.cpus_per_task`. The control job queued with `Reason=Priority` despite requesting only 1 CPU.
+
+6. Reconstruct the control sbatch command from `_control_sbatch_command` and the resolved manifest state when Slurm does not show the wrap details. Do not infer the command from interactive `srun` behavior.
+
+7. Apply the default correction that matched the user's requested change:
+
+   ```yaml
+   slurm:
+     control:
+       partition: cpuonly
+       qos: main
+       account: main
+       cpus_per_task: 32
+   ```
+
+   Important: keep `partition: cpuonly`. The requested fix was account/QOS `main` plus 32 CPUs for the control job, not switching the partition to `main`.
+
+8. Add validation that any `slurm.*.cpus_per_task` field is a positive integer. This fails closed on invalid manifest values before sbatch generation.
+
+9. Update `_control_sbatch_command` so it emits `--cpus-per-task=<value>` when the resolved control Slurm config includes `cpus_per_task`.
+
+10. Add a regression test for `control up --cluster m2` showing the submitted command includes:
+
+    ```text
+    --qos=main
+    --account=main
+    --cpus-per-task=32
+    ```
+
+11. Cancel and re-submit any existing pending control job after changing the manifest. Pending Slurm jobs keep the attributes they were submitted with; they do not pick up new manifest defaults in place.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Infer partition from `--gres=gpu:0` | Treated an interactive `srun -n 1 --cpus-per-task=32 --gres=gpu:0 --pty bash` placement as evidence that GPU-free requests target `cpuonly` | Without an explicit partition, the interactive job used the default `main` partition, not `cpuonly` | Always verify actual partition and QOS with `squeue` and `scontrol`; `--gres=gpu:0` is not a partition selector |
+| Debug only the low CPU count | Focused on the pending control job requesting only 1 CPU | The pending reason was priority in the explicitly selected `cpuonly` partition with account/QOS `k2m`; CPU count alone did not explain the scheduling lane | Inspect partition, account, QOS, CPU count, and pending reason together |
+| Expect Slurm to reveal the full wrapped command | Used `scontrol show job <job>` expecting to see every sbatch detail | The pending sbatch record could show `Command=(null)` | Reconstruct the command from `_control_sbatch_command` and resolved manifest state |
+| Switch partition based on the interactive comparison | Considered the fast interactive job on `main` as evidence to move control jobs to `main` | The requested product change was account/QOS `main` and `cpus_per_task: 32` while keeping `partition: cpuonly` | Preserve the intended control-node partition unless the user or platform policy explicitly changes it |
+| Wait for a pending job after editing the manifest | Left an already-submitted pending control job in place after updating defaults | Slurm jobs retain submit-time attributes | Cancel and re-submit control jobs to pick up manifest changes |
+
+## Results & Parameters
+
+### Manifest Correction
+
+The verified correction in `manifests/clusters/m2.yaml` was:
+
+```yaml
+slurm:
+  control:
+    partition: cpuonly
+    qos: main
+    account: main
+    cpus_per_task: 32
+```
+
+### Code and Test Contract
+
+- Manifest validation must reject any `slurm.*.cpus_per_task` value that is not a positive integer.
+- `_control_sbatch_command` must include `--cpus-per-task=<value>` when the resolved control Slurm config includes `cpus_per_task`.
+- The `control up --cluster m2` regression must assert the submitted sbatch includes `--qos=main`, `--account=main`, and `--cpus-per-task=32`.
+
+### Debug Evidence to Preserve
+
+Use sanitized summaries in durable docs, issues, and PRs. Keep raw endpoint addresses, absolute infrastructure paths, checkpoint paths, tokens, cookies, private prompts, and other secrets out of shared learning artifacts.
+
+| Evidence | Purpose |
+|----------|---------|
+| `squeue -j <job> -o '%i|%T|%R|%P|%q|%b|%D|%C|%m|%l|%S|%u|%j'` | Confirms state, reason, partition, QOS, GRES, node count, CPU count, and job name |
+| `scontrol show job <job>` | Confirms full job attributes where available |
+| `scontrol show partition cpuonly` and `scontrol show partition main` | Confirms partition policy differences directly |
+| Resolved manifest state | Shows which partition, account, QOS, and CPU count Inference360 intended to submit |
+| `_control_sbatch_command` output | Reconstructs the actual sbatch command when Slurm does not expose the wrap command |
+
+### Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | PR #286 for issue #285, merged 2026-06-26 | CI passed `validate`, `secrets`, `sast`, `python-sca`, and CodeQL before auto-merge. Local fallback validation passed with 852 passed and 8 skipped; rootless Podman unavailability blocked plain local `just validate` only. |


### PR DESCRIPTION
## Summary

New skill: `inference360-slurm-control-node-allocation-debugging`.

Documents how to debug pending Inference360 CPU control-node Slurm allocations and how PR #286 corrected the control-node defaults for issue #285.

- Captures the `squeue` and `scontrol` workflow for comparing live job state, full job attributes, and partition policy.
- Preserves the key finding that `--gres=gpu:0` does not select `cpuonly`; actual partition and QOS must be verified.
- Records the verified correction: keep `partition: cpuonly`, set control account/QOS to `main`, add `cpus_per_task: 32`, validate positive integer CPU fields, and assert sbatch emits `--cpus-per-task=32`.

## Verification Level

**verified-ci**

The source Inference360 PR #286 passed `validate`, `secrets`, `sast`, `python-sca`, and CodeQL before auto-merge. This ProjectMnemosyne skill was locally validated with `python3 scripts/validate_plugins.py`.

## Key Findings

**What Worked**:
- Inspect live queue state with `squeue -j <job> -o '%i|%T|%R|%P|%q|%b|%D|%C|%m|%l|%S|%u|%j'`.
- Compare `cpuonly` and `main` partition policy directly with `scontrol show partition`.
- Reconstruct control sbatch from `_control_sbatch_command` and resolved manifest state when Slurm reports `Command=(null)`.

**What Failed**:
- Inferring partition behavior from `--gres=gpu:0`; the interactive job landed on the default `main` partition, while Inference360 control explicitly submitted to `cpuonly`.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Run `git diff --check`
- [x] Search existing skills before creating the new file