### PR TITLE
fix: satisfy markdownlint for inference360 skills

### DIFF
--- a/skills/inference360-diffusion-sglang-dllm-manifests.md
+++ b/skills/inference360-diffusion-sglang-dllm-manifests.md
@@ -126,4 +126,3 @@ engine_command+=(--cuda-graph-bs 1 2 4 8)
 | Project | Context | Details |
 |---------|---------|---------|
 | LLM360/Inference360 | PR #286 for issue #285, merged 2026-06-26 | CI passed validate, secrets, sast, python-sca, and CodeQL before auto-merge; local host fallback validation passed with 852 passed and 8 skipped |
-

--- a/skills/inference360-slurm-control-node-allocation-debugging.md
+++ b/skills/inference360-slurm-control-node-allocation-debugging.md
@@ -160,7 +160,7 @@ Use sanitized summaries in durable docs, issues, and PRs. Keep raw endpoint addr
 
 | Evidence | Purpose |
 |----------|---------|
-| `squeue -j "$JOB_ID" -o '%i|%T|%R|%P|%q|%b|%D|%C|%m|%l|%S|%u|%j'` | Confirms state, reason, partition, QOS, GRES, node count, CPU count, and job name |
+| `squeue -j "$JOB_ID" -o '%i\|%T\|%R\|%P\|%q\|%b\|%D\|%C\|%m\|%l\|%S\|%u\|%j'` | Confirms state, reason, partition, QOS, GRES, node count, CPU count, and job name |
 | `scontrol show job "$JOB_ID"` | Confirms full job attributes where available |
 | `scontrol show partition cpuonly` and `scontrol show partition main` | Confirms partition policy differences directly |
 | Resolved manifest state | Shows which partition, account, QOS, and CPU count Inference360 intended to submit |


### PR DESCRIPTION
## Summary

Fixes markdownlint failures left after the Inference360 skill PRs merged.

- Removes the trailing blank line from the diffusion SGLang DLLM skill added in PR #2843
- Escapes table pipes in the control allocation skill added in PR #2844 so `<job>` is no longer parsed as inline HTML

## Verification

- [x] `python3 scripts/validate_plugins.py` passed, 525/525 valid
- [x] `npx markdownlint-cli2 "**/*.md" "!.claude/**"` passed, 0 errors across 651 files
- [x] `git diff --check` passed

Co-authored-by: OpenAI Codex <noreply@openai.com>