### PR TITLE
feat: amend homelab-nextcloud-data-dir-nfs-migration skill (v1.1.0)

### DIFF
--- a/skills/homelab-nextcloud-data-dir-nfs-migration.history
+++ b/skills/homelab-nextcloud-data-dir-nfs-migration.history
@@ -1,0 +1,126 @@
+# homelab-nextcloud-data-dir-nfs-migration — History
+
+## v1.1.0 (2026-06-28)
+
+**Changed by:** Session — relocate Nextcloud `/data` OFF a slow NFS share ONTO a fast local disk on a live HomeLabOS v1.0 server (apollo), 2026-06.
+**Verification:** verified-local
+
+### What changed
+
+- Generalized the skill from a one-directional "local NVMe → NFS NAS" migration to
+  **relocating the Nextcloud `/data` directory between storage tiers in either direction**,
+  adding the mirror scenario: moving `/data` off a slow NFS share onto a fast local disk
+  because NFS throughput/metadata latency was timing out uploads.
+- Added the HomeLabOS template-vs-rendered-compose dual-edit pattern: every service is
+  rendered from `roles/<svc>/templates/docker-compose.<svc>.yml.j2` →
+  `/var/homelabos/<svc>/docker-compose.yml` (owned by the `homelab` user) and run by the
+  `<svc>.service` systemd unit; changes must go in BOTH the template (persistence across
+  `ansible` redeploys) and the rendered compose (immediate effect).
+- Added making the data dir configurable via
+  `{{ nextcloud.data_dir | default(storage_dir + '/Documents/NextCloud') }}:/data` plus a
+  `nextcloud.data_dir` key in `settings/config.yml`.
+- Added reboot-safety hardening for the local-disk case: `/etc/fstab` entry with
+  `nofail,noatime,nosuid,nodev` (+ `findmnt --verify`) and a
+  `nextcloud.service.d/usb-data-mount.conf` drop-in with `RequiresMountsFor=<data path>`.
+- Added the live-cutover procedure using `occ maintenance:mode` + an additive final rsync
+  (no `--delete`) + `systemctl restart nextcloud` + the `docker inspect` mount verify
+  one-liner, and keeping the old copy as an instant rollback.
+- Added 3 new Failed Attempts rows (EACCES on rendered compose, WAN-hairpin upload speed
+  test, desktop-automount reboot risk) and the before/after performance numbers
+  (8 → 214 MB/s write, 1.7 s → 5 ms metadata, LAN DAV upload timing out → ~30 MB/s).
+
+### Why
+
+The v1.0.0 skill only covered moving data TO NFS to free local NVMe. A later session hit the
+opposite problem: the NFS-hosted `/data` was so slow (~8 MB/s, multi-second metadata) that
+uploads were timing out, so `/data` had to be relocated back onto a fast local disk. The same
+core gotchas apply in both directions (root_squash rsync-as-uid, `RequiresMountsFor` boot
+hardening, the `.ocdata` marker, fail-safe retention of the old copy), so the learnings belong
+in one skill rather than a near-duplicate file.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: homelab-nextcloud-data-dir-nfs-migration
+description: "Migrate Nextcloud data directory from local NVMe to NFS-mounted NAS while keeping core (webroot, config, DB) on fast local storage. Use when: (1) Nextcloud data dir lives on local disk and you want to move it to NAS, (2) HomelabOS Nextcloud compose has NFS bind mounts but NFS was mounted after container start, (3) need to rsync to NFS share that uses root_squash."
+category: architecture
+date: 2026-06-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: []
+---
+
+# Homelab Nextcloud Data Directory NFS Migration
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-23 |
+| **Objective** | Migrate Nextcloud's data directory (271 GB) from local NVMe to NFS-mounted NAS, keeping Nextcloud core on fast local NVMe |
+| **Outcome** | Successful — Nextcloud confirmed reading from NAS via `df -h /data` showing NFS server IP |
+| **Verification** | verified-local (executed end-to-end; CI validation pending) |
+
+## When to Use
+
+- Moving Nextcloud data directory from local disk to a NAS NFS share
+- HomelabOS Nextcloud compose already has the NFS path in the bind mount but NFS was mounted after container start (data silently stayed on local disk)
+- Rsyncing large data sets to an NFS share that has root_squash enabled (files must be owned by the Nextcloud uid, not root)
+- Hardening Docker service startup order so containers wait for NFS mounts
+
+## Verified Workflow
+
+> Verified locally only — CI validation pending.
+
+### Quick Reference
+
+(see v1.1.0 for full commands; original migrated bulk + delta rsync as uid 1002, bind-view
+of / to expose hidden local data, maintenance mode for the delta pass, df -h /data to confirm
+the NFS server IP, files:scan to reconcile the DB, and a docker.service RequiresMountsFor
+drop-in to harden boot order)
+
+### Detailed Steps
+
+1. Understand the root cause (data on local disk despite NFS bind in compose)
+2. Expose the hidden local data with `sudo mount --bind / /mnt/root-view`
+3. Identify Nextcloud's container uid (`docker exec nextcloud_nextcloud_1 id www-data` → 1002)
+4. Pass 1 rsync — online, no downtime, as `sudo -u '#1002' -g '#1002'`
+5. Take Nextcloud offline for the delta pass (`occ maintenance:mode --on` + compose stop)
+6. Pass 2 rsync — delta only
+7. Verify file tree identical with diff of `find . | sort`; confirm `.ocdata` owned by 1002
+8. Restart container; `df -h /data` shows the NFS server IP
+9. Reclaim local disk space (move to `.OLD` first as fail-safe)
+10. Harden boot startup order with a docker.service `RequiresMountsFor` drop-in
+11. Disable maintenance mode and `occ files:scan --all`
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| rsync as root to NFS | `sudo rsync ... /mnt/nas/Documents/NextCloud/` | NFS export has root_squash; all files landed owned nobody (99:99); Nextcloud cannot read them | Always rsync to NFS as the Nextcloud uid (`sudo -u '#1002' -g '#1002'`), never as root |
+| rsync without bind view | `sudo -u '#1002' rsync /mnt/nas/Documents/NextCloud/ ...` | Source path is the live NFS mount itself, not the local data hidden beneath it — copies NFS back to NFS | Mount a bind view of `/` first to expose the hidden local directory |
+| occ files:scan in maintenance mode | `docker exec ... php occ files:scan --all` while `maintenance:mode --on` | Returns "database isn't accessible" | Disable maintenance mode before running `occ files:scan`; maintenance mode blocks DB access |
+
+## Results & Parameters
+
+Nextcloud container user uid=1002 gid=1002; total data 271 GB / 610 folders / 48,346 files;
+files:scan ~33 seconds; NFS fstab entry with `defaults,_netdev,soft,timeo=30,retrans=3`;
+docker.service drop-in `RequiresMountsFor=/mnt/nas/Documents`; confirmation via
+`docker exec nextcloud_nextcloud_1 df -h /data` showing `192.168.2.11:/data/Documents/NextCloud`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| HomelabOS Nextcloud | apollo homelab server, NVMe to TrueNAS NFS | End-to-end migration; Nextcloud serving from NAS confirmed |
+```
+
+---
+
+## v1.0.0 (2026-06-23)
+
+**Initial version.** Migrate Nextcloud's 271 GB data directory from local NVMe to an
+NFS-mounted TrueNAS share while keeping core (webroot, config, DB) on fast local storage.
+Verified locally end-to-end on the apollo homelab server.

--- a/skills/homelab-nextcloud-data-dir-nfs-migration.md
+++ b/skills/homelab-nextcloud-data-dir-nfs-migration.md
@@ -1,39 +1,64 @@
 ---
 name: homelab-nextcloud-data-dir-nfs-migration
-description: "Migrate Nextcloud data directory from local NVMe to NFS-mounted NAS while keeping core (webroot, config, DB) on fast local storage. Use when: (1) Nextcloud data dir lives on local disk and you want to move it to NAS, (2) HomelabOS Nextcloud compose has NFS bind mounts but NFS was mounted after container start, (3) need to rsync to NFS share that uses root_squash."
+description: "Relocate the Nextcloud /data directory between storage tiers in HomelabOS (local NVMe/USB <-> NFS NAS) while keeping core (webroot, config, apps, DB) on fast storage, with a reboot-safe live cutover. Use when: (1) moving the Nextcloud data dir from local disk to a NAS NFS share, (2) moving it OFF a slow NFS share onto a fast local disk because uploads time out, (3) HomelabOS Nextcloud compose has NFS bind mounts but NFS mounted after container start, (4) rsyncing to/from a share with root_squash, (5) making the data dir bind reboot-safe with fstab + RequiresMountsFor."
 category: architecture
-date: 2026-06-23
-version: "1.0.0"
+date: 2026-06-28
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: homelab-nextcloud-data-dir-nfs-migration.history
 tags: []
 ---
 
-# Homelab Nextcloud Data Directory NFS Migration
+# Homelab Nextcloud Data Directory Relocation (NFS <-> Local)
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-23 |
-| **Objective** | Migrate Nextcloud's data directory (271 GB) from local NVMe to NFS-mounted NAS, keeping Nextcloud core on fast local NVMe |
-| **Outcome** | Successful — Nextcloud confirmed reading from NAS via `df -h /data` showing NFS server IP |
-| **Verification** | verified-local (executed end-to-end; CI validation pending) |
+| **Date** | 2026-06-28 |
+| **Objective** | Relocate Nextcloud's `/data` directory between storage tiers in HomelabOS — local NVMe/USB <-> NFS NAS — keeping core (webroot, config, apps, DB) on fast storage, with a reboot-safe live cutover |
+| **Outcome** | Successful in both directions: 271 GB moved local NVMe -> NFS NAS (v1.0.0); `/data` moved OFF a slow NFS share onto a fast local disk to fix upload timeouts (v1.1.0) |
+| **Verification** | verified-local (executed end-to-end on a live HomelabOS v1.0 host; CI validation pending) |
+| **History** | [changelog](./homelab-nextcloud-data-dir-nfs-migration.history) |
 
 ## When to Use
 
-- Moving Nextcloud data directory from local disk to a NAS NFS share
+- Moving the Nextcloud data directory from local disk to a NAS NFS share
+- Moving the Nextcloud data directory OFF a slow NFS share onto a fast local disk because uploads/metadata are timing out (only `/data` is slow; core + DB are already on fast storage)
 - HomelabOS Nextcloud compose already has the NFS path in the bind mount but NFS was mounted after container start (data silently stayed on local disk)
-- Rsyncing large data sets to an NFS share that has root_squash enabled (files must be owned by the Nextcloud uid, not root)
-- Hardening Docker service startup order so containers wait for NFS mounts
+- Rsyncing large data sets to/from an NFS share with root_squash (files must be owned by the Nextcloud uid, not root)
+- Making the `/data` bind reboot-safe so Nextcloud never starts against an empty mountpoint (fstab + systemd `RequiresMountsFor`)
+- Changing a HomelabOS service bind persistently (must edit BOTH the Jinja template and the rendered compose)
 
 ## Verified Workflow
 
 > Verified locally only — CI validation pending.
 
+This skill covers relocating `/data` in **either direction**. Scenario A (Quick Reference +
+Detailed Steps below) moves data **local -> NFS**. Scenario B moves data **off slow NFS ->
+fast local disk** and adds the reboot-safety hardening. The same core gotchas apply to both:
+rsync as the data-owner uid (root_squash), keep the `.ocdata` marker, and keep the old copy as
+a fail-safe/rollback.
+
+### HomelabOS service structure (read first)
+
+Each HomelabOS service is rendered from
+`roles/<svc>/templates/docker-compose.<svc>.yml.j2` -> `/var/homelabos/<svc>/docker-compose.yml`
+(the rendered file, owned by the `homelab` user) and run by a systemd unit `<svc>.service`
+whose `ExecStart` is `docker-compose -p <svc> up` (`WorkingDirectory=/var/homelabos/<svc>`).
+So you restart a service with `systemctl restart <svc>`, and any change must go in **BOTH**:
+
+- the **template** (`roles/<svc>/templates/...j2` + `settings/config.yml`) — for persistence across `ansible` redeploys, and
+- the **rendered compose** (`/var/homelabos/<svc>/docker-compose.yml`) — for immediate effect.
+
+The rendered compose is owned by `homelab`, so the Edit/Write tool fails with EACCES — edit it
+with `sudo sed` / `sudo tee`.
+
 ### Quick Reference
 
 ```bash
+# --- Scenario A: relocate local data -> NFS NAS ---
 # 1. Expose hidden local data beneath NFS mount
 sudo mount --bind / /mnt/root-view
 
@@ -68,7 +93,7 @@ docker exec nextcloud_nextcloud_1 php occ maintenance:mode --off
 docker exec nextcloud_nextcloud_1 php occ files:scan --all
 ```
 
-### Detailed Steps
+### Detailed Steps (Scenario A: local -> NFS)
 
 1. **Understand the root cause (if data is on local disk despite NFS bind in compose)**
 
@@ -178,39 +203,176 @@ docker exec nextcloud_nextcloud_1 php occ files:scan --all
     # Scan completes in ~33 seconds for 271 GB / 48,346 files
     ```
 
+### Relocating off a slow NFS share onto a fast local disk (Scenario B)
+
+Use this when `/data` is on a slow NFS share (e.g. ~8 MB/s, multi-second metadata) and uploads
+are timing out, while core (webroot/config/apps/themes) and MariaDB are already on fast NVMe.
+
+1. **Make the data dir configurable in the template, then mirror into the rendered compose**
+
+   In `roles/nextcloud/templates/docker-compose.nextcloud.yml.j2` change the `/data` bind so
+   it reads a config value (keep the separate `{{ storage_dir }}:/mnt/homelabos` external-storage
+   mount untouched):
+
+   ```diff
+   - - "{{ storage_dir }}/Documents/NextCloud:/data"
+   + - "{{ nextcloud.data_dir | default(storage_dir + '/Documents/NextCloud') }}:/data"
+   ```
+
+   Set the new value under the `nextcloud:` block in `settings/config.yml`:
+
+   ```yaml
+   nextcloud:
+     data_dir: /media/<user>/<disk>/.../NextCloud
+   ```
+
+   Mirror the same `/data` source change in the rendered compose. It is owned by `homelab`, so
+   the Edit/Write tool fails with EACCES — use `sudo`:
+
+   ```bash
+   sudo sed -i \
+     's#- "[^"]*:/data"#- "/media/<user>/<disk>/.../NextCloud:/data"#' \
+     /var/homelabos/nextcloud/docker-compose.yml
+   sudo grep -n ':/data"' /var/homelabos/nextcloud/docker-compose.yml   # verify
+   ```
+
+2. **Make the mount reboot-safe (critical — so Nextcloud never starts against an empty dir)**
+
+   a. Add the target disk to `/etc/fstab` (`nofail` so a missing disk does not block boot):
+
+   ```bash
+   # find the UUID
+   lsblk -o NAME,UUID,FSTYPE,MOUNTPOINT
+   # add (then validate, do NOT reboot on a bad fstab):
+   echo 'UUID=<uuid> <mountpoint> ext4 defaults,nofail,noatime,nosuid,nodev 0 2' | sudo tee -a /etc/fstab
+   findmnt --verify
+   ```
+
+   b. Add a systemd drop-in so `nextcloud.service` refuses to start until the data mount is
+   present. `RequiresMountsFor` makes systemd order the unit after — and depend on — the
+   generated `<mount>.mount` unit (which adopts the already-mounted fs):
+
+   ```bash
+   sudo mkdir -p /etc/systemd/system/nextcloud.service.d
+   sudo tee /etc/systemd/system/nextcloud.service.d/usb-data-mount.conf <<'EOF'
+   [Unit]
+   RequiresMountsFor=/media/<user>/<disk>/.../NextCloud
+   EOF
+   sudo systemctl daemon-reload
+   ```
+
+3. **Migrate with a live cutover (rsync as the data OWNER, not root)**
+
+   ```bash
+   PUID=1002   # the apache/www-data uid that owns the data
+   # bulk copy while Nextcloud is live
+   sudo -u "#${PUID}" -g "#${PUID}" rsync -aH --info=progress2 \
+     /path/to/nfs/NextCloud/ /media/<user>/<disk>/.../NextCloud/
+
+   # quiesce, then a FINAL consistent pass (additive — NO --delete, so the .ocdata marker and
+   # regenerable caches are never removed)
+   docker exec -u "$PUID" nextcloud_nextcloud_1 php occ maintenance:mode --on
+   sudo -u "#${PUID}" -g "#${PUID}" rsync -aH --info=progress2 \
+     /path/to/nfs/NextCloud/ /media/<user>/<disk>/.../NextCloud/
+
+   systemctl restart nextcloud           # recreates the container with the new /data bind
+   docker exec -u "$PUID" nextcloud_nextcloud_1 php occ maintenance:mode --off
+   ```
+
+4. **Verify, then keep the old copy as an instant rollback**
+
+   ```bash
+   # confirm /data now resolves to the new disk
+   docker inspect nextcloud_nextcloud_1 \
+     --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}'
+
+   ls -la /media/<user>/<disk>/.../NextCloud/.ocdata    # marker must be present
+   docker exec -u 1002 nextcloud_nextcloud_1 php occ status
+
+   # real upload test against the LAN path (NOT the public URL — see Failed Attempts)
+   curl --resolve <domain>:443:<lan-ip> -T testfile \
+     -u <user>:<pass> https://<domain>/remote.php/dav/files/<user>/testfile
+   ```
+
+   Keep the old NFS copy untouched: rolling back is just flipping the `/data` bind back to the
+   NFS path (template + rendered compose) and `systemctl restart nextcloud`.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| rsync as root to NFS | `sudo rsync ... /mnt/nas/Documents/NextCloud/` | NFS export has root_squash; all files landed owned nobody (99:99); Nextcloud cannot read them | Always rsync to NFS as the Nextcloud uid (`sudo -u '#1002' -g '#1002'`), never as root |
+| rsync as root to NFS | `sudo rsync ... /mnt/nas/Documents/NextCloud/` | NFS export has root_squash; all files landed owned nobody (99:99); Nextcloud cannot read them | Always rsync to/from NFS as the Nextcloud uid (`sudo -u '#1002' -g '#1002'`), never as root. With root_squash, client root is squashed to anon and cannot even read the uid-1002-owned `770` files |
 | rsync without bind view | `sudo -u '#1002' rsync /mnt/nas/Documents/NextCloud/ ...` | Source path is the live NFS mount itself, not the local data hidden beneath it — copies NFS back to NFS | Mount a bind view of `/` first to expose the hidden local directory |
 | occ files:scan in maintenance mode | `docker exec ... php occ files:scan --all` while `maintenance:mode --on` | Returns "database isn't accessible" | Disable maintenance mode before running `occ files:scan`; maintenance mode blocks DB access |
+| Edit rendered compose with the file tool | Opened `/var/homelabos/nextcloud/docker-compose.yml` with the Edit/Write tool | EACCES — the rendered compose is owned by the `homelab` user, not the current user | Edit rendered HomelabOS files with `sudo sed` / `sudo tee`; also mirror the change into the Jinja template + `settings/config.yml` so `ansible` does not revert it |
+| Public-URL upload speed test | Uploaded to `https://<domain>/...` from inside the LAN to "prove" the move helped | Saw ~5.7 MB/s and assumed the relocation failed — but the LAN client hairpinned out the WAN and was capped by upload bandwidth (~5 MB/s), masking real storage speed | Re-test with `curl --resolve <domain>:443:<lan-ip>` to force the local path (showed ~30 MB/s LAN DAV). For LAN clients, fix the slow public path with split-DNS (e.g. a Tailscale custom DNS record to the tailnet IP, since traefik answers there with a valid cert) |
+| Rely on the desktop automount for the bind | Let udisks auto-mount the disk at `/media/<user>/...` and pointed the docker bind there | After a reboot the disk may not be auto-mounted before Docker starts, so Nextcloud would start against an empty `/data` and re-fork data locally | Add an `/etc/fstab` entry (`nofail`) + a `nextcloud.service` `RequiresMountsFor` drop-in so Nextcloud refuses to start until the data mount is present |
 
 ## Results & Parameters
 
-```
-Nextcloud container user:  uid=1002 gid=1002
+```text
+Nextcloud container user:  uid=1002 gid=1002 (rsync/occ must run as this uid)
+
+--- Scenario A (local NVMe -> NFS NAS), v1.0.0 ---
 Total data:                271 GB, 610 folders, 48,346 files
 files:scan duration:       ~33 seconds
-
 NFS fstab entry:
   192.168.2.11:/data/Documents  /mnt/nas/Documents  nfs  defaults,_netdev,soft,timeo=30,retrans=3  0  0
-
-Systemd drop-in (/etc/systemd/system/docker.service.d/wait-nas.conf):
+docker.service drop-in (/etc/systemd/system/docker.service.d/wait-nas.conf):
   [Unit]
   RequiresMountsFor=/mnt/nas/Documents
-
-MariaDB dump (container renamed mysqldump to mariadb-dump):
-  docker exec nextcloud_mariadb mariadb-dump --single-transaction \
-    -u<user> -p"<pass>" nextcloud > backup.sql
-
-Confirmation command:
-  docker exec nextcloud_nextcloud_1 df -h /data
+Confirm: docker exec nextcloud_nextcloud_1 df -h /data
   # 192.168.2.11:/data/Documents/NextCloud  ...
+
+--- Scenario B (slow NFS -> fast local disk), v1.1.0 ---
+Before / after (only /data moved; core + MariaDB already on NVMe):
+  storage write throughput:  8 MB/s   -> 214 MB/s
+  rename / metadata op:      1.7 s    -> 5 ms
+  LAN DAV upload:            timing out -> ~30 MB/s
+  (public-URL upload stayed ~5 MB/s — WAN-hairpin capped, not a storage limit)
+
+Template change (roles/nextcloud/templates/docker-compose.nextcloud.yml.j2):
+  - "{{ nextcloud.data_dir | default(storage_dir + '/Documents/NextCloud') }}:/data"
+settings/config.yml:
+  nextcloud:
+    data_dir: /media/<user>/<disk>/.../NextCloud
+
+fstab entry (local disk):
+  UUID=<uuid> <mountpoint> ext4 defaults,nofail,noatime,nosuid,nodev 0 2
+  # validate with: findmnt --verify
+
+systemd drop-in (/etc/systemd/system/nextcloud.service.d/usb-data-mount.conf):
+  [Unit]
+  RequiresMountsFor=/media/<user>/<disk>/.../NextCloud
+  # then: sudo systemctl daemon-reload
+
+Live cutover (additive final rsync — no --delete, keep .ocdata):
+  docker exec -u 1002 nextcloud_nextcloud_1 php occ maintenance:mode --on
+  sudo -u '#1002' -g '#1002' rsync -aH --info=progress2 SRC/ DST/
+  systemctl restart nextcloud
+  docker exec -u 1002 nextcloud_nextcloud_1 php occ maintenance:mode --off
+
+Verify /data source disk (one-liner):
+  docker inspect nextcloud_nextcloud_1 \
+    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}'
+
+Force LAN upload test (bypass WAN hairpin):
+  curl --resolve <domain>:443:<lan-ip> -T testfile -u <user>:<pass> \
+    https://<domain>/remote.php/dav/files/<user>/testfile
 ```
+
+Notes:
+
+- The `.ocdata` validity marker may be MISSING on the old data dir yet present on the migrated
+  copy. Nextcloud 34 runs without it, but newer versions check for it and refuse to start if it
+  is absent — keep it. Its presence also doubles as a safety net: if the mount is ever missing,
+  Nextcloud sees no `.ocdata` and halts instead of writing to an empty mountpoint.
+- Cross-reference the NFS no_root_squash / root_squash skill for why rsync must run as the data
+  owner uid.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| HomelabOS Nextcloud | apollo homelab server, NVMe to TrueNAS NFS | End-to-end migration; Nextcloud serving from NAS confirmed |
+| HomelabOS Nextcloud | apollo homelab server, NVMe to TrueNAS NFS (v1.0.0, 2026-06-23) | End-to-end migration; Nextcloud serving from NAS confirmed |
+| HomelabOS Nextcloud | live HomelabOS v1.0 host, slow NFS to fast local disk (v1.1.0, 2026-06) | End-to-end live cutover; `docker inspect` confirmed `/data` on the new disk; 8 -> 214 MB/s write, real upload test passed |


### PR DESCRIPTION
## Summary

Amends the existing `homelab-nextcloud-data-dir-nfs-migration` skill from v1.0.0 to v1.1.0.

Generalizes it from a one-directional "local NVMe -> NFS NAS" migration to **relocating the Nextcloud `/data` directory between storage tiers in either direction**, adding the mirror scenario: moving `/data` OFF a slow NFS share onto a fast local disk (uploads were timing out) with a reboot-safe live cutover. Same core gotchas apply both ways, so the learnings belong in one skill rather than a near-duplicate file.

- Adds the HomelabOS template-vs-rendered-compose dual-edit pattern (template + `settings/config.yml` for persistence across ansible; `sudo sed`/`sudo tee` on the rendered `/var/homelabos/...` compose because it is owned by `homelab` and the Edit tool hits EACCES)
- Makes `/data` configurable via `nextcloud.data_dir | default(...)` and adds reboot-safety (fstab `nofail,noatime,nosuid,nodev` + `nextcloud.service` `RequiresMountsFor` drop-in)
- Adds the live cutover (occ maintenance mode + additive final rsync, no `--delete` so `.ocdata` survives) and the `docker inspect` mount-verify one-liner

## Verification Level

**verified-local**

Executed end-to-end on a live HomelabOS v1.0 host. The skill PR's own CI gate (validate + markdownlint) is pending; not claiming verified-ci.

## Key Findings

**What Worked**:
- rsync as the data-owner uid (`sudo -u '#1002'`) — NFS root_squash blocks root from reading the uid-1002-owned 770 files
- fstab + `RequiresMountsFor` so Nextcloud refuses to start until the data mount is present (never starts against an empty dir)
- Keeping the old copy untouched as an instant rollback (flip the `/data` bind back + restart)

**What Failed**:
- Editing the rendered `/var/homelabos/nextcloud/docker-compose.yml` with the file tool -> EACCES (owned by `homelab`); use `sudo sed`/`sudo tee`
- Upload speed test against the public URL -> ~5.7 MB/s (WAN-hairpin capped), masked the real ~30 MB/s LAN DAV speed; re-test with `curl --resolve`

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>