### PR TITLE
feat: amend pr-rebase-conflict-resolution-patterns skill

### DIFF
--- a/skills/pr-rebase-conflict-resolution-patterns.history
+++ b/skills/pr-rebase-conflict-resolution-patterns.history
@@ -1,6 +1,864 @@
 <!-- markdownlint-disable MD024 -->
 # pr-rebase-conflict-resolution-patterns — History
 
+## v1.12.0 (2026-06-29)
+
+**Changed by:** Inference360 PR #289 safe cleanup and Warden rebase recovery
+
+**Verification:** verified-ci
+
+### What changed
+- Added trigger #19 and a new When-to-Use bullet for Inference360 H200 Slurm PR branches where a stale/dirty local checkout must be preserved before rebase and master renamed the control lifecycle to Warden.
+- Added section O documenting the verified PR #289 workflow: patch backup + backup branch + stash before reset, rebase onto `origin/master`, non-interactive `env GIT_EDITOR=true git rebase --continue`, Warden env-name resolution, targeted validation, and explicit force-with-lease.
+- Added Failed Attempts rows for hard-resetting before preserving unrelated staged work, resolving Warden conflicts back to old control env names, interactive `git rebase --continue` in a non-interactive session, and passing shell scripts to Ruff.
+- Added Results & Parameters entries for Inference360 trunk, dirty-checkout safeguards, Warden conflict rules, shell validation, Python validation, and explicit leases.
+- Added a Verified On row for Inference360 PR #289 with verified-ci result: PR head `bbf82e799fa430f868af3d96c807e1e18a5eb15a`, GitHub `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`, no unresolved review threads, and green required checks.
+- Added tags: `inference360`, `warden`, `slurm`, `h200`, `dirty-local-checkout`, `staged-work-backup`, `explicit-force-lease`, `uv-verify`, `ruff-shell-split`.
+- Bumped version 1.11.0 -> 1.12.0 (MINOR — new verified workflow section + failed attempts); updated date to 2026-06-29.
+
+### Why
+Inference360 PR #289 combined three hazards that the existing generic rebase skill did not capture together: unrelated local staged work in a stale PR checkout, a branch rebase across the control-to-Warden lifecycle rename, and a force-push to a shared PR branch. The safe workflow required preserving local work through three independent recovery paths before reset, resolving conflicts by keeping Warden env names while preserving nested `srun --mem=0`, validating with the repo's targeted `uv`, Ruff, shell, and manifest checks, and force-pushing only with a lease pinned to the observed old remote SHA.
+
+### Previous version (v1.11.0) snapshot
+
+````markdown
+    ---
+    name: pr-rebase-conflict-resolution-patterns
+    description: "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted — later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing — the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes — confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED — the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit), (14) multiple rebased PRs — including ones unrelated to the failing test — all fail the SAME test after merging onto main; suspect a broken main from a SEMANTIC collision between two independently-merged PRs that never textually conflict (e.g. a return-tuple arity change + a stale test mock), prove it by running the failing test against bare origin/main, and fix main first, (15) two parallel cluster-extraction PRs both create the same new module file and the rebase produces an add/add conflict on BOTH the source module AND its test file — main's source is authoritative, test files must be semantically merged (keep main's richer base + append your branch's unique test classes), (16) a rebase hits AA (both-added) conflicts on new files — the conflicted file shows NO <<<<<<< markers and contains only one side's content; you must use git show HEAD:<path> and git show REBASE_HEAD:<path> to read both versions before resolving, (17) a CLUSTER of sibling refactor PRs all edit the SAME shared files and were run in parallel so all but one are CONFLICTING/DIRTY (and possibly hand-braked with state:skip) — land them as a SEQUENTIAL rebase chain SMALLEST-DIFF-FIRST, rebasing each onto trunk only AFTER the prior merges, resolving every conflict as the UNION of each refactor's extractions (keep both helpers; every duplicated method becomes a thin delegate; merge import lists and drop now-unused imports via lint), then re-sign all commits with `git rebase --exec '...-s -S' origin/main` for DCO+GPG, (18) after rebase, tests fail because test mocks expected the PR branch's refactored signatures but rebase brought in origin/main's different implementation — the git conflict resolved cleanly (no text-level conflicts), but the test mocks diverge from actual code. Test expects subprocess.check_output but code uses run_subprocess; mock returns 7-tuple but impl expects 9-tuple. After textual conflict resolution succeeds, run tests to surface semantic mismatches, then regenerate test mocks to match CURRENT implementation, not the PR's expected changes (see § L)"
+    category: ci-cd
+    date: 2026-06-27
+    version: "1.11.0"
+    user-invocable: false
+    history: pr-rebase-conflict-resolution-patterns.history
+    tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-net, parallel-swarm, serial-merge-train, full-rewrite, shadow-variable, tdz, numeric-equivalence, clang-format, cmake, pixi-lock, force-with-lease, auto-merge, already-merged-sibling, add-add-conflict, sha-pin, unpinned-actions, skipped-required-check, markdownlint, lint-blocked, org-policy, myrmidon-swarm, semantic-collision, broken-main, tuple-arity, stale-mock, merge-train-cascade, cluster-extraction, parallel-pr-same-module, aa-conflict, uu-conflict, both-added, git-status-codes, no-markers, same-file-cluster, sequential-rebase-chain, smallest-first, thin-delegate, union-resolution, dco-signoff, state-skip-stranded, test-mock-mismatch, mock-divergence, subprocess-api-change, implementation-divergence, test-fixture-regeneration, semantic-test-failure, rebase-not-reparented, stale-merge-base, merge-base-verification, main-only-symbol-check, false-rebase-success, half-applied-refactor, per-phase-timeout-regression, multi-layer-refactor, options-object-vs-helpers, value-regression]
+    ---
+
+    # PR Rebase & Conflict Resolution Patterns
+
+    ## Overview
+
+    | Field | Value |
+    |-------|-------|
+    | Date | 2026-06-07 |
+    | Objective | One canonical playbook for rebasing PR branches onto an advanced main and resolving every class of rebase/merge conflict — single PRs, mass waves, stacked PRs, parallel-swarm collisions, Safety-Net-blocked resolution, full-file rewrites, and language-level bugs introduced by merging two independent branch edits |
+    | Outcome | Verified across the HomericIntelligence ecosystem (ProjectOdyssey, ProjectScylla, ProjectMnemosyne, ProjectKeystone, ProjectHephaestus, ProjectHermes, ProjectNestor, AchaeanFleet, Myrmidons, Agamemnon, Odysseus) — hundreds of PRs rebased and merged |
+    | Verification | verified-ci |
+    | History | [changelog](./pr-rebase-conflict-resolution-patterns.history) |
+
+    ## When to Use
+
+    - A PR is `CONFLICTING`/`DIRTY` after main advances and needs a rebase + force-push.
+    - A mass rebase of 10-160+ PRs is needed after a major refactor lands on main.
+    - A systemic CI failure (bad pip-audit flag, broken workflow, broken pixi.lock) blocks all PRs — fix main first, then rebase the queue.
+    - PRs conflict on the same shared files (`pixi.lock`, `marketplace.json`, workflow YAML, core source) across the queue.
+    - A stacked PR goes DIRTY when its prerequisite merges; the base must be retargeted and later CI/lint fix commits are orphaned and must be cherry-picked.
+    - A Safety Net hook blocks `git checkout --ours/--theirs`, `git restore`, `git reset --hard`, or `git worktree remove --force` during automated conflict resolution.
+    - A file was completely rewritten on one branch while small targeted edits exist on the other (auto-merge produces an incoherent hybrid).
+    - A parallel swarm produced overlapping PRs that race auto-merge on the same paths; only one merges cleanly and the rest must be rebased onto it.
+    - A feature PR conflicts after a sibling refactor merges and the edits must be ported onto the new sub-package/facade structure.
+    - A TypeScript (TS7022/TS2448) or other block-scoped shadowing/TDZ bug appears only after a rebase because two branches independently added identically-named identifiers to the same scope.
+    - A numerical/optimizer PR conflicts because main merged its own version of a shared module and the API signature changed — must adapt call-sites while proving numeric equivalence.
+    - A C++ rebase touches both source and `CMakeLists.txt`; or a deletion commit replays and over-removes active code.
+    - A PR's substantive change independently landed on main via a sibling PR, so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual (only a trivial delta remains vs main).
+    - A PR is `DIRTY`/`CONFLICTING` with **all CI checks green/passing** — the merge conflict itself is the sole blocker; rebase, do not hunt for a failing job (`gh pr view N --json mergeStateStatus,mergeable,statusCheckRollup`).
+    - A rebase hits a **modify/delete conflict on a file the PR intentionally deletes** (`CONFLICT (modify/delete): <path> deleted in <commit> and modified in HEAD`) — confirm the base copy is still the stale content the PR removes, then `git rm`.
+    - A PR is **BLOCKED with `mergeable=MERGEABLE`** (no git conflict) but a **required check shows `SKIPPED`** — the required check (e.g. `markdownlint`) is declared `needs: lint` and the `lint` job fails because the branch carries **unpinned GitHub Actions** (`actions/setup-python@v6`) rejected by an org-wide SHA-pin policy. The fix is a **rebase onto current main** so the branch inherits main's pinned workflow files; pushing an empty re-trigger commit does NOT fix this.
+    - **Multiple rebased PRs — including ones unrelated to the failing test — all fail the SAME test** after merging onto main; suspect a **broken main from a semantic collision between two independently-merged PRs** (e.g. a return-tuple arity change + a stale test mock). The two PRs never textually conflict — each is green against the main it saw — but their UNION on main is inconsistent and fails at RUNTIME. Prove it by running the failing test against bare `origin/main`, then **fix main first** (one small PR); do NOT fix it inside each trailing PR.
+    - **Two parallel cluster-extraction PRs both create the same new module** (e.g. `loop_repo_manager.py`) via independent extraction from the same god-module; the rebase produces `CONFLICT (add/add)` on BOTH the source file AND the test file. This differs from a "near-no-op residual" case — both branches have genuine work; the resolution requires careful semantic merging (see § K2).
+    - A rebase produces `CONFLICT (add/add)` on newly-created files and the conflicted file has **no `<<<<<<<` markers** — AA (both-added) conflicts show only one side's content; use `git status` to distinguish AA from UU (both-modified) and `git show HEAD:<path>` / `git show REBASE_HEAD:<path>` to read both versions before resolving.
+    - **A CLUSTER of sibling refactor PRs all edit the SAME shared files** (e.g. every PR touches `address_review.py`; several touch `_review_utils.py` + `ci_driver.py`) and were dispatched in parallel by an automation loop with no file-overlap serialization — only the first to merge lands and the rest go `CONFLICTING`/`DIRTY` (and may have been hand-braked with `state:skip`, which then permanently strands them since skipped issues are never re-selected). The fix is **not** resolving one conflict — it is **sequencing the whole cluster**: land them as a serial rebase chain **smallest-diff-first**, rebasing each onto trunk only AFTER the prior merges, union-resolving every refactor's extractions into thin delegates, then re-signing for DCO+GPG (see § K3). This complements trigger #15/§ K2 (which resolves ONE add/add conflict) — § K3 is about ordering N mutually-conflicting refactors.
+    - **Rebase completes with NO git conflict markers, but tests fail on mock signature mismatches** — the PR branch's test mocks expected refactored function signatures; rebase brought in origin/main's different implementation. Git resolved textually cleanly (no `<<<<<<<` markers), but test mocks no longer match: test expects `subprocess.check_output` but code uses `run_subprocess`; mock returns 7-tuple but implementation expects 9-tuple; test function signature doesn't match current module. After rebase, run tests to surface these semantic divergences, then regenerate test mocks against ACTUAL current implementation, not the PR's expected changes. Do NOT try to "fix" the implementation to match test expectations — test expectations are stale; regenerate mocks to match code (see § L / ProjectHephaestus PR #1633, issue #1405).
+    - **A rebase agent reports "rebased onto origin/main, force-pushed" but the branch was NEVER re-parented** — `git merge-base origin/main origin/<branch>` is STILL the old stale base (e.g. 29 commits behind) and the branch does NOT contain main's recently-merged content (a known main-only symbol from a merged sibling is ABSENT). The rebase was run from/onto a stale ref, or a later force-push from a worktree built off the OLD branch tip silently reset the base. Do NOT trust the self-report — MANDATORY verify `git merge-base origin/main HEAD == git rev-parse origin/main` AND grep the pushed branch for a known main-only symbol (see § M).
+    - **A multi-layer refactor rebase is half-applied: one layer fixed, parallel layers still flattened** — a PR intentionally restores a set of related values (e.g. per-phase timeouts 300/1800/600 vs a flat 7200), and the conflict resolution fixes ONE layer (the dataclass/options-object field defaults in `models.py`) while LEAVING the parallel layers (the `*_timeout()` helper FUNCTIONS in `claude_timeouts.py` + the constants in `constants.py`) in the wrong/flattened state. A spot-check of `models.py` looks correct, but every helper function used at the call sites returns the wrong value — caught ONLY by reading the actual CI unit-test failure (`assert 300 == 7200`), never by any self-report (see § N).
+    - Common trigger phrases: "fix these failing PRs", "rebase all branches onto main", "mass rebase after merge wave", "stacked PR went dirty", "Safety Net blocked git checkout", "markdownlint SKIPPED BLOCKED", "action not allowed must be pinned", "CONFLICT (add/add) on new module", "rebase clean but tests fail on mock", "test mock divergence after rebase", "agent said it rebased but merge-base is stale", "branch is N commits behind after a claimed rebase", "rebased timeout PR but functions still return the flat value", "assert 300 == 7200 after rebase".
+
+    ## Verified Workflow
+
+    ### Quick Reference
+
+    ```bash
+    # ─── 0. PRE-FLIGHT: confirm there is work to do, and main is green ───
+    gh pr list --state open --json number --jq 'length'      # 0 → cleanup task, not a rebase task
+    gh run list --branch main --limit 3 --json status,conclusion,workflowName \
+      --jq '.[] | "\(.workflowName): \(.status)/\(.conclusion)"'   # main RED → fix main FIRST
+    # RE-CHECK main is green before EACH rebase wave — a sibling merge can turn main red AFTER the train starts
+    # (semantic collision: a 9-tuple return change + a stale 7-tuple test mock, each green alone). § K.
+    git cherry origin/main <branch>     # 0 lines → branch already merged (squash artifact); skip
+
+    # DIRTY/CONFLICTING with EVERY check green = the conflict IS the blocker (no phantom failing job):
+    gh pr view N --json mergeStateStatus,mergeable,statusCheckRollup
+    #   mergeStateStatus=DIRTY, mergeable=CONFLICTING, all rollup SUCCESS → rebase, do NOT chase CI
+    gh api repos/OWNER/REPO --jq '{allow_squash_merge,allow_rebase_merge,allow_merge_commit}'
+
+    # ─── 1. CLASSIFY ───
+    gh pr list --state open --json number,mergeStateStatus,autoMergeRequest --limit 200 \
+      --jq '.[] | "#\(.number) [\(.mergeStateStatus)]"'   # MERGEABLE→arm; DIRTY/CONFLICTING→rebase
+
+    # ─── 2. REBASE ONE PR (isolated worktree, never local checkout) ───
+    git worktree add /tmp/pr-<N> origin/<branch>            # clean checkout from remote ref
+    git -C /tmp/pr-<N> rebase origin/main                   # use -C for .claude/worktrees/agent-* paths too
+    # ... resolve conflicts (see decision table) ...
+    git -C /tmp/pr-<N> add <specific-files>                 # NEVER git add . / -A during rebase
+    GIT_EDITOR=true git -C /tmp/pr-<N> rebase --continue    # --continue takes NO --no-edit flag
+
+    # ─── 3. SILENT-DROP CHECK (mandatory after every rebase) ───
+    git -C /tmp/pr-<N> log origin/main..HEAD --oneline
+    # empty → commit dropped (already upstream / matched HEAD). DO NOT push empty.
+    #   close: gh pr close <N> --comment "Superseded: identical change merged via #<M>"
+    #   OR recover: git checkout -b recover-<N> <original-sha> and rebase keeping the PR's unique adds
+
+    # ─── 4. PUSH + RE-ARM (force-push ALWAYS clears auto-merge) ───
+    git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>   # dependabot: --force (auto-rebased)
+    gh pr merge <N> --auto --squash                         # re-arm; --squash if rebase-merge disabled
+    # enable auto-merge AFTER the push — CONFLICTING state silently ignores the flag
+
+    # ─── 5. SAFETY-NET-SAFE conflict resolution (git checkout/restore BLOCKED) ───
+    git show :2:path > path   # = --ours  (REBASE: upstream/main)  ; then git add path
+    git show :3:path > path   # = --theirs(REBASE: your replayed commit) ; then git add path
+    git ls-files --stage path # diagnose which stage is which BEFORE writing
+    # strip markers keeping both sides (additive CMakeLists/.pre-commit-config):
+    python3 -c "import re,sys;p=sys.argv[1];s=open(p).read();open(p,'w').write(re.sub(r'<<<<<<< HEAD\n|=======\n|>>>>>>> [^\n]+\n','',s))" CMakeLists.txt
+    # Alternative: take a specific ref's version (REBASE_HEAD = "theirs" in rebase context):
+    git show REBASE_HEAD:<path> > /tmp/file_main.py  # dump ref version to temp
+    cat /tmp/file_main.py > <conflicted_path>        # write to destination (bypasses Safety Net)
+    git add <conflicted_path>
+    # Use git show ORIGIN/MAIN:<path> for main's version outside active rebase conflict state
+
+    # ─── 6. SPECIAL FILES ───
+    rm pixi.lock && git add pixi.lock && pixi lock          # NEVER --ours/--theirs on lockfile; regen
+    git checkout --ours marketplace.json                    # main has the union; PR's is stale
+    # CHANGELOG.md → take HEAD/main (consolidation PR handles entries)
+    ```
+
+    ### Detailed Steps
+
+    #### A. Pre-flight (don't skip)
+
+    1. `gh pr list --state open` — if 0, this is a **cleanup task**, not a rebase. `git branch -vv` showing "ahead 1" on every branch is a **squash-merge artifact**, not unmerged work; confirm with `git cherry origin/main <branch>` (0 lines = merged).
+    2. Confirm main CI is green (`gh run list --branch main`). **Rebasing onto a broken main cannot unblock PRs.** If a systemic blocker exists (bad pip-audit flag, workflow `globs:"**/*.md"` overriding `.markdownlintignore`, broken `pixi.lock`, pre-existing violations in shared files), **fix main in its own small PR and let it merge first**, then rebase the queue. **Main can go red AFTER the train starts** — each PR that merges may collide semantically with an already-merged sibling (a return-tuple/signature change landing while a stale test mock of that function landed separately). RE-CHECK `gh run list --branch main` is green before EACH rebase wave, not just at the start. When two PRs both touch the same function-and-its-test (especially a return-tuple/arity/signature change in one and a mock of that function in the other), treat them as a **latent collision** even though they will never textually conflict.
+    3. Check allowed merge methods. Squash-only repos (e.g. Charybdis) reject `gh pr merge --auto --rebase` with a GraphQL error — use `--squash`.
+
+    #### B. The rebase mechanics that matter
+
+    - **Always work in an isolated worktree from the remote ref** (`git worktree add /tmp/x origin/<branch>`), never `git checkout`/`gh pr checkout` a local branch — stale local branches and Safety-Net-blocked `git reset --hard` cause wrong-branch rebases. For branches in `.claude/worktrees/agent-<id>/`, drive git with `git -C <path>`.
+    - **Rebase inverts ours/theirs.** During `git rebase X`: `--ours`/`:2:`/`HEAD` = **main** (the base); `--theirs`/`:3:`/`REBASE_HEAD` = **your replayed commit**. This is the OPPOSITE of merge. Get it wrong and you keep the wrong side silently. Run `git ls-files --stage <file>` to confirm before writing.
+    - **Silent-drop check after every rebase**: `git log origin/main..HEAD --oneline`. Empty means the commit's patch was already upstream (cherry-picked, or duplicate-swarm PR, or resolution matched HEAD making it empty) — git prints "dropping … patch contents already upstream". Close the PR as superseded; never force-push an empty branch. `git cherry` uses patch-id and can falsely report `+` when surrounding lines differ — cross-check with `diff <(git show <sha>:<file>) <(git show origin/main:<file>)`.
+    - **Force-push always clears GitHub auto-merge.** Re-arm with `gh pr merge <N> --auto --squash` immediately after every push. Enable auto-merge only AFTER the push lands the PR in MERGEABLE — CONFLICTING state ignores the flag. Dependabot branches need `git push --force` (GitHub auto-rebases them, making the lease stale).
+    - `git rebase --continue` opens no editor non-interactively; it has **no `--no-edit` flag**. If the staged diff is empty use `git rebase --skip`, not `--continue`.
+
+    #### B2. Re-sign replayed commits (repos requiring verified commits)
+
+    - **Rebasing STRIPS GPG/SSH commit signatures** — every replayed commit becomes unsigned. On a repo that requires verified commits, a plain rebase pushes unsigned commits and the merge stalls. Re-sign all replayed commits in one pass: `git rebase --exec "git commit --amend --no-edit -S --no-verify" <base>` (e.g. `<base>` = `origin/main`).
+    - **Local `git log --format='%G?'` is NOT authoritative** — it may show `U` (unknown/untrusted) even when the commit IS validly signed (e.g. the signing key isn't in the local keyring). GitHub's REST `commit.verification.verified` field is the source of truth: `gh api repos/OWNER/REPO/commits/SHA --jq .commit.verification`. Trust that over local `%G?` before re-signing or worrying a signature is broken.
+
+    #### C. Conflict resolution decision table
+
+    | Conflict | Resolution |
+    |----------|------------|
+    | `pixi.lock` | `rm pixi.lock && git add pixi.lock`; after rebase `pixi lock` (regenerate — encodes SHA256, never `--ours/--theirs` or hand-merge). After any `pyproject.toml` edit, `pixi lock` again. |
+    | `marketplace.json` | `git checkout --ours` (main has the union; the PR's regenerated copy is stale). Never take the PR side. |
+    | `CHANGELOG.md` | Take HEAD/main; let a consolidation PR gather entries (avoids a conflict spiral across the wave). |
+    | Workflow YAML (`.github/workflows/*.yml`), `.pre-commit-config.yaml` — additive | Keep BOTH sides' additions (main's `concurrency`/`permissions`/`timeout-minutes` AND the branch's container/job/hook). Read the commit message: a later "remove X" commit on the same branch flips intent — take the removal. |
+    | Workflow YAML — two DIFFERENT fix approaches | Take main's approach (established convention; simpler wins). Then **hunt orphaned lines**: grep the discarded approach's keywords (e.g. `/tmp/benchmark-results\|podman cp`) — lines outside the conflict markers survive silently. |
+    | Test files — both sides added coverage | Semantic merge: keep main's new tests AND the PR's helpers/tests; upgrade inherited tests to the PR's docstring standard; re-run the owned test file. |
+    | Add/add conflict — parallel cluster extraction created the same new module | SOURCE file: diff main's vs branch's version (`diff <(git show HEAD:<path>) <(git show REBASE_HEAD:<path>)`); differences are typically docstrings/comments only, not logic — take main's version as authoritative (`git show HEAD:<path> > <path>`). TEST file: merge both — take main's richer base and append your branch's unique test classes (`grep "^class " <branch-test>` identifies unique classes); never take just one side. `pyproject.toml`/allowlist comment-only conflicts: take main's comment (reviewed longer). After resolution verify: `grep "^class " <merged-test>` must include all classes from both sides. |
+    | Full-file rewrite vs small delta | Take the rewrite side (`git checkout --theirs` in rebase = PR), then hand-apply the small delta from main's commit. Never auto-merge — it produces an incoherent hybrid. |
+    | Absorbed/deleted file (UD: deleted by us, modified by them) | `git rm <file>` (keep the deletion). |
+    | Source code, semantic | Read each hunk's intent (`git show REBASE_HEAD -- <file>` vs `git show HEAD:<file>`); decide per-hunk, never blanket `--ours`/`--theirs`. Use Sonnet+ for analysis, not Haiku. |
+    | Whitespace-only / EOF-fixer cascade (stacked PRs) | sed-loop auto-resolver keeping HEAD — ONLY after pre-flight confirms whitespace-only, ≤5 lines, HEAD provably correct. |
+    | Trivial conflict, Edit can't exact-match (em-dashes/alignment) | Python regex hunk-replace; then `grep -c '^<<<\|^>>>\|^===' file` must be 0. |
+
+    #### D. Stacked PRs & cherry-picking diverged fixes
+
+    - **Stacked-PR retarget orphan**: `gh pr edit B --base A-branch` only fast-forwards commits present at retarget time. Later CI/lint fixes on B's branch stay orphaned from A; when the same failure hits A, cherry-pick the orphan onto A: `git worktree add /tmp/fix origin/<A>; git cherry-pick <orphan-sha>`, verify the exact CI command, fast-forward push. Prevention: land lint/CI fixes on the **prerequisite** branch first, then rebase the dependent on top.
+    - **Diverged history (same content, different SHA)**: a direct `git push <fix-sha>:<branch>` is rejected non-fast-forward; `git diff <local-parent> <remote-tip>` shows no diff but `git merge-base` is neither. Fix = checkout a temp branch from `origin/<pr-branch>`, cherry-pick the small fix commit (clean fast-forward, no force needed).
+    - Re-running CI (`gh run rerun`) never helps if the fix was never pushed to the remote branch tip.
+
+    #### E. Mass / parallel / swarm rebases
+
+    1. **Triage & dedupe first** — a single Opus triage agent identifies exact-duplicate diffs and PRs mooted by main (e.g. 9 of 46 close-as-superseded), saving whole waves. Two PRs solving the same problem with **different mechanisms** are design collisions — escalate to a human, never silently pick one.
+    2. **Disjoint-file PRs → parallel waves** of Sonnet/Haiku sub-agents in worktree isolation (`run_in_background`, ~9 PRs/agent). Sonnet for conflict analysis, Haiku only for mechanical format/lint. Verify each agent's output: `git diff origin/main..HEAD --stat` must match the PR's stated intent (agents have force-pushed wrong-PR content).
+    3. **Shared-hot-file PRs → SERIAL MERGE TRAIN.** When 10+ PRs touch the same 3-5 core files, parallel waves never converge — the first to merge re-DIRTYs all siblings. Switch to: rebase one → wait for it to MERGE → fetch fresh main → rebase next. Order simplest-footprint-first / widest-footprint-last (by hot-file hunk count). Never block the train on one car — flag NEEDS-AUTHOR / RED-OWN-TESTS and move on. For 10+ same-file conflicts where main is the superset, take HEAD for all (`git show HEAD:f > /tmp/f && cp /tmp/f f`).
+    4. **Re-rebase in waves** — main advancing via auto-merge re-DIRTYs just-rebased PRs; loop rebase→wait ~60s→re-fetch→re-check until zero DIRTY. A mid-flight hotfix on main (regenerated pixi.lock, coverage-gate) mandates a second clean pass.
+    5. **Semantic rules for swarm agents**: CI/infra files → take main; source/test → preserve PR intent; binary/cache → take main. Read the PR's linked issue (`gh issue view`) before resolving feature-file conflicts.
+    6. **Extraction reconciliation (decouple→port→delete)**: a pure-deletion PR stalls because the retained core still references the doomed module. Decouple FIRST behind a tiny core-owned interface (own PR, merge first; `grep -rn "doomed_module/" <core> == 0` + non-module stub test), verify-or-port to the destination (build standalone, no dep back), then delete in order build-refs → sources → dead-deps, re-audit for sibling leftovers.
+
+    #### F. Feature-on-refactor port (DIRTY after a sibling refactor merges)
+
+    - When `<<<<<<< HEAD` is a ~50-line facade and the incoming side is the ~1000-line pre-refactor file, **do NOT hand-merge**. `git rebase --abort`, `git reset --keep origin/main` (safer than `--hard`, dodges Safety Net), `git apply` the clean (untouched-by-refactor) files, then hand-port the feature delta onto the new sub-package modules (edit the modules where impl lives, NOT the facade). Read `__init__.py` re-exports to find each symbol's new home.
+    - **Drop-and-redo** when porting is uneconomic (conflicts on ≥3 sibling-rewritten files, each needing interpretation): reset to main, cherry-pick only the surgical single-file commits, drop the cross-cutting commit, mark its issue deferred, redo it mechanically in a follow-up off post-merge main. `--theirs` here silently reverts the sibling's substantive work.
+
+    #### G. Language-level bugs from merging two independent edits
+
+    - **Shadow/TDZ (TS7022 + TS2448)**: two non-overlapping edits independently add a param and a local `const` of the same name in one scope; auto-merge has no conflict markers but the result is broken. Fix = rename the **narrower-scope** identifier (local `const tags`→`tagList`, fewer call sites). General rule: **after any rebase touching shared code, run the type-checker/linter before assuming semantic correctness** (`npx tsc --noEmit`, `pixi run mojo --Werror`, etc.). Never silence with `@ts-ignore` — the runtime bug remains.
+    - **Over-deletion replay**: a "remove deprecated X" commit authored pre-fix, replayed post-fix, also removes the new symbols → ImportError for symbols that should exist. Restore the missing classes, strip stale decorators/duplicate fields/unused imports (canary: `import warnings`/`dataclasses` left unused), update `__init__` exports.
+    - **C++ signature drift**: a sibling PR changed a shared function signature; your call sites (incl. tests) fail "too few/many arguments". Build LOCALLY before pushing — one build surfaces every error at once.
+    - **Numeric/optimizer add/add**: main merged its own copy of a shared module with a changed signature. Dropping the PR's duplicate compiles but can be silently wrong. Classify DUPLICATE vs NEW, adapt the call-site to main's API while **documenting numeric equivalence in a code comment** (e.g. NorMuon's per-axis normalization divides out main's global Muon scale → only direction matters), test the math, fix unreachable assertions with **derived** values (Lion floor `max(0,1−N·lr)` → `< 0.55`), and **defer provably-broken algorithms** (remove from PR, file follow-up) rather than merge wrong math.
+
+    #### K2. Cluster-extraction add/add conflict (two parallel PRs extract the same new module)
+
+    **Trigger**: Two PRs independently extract the same function cluster from a god-module (e.g. `loop_runner.py → loop_repo_manager.py`). Both create new files. After the first PR merges, the second PR's rebase produces `CONFLICT (add/add)` on the source file AND the test file.
+
+    This is NOT the same as a "near-no-op residual" — both branches have genuine extraction work. The resolution is:
+
+    **Step 1: Audit the source file**
+
+    ```bash
+    # In the rebase worktree, compare HEAD (main's merged version) vs REBASE_HEAD (your branch's version):
+    diff <(git show HEAD:<new-module.py>) <(git show REBASE_HEAD:<new-module.py>)
+    ```
+
+    - If differences are ONLY in docstrings/comments (not logic): take main's version entirely
+      ```bash
+      git show HEAD:<new-module.py> > <new-module.py>
+      git add <new-module.py>
+      ```
+    - If there are genuine logic differences: escalate — two parallel extractions should not produce logic divergence; something went wrong upstream
+
+    **Step 2: Merge the test file (semantic merge)**
+
+    Both branches independently wrote test classes for the new module. Take ALL of them:
+
+    ```bash
+    # Identify unique test classes on each side:
+    grep "^class " <(git show HEAD:<test_new_module.py>)        # main's classes
+    grep "^class " <(git show REBASE_HEAD:<test_new_module.py>) # your branch's classes
+    ```
+
+    Take main's version as the base, then append any test classes present ONLY on your branch.
+
+    ```bash
+    git show HEAD:<test_new_module.py> > <test_new_module.py>
+    # Manually append unique classes from REBASE_HEAD that are not in HEAD
+    git add <test_new_module.py>
+    ```
+
+    **Step 3: Handle `pyproject.toml` / allowlist comment-only conflicts**
+
+    Take main's comment (reviewed longer, more complete):
+    ```bash
+    git show HEAD:pyproject.toml > pyproject.toml
+    git add pyproject.toml
+    ```
+
+    **Step 4: Verify the merge**
+
+    ```bash
+    # Source: must not add or remove logic vs main
+    diff <new-module.py> <(git show HEAD:<new-module.py>)  # should show only comment/docstring diffs or nothing
+
+    # Tests: must contain ALL classes from both sides
+    grep "^class " <test_new_module.py>  # must include every class from both branches
+
+    # Run the tests:
+    pixi run pytest <test_new_module.py> -v
+    ```
+
+    **Step 5: Continue the rebase (signed)**
+
+    ```bash
+    GIT_EDITOR=true git -C <worktree> rebase --continue
+    # Then re-sign:
+    git -C <worktree> rebase --exec "git commit --amend --no-edit -S --no-verify" origin/main
+    git -C <worktree> push --force-with-lease origin HEAD:<branch>
+    gh pr merge <N> --auto --squash
+    ```
+
+    #### K3. Cluster of same-file refactor PRs → sequential smallest-first rebase chain
+
+    **Trigger**: A CLUSTER of N sibling refactor PRs all edit the SAME shared files — e.g. 5 PRs where every one touches `address_review.py` and most touch `_review_utils.py` + `ci_driver.py`. The automation loop ran them in PARALLEL with no file-overlap serialization, so only the first to merge landed; the other N−1 went `CONFLICTING`/`DIRTY`. An operator may have hand-applied `state:skip`, which then **permanently strands them** — skipped issues are never re-selected by the loop.
+
+    This differs from § K2 (resolving ONE add/add conflict between two parallel extractions). Here the problem is **ordering an entire cluster** of mutually-conflicting refactors so they all land. The loop's parallel dispatch has no file-overlap awareness; you must serialize the cluster yourself.
+
+    **The orchestration that unblocks the cluster:**
+
+    **Step 1 — Order smallest-diff-first.** Rank the PRs by footprint (fewest insertions / files changed) and land them in that order. The smallest clears the cheapest; each subsequent PR then rebases onto a trunk that already contains the prior refactor's extractions, so the conflicts SHRINK as the chain progresses.
+
+    ```bash
+    # Rank cluster PRs by diff size (smallest first)
+    for N in <cluster-prs>; do
+      branch=$(gh pr view $N --json headRefName --jq .headRefName)
+      ins=$(gh pr view $N --json additions,changedFiles --jq '"\(.additions)\t\(.changedFiles)"')
+      printf '%s\t%s\t%s\n' "$N" "$branch" "$ins"
+    done | sort -t$'\t' -k3,3n -k4,4n   # smallest insertions / fewest files first
+    ```
+
+    **Step 2 — Resolve every conflict as the UNION of each refactor's extractions.**
+
+    - In the **shared module** (`_review_utils.py`): keep BOTH new helper functions — each refactor extracted a different helper.
+    - In each **consumer module** (`address_review.py`, `ci_driver.py`): each duplicated method becomes a **thin DELEGATE** to the shared helper. Keep ALL delegations from both refactors.
+    - **Merge the import lists** — take the UNION of imported symbols across both sides.
+    - Then **run lint (ruff)** to catch which now-unused imports to DROP: once a consumer stops calling a helper directly (e.g. a parser-builder refactor makes `add_max_workers_arg` unused), the import is dead and ruff flags it.
+
+    ```bash
+    git show HEAD:<shared-module.py>        # main's merged helpers
+    git show REBASE_HEAD:<shared-module.py> # your branch's helpers — keep BOTH
+    # After hand-merging delegates + union imports:
+    ruff check <consumer-modules>          # drop the now-unused imports it flags
+    ```
+
+    **Step 3 — Rebase each branch onto `origin/main` ONLY AFTER the previous PR merges** (not all upfront), so each diff is against the CURRENT trunk that already contains the prior extractions.
+
+    ```bash
+    # After PR k merges and main advances:
+    git -C <worktree-k+1> fetch origin
+    git -C <worktree-k+1> rebase origin/main   # conflicts are now smaller — prior extractions are upstream
+    ```
+
+    **Step 4 — Re-sign all commits for DCO + GPG.** These auto-impl commits frequently lack the DCO `Signed-off-by` trailer (see the `git-dco-signoff` skill), and rebasing strips GPG signatures. Re-add both in one pass:
+
+    ```bash
+    git rebase --exec "git commit --amend --no-edit -s -S" origin/main
+    #                                           ^^  ^^
+    #                                  -s = DCO Signed-off-by ; -S = GPG sign
+    ```
+
+    **Step 5 — Legitimately earn `state:implementation-go`; do NOT force-flip the label.** Cluster members may carry an operator-set `state:implementation-no-go`. Do not hand-flip it — run the implementation reviewer so the PR EARNS the go label before the auto-merge-policy gate will allow merge:
+
+    ```bash
+    hephaestus-implement-issues --issues <N> ...   # earns state:implementation-go legitimately
+    ```
+
+    #### C3. AA vs UU conflict detection — "no markers" diagnostic
+
+    **When you open a conflicted file and see no `<<<<<<<` markers**, it is almost certainly an **AA (both-added)** conflict, not a UU (both-modified) conflict. Understand the difference before resolving.
+
+    **Reading `git status` left-column codes:**
+
+    ```bash
+    git status
+    # Left two characters are index status / worktree status:
+    # AA = both-added (both branches created this file for the first time)
+    # UU = both-modified (both branches edited the same pre-existing file)
+    # DD = both-deleted
+    # UD = deleted by us, modified by them
+    # DU = modified by us, deleted by them
+    ```
+
+    **AA (both-added) — no conflict markers:**
+
+    The file on disk shows **one side's content only** (whichever git chose). There are no `<<<<<<< HEAD`, `=======`, or `>>>>>>> <sha>` markers. To see both sides:
+
+    ```bash
+    git show HEAD:<path/to/file>         # main's version (what we're rebasing onto)
+    git show REBASE_HEAD:<path/to/file>  # your branch's replayed commit version
+    diff <(git show HEAD:<path>) <(git show REBASE_HEAD:<path>)  # compare them
+    ```
+
+    Resolutions for AA:
+
+    ```bash
+    # Take main's version (most common — main is authoritative for source files):
+    git show HEAD:<path/to/file> > path/to/file
+    git add path/to/file
+
+    # Take your branch's version:
+    git show REBASE_HEAD:<path/to/file> > path/to/file
+    git add path/to/file
+
+    # Manual merge: read both with git show, combine content by hand, then git add
+    ```
+
+    **UU (both-modified) — conflict markers ARE present:**
+
+    ```text
+    <<<<<<< HEAD
+    main's version of this section
+    =======
+    your branch's version of this section
+    >>>>>>> <sha>
+    ```
+
+    Edit the file to resolve each hunk, then `git add`.
+
+    **When main already merged your feature (AA on all new files):**
+
+    If the rebase hits AA on every new file the branch added, main already has the feature. Pattern:
+
+    1. For each AA file: `diff <(git show HEAD:<f>) <(git show REBASE_HEAD:<f>)` — if main's version is more complete, take HEAD; if your branch added something unique (e.g. wrapper functions), manually merge.
+    2. For test files (UU or AA): take the union — keep all tests from both sides.
+    3. After resolving all conflicts and `git add`-ing: `git rebase --continue` (or `git rebase --skip` if the commit is now empty / was already upstream).
+
+    **Commit already upstream (empty after resolution):**
+
+    ```bash
+    # After git add of all resolved files, if git rebase --continue says:
+    # "No changes - did you forget to use 'git add'?" or produces an empty commit:
+    git rebase --skip   # drop this commit (its content is already in main)
+    ```
+
+    #### H. C++ clang-format vs CMake
+
+    - `clang-format` is C/C++/Java/JS only — pointing it at `CMakeLists.txt` silently mangles it (`include(cmake / X.cmake)`, broken `project()`/`if()`) into a CMake CONFIGURE-time parse error. Format only the `.cpp/.h` files you edited, **by name**. For an additive CMake conflict, take main's version verbatim and `sed`-insert only the PR's new source lines after a stable anchor.
+
+    #### I. Safety Net constraints (recurring)
+
+    `git checkout --ours/--theirs/--`, `git restore`, `git reset --hard`, `git branch -D`, `git worktree remove --force`, `rm -rf <fixed-path>`, and even commit-message text containing `git restore --theirs` are blocked. Safety Net custom rules can only ADD restrictions, not bypass built-ins. Workarounds: `git show :2:/:3:` writes (conflict take); `git reset --keep` (not `--hard`); `git branch -d` (not `-D`); `git worktree remove` (not `--force`); `git stash`/`stash drop` to discard artifact edits (NOT mid-rebase with unmerged paths — git refuses); `mktemp -d` (not pre-cleaning a fixed path); write commit messages via `git commit -F /tmp/msg.txt`; escalate `git checkout --ours` to the main conversation (sub-agents share the hook environment).
+
+    **Cat-through-tmp pattern** (when `git show :2:/:3:` is insufficient, e.g. Safety Net also blocks the redirect-to-destination or you want a specific named ref outside of an active conflict):
+
+    ```bash
+    # Takes the version at REBASE_HEAD (= "theirs" in a rebase = your replayed commit's version)
+    git show REBASE_HEAD:<path/to/file> > /tmp/file_version.py
+    cat /tmp/file_version.py > <path/to/file>   # shell cat-redirect is not git; Safety Net doesn't intercept
+    git add <path/to/file>
+
+    # For main's version (= "ours" in a rebase) use origin/main or HEAD:
+    git show origin/main:<path/to/file> > /tmp/file_main.py
+    cat /tmp/file_main.py > <path/to/file>
+    git add <path/to/file>
+    ```
+
+    Why it works: Safety Net pattern-matches on `git checkout <file-args>` and `git restore --source=<ref>` by command name. `git show <ref>:<path>` + shell redirection is not a destructive git command — it only reads. The `cat /tmp/X > <dest>` write step is a pure shell operation that Safety Net does not intercept. Verified: ProjectHephaestus issue #1357 rebase conflict resolution, 2026-06-15.
+
+    #### J. SHA-pin-blocked stale PRs — required check SKIPPED via dependency chain
+
+    **Symptom:** A PR shows `mergeable=MERGEABLE` (no git conflict) but `mergeStateStatus=BLOCKED`. Inspecting check-runs reveals a required context (e.g. `markdownlint`) has status `SKIPPED`, not `failed`. The PR's `validate` check passed.
+
+    **Root cause chain:**
+
+    1. An org-wide policy PR pinned all GitHub Actions to full commit SHAs and forbade unpinned action references (e.g. `actions/setup-python@v6` → must be `actions/setup-python@<sha>`).
+    2. PR branches created **before** that policy PR still carry unpinned actions in their local copy of the workflow files.
+    3. Those branches' `lint` job fails with: `The action X is not allowed. Actions in this workflow must be pinned to a full-length commit SHA.`
+    4. The required `markdownlint` job is declared `needs: lint` — when `lint` fails (not `skipped`, but `failure`), `markdownlint` is **SKIPPED** by GitHub Actions dependency semantics.
+    5. GitHub branch protection treats `SKIPPED` as **not satisfied** for a required check context — identical to the check never running. The PR stays BLOCKED even though `validate` passed and there is no git conflict.
+
+    **Diagnosis commands:**
+
+    ```bash
+    # 1. Confirm the required contexts
+    gh api repos/OWNER/REPO/branches/main/protection/required_status_checks --jq '.contexts'
+    # or for rulesets:
+    gh api repos/OWNER/REPO/rulesets --jq '.[].rules[].parameters.required_status_checks'
+
+    # 2. List check-runs on the PR's head SHA — find any required context that is SKIPPED
+    gh pr view <N> --json statusCheckRollup \
+      --jq '.statusCheckRollup[] | select(.conclusion == "SKIPPED" or .conclusion == null) | {name, conclusion, status}'
+
+    # 3. Inspect the failing lint log for the pin-policy error
+    gh run list --json databaseId,name,conclusion --jq '.[] | select(.conclusion == "failure") | .databaseId' | head -3
+    gh run view <id> --log-failed | grep -iE 'not allowed|must be pinned|pin'
+    # Expected: "The action 'actions/setup-python@v6' is not allowed ... must be pinned to a full-length commit SHA"
+
+    # 4. Confirm the PR branch still carries the unpinned action
+    git show origin/<branch>:.github/workflows/<workflow>.yml | grep -E 'uses:.*@v[0-9]'
+    ```
+
+    **Fix:**
+
+    ```bash
+    # Rebase the branch onto current main — inherits main's pinned workflow files
+    git worktree add /tmp/pr-<N> origin/<branch>
+    git -C /tmp/pr-<N> rebase origin/main
+    # Skill PRs touching only skills/*.md rebase CLEANLY (0 conflicts typical)
+    git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+    gh pr merge <N> --auto --squash   # re-arm after every force-push
+    git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/pr-<N>
+    ```
+
+    **Why an empty re-trigger commit does NOT work:** an empty commit replays on the same branch tip, which still carries the unpinned workflow file. CI runs `lint` against those same unpinned actions, fails identically, and `markdownlint` is SKIPPED again. The branch MUST inherit main's pinned workflow files via rebase.
+
+    **Companion: combined-status "pending" with count=0 (separate stuck state)**
+
+    After rebasing and arming auto-merge, you may observe a second stuck state: **both required check-runs pass** (`validate=success`, `markdownlint=success`) but GitHub's legacy combined-status still reads `pending` and blocks auto-merge. This is a GitHub caching artifact — the combined-status engine has not recomputed after the force-push. Pushing an **empty signed commit** forces GitHub to recompute:
+
+    ```bash
+    git -C /tmp/pr-<N> commit --allow-empty -S -m "chore: re-trigger combined-status recompute"
+    git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+    gh pr merge <N> --auto --squash
+    ```
+
+    Once GitHub recomputes (typically seconds to minutes), all passing PRs merge. This is a pure caching fix, not a workflow fix — it only applies AFTER the rebase has already made the check-runs green.
+
+    **Swarm execution for 100+ affected PRs:**
+
+    Partition PRs across parallel Haiku sub-agents, one isolated worktree per PR:
+
+    ```bash
+    # Per sub-agent: sequential rebase over assigned PR list
+    for N in <assigned-prs>; do
+      branch=$(gh pr view $N --repo OWNER/REPO --json headRefName --jq .headRefName)
+      git worktree add /tmp/rebase-$N origin/$branch
+      if git -C /tmp/rebase-$N rebase origin/main 2>&1 | grep -q CONFLICT; then
+        echo "CONFLICT PR#$N — flag, do not stall"
+        git -C /tmp/rebase-$N rebase --abort
+        git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/rebase-$N
+        continue
+      fi
+      git -C /tmp/rebase-$N push --force-with-lease origin HEAD:$branch
+      gh pr merge $N --auto --squash --repo OWNER/REPO
+      git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/rebase-$N
+    done
+    ```
+
+    - Flag genuine conflicts (stale skills/*.md rarely conflict; workflow conflicts mean the branch predates even main's structure).
+    - Use `--squash` — squash-only repos reject `--rebase`.
+    - Re-arm auto-merge AFTER the push, not before.
+
+    #### K. Broken main from a semantic collision between two independently-merged PRs
+
+    **Symptom:** During a serial merge-train, after several PRs merge, the *trailing* PRs — including ones that NEVER touched the failing test — all fail the **same** test when re-rebased onto the now-advanced main. There are NO conflict markers; each rebase is textually clean. The tell is the *shared* failure across unrelated PRs.
+
+    **Root cause:** Two PRs each modified the same function/test pair in compatible-looking ways. Each passed its OWN CI (each was green against the main it saw). But once BOTH merge, their UNION on main is inconsistent and fails at RUNTIME. Because there is no textual conflict, conflict resolution never surfaces it — only a test run catches it.
+
+    **Concrete case (ProjectHephaestus, 2026-06-14):**
+
+    - PR #1336 extended `_process_review_iteration` to return a **9-tuple** (added `reopened_keys, validator_clean`); its caller `_run_impl_review_loop` was updated to unpack 9.
+    - PR #1337 (merged independently) ADDED a new test `test_review_loop_resolves_conflict_before_first_review` whose mock `_iter` returned the OLD **7-tuple** (`return "GO","A","ok",[],False,[],True`).
+    - Each PR was green on its own. After BOTH merged, main failed: `ValueError: not enough values to unpack (expected 9, got 7)` at `_review_phase.py:635`.
+    - Fix was a 1-line mock update appending the 2 new fields (`..., True, set(), True`) — landed as #1340 / issue #1339.
+
+    **Diagnosis procedure:**
+
+    1. Get the exact failing test name + error from the run log:
+       `gh run view <id> --log-failed | grep -E "FAILED tests/|^E "`.
+    2. If the SAME test fails across MULTIPLE unrelated rebased PRs → it is almost certainly **main**, not the PRs.
+    3. **PROVE main is red, don't guess** — check the failing test out against bare `origin/main` in a clean worktree and run it:
+
+       ```bash
+       git worktree add /tmp/main-check origin/main
+       cd /tmp/main-check && pixi run python -m pytest <exact::failing::test> -x
+       # fails on bare main → the bug is main's, not any PR's
+       ```
+
+    4. Find the arity/signature mismatch: locate ALL return statements of the function AND the call site's unpack arity, AND any MOCK of that function in tests (the stale mock is the usual culprit — a test that hard-codes the old tuple).
+
+       ```bash
+       git show origin/main:<func-file> | grep -nE 'return '        # real return arity
+       grep -rnE '<func-name>|return \(|return "' <test-file>       # stale mock of the function
+       ```
+
+    5. **FIX MAIN FIRST** in its own small PR: file an issue, branch off `origin/main`, fix the mock/signature, sign, PR, label go, arm auto-merge. Do NOT try to fix it inside each trailing PR — the breakage is shared; fix it once on main.
+    6. After the main-fix merges, the trailing PRs re-green by **RE-RUNNING their CI** (or a trivial rebase) against the corrected main — they do NOT each need the fix.
+
+    #### C2. Post-rebase verification checklist (run before claiming clean)
+
+    - **No conflict markers survive** in any rewritten file: `grep -nE '^(<<<<<<<|=======|>>>>>>>)' <file>` returns nothing.
+    - **Distinguish stale-practice-being-taught from anti-pattern-being-warned-against by reading surrounding context, not raw grep counts.** A rewritten file that intentionally teaches "❌ flake8" / "Never use `src/`" will still match `grep flake8|src/`; those are correct anti-pattern examples, not residue. Read the surrounding lines before treating a token hit as a failure — raw counts mislead.
+    - **Run the REAL gate, not just formatting hooks**: `pre-commit run --all-files` (all hooks, not a single markdownlint) AND the full test suite (`pixi run python -m pytest tests/`). A clean rebase with green formatting can still ship broken code.
+    - **Local `git log --format='%G?'`=`U`/`N` after a rebase is a FALSE NEGATIVE** when the environment lacks an `allowedSignersFile` for the SSH key — the commit IS signed and GitHub verifies it server-side. Trust GitHub REST `.commit.verification.verified`, not local `%G?` (see § B2).
+
+    #### L. Test mock divergence after rebase — regenerate mocks against actual implementation
+
+    **Trigger**: Rebase completes with NO git conflict markers (textually clean), but tests immediately fail with signature mismatches or tuple-arity errors. Test mocks expected the PR branch's refactored function signatures; rebase brought in origin/main's DIFFERENT implementation. The git conflict resolved cleanly, but semantic divergence between test expectations and actual code remains hidden until test-time.
+
+    **Concrete case (ProjectHephaestus PR #1633, issue #1405):**
+
+    - PR branch refactored `local_branch_exists()` to use `run_subprocess()` instead of `subprocess.check_output()`. Tests were mocked to expect `run_subprocess`.
+    - Rebase onto origin/main brought in origin/main's implementation which still uses `subprocess.check_output()` (pre-refactor).
+    - Git conflict on the source file resolved cleanly because the changes didn't textually overlap in the conflict markers.
+    - But tests failed: mock expected `run_subprocess` calls; actual code calls `subprocess.check_output()`. Mismatch was NOT visible during conflict resolution — only at test-run.
+
+    **Key insight**: Git textual conflict resolution is INSUFFICIENT. After a rebase that brings in different implementation, test mocks may be stale relative to actual code, even though there are no conflict markers.
+
+    **Diagnosis and fix:**
+
+    1. **Run tests immediately after rebase**:
+       ```bash
+       git -C <worktree> rebase origin/main
+       # Rebase completes successfully, no conflicts
+
+       # Run tests in the worktree
+       cd <worktree>
+       pixi run pytest tests/unit/ -v --tb=short
+       ```
+
+    2. **Identify mock mismatches** — look for:
+       - `AssertionError: expected call to <func>(...) not found` — test expects a call that doesn't happen in actual code
+       - `TypeError: <func>() takes N positional arguments but M were given` — function signature changed
+       - `ValueError: not enough values to unpack (expected N, got M)` — return-tuple arity mismatch
+       - `AttributeError: module '<mod>' has no attribute '<func>'` — test mocks a function that doesn't exist in current code
+
+    3. **Compare actual implementation vs test mocks**:
+       ```bash
+       # Read the ACTUAL current implementation in the worktree
+       git show HEAD:<file-path>  # current post-rebase code
+
+       # Read test file expectations
+       cat <test-file>
+
+       # Identify divergences:
+       # - Test mocks subprocess.check_output; code uses run_subprocess
+       # - Test expects 9 return values; code returns 7
+       # - Test imports non-existent function
+       ```
+
+    4. **REGENERATE test mocks to match actual code** (do NOT "fix" code to match test expectations):
+       ```python
+       # BEFORE (stale mock from PR branch):
+       from unittest.mock import patch
+       with patch('subprocess.check_output') as mock_co:
+           mock_co.return_value = b"some-branch"
+           # ... test code ...
+
+       # AFTER (regenerated to match ACTUAL implementation):
+       from unittest.mock import patch
+       from hephaestus.utils import run_subprocess  # actual function used
+       with patch('hephaestus.utils.run_subprocess') as mock_rs:
+           mock_rs.return_value = "some-branch"  # matches actual signature
+           # ... test code ...
+       ```
+
+    5. **Fix implementation bugs surfaced during rebase** (separate from mock regeneration):
+       ```python
+       # If rebase brought in a function that takes wrong arguments:
+       def local_branch_exists(branch: str, timeout: int = 30) -> bool:
+           # Code expects timeout; test was calling without it
+           pass
+
+       # Test call needed updating:
+       # BEFORE: local_branch_exists(branch_name)
+       # AFTER: local_branch_exists(branch_name, timeout=60)
+       ```
+
+    6. **Re-run tests to verify all mocks now match**:
+       ```bash
+       pixi run pytest tests/unit/ -v --tb=short
+       # All tests PASS after mock regeneration
+       ```
+
+    7. **Commit with clear message**:
+       ```bash
+       git -C <worktree> add tests/unit/  # only test files, mocks updated
+       GIT_EDITOR=true git -C <worktree> rebase --continue
+       # Or if this is the only fix needed after successful rebase conflict resolution:
+       git -C <worktree> push --force-with-lease origin HEAD:<branch>
+       ```
+
+    **Why this happens:**
+
+    - Rebase brings in DIFFERENT implementation than the PR branch expected
+    - Git's textual conflict detection only catches overlapping line edits
+    - Test mocks hardcode expected function names, signatures, return types
+    - These mocks are NOT updated during conflict resolution (they're not in conflict)
+    - Tests run AFTER push, surfacing the divergence only then
+
+    **Prevention:**
+
+    - After rebase completes, ALWAYS run `pixi run pytest` before pushing
+    - Never assume "clean rebase" = "semantically correct" — test suite is the truth
+    - For PRs touching both implementation AND tests that mock it, prioritize re-validating mocks post-rebase
+
+    **Related to trigger #14 (broken main)** but INVERTED: Trigger #14 is when main is broken because two independently-merged PRs never textually conflict but their UNION on main is inconsistent. Here, the PR branch's tests were correct for the PR's refactored code, but rebase brought in different code — the PR's tests become stale.
+
+    #### M. Rebase reported success but the branch was NEVER re-parented (stale merge-base)
+
+    **Trigger**: An agent (or you) runs `git rebase origin/main`, reports "rebased onto current main, force-pushed" — but the branch's merge-base with main is STILL the old base (e.g. 29 commits behind), and the branch does NOT contain main's recently-merged content. A "success" report is NOT evidence that the rebase took.
+
+    **Concrete case (ProjectHephaestus PR #1657)**: Two Opus agents each claimed to rebase the branch onto current main. In reality `git merge-base origin/main origin/<branch>` stayed pinned at the stale base, and a known main-only symbol (`load_state_file`, introduced by a merged sibling PR) was ABSENT from the branch. Trusting the self-report wasted multiple CI rounds.
+
+    **Root cause**: The rebase was performed from/onto a STALE ref (the worktree's `origin/main` was never re-fetched, or the rebase targeted a local stale `main`), OR — more insidiously — a later force-push from a SECOND worktree that had been created off the OLD branch tip silently re-based the WRONG base, resetting the branch back behind main. When several worktrees are created off `origin/<branch>` across multiple fix rounds, the last force-push wins, and if it came from a worktree built on an older tip it un-does the rebase.
+
+    **MANDATORY verification after ANY claimed rebase onto main** (do this BEFORE believing a "success" report):
+
+    ```bash
+    # 0. Re-fetch first — a stale local origin/main makes every check below lie.
+    git fetch origin
+
+    # 1. The merge-base MUST equal current origin/main. If it doesn't, the rebase did NOT take.
+    test "$(git merge-base origin/main HEAD)" = "$(git rev-parse origin/main)" \
+      && echo "RE-PARENTED OK" || echo "STALE BASE — rebase did NOT take"
+
+    # Same check against the PUSHED remote branch (catches a wrong-base force-push):
+    test "$(git merge-base origin/main origin/<branch>)" = "$(git rev-parse origin/main)" \
+      && echo "REMOTE RE-PARENTED OK" || echo "REMOTE STALE — last force-push reset the base"
+
+    # 2. The branch MUST now CONTAIN a known main-only symbol from a recently-merged sibling.
+    #    >0 means the merged content is present; 0 means the branch never picked up main.
+    git show origin/<branch>:<file-with-the-symbol> | grep -c '<symbol-only-on-recent-main>'
+    #    e.g.  git show origin/1657-branch:hephaestus/automation/state.py | grep -c 'load_state_file'
+    ```
+
+    If EITHER check fails, the rebase did NOT take — discard the "success" report and redo the rebase from the CURRENT `origin/<branch>` tip.
+
+    **Prevention / correct procedure**:
+
+    - Always create the rebase worktree from the CURRENT `origin/<branch>` (re-fetch first): `git fetch origin && git worktree add /tmp/pr-<N> origin/<branch>`.
+    - Never force-push from a worktree built on an OLDER branch tip — across multiple fix rounds, always re-fetch and re-create from the latest `origin/<branch>`.
+    - After pushing, RE-VERIFY the remote merge-base (`git merge-base origin/main origin/<branch> == origin/main`) — a force-push from a stale worktree silently resets it.
+    - The pair of checks above (merge-base + main-only-symbol grep) is the contract; a self-reported "rebased and pushed" is not.
+
+    #### N. Half-applied multi-layer refactor rebase (options-object fixed, helper functions still flattened)
+
+    **Trigger**: A PR intentionally changes a SET of related values across MULTIPLE layers — e.g. restores per-phase timeouts (300/1800/600) over a regressed flat value (7200). The conflict resolution fixes ONE layer (the dataclass/pydantic options-object field defaults in `models.py`) but LEAVES the parallel layers — the `*_timeout()` helper FUNCTIONS in `claude_timeouts.py` and the constants in `constants.py` — in the WRONG/flattened state. The PR then passes a spot-check of `models.py` but the helper functions used at most call sites return the wrong value.
+
+    **Concrete case (ProjectHephaestus PR #1657)**: After rebase, `models.py` correctly had `AGENT_PLAN_TIMEOUT(300)` / `AGENT_IMPL_TIMEOUT(1800)`, but EVERY helper — `planner_claude_timeout()`, `implementer_claude_timeout()`, etc. — returned a flat `DEFAULT_AGENT_TIMEOUT` of `7200`, and `constants.py`'s `AGENT_*` constants plus `read_timeout_env` had been DELETED. The regression was invisible to a `models.py` spot-check; it was caught ONLY by reading the actual CI unit-test failure `assert 300 == 7200` (test `test_uses_central_learn_timeout`), not by any agent self-report.
+
+    **Key insight**: When a refactor spans multiple layers (constants + helper functions + options-object defaults + tests), VERIFY EVERY layer after the rebase, not just one. A correct `models.py` is necessary but NOT sufficient — the functions consumers actually call live in a different file and may still be flattened.
+
+    **Correct resolution for a "restore main's per-phase values" conflict**:
+
+    - For the constants / helper / test files, take main's version WHOLESALE, then re-add ONLY the PR's genuinely-new additions:
+
+      ```bash
+      # Restore the correct per-phase constants and helper functions from main:
+      git show origin/main:hephaestus/.../constants.py      > hephaestus/.../constants.py
+      git show origin/main:hephaestus/.../claude_timeouts.py > hephaestus/.../claude_timeouts.py
+      git show origin/main:tests/.../test_claude_timeouts.py > tests/.../test_claude_timeouts.py
+      git add hephaestus/.../constants.py hephaestus/.../claude_timeouts.py tests/.../test_claude_timeouts.py
+      # THEN re-add only the PR's genuinely-new additions (e.g. a new CLI DEFAULT_ constant),
+      # not the flattened values the rebase carried in.
+      ```
+
+    - Add an EXPLICIT per-value assertion check — run the helper functions and assert each per-phase result, not just the options-object default:
+
+      ```bash
+      python3 -c "
+      from hephaestus.automation.claude_timeouts import planner_claude_timeout, implementer_claude_timeout
+      assert planner_claude_timeout() == 300, planner_claude_timeout()
+      assert implementer_claude_timeout() == 1800, implementer_claude_timeout()
+      print('per-phase timeouts OK')
+      "
+      # And run the SPECIFIC test that encodes the contract:
+      pixi run pytest tests/.../test_claude_timeouts.py::...::test_uses_central_learn_timeout -x
+      ```
+
+    - READ the CI test-failure output — `assert 300 == 7200`-style messages pinpoint a half-applied value regression. The expected-vs-actual pair tells you exactly which layer is still flattened (here: the function returned the flat default `7200` instead of the per-phase `300`).
+
+    **Why this happens**: Git's textual conflict resolution operates file-by-file. A resolver focused on the most-visible layer (`models.py`) can cleanly resolve it while the parallel layers — the helper functions and constants that the call sites actually use — silently retain the regressed/flattened values from whichever side the rebase happened to keep. The options-object default and the helper-function return are two independent encodings of the SAME contract; fixing one does not fix the other.
+
+    ## Failed Attempts
+
+    | Attempt | What Was Tried | Why It Failed | Lesson Learned |
+    |---------|----------------|---------------|----------------|
+    | Blanket `--ours`/`--theirs` for all conflicts | Resolved every hunk with one global side | Loses PR-specific work / keeps inferior side; misses genuine improvements | Resolve per-hunk after reading `git show REBASE_HEAD -- <file>` vs `git show HEAD:<file>`; subsume-vs-integrate decision first |
+    | `--ours`/`--theirs`/hand-merge for `pixi.lock` | Standard conflict resolution on the lockfile | Encodes SHA256 of local editable pkg; merged/manual result is always invalid → "lock-file not up-to-date" | `rm pixi.lock && git add`, then `pixi lock`; after any `pyproject.toml` edit, `pixi lock` again |
+    | Taking the PR's `marketplace.json`/dropping orphaned lines unchecked | Took PR-regenerated marketplace; cleared markers but missed lines outside them | PR copy is stale (missing entries merged since); discarded approach's lines survived outside conflict blocks | `git checkout --ours marketplace.json`; after resolving markers grep the losing approach's keywords |
+    | Auto-merge a full-file rewrite | `git mergetool`/accepted 3-way result | Interleaved old+new structure, duplicate tables, broken headings | Take the rewrite side, then hand-apply the small delta |
+    | Wrong rebase ours/theirs | Used `--ours` to keep the PR / `--theirs` to keep main | In rebase ours=main, theirs=PR (opposite of merge) | Verify with `git ls-files --stage` before writing; remember rebase inverts the sides |
+    | `git checkout --ours/--theirs/--`, `git restore`, `--hard`, `-D`, `worktree remove --force` | Standard git during rebase / cleanup | Safety Net blocks them (and can't be whitelisted) | Use `git show :2:/:3:`, `git reset --keep`, `git branch -d`, `git stash`/`mktemp -d`, escalate to main conversation |
+    | `git checkout --theirs <file>` / `git restore --source=REBASE_HEAD -- <file>` during rebase conflict resolution | Tried to take "their" (main's rebased-onto) version of conflicted files during PR rebase in Safety-Net-protected environment | `git checkout --theirs` blocked ("may overwrite files"); `git restore --source=REBASE_HEAD` blocked ("discards uncommitted changes") | Use cat-through-tmp pattern: `git show REBASE_HEAD:<path> > /tmp/X && cat /tmp/X > <dest> && git add <dest>` — Safety Net intercepts git checkout/restore by command name but not `git show` (read-only) + shell redirect (not git) (ProjectHephaestus issue #1357, 2026-06-15) |
+    | `git stash` mid-rebase per Safety Net's own hint | Followed "use git stash first" with unmerged paths | git refuses to stash with unmerged paths | Mid-rebase the only safe ops are `git show :<stage>:<file>` writes or escalation |
+    | Enabling auto-merge before rebasing / not re-arming after force-push | Armed `--auto` on CONFLICTING PRs; assumed it persisted | CONFLICTING ignores the flag; every force-push silently clears auto-merge | Rebase→push→THEN arm; re-arm after every force-push |
+    | Pushing replayed commits without re-signing / trusting local `%G?` | Plain rebase on a verified-commits repo, then force-pushed; read `U` from `git log --format='%G?'` as "broken signature" | Rebase strips GPG/SSH signatures → unsigned replayed commits stall the merge; local `%G?` reports `U` even for validly-signed commits (key not in keyring) | Re-sign all replayed commits: `git rebase --exec "git commit --amend --no-edit -S --no-verify" <base>`; verify via GitHub REST `commit.verification.verified`, not local `%G?` |
+    | `git checkout --theirs`/blind take-theirs across a rebase | Looped take-theirs at each conflict | Resolves to main-at-that-replay-step, and a PR's own later commit re-introduces a stale value (`>=1` vs main's `==0`) → hybrid tree | Conflict-resolution ≠ "make this file match main"; verify the file at the final sha and fix the stale assertion |
+    | Single-step resolution for a multi-commit rebase | Assumed one conflict round | A later commit removed what an earlier one added — opposite intent | Read `git log origin/<branch>` first; resolve each commit by its message's intent |
+    | Trusting auto-merge / no-conflict-markers = semantically correct | Pushed a clean rebase without type-check | Two non-overlapping edits produced a TS7022/TS2448 shadow/TDZ bug | After any rebase touching shared code, run the type-checker/linter before pushing |
+    | Trusting a stale automated fix plan ("already merged") | Acted on plan claiming the commit was on main | `git log origin/main \| grep <sha>` returned nothing | Always verify git state independently before acting on a plan |
+    | Force-pushing a near-no-op after an add/add already-merged rebase | A PR's whole substantive change (emoji removal + a new regression test) had independently landed on main via a sibling PR; rebasing produced `CONFLICT (add/add)` on the duplicated new test file; blindly took one side and shipped | Both branches created the same new file, so the conflict is a duplicate not a divergence; resolving it left only a trivial residual delta — the PR had become a near-no-op nobody flagged | INVERSE of the row above: don't distrust the "already merged" claim — independently CONFIRM it (`git show origin/main:<path>`; `git diff <merge-base>..origin/main -- <paths>`). For add/add, take main's merged file as base and re-apply ONLY your genuine residual delta (here a 4-line comment fix). After `--continue`, run `git diff origin/main...HEAD --stat`; if empty/trivial the PR is superseded — surface to the human (close as superseded), don't silently ship a no-op. Re-sign the replayed commit with the key-UID-matched committer email (`git -c user.email=<key-UID> -c user.name=... rebase --continue`) or GitHub reports `verified=false reason=no_user`; verify via `gh api repos/O/R/commits/<sha> --jq .commit.verification`, not local `%G?` |
+    | Re-running CI / direct-pushing a diverged fix | `gh run rerun`; `git push <fix-sha>:<branch>` | CI ran the unfixed SHA; push rejected non-fast-forward (diverged history) | Cherry-pick the fix onto a temp branch from `origin/<pr-branch>` and fast-forward push |
+    | Trusting GitHub retarget to propagate later commits | Assumed retargeting B onto A pulls in B's later fixes | Retarget is a one-shot fast-forward; later commits stay orphaned from A | Cherry-pick orphan fixes onto the prereq, or land fixes on the prereq first |
+    | Parallel waves on shared-hot-file PRs | Re-ran parallel re-rebase waves on the diminishing DIRTY subset | Each merge re-DIRTYs siblings sharing routes.cpp/CMakeLists; never converges | Switch to a serial merge train for shared-hot-file PRs |
+    | `git add .`/`-A` during rebase | Staged all files | Committed untracked artifacts / build outputs | Stage specific files by name only |
+    | `gh pr checkout`/local checkout for rebase | Reused a stale local branch / shared working tree | Wrong-branch rebases; `--hard` reset blocked; "branch already used by worktree" | `git worktree add /tmp/x origin/<branch>`; per-agent isolated worktrees |
+    | `git checkout --theirs` for additive CMake test targets | Took one side of two independent `add_executable`/`gtest_discover_tests` blocks | Dropped the rebasing PR's new test target | Keep BOTH: Python strip-conflict-markers retaining HEAD + incoming |
+    | `clang-format -i src.cpp CMakeLists.txt` | Formatted a build file during resolution | Mangled CMake → CONFIGURE parse error (not where you'd suspect) | Format only the C/C++ files you edited, by name; resolve CMake by hand/regen |
+    | Pushing a hand-resolved C++ merge without a local build | Let CI find errors | CI surfaces one slow error per round; missed a sibling signature change | Build locally first — one build surfaces every error (CMake parse + signature) at once |
+    | Dropping the PR's duplicate optimizer module / loosening a failing test | Kept main's copy; relaxed a bound to go green | API signature differs → broke dependent code; loosened test guards nothing; compiling ≠ correct | Adapt call-site to main's API + document numeric equivalence; fix asserts with derived values; defer provably-broken math |
+    | Hunting for a failing CI job on a DIRTY PR | Re-ran/inspected checks on a PR stuck BLOCKED with `mergeStateStatus=DIRTY`, `mergeable=CONFLICTING` | Every check was already green — the **merge conflict itself** was the blocker, no job to fix | `gh pr view N --json mergeStateStatus,mergeable,statusCheckRollup`; DIRTY+all-green → rebase, do not chase CI (ProjectHephaestus PR #1014) |
+    | `git rm` on a modify/delete conflict without checking the base copy | Blindly deleted the file to keep the PR's intent | If main legitimately ADDED content to that file, the deletion silently discards it | A modify/delete is a decision about intent: first `git show origin/main:<path> \| grep -niE '<stale-tokens>'` to confirm the base is still stale, THEN `git rm` + `GIT_EDITOR=true git rebase --continue` |
+    | Treating raw grep token counts as conflict residue after a rewrite | Failed a rewritten skill because `grep flake8` still matched | The matches were intentional anti-pattern examples ("❌ flake8", "Never use `src/`"), not stale practice | Read surrounding context — distinguish a practice being WARNED-against from one being TAUGHT; counts mislead |
+    | `--theirs` for every file in drop-and-redo | Took the PR's pre-sibling version of cross-cutting files | Silently reverted siblings' substantive changes | `--theirs` is safe only for incidental upstream changes; else drop-and-redo |
+    | Hand-merging a 1000+ line facade-vs-monolith conflict | Resolved markers by hand | Hundreds of moved lines interleaved with ~50 feature lines; not auditable | Abort, reset to main, `git apply` clean files, hand-port delta onto sub-modules |
+    | Validating `marketplace.json` count mid-rebase | Expected the final entry count during commit 8/11 | Mid-rebase tree is a snapshot, not the final state | Only validate the final count after `git rebase` completes |
+    | Reading top-level CI `conclusion: failure` | Assumed required checks failed | Overall conclusion is failure if ANY job (incl. non-required) fails | Inspect per-job and cross-ref `required_status_checks.contexts` |
+    | Re-arming/rebasing a PR with ZERO checks on its head SHA | Tried auto-merge/rebase to clear BLOCKED+MERGEABLE | Required named contexts never ran (workflow not triggered / `paths:` filter) | Push an empty signed commit to re-trigger, or fix the workflow `paths:` |
+    | Suppressing a transitive-dep CVE with `--ignore-vuln` | Silenced a pip-audit red across all PRs | Hides the advisory; must repeat per CVE | Pin the fixed version in `pixi.toml`, regen lock, ship as a separate small PR that unblocks the repo |
+    | Punting a mechanical lint failure to the author | Deferred a Mojo Syntax Validation failure | It was mechanical (variadic `List[T](args)` → typed literal `var x: List[Int]=[...]`) | Read the actual error; reserve "needs author" for real domain decisions |
+    | Rebasing onto a broken main / starting without checking for open PRs | Rebased a queue while main CI was red / `git branch -vv` "ahead 1" misled | Can't unblock PRs via a broken main; "ahead 1" is a squash artifact | `gh pr list --state open` + `gh run list --branch main` first; `git cherry` to confirm unmerged work |
+    | Empty re-trigger commit to fix SHA-pin-blocked SKIPPED required check | Pushed an empty commit to force CI re-run on a branch where `markdownlint` showed SKIPPED and PR was BLOCKED with `mergeable=MERGEABLE` | The empty commit replays against the same branch tip, which still carries the unpinned action in its workflow file — `lint` fails identically with "action must be pinned to full-length commit SHA", `markdownlint` is SKIPPED again, and the PR stays BLOCKED | The branch must REBASE onto current main to inherit main's pinned workflow files; only then will `lint` pass and `markdownlint` run to completion (verified-ci: 107 PRs unblocked, ProjectMnemosyne 2026-06-13) |
+    | Enabling auto-merge while required check still SKIPPED (before rebase) | Armed `gh pr merge --auto --squash` on a BLOCKED PR before rebasing | `mergeStateStatus=BLOCKED` means auto-merge is ignored even after arming — GitHub records the arm but cannot merge; the branch stays stuck | Rebase first → push → THEN arm auto-merge; re-arm after every force-push |
+    | `git checkout --ours/--theirs` during rebase in Safety-Net-guarded repo | Attempted standard conflict resolution shortcut during the rebase phase | Safety Net hook blocks `git checkout <ref> -- <path>` as a destructive operation | Use `git show origin/main:<path> > <path>` (equivalent to `--ours` in rebase context) then `git add <path>` |
+    | Diagnosing SHA-pin-blocked PRs as a CI/code failure | Investigated failing job logs in the PR's own code/tests | The real failure is in the workflow file (unpinned action reference), not the PR's code content — the PR's actual code is typically fine | Compare required contexts list against head-SHA check-runs; a required context showing SKIPPED when it should be SUCCESS points to a `needs:` chain collapse upstream, not a code bug |
+    | Assume a rebased PR's red CI is the PR's fault | Investigated each trailing PR's own code when its required CI went red after rebasing onto main | The SAME test (`test_review_loop_resolves_conflict_before_first_review`) failed on MULTIPLE unrelated PRs because MAIN was red from a 9-tuple-vs-7-tuple-mock semantic collision (#1336 return-arity change + #1337 stale mock, each green alone) — no textual conflict, invisible to rebase | When the same test fails across multiple unrelated rebased PRs, run that test against bare `origin/main` to PROVE main is red, then fix main first (ProjectHephaestus #1340/#1339, 2026-06-14) |
+    | Try to fix the broken test inside each trailing PR | Started patching the stale mock separately in each of the 4 trailing PRs | The breakage is SHARED on main, not per-PR; per-PR fixes duplicate work, diverge, and collide on the next merge | Land ONE main-fix PR (issue → branch off origin/main → 1-line fix → sign → label go → arm), then re-green the queue by re-running CI; trailing PRs need no per-PR change |
+    | Opened an AA-conflicted file and searched for `<<<<<<<` markers | Expected standard conflict marker syntax in a file with `CONFLICT (add/add)` in rebase output | AA (both-added) conflicts do NOT produce `<<<<<<<` markers — the file shows only one side's content (whichever git chose to write). Searched for markers that don't exist, missed the real conflict | Check `git status` left-column codes first: `AA` = both-added (no markers), `UU` = both-modified (markers present). For AA, read both sides with `git show HEAD:<path>` and `git show REBASE_HEAD:<path>` before resolving (ProjectOdyssey PR #5500, 2026-06-19) |
+    | Called `git rebase --continue` before adding all AA-conflicted files | Ran `--continue` after resolving some files, assuming git would prompt for the rest | Got "unresolved conflicts" error — git requires ALL conflicted paths to be staged before `--continue` | After resolving each AA/UU conflict with `git show` + edit + `git add`, verify `git status` shows no remaining `AA`/`UU` entries before calling `git rebase --continue` |
+    | Called `git rebase --continue` when the commit's changes were already on main | Tried `--continue` on a commit that was upstream-equivalent after AA resolution | Git refused with "No changes — did you forget to use 'git add'?" because the resolved content was identical to HEAD — the commit was already upstream | Use `git rebase --skip` to drop a commit whose content is already on main; `--continue` is only for commits with genuine new content after resolution |
+    | Assumed clean rebase = semantically correct; skipped post-rebase tests | Rebase completed with no conflict markers; force-pushed immediately | Tests failed post-push with mock signature mismatches: test mocked `subprocess.check_output`, actual code uses `run_subprocess`; test expected 9-tuple return, code returns 7. Git conflict resolution is textual-only; test mocks for refactored functions remained stale. | ALWAYS run `pixi run pytest` immediately after rebase completes (before push). Test suite is the source of truth for semantic correctness. Regenerate mocks to match actual implementation, not PR expectations (ProjectHephaestus PR #1633, issue #1405 — trigger #18, § L) |
+    | Tried to rebase/land all cluster PRs in parallel (as the loop did) | Assumed independent PRs could merge concurrently | Only the first merged; the other 4 went CONFLICTING because they edit the same files — operator `state:skip` then stranded them | Serialize a same-file refactor cluster into a smallest-first rebase chain; the loop's parallel dispatch has no file-overlap awareness (§ K3) |
+    | Trusted a rebase agent's "rebased onto origin/main, force-pushed" self-report | Believed the success report and moved on without verifying the merge-base | The branch's merge-base stayed at the stale base (29 commits behind); the branch never contained main's merged sibling refactors (known main-only symbol absent); two Opus agents both reported success while the rebase never took — a later force-push from a worktree built on the OLD branch tip silently reset the base. Wasted multiple CI rounds. | ALWAYS verify after any claimed rebase: `git merge-base origin/main HEAD == git rev-parse origin/main` (re-fetch first) AND `git show origin/<branch>:<file> \| grep -c <known-main-only-symbol>` > 0 before believing a rebase succeeded; create the rebase worktree from the CURRENT `origin/<branch>` and re-verify the remote merge-base after pushing (ProjectHephaestus #1657, § M) |
+    | Resolved a multi-layer timeout refactor rebase by fixing only `models.py` options-object defaults | Spot-checked `models.py`, saw correct per-phase values (300/1800/600), declared the rebase resolved | `claude_timeouts.py`'s `*_claude_timeout()` functions stayed flattened to `7200` and `constants.py`'s `AGENT_*` constants + `read_timeout_env` were DELETED — a hidden per-phase value regression that passed the `models.py` spot-check but failed CI with `assert 300 == 7200` (test `test_uses_central_learn_timeout`). The options-object default and the helper-function return are two independent encodings of the same contract; fixing one didn't fix the other. | Verify EVERY layer of a multi-layer refactor (constants + helper functions + options-object defaults + tests), not just the most-visible one; for a "restore main's values" conflict take main's constants/helpers/tests files WHOLESALE (`git show origin/main:<file> > <file>`) then re-add ONLY the PR's genuinely-new additions; assert the actual function return values (`assert planner_claude_timeout()==300`) and run the contract test; read the CI `assert 300 == 7200` output to pinpoint the still-flattened layer (ProjectHephaestus #1657, § N) |
+
+    ## Results & Parameters
+
+    ```yaml
+    rebase_strategy: rebase (never merge main into the branch; keep history linear)
+    worktree: git worktree add /tmp/<name> origin/<branch>   # never local checkout
+    push_flag: --force-with-lease            # dependabot: --force (GitHub auto-rebases)
+    auto_merge: re-arm after EVERY force-push; --squash if rebase-merge disabled; arm AFTER push
+    silent_drop_check: git log origin/main..HEAD --oneline   # empty → close as superseded
+    ours_theirs_in_rebase: ours=:2:=HEAD=main ; theirs=:3:=REBASE_HEAD=your replayed commit
+    safety_net_take: git show :2:file > file (ours) | git show :3:file > file (theirs)
+    pixi_lock: rm + git add, then `pixi lock`  (never --ours/--theirs/hand-merge)
+    marketplace_json: git checkout --ours     (main = union of all merged entries)
+    changelog: take HEAD/main; consolidation PR gathers entries
+    shared_hot_files: SERIAL MERGE TRAIN (rebase→wait-MERGE→fetch→next), simplest-first
+    disjoint_files: parallel Sonnet/Haiku sub-agents in worktrees (~9 PRs/agent)
+    post_rebase_check: run type-checker/linter/local-build before pushing (semantic conflicts)
+    pre_push: pre-commit run --all-files (or repo recipe) before every push
+    ```
+
+    Auto-resolve "keep both / keep HEAD" (additive CMake/.pre-commit-config, or whitespace-only cascade):
+
+    ```python
+    import re, sys
+    p = sys.argv[1]; s = open(p).read()
+    # keep BOTH sides (strip markers only):
+    s = re.sub(r'<<<<<<< HEAD\n|=======\n|>>>>>>> [^\n]+\n', '', s)
+    open(p, 'w').write(s)
+    # then: grep -c '^<<<\|^>>>\|^===' file  → MUST be 0
+    ```
+
+    ```bash
+    # Stacked-PR orphan cherry-pick
+    git worktree add /tmp/fix origin/<prereq-branch> && cd /tmp/fix
+    git cherry-pick <orphan-sha> && npx markdownlint-cli2 <files>   # or the exact CI cmd
+    git push origin HEAD:<prereq-branch>                            # fast-forward, no --force
+
+    # Diverged-history fix (same content, different SHA)
+    git checkout -b <pr-branch>-fix origin/<pr-branch>
+    git cherry-pick <fix-sha> && git push origin <pr-branch>-fix:<pr-branch>
+
+    # Empty signed commit to re-trigger checks that never ran (NOT for SHA-pin SKIPPED — use rebase)
+    git commit --allow-empty -S -m "chore: re-trigger CI"
+
+    # SHA-pin BLOCKED: diagnose and fix
+    # 1. Identify which required context is SKIPPED
+    gh pr view <N> --json statusCheckRollup \
+      --jq '.statusCheckRollup[] | select(.conclusion == "SKIPPED") | {name, conclusion}'
+    # 2. Inspect lint failure for pin-policy error
+    gh run view <failing-run-id> --log-failed | grep -iE 'not allowed|must be pinned'
+    # 3. Fix: rebase to inherit main's pinned workflow files
+    git worktree add /tmp/pr-<N> origin/<branch>
+    git -C /tmp/pr-<N> rebase origin/main
+    git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+    gh pr merge <N> --auto --squash --repo OWNER/REPO
+    git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/pr-<N>
+    # 4. If combined-status still "pending" after checks turn green: empty-commit recompute
+    git -C /tmp/pr-<N> commit --allow-empty -S -m "chore: re-trigger combined-status recompute"
+    git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+    ```
+
+    ## Verified On
+
+    | Project | Context | Details |
+    |---------|---------|---------|
+    | ProjectOdyssey | 73 PRs post-#4902 CI fix (8 parallel Sonnet agents); PR #3097 (23 conflicts); PR #5348 semantic resolution; #5485/#5487 optimizer numeric-equivalence (Shampoo deferred → #5491); PR #3189 diverged-history cherry-pick | verified-ci / verified-local |
+    | ProjectMnemosyne | 157 PRs rebased + 27 superseded closed; 800+ CI-queue cherry-pick consolidation; stacked-PR #1976/#1978 markdownlint orphan cherry-pick; 1,176-file bulk-reformat conflicts; markdownlint `globs:"**/*.md"` main-fix-first | verified-ci / verified-local |
+    | ProjectScylla | 30 stale PRs; 21 PRs (17 conflicting) semantic+parallel; PR #1931 feature-on-refactor port (#1929 runner.py decomposition); pip-audit `--min-severity high` blocker fix + 13-issue wave; git-rebase-over-deletion #832→#882 | verified-ci / verified-local |
+    | ProjectKeystone | 14 + 11 PRs rebased; additive CMakeLists keep-both; #329 silent-drop recovery; pure-transport decouple→port→delete (#577-#581) per ADR-015/016 | verified-ci |
+    | ProjectNestor | 8 hot-file-sharing PRs via SERIAL MERGE TRAIN (#83/#87/#94/#97/#99/#101); PR #101 clang-format-CMake mangling + local-build-before-push | verified-ci |
+    | ProjectHephaestus | 30+ PR myrmidon waves; pixi task path / ruff S101 / caplog propagation; transitive-CVE pin #881 unblocked #879; PR #394 drop-and-redo (f-string conversion deferred) | verified-ci |
+    | ProjectHephaestus | 2026-06-11, PR #967 (issue #768): Emoji-removal fix + test had independently landed on main via a sibling PR; rebase produced `CONFLICT (add/add)` on `tests/unit/scripts/test_compare_benchmarks_no_emoji.py`. Resolved by taking main's merged file + re-applying only a 4-line comment correction; residual diff vs main was trivial (PR became near-no-op). Re-signed the replayed commit with key-matched committer email (`4211002+mvillmow@users.noreply.github.com`) so GitHub would not report `no_user`. verified-local: 4134 passed/19 skipped + pre-commit clean; not pushed. | verified-local |
+    | ProjectHephaestus | PR #1014/#720 DIRTY-with-all-green diagnosis + modify/delete resolution on an intentionally-deleted `references/notes.md` (rebase clean, pre-commit 32/32 hooks + 4134 tests green) | verified-ci |
+    | ProjectHermes | ~30 PRs sharing server.py/config.py/publisher.py via batch take-HEAD; PR 120 incomplete-implementation; CLEAN-but-un-armed arming #645/#648 | verified-ci |
+    | AchaeanFleet | Wave 2+3 rebase of 21 DIRTY PRs (Dockerfiles/ci.yml); PR #661 TS7022/TS2448 shadow/TDZ fix; #690 self-inflicted CI_BLOCKER removal via detached worktree | verified-ci |
+    | Myrmidons | 13 stacked-PR EOF-fixer cascade (~39 trivial conflicts, sed loop); shellcheck swarm in `.claude/worktrees/agent-*` (git -C + detached-HEAD branch -f); 0-open-PR squash-artifact detection | verified-ci / verified-local |
+    | Agamemnon / Odysseus | Extraction destination PRs #419/#420/#421; Odysseus #43 NATS reconciliation vs merged #32; Agamemnon #422 empty-commit re-trigger of 6 required checks | verified-ci / verified-local |
+    | HomericIntelligence/Odysseus | PR #64 full-file-rewrite conflict on docs/architecture.md (234-line rewrite vs 3-line delta) | verified-local |
+    | ProjectMnemosyne | 2026-06-13: org-wide SHA-pin policy PR landed on main; ~107 skill PRs created before the pin carried `actions/setup-python@v6` (unpinned). `lint` failed with "action not allowed — must be pinned", cascading to `markdownlint=SKIPPED` (declared `needs: lint`). All 107 PRs showed `mergeable=MERGEABLE` + `mergeStateStatus=BLOCKED`. Parallel Myrmidon Haiku swarm rebased each PR onto main (~9 PRs/agent in isolated worktrees, `--force-with-lease`). Skill PRs touching only `skills/*.md` rebased cleanly (0 conflicts). After push, CI re-ran with pinned actions, `lint` passed, `markdownlint` ran to success, auto-merge-armed PRs merged. Secondary: 107 PRs exhibited combined-status `pending` (count=0) caching; empty signed commit forced recompute and cleared the block. **verified-ci** | verified-ci |
+    | ProjectHephaestus | 2026-06-15, PR #1360 (issue #1360): Two parallel cluster-extraction PRs (#1360 and #1361) both extracted 12 repo-management functions from `loop_runner.py` into `loop_repo_manager.py`. After #1361 merged, #1360 rebased and produced `CONFLICT (add/add)` on `hephaestus/automation/loop_repo_manager.py` AND `tests/unit/automation/test_loop_repo_manager.py`. Source differences were docstrings/comments only — took main's version. Test file merged both sets of test classes. `pyproject.toml` allowlist comment conflict took main's. verified-ci: 1747 tests passed after rebase. | verified-ci |
+    | ProjectHephaestus | 2026-06-14 serial merge-train of ~12 PRs: 8/12 merged, then the trailing 4 all went red on `test_review_loop_resolves_conflict_before_first_review` (a test none of them touched). Root-caused to a SEMANTIC collision between two independently-merged PRs that never textually conflict: #1336 changed `_process_review_iteration` to return a 9-tuple; #1337 added a test whose mock returned the old 7-tuple. Union on main raised `ValueError: not enough values to unpack (expected 9, got 7)` at `_review_phase.py:635`. Proved via running the failing test against bare `origin/main`. Fixed once on main via a 1-line mock update (#1340 / issue #1339); trailing PRs re-greened by re-running CI. | verified-local (fix PR not yet merged at capture) |
+    | ProjectOdyssey | 2026-06-19, PR #5500 (`5451-auto-impl` branch): main had already merged the same shampoo.mojo, lion.mojo, and test_optimizers.mojo files the feature branch was implementing, causing AA conflicts across 3 commits. Key diagnostic: AA-conflicted files had NO `<<<<<<<` markers — file showed one side's content only. Resolution: `git show HEAD:<path>` / `git show REBASE_HEAD:<path>` to read both sides, took main's version for source files + cherry-picked unique wrapper functions from feature branch, union of test cases for test file. One commit was upstream-equivalent after resolution and needed `git rebase --skip`. Branch force-pushed with `--force-with-lease` and PR updated. | verified-local |
+    | ProjectHephaestus | 2026-06-26, 5-PR same-file refactor cluster (issues #1383/#1384/#1381/#1385/#1392, PRs #1613/#1615/#1612/#1616/#1621 — all merged): every PR edited `address_review.py`; 4 also touched `_review_utils.py` + `ci_driver.py`. The automation loop dispatched them in parallel with no file-overlap serialization, so only the first merged and the other 4 went CONFLICTING/DIRTY; an operator `state:skip` then stranded them. Unblocked by serializing into a smallest-diff-first rebase chain: each branch rebased onto trunk only AFTER the prior PR merged (conflicts shrank as extractions accumulated upstream), every conflict union-resolved (both helpers kept in `_review_utils.py`; each duplicated method made a thin delegate in the consumers; import lists merged and now-unused imports like `add_max_workers_arg` dropped via ruff), commits re-signed with `git rebase --exec "git commit --amend --no-edit -s -S" origin/main` for DCO+GPG. Two members carried `state:implementation-no-go` and earned `state:implementation-go` via `hephaestus-implement-issues` rather than a forced label flip. All 5 merged. | verified-ci |
+    | ProjectHephaestus | 2026-06-27, PR #1633 (issue #1405): Rebased autoimpl-generated PR onto origin/main; git conflicts in `hephaestus/github/pr_merge.py` and `tidy.py` resolved cleanly (no markers). Post-rebase tests failed with mock signature mismatches: test mocks expected PR's refactored code (`run_subprocess` calls) but rebase brought origin/main's pre-refactor implementation (`subprocess.check_output` calls). TRIGGER #18 / § L scenario: textual conflict resolved but semantic divergence hidden until test-run. FIX: regenerated test mocks to match ACTUAL current implementation (not PR's expected changes). Changed subprocess mocking target from `subprocess.check_output` back to `run_subprocess`; updated test function signatures to match current module. Also fixed implementation bug: `local_branch_exists()` needed to use `run_subprocess` to match test expectations of current code. verified-ci: all 335 github tests pass, pre-commit clean. | verified-ci |
+    | ProjectHephaestus | 2026-06-27, PR #1657 (Option-A timeout rebase) — STALE MERGE-BASE: two Opus agents each reported "rebased onto origin/main, force-pushed", but `git merge-base origin/main origin/<branch>` stayed at the stale base (29 commits behind) and the branch never contained `load_state_file` (a known main-only symbol from a merged sibling). Root cause: a later force-push from a worktree built on the OLD branch tip silently reset the base. Lesson: after any claimed rebase, verify `git merge-base origin/main HEAD == origin/main` (re-fetch first) AND grep the pushed branch for a known main-only symbol; create the rebase worktree from the CURRENT `origin/<branch>` and re-verify the remote merge-base after pushing (§ M). | verified-ci |
+    | ProjectHephaestus | 2026-06-27, PR #1657 (Option-A timeout rebase) — HALF-APPLIED MULTI-LAYER REFACTOR: a per-phase-timeout restore (300/1800/600 over a flat 7200) was resolved correctly in `models.py` (`AGENT_PLAN_TIMEOUT=300`, `AGENT_IMPL_TIMEOUT=1800`) but every `*_claude_timeout()` helper in `claude_timeouts.py` still returned the flat `DEFAULT_AGENT_TIMEOUT=7200`, and `constants.py`'s `AGENT_*` constants + `read_timeout_env` were deleted. Passed a `models.py` spot-check; caught only by CI's `assert 300 == 7200` (test `test_uses_central_learn_timeout`). Fix: take main's constants/helpers/tests wholesale (`git show origin/main:<file> > <file>`), re-add only the PR's new CLI DEFAULT_ constant, assert the actual function returns (`planner_claude_timeout()==300`), run the contract test (§ N). | verified-ci |
+````
+
+---
+
 ## v1.11.0 (2026-06-27)
 
 **Changed by:** ProjectHephaestus #1657 Option-A timeout rebase

--- a/skills/pr-rebase-conflict-resolution-patterns.md
+++ b/skills/pr-rebase-conflict-resolution-patterns.md
@@ -1,12 +1,12 @@
 ---
 name: pr-rebase-conflict-resolution-patterns
-description: "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted — later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing — the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes — confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED — the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit), (14) multiple rebased PRs — including ones unrelated to the failing test — all fail the SAME test after merging onto main; suspect a broken main from a SEMANTIC collision between two independently-merged PRs that never textually conflict (e.g. a return-tuple arity change + a stale test mock), prove it by running the failing test against bare origin/main, and fix main first, (15) two parallel cluster-extraction PRs both create the same new module file and the rebase produces an add/add conflict on BOTH the source module AND its test file — main's source is authoritative, test files must be semantically merged (keep main's richer base + append your branch's unique test classes), (16) a rebase hits AA (both-added) conflicts on new files — the conflicted file shows NO <<<<<<< markers and contains only one side's content; you must use git show HEAD:<path> and git show REBASE_HEAD:<path> to read both versions before resolving, (17) a CLUSTER of sibling refactor PRs all edit the SAME shared files and were run in parallel so all but one are CONFLICTING/DIRTY (and possibly hand-braked with state:skip) — land them as a SEQUENTIAL rebase chain SMALLEST-DIFF-FIRST, rebasing each onto trunk only AFTER the prior merges, resolving every conflict as the UNION of each refactor's extractions (keep both helpers; every duplicated method becomes a thin delegate; merge import lists and drop now-unused imports via lint), then re-sign all commits with `git rebase --exec '...-s -S' origin/main` for DCO+GPG, (18) after rebase, tests fail because test mocks expected the PR branch's refactored signatures but rebase brought in origin/main's different implementation — the git conflict resolved cleanly (no text-level conflicts), but the test mocks diverge from actual code. Test expects subprocess.check_output but code uses run_subprocess; mock returns 7-tuple but impl expects 9-tuple. After textual conflict resolution succeeds, run tests to surface semantic mismatches, then regenerate test mocks to match CURRENT implementation, not the PR's expected changes (see § L)"
+description: "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted — later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing — the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes — confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED — the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit), (14) multiple rebased PRs — including ones unrelated to the failing test — all fail the SAME test after merging onto main; suspect a broken main from a SEMANTIC collision between two independently-merged PRs that never textually conflict (e.g. a return-tuple arity change + a stale test mock), prove it by running the failing test against bare origin/main, and fix main first, (15) two parallel cluster-extraction PRs both create the same new module file and the rebase produces an add/add conflict on BOTH the source module AND its test file — main's source is authoritative, test files must be semantically merged (keep main's richer base + append your branch's unique test classes), (16) a rebase hits AA (both-added) conflicts on new files — the conflicted file shows NO <<<<<<< markers and contains only one side's content; you must use git show HEAD:<path> and git show REBASE_HEAD:<path> to read both versions before resolving, (17) a CLUSTER of sibling refactor PRs all edit the SAME shared files and were run in parallel so all but one are CONFLICTING/DIRTY (and possibly hand-braked with state:skip) — land them as a SEQUENTIAL rebase chain SMALLEST-DIFF-FIRST, rebasing each onto trunk only AFTER the prior merges, resolving every conflict as the UNION of each refactor's extractions (keep both helpers; every duplicated method becomes a thin delegate; merge import lists and drop now-unused imports via lint), then re-sign all commits with `git rebase --exec '...-s -S' origin/main` for DCO+GPG, (18) after rebase, tests fail because test mocks expected the PR branch's refactored signatures but rebase brought in origin/main's different implementation — the git conflict resolved cleanly (no text-level conflicts), but the test mocks diverge from actual code. Test expects subprocess.check_output but code uses run_subprocess; mock returns 7-tuple but impl expects 9-tuple. After textual conflict resolution succeeds, run tests to surface semantic mismatches, then regenerate test mocks to match CURRENT implementation, not the PR's expected changes (see § L), (19) an Inference360 H200 Slurm PR branch has stale/dirty local checkout work before rebase and master renamed control lifecycle to Warden; preserve unrelated staged work first, rebase onto origin/master, keep Warden env names while preserving nested srun --mem=0, and push with an explicit force-with-lease after local + remote head comparison (see § O)"
 category: ci-cd
-date: 2026-06-27
-version: "1.11.0"
+date: 2026-06-29
+version: "1.12.0"
 user-invocable: false
 history: pr-rebase-conflict-resolution-patterns.history
-tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-net, parallel-swarm, serial-merge-train, full-rewrite, shadow-variable, tdz, numeric-equivalence, clang-format, cmake, pixi-lock, force-with-lease, auto-merge, already-merged-sibling, add-add-conflict, sha-pin, unpinned-actions, skipped-required-check, markdownlint, lint-blocked, org-policy, myrmidon-swarm, semantic-collision, broken-main, tuple-arity, stale-mock, merge-train-cascade, cluster-extraction, parallel-pr-same-module, aa-conflict, uu-conflict, both-added, git-status-codes, no-markers, same-file-cluster, sequential-rebase-chain, smallest-first, thin-delegate, union-resolution, dco-signoff, state-skip-stranded, test-mock-mismatch, mock-divergence, subprocess-api-change, implementation-divergence, test-fixture-regeneration, semantic-test-failure, rebase-not-reparented, stale-merge-base, merge-base-verification, main-only-symbol-check, false-rebase-success, half-applied-refactor, per-phase-timeout-regression, multi-layer-refactor, options-object-vs-helpers, value-regression]
+tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-net, parallel-swarm, serial-merge-train, full-rewrite, shadow-variable, tdz, numeric-equivalence, clang-format, cmake, pixi-lock, force-with-lease, auto-merge, already-merged-sibling, add-add-conflict, sha-pin, unpinned-actions, skipped-required-check, markdownlint, lint-blocked, org-policy, myrmidon-swarm, semantic-collision, broken-main, tuple-arity, stale-mock, merge-train-cascade, cluster-extraction, parallel-pr-same-module, aa-conflict, uu-conflict, both-added, git-status-codes, no-markers, same-file-cluster, sequential-rebase-chain, smallest-first, thin-delegate, union-resolution, dco-signoff, state-skip-stranded, test-mock-mismatch, mock-divergence, subprocess-api-change, implementation-divergence, test-fixture-regeneration, semantic-test-failure, rebase-not-reparented, stale-merge-base, merge-base-verification, main-only-symbol-check, false-rebase-success, half-applied-refactor, per-phase-timeout-regression, multi-layer-refactor, options-object-vs-helpers, value-regression, inference360, warden, slurm, h200, dirty-local-checkout, staged-work-backup, explicit-force-lease, uv-verify, ruff-shell-split]
 ---
 
 # PR Rebase & Conflict Resolution Patterns
@@ -15,7 +15,7 @@ tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-n
 
 | Field | Value |
 |-------|-------|
-| Date | 2026-06-07 |
+| Date | 2026-06-29 |
 | Objective | One canonical playbook for rebasing PR branches onto an advanced main and resolving every class of rebase/merge conflict — single PRs, mass waves, stacked PRs, parallel-swarm collisions, Safety-Net-blocked resolution, full-file rewrites, and language-level bugs introduced by merging two independent branch edits |
 | Outcome | Verified across the HomericIntelligence ecosystem (ProjectOdyssey, ProjectScylla, ProjectMnemosyne, ProjectKeystone, ProjectHephaestus, ProjectHermes, ProjectNestor, AchaeanFleet, Myrmidons, Agamemnon, Odysseus) — hundreds of PRs rebased and merged |
 | Verification | verified-ci |
@@ -46,7 +46,8 @@ tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-n
 - **Rebase completes with NO git conflict markers, but tests fail on mock signature mismatches** — the PR branch's test mocks expected refactored function signatures; rebase brought in origin/main's different implementation. Git resolved textually cleanly (no `<<<<<<<` markers), but test mocks no longer match: test expects `subprocess.check_output` but code uses `run_subprocess`; mock returns 7-tuple but implementation expects 9-tuple; test function signature doesn't match current module. After rebase, run tests to surface these semantic divergences, then regenerate test mocks against ACTUAL current implementation, not the PR's expected changes. Do NOT try to "fix" the implementation to match test expectations — test expectations are stale; regenerate mocks to match code (see § L / ProjectHephaestus PR #1633, issue #1405).
 - **A rebase agent reports "rebased onto origin/main, force-pushed" but the branch was NEVER re-parented** — `git merge-base origin/main origin/<branch>` is STILL the old stale base (e.g. 29 commits behind) and the branch does NOT contain main's recently-merged content (a known main-only symbol from a merged sibling is ABSENT). The rebase was run from/onto a stale ref, or a later force-push from a worktree built off the OLD branch tip silently reset the base. Do NOT trust the self-report — MANDATORY verify `git merge-base origin/main HEAD == git rev-parse origin/main` AND grep the pushed branch for a known main-only symbol (see § M).
 - **A multi-layer refactor rebase is half-applied: one layer fixed, parallel layers still flattened** — a PR intentionally restores a set of related values (e.g. per-phase timeouts 300/1800/600 vs a flat 7200), and the conflict resolution fixes ONE layer (the dataclass/options-object field defaults in `models.py`) while LEAVING the parallel layers (the `*_timeout()` helper FUNCTIONS in `claude_timeouts.py` + the constants in `constants.py`) in the wrong/flattened state. A spot-check of `models.py` looks correct, but every helper function used at the call sites returns the wrong value — caught ONLY by reading the actual CI unit-test failure (`assert 300 == 7200`), never by any self-report (see § N).
-- Common trigger phrases: "fix these failing PRs", "rebase all branches onto main", "mass rebase after merge wave", "stacked PR went dirty", "Safety Net blocked git checkout", "markdownlint SKIPPED BLOCKED", "action not allowed must be pinned", "CONFLICT (add/add) on new module", "rebase clean but tests fail on mock", "test mock divergence after rebase", "agent said it rebased but merge-base is stale", "branch is N commits behind after a claimed rebase", "rebased timeout PR but functions still return the flat value", "assert 300 == 7200 after rebase".
+- **An Inference360 H200 Slurm PR branch needs cleanup before rebase** — local checkout is stale/dirty and contains unrelated staged operator/wizard work; preserve it with a patch, backup branch, and stash before resetting to the remote PR branch, then rebase onto `origin/master` and resolve Warden rename conflicts without losing nested `srun --mem=0` behavior (see § O).
+- Common trigger phrases: "fix these failing PRs", "rebase all branches onto main", "mass rebase after merge wave", "stacked PR went dirty", "Safety Net blocked git checkout", "markdownlint SKIPPED BLOCKED", "action not allowed must be pinned", "CONFLICT (add/add) on new module", "rebase clean but tests fail on mock", "test mock divergence after rebase", "agent said it rebased but merge-base is stale", "branch is N commits behind after a claimed rebase", "rebased timeout PR but functions still return the flat value", "assert 300 == 7200 after rebase", "Inference360 control renamed to Warden", "safe PR cleanup before hard reset", "explicit force-with-lease with expected old SHA".
 
 ## Verified Workflow
 
@@ -693,6 +694,116 @@ If EITHER check fails, the rebase did NOT take — discard the "success" report 
 
 **Why this happens**: Git's textual conflict resolution operates file-by-file. A resolver focused on the most-visible layer (`models.py`) can cleanly resolve it while the parallel layers — the helper functions and constants that the call sites actually use — silently retain the regressed/flattened values from whichever side the rebase happened to keep. The options-object default and the helper-function return are two independent encodings of the SAME contract; fixing one does not fix the other.
 
+#### O. Inference360 dirty local PR checkout + Warden rename conflict
+
+**Trigger**: An Inference360 H200 Slurm PR branch must be rebased onto current `origin/master`, but
+the local checkout is stale/dirty and contains unrelated staged work. Main has also renamed the
+control lifecycle to Warden, so a PR commit that still touches the launch path conflicts in
+`inference360/__init__.py` and `tests/test_warden_lifecycle.py`.
+
+**Verified case**: Inference360 PR #289, branch `feat/config-derived-8b-serving-limits`,
+rebased on 2026-06-29. Objective: clean up a stale/dirty local PR checkout, rebase onto current
+`origin/master`, resolve Warden rename conflicts while preserving the PR's nested `srun --mem=0`
+serving-launch behavior, and make the PR mergeable again.
+
+**Quick reference**:
+
+```bash
+# 1. Before syncing a dirty local PR checkout, inspect and preserve unrelated work.
+git status --short --branch
+git log --oneline --decorate --left-right --cherry-pick \
+  origin/feat/config-derived-8b-serving-limits...HEAD
+git diff --staged > /tmp/inference360-pr289-local-staged-backup-20260629.patch
+git branch backup/pr289-local-pre-sync-20260629
+git stash push --staged -m "backup wizard work before syncing PR 289 2026-06-29"
+git reset --hard origin/feat/config-derived-8b-serving-limits
+
+# 2. Rebase onto Inference360 trunk (master, not main).
+git fetch origin master feat/config-derived-8b-serving-limits
+git log --oneline --decorate --left-right --cherry-pick \
+  origin/master...origin/feat/config-derived-8b-serving-limits
+git rebase origin/master
+# Resolve conflicts, then stage only the resolved files.
+git add inference360/__init__.py tests/test_warden_lifecycle.py
+env GIT_EDITOR=true git rebase --continue
+
+# 3. Verify locally before pushing.
+git diff --check origin/master...HEAD
+rg -n "<<<<<<<|=======|>>>>>>>" inference360 tests scripts manifests
+env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest \
+  tests/test_warden_lifecycle.py \
+  tests/test_inference360_utils.py \
+  tests/test_manifest_validation.py \
+  tests/test_quality_gate_scripts.py -q
+env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check \
+  inference360/__init__.py \
+  tests/test_warden_lifecycle.py \
+  tests/test_inference360_utils.py \
+  tests/test_manifest_validation.py \
+  tests/test_quality_gate_scripts.py
+bash -n scripts/run_inference360_container.sh
+env UV_CACHE_DIR=/tmp/uv-cache uv run inference360 check manifests --cluster m2
+env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff format --check \
+  inference360/__init__.py \
+  tests/test_warden_lifecycle.py \
+  tests/test_inference360_utils.py \
+  tests/test_manifest_validation.py \
+  tests/test_quality_gate_scripts.py
+
+# 4. Force-push only after proving the remote still points at the expected old SHA.
+git rev-parse HEAD
+git ls-remote origin refs/heads/feat/config-derived-8b-serving-limits
+git push --force-with-lease=refs/heads/feat/config-derived-8b-serving-limits:864f86889bddaaffdced6c0fdf66ff53d87ab43e \
+  origin HEAD:feat/config-derived-8b-serving-limits
+```
+
+**Local cleanup contract**:
+
+- Do NOT hard-reset a dirty PR checkout until unrelated local work has all three recovery paths:
+  a patch backup, a backup branch, and a stash. In PR #289 those were
+  `/tmp/inference360-pr289-local-staged-backup-20260629.patch`,
+  `backup/pr289-local-pre-sync-20260629`, and
+  `stash@{0}: backup wizard work before syncing PR 289 2026-06-29`.
+- After the safeguards exist, reset the local branch to the remote PR branch before rebasing.
+  This avoids mixing unrelated staged work into the conflict resolution.
+
+**Warden conflict resolution rule**:
+
+- Keep Warden environment names introduced on `master`:
+  `INFERENCE360_WARDEN_SLURM_JOB_ID`, `INFERENCE360_WARDEN_NODE_ID`, and
+  `INFERENCE360_WARDEN_LAUNCH_SCRIPT`.
+- Preserve the PR's nested `srun --mem=0` behavior. The test helper
+  `_parse_safe_warden_srun_arguments` expects the ten-argument shape including `--mem=0`; do not
+  resolve the conflict by reverting to the old control lifecycle names or by dropping that nested
+  `srun` argument.
+
+**Verification details**:
+
+- Conflict-marker scans should use the full marker regex. A search for only `=======` can flag
+  decorative shell separator lines made of `====` and waste time on false positives.
+- Do not pass `.sh` files to Ruff. Ruff parses Python and will report invalid syntax on shell
+  scripts; use `bash -n scripts/run_inference360_container.sh` for shell syntax.
+- In the verified PR #289 run, the targeted pytest command reported `489 passed`; Ruff check,
+  Ruff format check, shell syntax, `git diff --check`, and
+  `inference360 check manifests --cluster m2` all passed.
+
+**Safe push rule**:
+
+- Compare local `HEAD` and the remote branch tip immediately before pushing.
+- Use an explicit lease pinned to the observed old remote SHA. For PR #289, remote still pointed to
+  `864f86889bddaaffdced6c0fdf66ff53d87ab43e`, local rebased head was
+  `bbf82e799fa430f868af3d96c807e1e18a5eb15a`, and the safe push command was:
+
+  ```bash
+  git push --force-with-lease=refs/heads/feat/config-derived-8b-serving-limits:864f86889bddaaffdced6c0fdf66ff53d87ab43e \
+    origin HEAD:feat/config-derived-8b-serving-limits
+  ```
+
+**Result**: PR #289 head became `bbf82e799fa430f868af3d96c807e1e18a5eb15a`; GitHub reported
+`mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`, no active unresolved review threads, and green
+required checks (`validate`, CodeQL, secrets, SAST, Python SCA, analyzers). Verification level:
+`verified-ci`.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -745,6 +856,10 @@ If EITHER check fails, the rebase did NOT take — discard the "success" report 
 | Tried to rebase/land all cluster PRs in parallel (as the loop did) | Assumed independent PRs could merge concurrently | Only the first merged; the other 4 went CONFLICTING because they edit the same files — operator `state:skip` then stranded them | Serialize a same-file refactor cluster into a smallest-first rebase chain; the loop's parallel dispatch has no file-overlap awareness (§ K3) |
 | Trusted a rebase agent's "rebased onto origin/main, force-pushed" self-report | Believed the success report and moved on without verifying the merge-base | The branch's merge-base stayed at the stale base (29 commits behind); the branch never contained main's merged sibling refactors (known main-only symbol absent); two Opus agents both reported success while the rebase never took — a later force-push from a worktree built on the OLD branch tip silently reset the base. Wasted multiple CI rounds. | ALWAYS verify after any claimed rebase: `git merge-base origin/main HEAD == git rev-parse origin/main` (re-fetch first) AND `git show origin/<branch>:<file> \| grep -c <known-main-only-symbol>` > 0 before believing a rebase succeeded; create the rebase worktree from the CURRENT `origin/<branch>` and re-verify the remote merge-base after pushing (ProjectHephaestus #1657, § M) |
 | Resolved a multi-layer timeout refactor rebase by fixing only `models.py` options-object defaults | Spot-checked `models.py`, saw correct per-phase values (300/1800/600), declared the rebase resolved | `claude_timeouts.py`'s `*_claude_timeout()` functions stayed flattened to `7200` and `constants.py`'s `AGENT_*` constants + `read_timeout_env` were DELETED — a hidden per-phase value regression that passed the `models.py` spot-check but failed CI with `assert 300 == 7200` (test `test_uses_central_learn_timeout`). The options-object default and the helper-function return are two independent encodings of the same contract; fixing one didn't fix the other. | Verify EVERY layer of a multi-layer refactor (constants + helper functions + options-object defaults + tests), not just the most-visible one; for a "restore main's values" conflict take main's constants/helpers/tests files WHOLESALE (`git show origin/main:<file> > <file>`) then re-add ONLY the PR's genuinely-new additions; assert the actual function return values (`assert planner_claude_timeout()==300`) and run the contract test; read the CI `assert 300 == 7200` output to pinpoint the still-flattened layer (ProjectHephaestus #1657, § N) |
+| Hard-resetting a dirty local Inference360 PR checkout before preserving unrelated staged work | Local branch had stale PR state plus unrelated staged wizard/operator work; a reset was needed before rebasing | A reset without backups would discard work that did not belong to the PR cleanup | Before syncing, inspect status and left/right commits, then create all three safeguards: patch backup, backup branch, and stash; only then `git reset --hard origin/<pr-branch>` (§ O) |
+| Resolving Inference360 Warden rename conflicts by keeping old control env names | Conflict was in `inference360/__init__.py` and `tests/test_warden_lifecycle.py` after master renamed control lifecycle to Warden | Old control names no longer match current platform contracts and would regress the H200 Slurm Warden lifecycle | Keep `INFERENCE360_WARDEN_*` env names from master while preserving the PR's nested `srun --mem=0`; `_parse_safe_warden_srun_arguments` expects the ten-argument shape including `--mem=0` (§ O) |
+| Running `git rebase --continue` interactively in a non-interactive session | Conflict files were staged, but rebase opened an editor and failed | The rebase needed the original commit message reused without an editor | Rerun as `env GIT_EDITOR=true git rebase --continue`; do not invent a new message or use unsupported `--no-edit` (§ O) |
+| Passing shell scripts to Ruff during post-rebase verification | Included `.sh` files in a broad Ruff command | Ruff parses Python and reports invalid syntax for shell files, creating a false failure | Run Ruff only on Python files; use `bash -n scripts/run_inference360_container.sh` for shell syntax (§ O) |
 
 ## Results & Parameters
 
@@ -752,6 +867,7 @@ If EITHER check fails, the rebase did NOT take — discard the "success" report 
 rebase_strategy: rebase (never merge main into the branch; keep history linear)
 worktree: git worktree add /tmp/<name> origin/<branch>   # never local checkout
 push_flag: --force-with-lease            # dependabot: --force (GitHub auto-rebases)
+explicit_lease_for_shared_pr_branch: --force-with-lease=refs/heads/<branch>:<observed-old-remote-sha>
 auto_merge: re-arm after EVERY force-push; --squash if rebase-merge disabled; arm AFTER push
 silent_drop_check: git log origin/main..HEAD --oneline   # empty → close as superseded
 ours_theirs_in_rebase: ours=:2:=HEAD=main ; theirs=:3:=REBASE_HEAD=your replayed commit
@@ -759,6 +875,11 @@ safety_net_take: git show :2:file > file (ours) | git show :3:file > file (their
 pixi_lock: rm + git add, then `pixi lock`  (never --ours/--theirs/hand-merge)
 marketplace_json: git checkout --ours     (main = union of all merged entries)
 changelog: take HEAD/main; consolidation PR gathers entries
+inference360_trunk: origin/master
+inference360_dirty_checkout_safeguards: patch backup + backup branch + stash before hard reset
+inference360_warden_conflict_rule: keep INFERENCE360_WARDEN_* env names and preserve nested srun --mem=0
+inference360_shell_validation: bash -n scripts/run_inference360_container.sh
+inference360_python_validation: uv run pytest targeted tests + ruff check/format on Python files only
 shared_hot_files: SERIAL MERGE TRAIN (rebase→wait-MERGE→fetch→next), simplest-first
 disjoint_files: parallel Sonnet/Haiku sub-agents in worktrees (~9 PRs/agent)
 post_rebase_check: run type-checker/linter/local-build before pushing (semantic conflicts)
@@ -831,3 +952,4 @@ git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
 | ProjectHephaestus | 2026-06-27, PR #1633 (issue #1405): Rebased autoimpl-generated PR onto origin/main; git conflicts in `hephaestus/github/pr_merge.py` and `tidy.py` resolved cleanly (no markers). Post-rebase tests failed with mock signature mismatches: test mocks expected PR's refactored code (`run_subprocess` calls) but rebase brought origin/main's pre-refactor implementation (`subprocess.check_output` calls). TRIGGER #18 / § L scenario: textual conflict resolved but semantic divergence hidden until test-run. FIX: regenerated test mocks to match ACTUAL current implementation (not PR's expected changes). Changed subprocess mocking target from `subprocess.check_output` back to `run_subprocess`; updated test function signatures to match current module. Also fixed implementation bug: `local_branch_exists()` needed to use `run_subprocess` to match test expectations of current code. verified-ci: all 335 github tests pass, pre-commit clean. | verified-ci |
 | ProjectHephaestus | 2026-06-27, PR #1657 (Option-A timeout rebase) — STALE MERGE-BASE: two Opus agents each reported "rebased onto origin/main, force-pushed", but `git merge-base origin/main origin/<branch>` stayed at the stale base (29 commits behind) and the branch never contained `load_state_file` (a known main-only symbol from a merged sibling). Root cause: a later force-push from a worktree built on the OLD branch tip silently reset the base. Lesson: after any claimed rebase, verify `git merge-base origin/main HEAD == origin/main` (re-fetch first) AND grep the pushed branch for a known main-only symbol; create the rebase worktree from the CURRENT `origin/<branch>` and re-verify the remote merge-base after pushing (§ M). | verified-ci |
 | ProjectHephaestus | 2026-06-27, PR #1657 (Option-A timeout rebase) — HALF-APPLIED MULTI-LAYER REFACTOR: a per-phase-timeout restore (300/1800/600 over a flat 7200) was resolved correctly in `models.py` (`AGENT_PLAN_TIMEOUT=300`, `AGENT_IMPL_TIMEOUT=1800`) but every `*_claude_timeout()` helper in `claude_timeouts.py` still returned the flat `DEFAULT_AGENT_TIMEOUT=7200`, and `constants.py`'s `AGENT_*` constants + `read_timeout_env` were deleted. Passed a `models.py` spot-check; caught only by CI's `assert 300 == 7200` (test `test_uses_central_learn_timeout`). Fix: take main's constants/helpers/tests wholesale (`git show origin/main:<file> > <file>`), re-add only the PR's new CLI DEFAULT_ constant, assert the actual function returns (`planner_claude_timeout()==300`), run the contract test (§ N). | verified-ci |
+| Inference360 | 2026-06-29, PR #289 (`feat/config-derived-8b-serving-limits`): stale/dirty local checkout cleaned safely by preserving unrelated staged wizard work with `/tmp/inference360-pr289-local-staged-backup-20260629.patch`, `backup/pr289-local-pre-sync-20260629`, and `stash@{0}: backup wizard work before syncing PR 289 2026-06-29`; branch reset to remote, rebased onto `origin/master`, and Warden conflicts in `inference360/__init__.py` + `tests/test_warden_lifecycle.py` resolved by keeping `INFERENCE360_WARDEN_*` env names while preserving nested `srun --mem=0`. Verified with `git diff --check`, conflict-marker scan, 489 targeted pytest passes, Ruff check/format on Python files, `bash -n` for shell, and `inference360 check manifests --cluster m2`; pushed with explicit lease from `864f86889bddaaffdced6c0fdf66ff53d87ab43e` to `bbf82e799fa430f868af3d96c807e1e18a5eb15a`. GitHub reported `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`, no unresolved review threads, and green required checks. | verified-ci |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.11.0 to v1.12.0.

Documents the verified Inference360 PR #289 safe cleanup and rebase workflow for a stale/dirty local PR checkout, Warden rename conflicts, targeted validation, and explicit force-with-lease push safety.

- Preserve unrelated staged work with patch backup, backup branch, and stash before resetting a stale local PR checkout
- Rebase Inference360 PR branches onto origin/master and resolve Warden rename conflicts by keeping INFERENCE360_WARDEN_* env names while preserving nested srun --mem=0 behavior
- Verify with targeted pytest, Ruff on Python files, bash -n for shell, manifest checks, GitHub mergeability, and explicit remote-head lease comparison

## Verification Level

**verified-ci**

PR #289 was verified with local targeted checks and green GitHub CI before capture. This ProjectMnemosyne skill amendment was validated locally with python3 scripts/validate_plugins.py.

## Key Findings

**What Worked**:
- Amending the existing broad PR rebase skill instead of creating a duplicate Inference360-only PR rebase skill
- Safeguarding unrelated local staged work before reset with all three recovery paths
- Using env GIT_EDITOR=true git rebase --continue when the editor path failed non-interactively
- Pushing with --force-with-lease pinned to the observed old remote SHA

**What Failed**:
- Passing shell scripts to Ruff -> Ruff parses Python and reports invalid syntax; use bash -n for shell scripts
- Resolving Warden rename conflicts back to old control env names -> regresses current Warden lifecycle contracts

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Run `git diff --check`
- [x] Verify skill remains discoverable via Inference360, Warden, rebase, force-with-lease, and PR cleanup tags

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>