### PR TITLE
ci: unify job naming to canonical 8-category scheme

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -220,6 +220,18 @@ jobs:
           echo "Declared: $declared, Actual: $actual"
           [ "$declared" -eq "$actual" ] || { echo "Plugin count mismatch"; exit 1; }
 
+  # Canonical aggregate test gate (ci-naming-convention.md). Surfaces a single
+  # `test` check-run that fails if either split suite fails. The split
+  # unit-tests / integration-tests sub-checks are KEPT.
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [unit-tests, integration-tests]
+    steps:
+      - name: Aggregate test result
+        run: echo "All test suites (unit-tests, integration-tests) passed."
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Unifies ProjectMnemosyne's CI job naming toward the canonical 8-category scheme used by the [Odysseus ecosystem CI board](https://github.com/HomericIntelligence/Odysseus/blob/main/docs/ci-naming-convention.md).

### Change

- **test (aggregate):** added a `test` job to `_required.yml` with `needs: [unit-tests, integration-tests]` emitting the canonical `test` check-run. The split `unit-tests` / `integration-tests` sub-checks are **kept**. `_required.yml` already runs on every push/PR to `main`, so the aggregate always posts (no path filters).

### Already canonical (verified, left as-is)

- `build`, `lint`, `security/dependency-scan`, `security/secrets-scan` — all emit canonical names.
- Custom checks (`deps/version-sync`, `pixi-check`, `schema-validation`, `symlink-check`, `markdownlint`, `justfile-check`, `forbid-suppressions`, `validate`) fall under **custom**.
- `Analyze (python)` / `Analyze (actions)` are CodeQL action-generated, non-renameable — left as-is.
- `submit-pypi` is GitHub's **Automatic Dependency Submission (Python)** (`dynamic/dependency-graph/auto-submission`), **not** a PyPI publish — non-renameable, left as-is.

### Categories now emitting (of 8)

build, test (new), lint, security, custom = **5 of 8**.

### Gaps filed (truly-absent categories — not fabricated)

The project's `pyproject.toml` is **not buildable** (no `[build-system]`, flat-layout auto-discovery failure across `skills/plugins/schemas/templates`), the `build` job produces no dist artifact, and there is no real publish/release path. So package/install/release cannot be wired cleanly without changing distribution semantics. Filed as gap issues:

- **package** → #2911
- **install** → #2912
- **release** → #2913

### Notes

- `validate_plugins.py` validates skill files, not workflows — unaffected by this change.
- Workflow validated with `yamllint` + `check-jsonschema --builtin-schema vendor.github-workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
