### PR TITLE
feat: add prefix-cache Nsight kernel evidence skill

### DIFF
--- a/skills/cluster-endpoint-incident-reproducer-validation.history
+++ b/skills/cluster-endpoint-incident-reproducer-validation.history
@@ -1,12 +1,35 @@
+# cluster-endpoint-incident-reproducer-validation — History
+
+## v1.1.0 (2026-07-02)
+
+**Changed by:** LLM360/Inference360 PR #327 strict review fix session for an issue #257 H200 Slurm profiler helper.
+**Verification:** verified-ci
+
+### What changed
+
+- Added profiler-helper hardening to the verified workflow: CLI flags with env fallbacks, non-launching `--print`, early enum/numeric validation, and shell quoting across nested `bash -lc` boundaries.
+- Added operator-contract and shell syntax coverage expectations for issue-local Slurm profiler helpers.
+- Added failed-attempt rows for env-only contracts, unvalidated profiler modes, unquoted inner shell scripts, missing shell/helper docs gates, and over-broad deterministic-kernel fixes.
+- Added PR #327 validation evidence.
+
+### Why
+
+The previous workflow covered endpoint reproducers and cleanup safety but did not explicitly cover
+issue-local profiler helpers that allocate H200 Slurm jobs and build second-stage shell commands.
+Strict review surfaced that such helpers need the same reproducibility and reviewability guarantees:
+printable commands, validated inputs before allocation, shell syntax tests, operator docs, and clear
+separation between replay controls and production fixes.
+
+### Previous version (v1.0.0) snapshot
+
 ---
 name: cluster-endpoint-incident-reproducer-validation
-description: "Build and harden cluster endpoint incident reproducer PRs after strict review. Use when: (1) a model-serving/HPC incident needs a checkout-to-validation reproducer, (2) a shell reproducer allocates Slurm or similar cluster resources, (3) artifacts may contain private prompts, responses, tokens, endpoint metadata, profiler traces, or control-plane evidence, (4) a strict PR review produced blockers around security, cleanup, reproducibility, shell quoting, tests, operator docs, or CI."
+description: "Build and harden cluster endpoint incident reproducer PRs after strict review. Use when: (1) a model-serving/HPC incident needs a checkout-to-validation reproducer, (2) a shell reproducer allocates Slurm or similar cluster resources, (3) artifacts may contain private prompts, responses, tokens, endpoint metadata, or control-plane evidence, (4) a strict PR review produced blockers around security, cleanup, reproducibility, tests, typing, docs, or CI."
 category: debugging
-date: 2026-07-02
-version: "1.1.0"
+date: 2026-06-25
+version: "1.0.0"
 user-invocable: false
 verification: verified-ci
-history: cluster-endpoint-incident-reproducer-validation.history
 tags:
   - incident-reproducer
   - cluster
@@ -18,9 +41,6 @@ tags:
   - dry-run
   - strict-review
   - validation
-  - profiler
-  - shell-quoting
-  - operator-contract
 ---
 
 # Cluster Endpoint Incident Reproducer Validation
@@ -29,11 +49,10 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-02 |
+| **Date** | 2026-06-25 |
 | **Objective** | Turn a strict PR review of a cluster endpoint incident reproducer into a concrete fix list and a reusable validation contract. |
-| **Outcome** | Checkout-to-validation reproducers and issue-local profiler helpers were hardened for private artifacts, non-launching testability, allocation-safe cleanup, shell-safe command construction, reproducibility evidence, operator docs, tests, and CI. |
+| **Outcome** | A checkout-to-validation reproducer was hardened for private artifacts, non-launching testability, allocation-safe cleanup, reproducibility evidence, typed helper scripts, docs, and CI. |
 | **Verification** | verified-ci |
-| **History** | [changelog](./cluster-endpoint-incident-reproducer-validation.history) |
 
 ## When to Use
 
@@ -42,8 +61,6 @@ tags:
 - A strict review reports blockers across security/privacy, cleanup safety, reproducibility metadata, test coverage, typing, docs, or CI, and you need to convert them into implementation work.
 - You need a testable prepare/dry-run path that proves manifests, configs, command logs, and artifact metadata without allocating GPUs or binding a live control socket.
 - Cleanup correctness depends on allocated node IDs, Slurm job IDs, or endpoint registration state, and failures may occur between allocation and startup.
-- The incident helper launches a profiler such as Nsight Systems or Nsight Compute inside an H200 Slurm container and builds a second-stage `bash -lc` command.
-- A review flags env-only helper contracts, unvalidated enum/numeric inputs, missing operator docs, or missing shell syntax tests for a cluster script.
 
 ## Verified Workflow
 
@@ -52,12 +69,10 @@ tags:
 ```bash
 # Static shell validation for reproducer scripts.
 bash -n scripts/<incident-reproducer>.sh
-bash -n docs/runbooks/<incident>/profile_<incident>_kernels.sh
 
 # Focused tests before full validation.
 pytest tests/<focused-reproducer-tests>.py -q
 pytest tests/<focused-http-or-parser-tests>.py -q
-pytest tests/<focused-profiler-helper-tests>.py -q
 
 # Python tooling only on Python files; shell files need shell-specific checks.
 ruff format scripts/<helper>.py tests/<focused-python-tests>.py
@@ -79,18 +94,13 @@ gh pr view <pr-number> --repo <owner>/<repo> --json mergeStateStatus,mergeable,s
 1. **Translate strict review into a fix list.** Treat the review as concrete work, not commentary. Use the review categories as implementation buckets: security/privacy, cleanup safety, reproducibility metadata, test coverage, typing, docs, and CI.
 2. **Add a non-launching prepare/dry-run mode.** The reproducer should be able to generate manifests, configs, replay metadata, and artifact README files without allocating GPUs, registering endpoints, starting services, binding control sockets, or sending live HTTP requests. This makes the shell contract testable in restricted sandboxes and CI.
 3. **Make private artifact handling explicit.** Set `umask 077`, create shared log/artifact directories with mode `700`, and write token-bearing or prompt/response-bearing files with mode `600`. Add an artifact README warning that full prompts, responses, endpoint metadata, and control-plane evidence are private incident evidence.
-4. **Keep live tokens out of replay logs.** Do not print control tokens or token-bearing environment values into command logs. Write replay metadata using shell-safe quoting (`printf '%q'`) or a structured serialization format. Validate required environment variables and ports before interpolating them into shell commands, YAML, manifests, HTTP URLs, or profiler command lines.
+4. **Keep live tokens out of replay logs.** Do not print control tokens or token-bearing environment values into command logs. Write replay metadata using shell-safe quoting (`printf '%q'`) or a structured serialization format. Validate required environment variables and ports before interpolating them into shell commands, YAML, manifests, or HTTP URLs.
 5. **Capture allocation metadata immediately.** Record allocated node IDs and Slurm job IDs immediately after allocation, before endpoint registration or startup. Failures can occur after allocation but before the endpoint has a started node ID, so cleanup cannot rely only on "started endpoint" metadata.
 6. **Make cleanup release allocated resources, not just started endpoints.** Cleanup should release based on the allocation metadata captured in step 5. Do not clear allocated node IDs unless release succeeds; failed release attempts are evidence and must remain visible for follow-up cleanup.
 7. **Preserve reproducibility and evidence.** Keep endpoint metadata, launch command, parser/serving flags when relevant, control registry path, allocated node IDs, Slurm job IDs, and best-effort `squeue`/`sacct` snapshots before and after cleanup. Treat these as audit evidence, not optional logs.
-8. **Expose a non-launching command preview for profiler helpers.** If the helper allocates Slurm resources or starts a profiler, add `--print` or `--dry-run` so tests and reviewers can inspect the exact `srun` command without needing GPUs. Prefer CLI flags with environment fallbacks over env-only contracts.
-9. **Validate script inputs before Slurm launch.** Reject invalid profiler enum values (`nsys`/`ncu`), nonnumeric ports/counts/seeds, missing required paths, and unknown options before constructing `srun`. A bad local option should fail with exit 2 before any cluster command is printed or executed.
-10. **Quote nested shell command boundaries explicitly.** For scripts that build an inner `bash -lc` body, shell-quote host-provided values before interpolating them into the inner script, and keep arrays for outer `srun` arguments. Add tests that use paths with spaces to prove the quoted command survives preview mode.
-11. **Register operator-facing contracts.** Add the helper to shell syntax tests and operator-script contract docs. Document required CLI flags, env fallbacks, private artifact expectations, and any intentionally dangerous serving flags such as `--trust-remote-code`.
-12. **Separate replay controls from production fixes.** For determinism investigations, document that slower global batch-invariant or deterministic kernels are replay/verification controls unless the serving engine owns a production path with measured performance. Do not present them as the default incident fix when the bug is local to cache shape or scheduler contracts.
-13. **Test the shell reproducer contract directly.** Add tests for bash syntax, private file modes, shell-safe replay logs, allocation cleanup behavior, Slurm evidence capture, prepare-only artifact generation, profiler `--print` output, enum/numeric validation, and operator docs coverage. Use fake control commands or temp fixtures so tests do not need a live cluster.
-14. **Add focused coverage for nearby Python behavior.** If review identified HTTP error logging gaps, parser edge cases, or profiler extractors, add targeted tests for those paths rather than relying on the reproducer integration path to exercise them indirectly.
-15. **Verify in layers.** Run focused pytest first, then `bash -n`, `git diff --check`, Ruff format/check only on touched Python files, direct mypy for touched Python scripts, pre-commit on staged files, full repo validation, and finally GitHub PR checks plus mergeability.
+8. **Test the shell reproducer contract directly.** Add tests for bash syntax, private file modes, shell-safe replay logs, allocation cleanup behavior, Slurm evidence capture, and prepare-only artifact generation. Use fake control commands or temp fixtures so tests do not need a live cluster.
+9. **Add focused coverage for nearby Python behavior.** If review identified HTTP error logging gaps or parser edge cases, add targeted tests for those paths rather than relying on the reproducer integration path to exercise them indirectly.
+10. **Verify in layers.** Run focused pytest first, then `bash -n`, `git diff --check`, Ruff format/check only on touched Python files, direct mypy for touched Python scripts, pre-commit on staged files, full repo validation, and finally GitHub PR checks plus mergeability.
 
 ## Failed Attempts
 
@@ -102,11 +112,6 @@ gh pr view <pr-number> --repo <owner>/<repo> --json mergeStateStatus,mergeable,s
 | Clearing allocation metadata too early | Cleanup erased allocated node IDs even when release failed | The evidence needed for manual cleanup disappeared | Clear allocation metadata only after release succeeds |
 | Raw environment interpolation in generated commands | Shell/YAML snippets interpolated raw env values directly | Tokens can leak, quoting can break, and replay artifacts become malformed or unreproducible | Validate inputs first; quote with `printf '%q'` or serialize structurally |
 | Treating command logs as safe by default | Replay logs included live control-token context | Command logs persist and are often shared during incident review | Keep tokens out of logs; store private control metadata in mode-600 evidence files |
-| Env-only profiler helper contract | Required `MODEL_PATH`, `CONTAINER_IMAGE`, and `OUTPUT_DIR` only through environment variables | Reviewers and tests could not see the contract at the call site, and missing values failed late | Add explicit CLI flags with env fallbacks and keep `--print` output copy-pasteable |
-| Unvalidated profiler mode | Let arbitrary `PROFILER` values flow into branch logic | Typos can silently select the wrong path or fail after allocation | Validate enum-like inputs before printing or executing `srun` |
-| Unquoted second-stage `bash -lc` values | Built the inner script from host paths and flags without shell quoting | Paths with spaces or shell metacharacters can break commands or become injection surfaces | Shell-quote each host-provided value before interpolation; test with paths containing spaces |
-| Shell helper omitted from quality gates | Added a new cluster shell helper without including it in syntax tests or operator docs | The PR can pass Python tests while the operator script remains unreviewed and syntactically unguarded | Add shell syntax coverage plus operator-script contract docs in the same PR |
-| Treat deterministic kernels as the production answer | Proposed global batch-invariant or deterministic kernels for a local cache-shape bug | They can be useful for replay but may carry performance cost and solve a broader problem than needed | Keep production guidance shape-stable and engine-owned; use deterministic kernels as controls unless measured otherwise |
 
 ## Results & Parameters
 
@@ -117,14 +122,11 @@ gh pr view <pr-number> --repo <owner>/<repo> --json mergeStateStatus,mergeable,s
 | Prepare mode | Generates manifests/configs/replay metadata/artifact README without GPU allocation, endpoint startup, network calls, or socket binding |
 | Artifact permissions | `umask 077`; directories mode `700`; prompt/response/token/control files mode `600` |
 | Replay metadata | Shell-safe or structured; no live tokens in command logs; validated env vars and ports before interpolation |
-| Profiler preview | `--print`/dry-run mode prints exact `srun` commands without allocating GPUs; tests assert good and bad cases both appear |
-| Profiler inputs | CLI flags with env fallbacks; `nsys`/`ncu` enum validation; integer validation for ports, launch counts, token counts, and seeds |
-| Nested shell quoting | Host-provided paths and flags are shell-quoted before inner `bash -lc` interpolation; outer command remains an argv array |
 | Allocation metadata | Captured immediately after allocation; includes node IDs and job IDs before register/start |
 | Cleanup | Releases allocated node IDs; preserves node IDs if release fails; records before/after `squeue` and `sacct` snapshots best-effort |
-| Evidence files | Endpoint metadata, launch command, parser/serving flags when relevant, profiler reports/exports/summaries, control registry path, node IDs, job IDs, cleanup snapshots |
-| Static tests | Bash syntax, file modes, command-log quoting, allocation cleanup contract, Slurm evidence contract, profiler preview contract, prepare-only generation |
-| Focused Python tests | HTTP error logging, parser edge cases, and profiler extractor edge cases when touched by the incident reproducer PR |
+| Evidence files | Endpoint metadata, launch command, parser/serving flags when relevant, control registry path, node IDs, job IDs, cleanup snapshots |
+| Static tests | Bash syntax, file modes, command-log quoting, allocation cleanup contract, Slurm evidence contract, prepare-only generation |
+| Focused Python tests | HTTP error logging and parser edge cases when touched by the incident reproducer PR |
 | Validation | Focused pytest, `bash -n`, `git diff --check`, Ruff on Python files only, mypy on touched Python scripts, pre-commit on staged files, full validation, GitHub checks and mergeability |
 
 ### Verification Evidence
@@ -139,10 +141,8 @@ Verified in LLM360/Inference360 PR #262 on 2026-06-25 at commit `48c2e1f` with s
 
 Do not copy raw prompts, responses, model/checkpoint names, internal hostnames, tokens, or corrupted output snippets into a durable skill or shared PR body. Keep this skill generic; cite the PR only as the verified workflow context.
 
-Verified again in LLM360/Inference360 PR #327 on 2026-07-02 with sanitized context only:
+---
 
-- Strict review findings on an issue-local H200 Slurm profiler helper were fixed with CLI flags, `--print`, early enum/numeric validation, shell quoting for nested `bash -lc`, operator contract docs, and shell syntax coverage.
-- Local focused tests passed: `tests/test_issue257_profile_prefix_cache_kernels.py`, `tests/test_issue257_nsys_kernel_extractor.py`, and `tests/test_quality_gate_scripts.py` reported 75 passed.
-- Local full validation passed with `just validate`: 1051 passed, 9 skipped.
-- The pre-push hook passed: 1059 passed, 1 skipped.
-- GitHub checks passed, including `validate`, `pre-commit`, `sast`, `secrets`, `python-sca`, CodeQL, and action/python analysis.
+## v1.0.0 (2026-06-25)
+
+**Initial version.**

--- a/skills/debugging-prefix-cache-nsight-kernel-evidence.md
+++ b/skills/debugging-prefix-cache-nsight-kernel-evidence.md
@@ -1,0 +1,159 @@
+---
+name: debugging-prefix-cache-nsight-kernel-evidence
+description: "Capture and interpret Nsight kernel-name evidence for vLLM or SGLang prefix-cache nondeterminism. Use when: (1) cache hits change output despite temperature=0, (2) warm prefix-cache paths may select different GEMM tiling, (3) you need actual GPU kernel names rather than profiler-free hypotheses, (4) batch-invariant or deterministic kernels are being considered as a replay control instead of a production fix."
+category: debugging
+date: 2026-07-02
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - inference
+  - vllm
+  - sglang
+  - prefix-cache
+  - nsight
+  - nsys
+  - ncu
+  - h200
+  - slurm
+  - determinism
+---
+
+# Prefix-Cache Nsight Kernel Evidence
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-02 |
+| **Objective** | Prove whether a warm prefix-cache path changes the executed GPU kernel regime by collecting actual Nsight kernel names from matched good and bad H200 Slurm cases. |
+| **Outcome** | Successful. The good/no-prefix case and warm prefix-cache case produced endpoint-level Nsight Systems traces; the warm prefix-cache case showed additional smaller-tile `nvjet_tst_*` GEMM symbols. |
+| **Verification** | verified-ci for helper/extractor/tests and verified H200 Slurm execution for the profiler run. |
+
+## When to Use
+
+- A vLLM or SGLang endpoint returns different text for a matched request only when prefix caching is enabled.
+- A temperature-0 or otherwise deterministic request appears nondeterministic and the suspected difference is cache hit shape, active prefill rows, block/page alignment, or GEMM tiling.
+- A reviewer asks for actual GPU kernel names instead of a prose hypothesis about prefix-cache behavior.
+- You need to distinguish production fixes from replay controls such as slower batch-invariant or deterministic kernels.
+- You need a redacted, durable runbook/blog section that names kernel families without publishing private prompts, checkpoint paths, endpoints, or artifact roots.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Preview both Slurm profiler cases without allocating GPUs.
+docs/runbooks/<incident>/profile_prefix_cache_kernels.sh \
+  --print \
+  --model-path <REDACTED_CHECKPOINT_PATH>/<model> \
+  --container-image <REDACTED_INFRA_PATH>/<image>.sqsh \
+  --output-dir <REDACTED_INFRA_PATH>/<incident>-kernels \
+  --profiler nsys
+
+# Run the same helper on the H200 Slurm cluster when ready.
+docs/runbooks/<incident>/profile_prefix_cache_kernels.sh \
+  --model-path <REDACTED_CHECKPOINT_PATH>/<model> \
+  --container-image <REDACTED_INFRA_PATH>/<image>.sqsh \
+  --output-dir <REDACTED_INFRA_PATH>/<incident>-kernels \
+  --profiler nsys
+
+# Extract kernel names from the exported Nsight SQLite database.
+python docs/runbooks/<incident>/extract_nsys_kernel_names.py \
+  <artifact-root>/<case>/server.sqlite \
+  --contains cublas,gemm,cutlass,xmma,wgmma,mma \
+  --output-json <artifact-root>/<case>/kernel_names.filtered.json \
+  --output-md <artifact-root>/<case>/kernel_names.filtered.md \
+  --limit 120
+```
+
+### Detailed Steps
+
+1. **Build matched endpoint cases.** Use one good/no-prefix case and one bad/warm-prefix-cache case with the same model, prompt shape, max tokens, seed, tensor parallelism, and endpoint flags except the cache control. For warm cache, send one warmup request to populate the shared prefix before measuring the matched request.
+2. **Capture kernel names under the profiler, not by inference.** Use Nsight Systems for endpoint-level kernel-name evidence. Add an Nsight Compute mode only when you need launch counts, sections, or per-kernel metrics and can tolerate the higher overhead.
+3. **Keep command construction reviewable.** The profiler helper should support `--print`, CLI flags with env fallbacks, enum validation for `nsys`/`ncu`, integer validation for ports and counts, and shell-safe quoting for any nested `bash -lc` script.
+4. **Preserve the raw evidence privately.** Keep `.nsys-rep`, SQLite exports, filtered/all JSON summaries, filtered/all Markdown summaries, launch commands, client JSON, and the commit SHA under a private artifact root. Redact checkpoint paths, endpoints, prompts, tokens, and user-specific infrastructure paths before writing docs or PR bodies.
+5. **Compare kernel families by case.** Start with the filtered GEMM-like set, then inspect the all-kernel summary for supporting kernels such as FlashAttention and KV-cache write kernels.
+6. **Decode names conservatively.** Treat `nvjet_tst_<M>x<N>_<K>x<...>_...` names as evidence of tile-shape families, not as a complete cuBLASLt algorithm contract. `splitK`, `coopA`, and `coopB` suffixes are useful clues, but a per-layer claim still needs launch correlation or NVTX ranges.
+7. **Separate active compute rows from logical context length.** A cache hit can keep the same logical context length while reducing the number of newly computed prefill rows. Kernel selection usually responds to the active compute shape, not just the total prompt length.
+8. **Avoid over-broad deterministic-kernel fixes.** Batch-invariant or deterministic kernels are good replay controls, but they may be slower and broader than the cache-shape bug. Prefer an engine-owned, shape-stable fast path when the evidence points to a local cache-hit tiling transition.
+9. **Document limitations.** Endpoint traces can show that the warm path entered a smaller-tile regime. They do not automatically prove which layer produced a bad token, which cuBLASLt algorithm ID was selected, or that a named kernel caused corruption. State those limits explicitly.
+10. **Verify helper code and docs through CI.** Add tests for profiler print mode, invalid profiler rejection, nonnumeric controls, markdown escaping in extractors, and shell syntax/operator contract coverage. Run focused tests, full validation, pre-push hooks, and GitHub checks.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Reason from text outputs only | Compared good/bad generations and latency without profiler evidence | It showed the symptom but not the GPU execution path | Capture kernel names before making a root-cause claim about tiling or GEMM mode |
+| Treat cache hit as only a performance event | Assumed identical tokens plus same logical context length meant the numerical path was equivalent | Warm cache can change active prefill rows and therefore kernel selection | Track token identity, logical context length, and active compute shape separately |
+| Use global deterministic kernels as the fix | Proposed slower batch-invariant or deterministic kernels for all requests | They are useful controls but can mask a local scheduler/cache contract bug and may regress performance | Use deterministic modes for replay; target production fixes at shape-stable cache-hit scheduling |
+| Publish profiler evidence with local paths | Wanted to cite local notes, artifact roots, or infrastructure paths directly | Durable docs and skills must not leak private endpoint, checkpoint, prompt, or path data | Redact all operational evidence and cite checked-in runbooks/helpers instead |
+| Assert layer-level causality from endpoint names | Interpreted endpoint-level kernel symbols as proof of a specific layer failure | Kernel names alone lack per-layer launch correlation | Phrase the result as endpoint-level evidence unless NVTX/per-layer hashes bind launches to layers |
+| Markdown table emitted raw kernel names | Wrote kernel names with `|`, backticks, or newlines directly into Markdown | Special characters can corrupt tables or render misleading rows | Escape `\`, `|`, backticks, carriage returns, and newlines before writing Markdown summaries |
+
+## Results & Parameters
+
+### Evidence Pattern
+
+The verified H200 Slurm run compared:
+
+| Case | Cache State | Request Shape | Expected Evidence |
+|------|-------------|---------------|-------------------|
+| `good-no-prefix` | Prefix caching disabled | One measured prompt and one generated token | Baseline larger-prefill GEMM kernel families |
+| `bad-prefix-cache-warm-hit` | Prefix caching enabled and warmed | One warmup to fill the shared prefix, then the same measured prompt and one generated token | Baseline kernels plus smaller-tile warm-cache GEMM families |
+
+The observed endpoint-level warm-cache trace added smaller-tile `nvjet_tst_*` symbols such as:
+
+```text
+nvjet_tst_192x16_64x8_4x1_v_bz_TNT
+nvjet_tst_128x16_64x11_4x1_v_bz_splitK_TNT
+nvjet_tst_64x16_64x16_4x1_v_bz_TNT
+nvjet_tst_64x16_64x16_4x1_v_bz_splitK_TNT
+```
+
+Both traces also included larger-prefill-style symbols such as:
+
+```text
+nvjet_tst_256x128_64x4_1x2_h_bz_coopA_TNT
+nvjet_tst_320x128_64x3_1x2_h_bz_coopB_TNT
+nvjet_tst_192x8_64x8_4x1_v_bz_TNT
+```
+
+Supporting kernels in the same evidence set included `cublasLt::splitKreduce_kernel<...>`, FlashAttention SM90 forward kernels, and a vLLM KV-cache reshape/cache write kernel.
+
+### Interpretation Rules
+
+| Signal | Interpretation | Do Not Claim Without More Evidence |
+|--------|----------------|------------------------------------|
+| `MxN` tile changes in `nvjet_tst_*` | Different GEMM tile family was executed | Exact layer, exact cuBLASLt algorithm ID, or causal corruption |
+| `splitK` suffix | Split-K reduction path was present | That split-K alone caused nondeterminism |
+| `coopA` / `coopB` suffix | Cooperative operand-loading variant changed | That the operand variant is wrong |
+| FlashAttention kernels present | Attention backend participated in the request | That attention caused the bad token |
+| KV-cache write kernel present | Cache write/reshape path ran | That cache storage is corrupt |
+
+### Verification Commands
+
+The Inference360 PR that captured this learning used:
+
+```bash
+uv run pytest tests/test_issue257_profile_prefix_cache_kernels.py \
+  tests/test_issue257_nsys_kernel_extractor.py \
+  tests/test_quality_gate_scripts.py -q
+
+uv run pre-commit run --all-files
+just validate
+gh pr checks <pr-number>
+```
+
+Observed sanitized results:
+
+- Focused tests: 75 passed.
+- Local full validation: 1051 passed, 9 skipped.
+- Pre-push hook: 1059 passed, 1 skipped.
+- GitHub checks: `validate`, `pre-commit`, `sast`, `secrets`, `python-sca`, CodeQL, and action/python analysis passed.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | PR #327, issue #257 prefix-cache nondeterminism blog/runbook/profiler work, 2026-07-02 | H200 Slurm Nsight Systems run completed for good/no-prefix and bad/warm-prefix-cache cases. Helper/extractor/docs changes passed local full validation, pre-push pytest, and GitHub checks. |


### PR DESCRIPTION
## Summary

Adds one new skill and amends one existing skill.

- New skill: `debugging-prefix-cache-nsight-kernel-evidence` for H200 Slurm Nsight kernel-name capture and interpretation in vLLM/SGLang prefix-cache nondeterminism investigations.
- Amends `cluster-endpoint-incident-reproducer-validation` from v1.0.0 to v1.1.0 with profiler-helper hardening: CLI flags, `--print`, early validation, nested shell quoting, operator docs, and shell syntax coverage.
- Adds first history file for the amended cluster reproducer skill with the v1.0.0 snapshot.

## Verification Level

**verified-ci**

The captured Inference360 workflow had local full validation and GitHub PR checks passing. This ProjectMnemosyne PR also passed local skill validation and pre-push tests.

## Key Findings

**What Worked**:
- Use actual Nsight kernel names before claiming prefix-cache GEMM tiling changes.
- Keep H200 Slurm profiler helpers inspectable with non-launching `--print` output.
- Treat batch-invariant/deterministic kernels as replay controls unless a measured engine-owned fast path exists.

**What Failed**:
- Env-only profiler helper contracts obscure required inputs and are hard to test.
- Unquoted second-stage `bash -lc` interpolation is fragile for paths with spaces and shell metacharacters.
- Endpoint-level kernel names alone do not prove layer-level causality.

## Test Plan

- [x] Validate with `.venv/bin/python scripts/validate_plugins.py` (570/570 valid)
- [x] `git diff --cached --check`
- [x] Pre-push hook: `pytest -q` (222 passed)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Codex <noreply@openai.com>
