### PR TITLE
ci: add canonical install check (ecosystem CI-naming)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -304,6 +304,72 @@ jobs:
           done
           echo "All JSON files valid"
 
+  package:
+    name: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: pip install --quiet build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: twine check
+        run: twine check dist/*
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  install:
+    name: install
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: package
+    permissions:
+      contents: read
+    steps:
+      # Deliberately NO checkout: the smoke test must import the installed
+      # wheel, and an absent repo tree guarantees `skill_utils` cannot be
+      # satisfied from the checkout's scripts/ directory.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Download dist artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          name: dist
+          path: dist/
+      - name: Install the wheel into a clean virtualenv
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/mnemosyne-venv"
+          # shellcheck disable=SC1091
+          . "$RUNNER_TEMP/mnemosyne-venv/bin/activate"
+          wheel=$(ls dist/*.whl)
+          pip install --quiet "$wheel"
+      - name: Import-smoke the installed package
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          . "$RUNNER_TEMP/mnemosyne-venv/bin/activate"
+          python - <<'PY'
+          import inspect
+          import skill_utils
+          src = inspect.getsourcefile(skill_utils)
+          assert "site-packages" in src, f"imported from checkout, not wheel: {src}"
+          fm, body, errs = skill_utils.parse_frontmatter("---\nname: smoke\n---\nbody\n")
+          assert fm["name"] == "smoke" and not errs, (fm, errs)
+          print("OK: installed wheel imports and parses frontmatter:", src)
+          PY
+
   schema-validation:
     name: schema-validation
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=77.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "project-mnemosyne"
 version = "2.1.0"
@@ -12,6 +16,14 @@ dev = [
     "pytest>=9.0",
     "pytest-cov>=7.0",
 ]
+
+# Flat repo layout (scripts/, skills/, tests/, ...) breaks setuptools
+# auto-discovery, so the distributable is declared explicitly: the shared
+# library module scripts/skill_utils.py ships as top-level `skill_utils`,
+# matching the flat `from skill_utils import ...` imports used repo-wide.
+[tool.setuptools]
+package-dir = {"" = "scripts"}
+py-modules = ["skill_utils"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
Add canonical `install` CI check-run per Odysseus ecosystem naming convention. Implements clean venv install smoke test of built artifact with import verification.

## Changes
- Add `install` job to `.github/workflows/_required.yml` that creates clean venv and installs built artifact
- Add import smoke test to verify package loads after installation
- Update `pyproject.toml` to support the install workflow

## Testing
- Run full CI pipeline to verify `install` check-run appears as canonical name
- Verify venv is truly clean (no pre-installed dependencies)
- Verify import smoke test passes with installed package

## Closes
Closes #2912

Generated by Claude Code via ProjectHephaestus automation.
