### PR TITLE
fix: clean markdownlint issues after skill merge

### DIFF
--- a/skills/batch-loss-averaging-with-partial-batches.md
+++ b/skills/batch-loss-averaging-with-partial-batches.md
@@ -232,7 +232,7 @@ If the loss function returns the **sum** (common for accumulation patterns):
 | Method | Calculation | Result | Error |
 |--------|-------------|--------|-------|
 | Naive | 102.12 / 79 | 1.292 | 129.2% of true (way off) |
-| Correct | 102.12 / 10000 | 0.01021 | ≈ true | ✓
+| Correct | 102.12 / 10000 | 0.01021 | ≈ true | ✓ |
 
 ## Verified On
 

--- a/skills/planning-absorb-existing-module-into-unmerged-stage.md
+++ b/skills/planning-absorb-existing-module-into-unmerged-stage.md
@@ -64,7 +64,7 @@ tags:
   destination path (`.../pipeline/stages/<stage>.py`) and its test (`.../pipeline/test_stage_<stage>.py`)
   do not exist yet.
 - The issue's own wording betrays the dependency: phrasing like "absorbed into `stages/<stage>.py`
-  **in the epic**" or "the pipeline package **from #<earlier>**" means the target is PRODUCED by an
+  **in the epic**" or "the pipeline package **from #N**" means the target is PRODUCED by an
   earlier unmerged sub-issue, not by this one. Read that phrasing as a BLOCKED signal, not an
   instruction to create the destination yourself.
 - You must decide: implement now vs. write a forward-referencing "execute after #N merges" plan. (If
@@ -131,7 +131,7 @@ grep -rn "build_automation_parser" hephaestus/automation/_review_utils.py
    sub-issue and this issue is BLOCKED. Do not skip this because the issue "reads implementable."
 
 2. **Read the issue's own wording as the tell.** Phrasing like "absorbed into `stages/<stage>.py`
-   **in the epic**", "the pipeline package **from #<earlier>**", or "once the coordinator exists"
+   **in the epic**", "the pipeline package **from #N**", or "once the coordinator exists"
    reveals that the destination is another sibling's deliverable. This is the cheapest BLOCKED signal —
    it is right there in the AC. Read it as "not my file to create," not as license to scaffold the
    whole pipeline yourself.


### PR DESCRIPTION
## Summary
- add the missing trailing table pipe in the batch-loss skill
- replace markdown placeholder issue references that markdownlint treats as inline HTML

## Verification
- /opt/homebrew/Caskroom/miniconda/base/bin/python3 scripts/check_pii.py
- /opt/homebrew/Caskroom/miniconda/base/bin/python3 scripts/validate_plugins.py
- /opt/homebrew/Caskroom/miniconda/base/bin/python3 -m pytest tests/ -q