### PR TITLE
feat: amend hephaestus-implement-issues skill (v1.1.0)

### DIFF
--- a/skills/hephaestus-implement-issues-bulk-implementer.history
+++ b/skills/hephaestus-implement-issues-bulk-implementer.history
@@ -1,0 +1,107 @@
+# hephaestus-implement-issues-bulk-implementer — History
+
+## v1.1.0 (2026-07-06)
+
+**Changed by:** ProjectHephaestus epic #1809 cleanup wave (issues #1819–#1823); bug #1940 filed
+**Verification:** verified-ci
+
+### What changed
+
+- Documented a NEW, high-severity failure mode of `hephaestus-implement-issues`: the `--issues N`
+  Depends-on scope leak (bug #1940). `--issues N` expands `N` through its `Depends on #M` chain and
+  re-implements already-CLOSED dependency issues, creating DUPLICATE PRs for merged work.
+- Added the verified per-issue workaround for serial `Depends on` chains: sub-agent implementation +
+  `hephaestus-review-prs` (which has NO dependency-resolver, so it does not leak scope), including the
+  pre-flight (close zombie issues, prune stale worktrees/branches, `--dry-run` and read the
+  `Loaded N issues` line).
+- Added a new "DO NOT use `--issues N` for a `Depends on` chain" subsection to the Verified Workflow,
+  with the root-cause pointer (`implementer.py:_load_issues` ~line 401 vs
+  `resolver._load_dependencies` ~line 427) and a copy-paste per-issue driver.
+- Added 4 Failed Attempts rows: `--issues N` on a Depends-on chain; re-run after closing deps (still
+  `Loaded 3 issues` — bug is in resolver expansion, not the input filter); trusting auto-close for a
+  ZOMBIE dep issue; reusing stale worktrees/branches for chained runs.
+- Extended Results & Parameters with the bug root cause and the full serial-chain workaround.
+- Bumped verification from `verified-local` to `verified-ci` — the workaround landed all 5 cleanup-wave
+  PRs (issues #1819–#1823) through CI to merge.
+- Extended description, `When to Use`, tags, and the Overview table; added the `history` frontmatter
+  field; updated date to 2026-07-06.
+
+### Why
+
+The original v1.0.0 skill documented three failure modes but not the scope leak. On epic #1809's
+`#1819→#1823` cleanup wave, `--issues 1819 --dry-run` logged `Loaded 3 issues` and processed CLOSED
+merged #1817/#1818 before #1819; a live run created duplicate PRs #1938/#1939 on stale `*-auto-impl`
+branches, hit rebase conflicts, and even ran `/learn` on merged #1817. The skip-closed filter in
+`_load_issues` is applied only to the INPUT issue numbers, not to the resolver-expanded `Depends on`
+targets from `_load_dependencies`. Closing/filtering the input deps does NOT help (verified: re-run
+still `Loaded 3 issues`) because the bug is in dependency-resolver expansion. The reliable path until
+#1940 lands is to drive the chain per-issue with a focused sub-agent for implementation and
+`hephaestus-review-prs` (no dependency-resolver) for review.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: hephaestus-implement-issues-bulk-implementer
+description: "How to use ProjectHephaestus's canonical bulk issue-implementer (hephaestus-implement-issues) to implement many GitHub issues per repo instead of hand-rolling agent prompts — flags, worker-cap math, and the three failure modes that actually bite (signal-not-main-thread, 429 session-quota, blocking-inside-a-schema'd-Workflow-subagent). Use when: (1) you need to implement N GitHub issues across one or more repos and are tempted to write your own agent loop, (2) you hit 'ValueError: signal only works in main thread', (3) you hit HTTP 429 'session limit' mid-batch, (4) a Workflow subagent wrapping the implementer fails with 'subagent completed without calling StructuredOutput', (5) you need to size --max-workers to a per-CPU-core cap, (6) cleaning up orphaned .worktrees/issue-N after an interrupted run."
+category: tooling
+date: 2026-05-29
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [hephaestus, implementer, bulk-issues, max-workers, worktree, claude-session-quota, signal-main-thread, workflow-subagent, automation, pixi]
+---
+
+# hephaestus-implement-issues Bulk Implementer — Usage and Failure Modes
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-29 |
+| **Objective** | Use ProjectHephaestus's purpose-built bulk issue-implementer to implement many GitHub issues per repo, rather than hand-rolling agent prompts, worktree isolation, and PR merge logic. |
+| **Outcome** | The console entry `hephaestus-implement-issues` does worktree isolation, signed commits, squash auto-merge, learn/follow-up, and per-issue state persistence out of the box. Three concrete failure modes were observed live and are documented below. |
+| **Verification** | verified-local — the tool was run and observed to fail live; the run mechanics and failure modes were directly observed, not confirmed in CI. |
+
+## When to Use
+
+- You need to implement a batch of GitHub issues (by number, by epic, or all open) in one or more repos and are about to write your own per-issue agent loop — don't; this tool already exists.
+- You hit `ValueError: signal only works in main thread of the main interpreter`.
+- You hit HTTP 429 `You've hit your session limit · resets <time>` partway through a batch.
+- A Workflow `agent({schema})` wrapping the implementer fails with `subagent completed without calling StructuredOutput`.
+- You need to size `--max-workers` to a "2 workers per CPU core" cap.
+- You need to clean up orphaned `.worktrees/issue-N` directories after an interrupted run.
+
+## Verified Workflow
+
+### Quick Reference
+
+(bash quick-reference and detailed steps — see git history at origin/main for the exact block)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Run via `python -m` inside an agent shell | ... | `ValueError: signal only works in main thread ...` | Use the pixi console entry from a main-thread shell |
+| Large worker batch against a single Claude account | `--max-workers 16` | HTTP 429 session limit | Size batches to session quota; `--resume` after reset |
+| Wrap implementer in a schema'd Workflow subagent, run FOREGROUND | `agent({schema})` blocking | `subagent completed without calling StructuredOutput` | Don't block a long implementer inside a schema'd subagent |
+| Background implementer from a subagent, return early | detach + return | repo overlap cap violation; orphaned worktrees | Run repos one at a time in the foreground |
+
+## Results & Parameters
+
+(Console entry, flags, built-in behavior, worker-cap math, orphan cleanup — see git history at
+origin/main for the exact block.)
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| ProjectHephaestus / HomericIntelligence repos | Bulk issue-implementer run observed live (run mechanics + three failure modes) during a multi-repo implementation session | Verified locally — tool ran and failed live; CI validation pending |
+```
+
+---
+
+## v1.0.0 (2026-05-29)
+
+**Initial version.** Documented usage of `hephaestus-implement-issues` and three live failure modes:
+signal-not-main-thread, 429 session-quota, and blocking-inside-a-schema'd-Workflow-subagent.

--- a/skills/hephaestus-implement-issues-bulk-implementer.md
+++ b/skills/hephaestus-implement-issues-bulk-implementer.md
@@ -97,9 +97,9 @@ merged #1817.
 3. **`--dry-run` and read the `Loaded N issues` line.** For a truly-scoped single-issue run it should be
    `1`. It currently isn't (that's the bug) — which is your signal to fall back to the workaround below.
 
-**The verified workaround — sub-agent impl + `hephaestus-review-prs`, PER ISSUE:** (drove epic #1809's
-#1819→#1823 cleanup wave to a clean merge). `hephaestus-review-prs` has NO dependency-resolver, so it
-does not leak scope.
+**The verified workaround — sub-agent impl + `hephaestus-review-prs`, PER ISSUE:** (this drove the
+epic #1809 `#1819`→`#1823` cleanup wave to a clean merge). `hephaestus-review-prs` has NO
+dependency-resolver, so it does not leak scope.
 
 ```bash
 N=1819   # per issue, in dependency order, prev already merged into main

--- a/skills/hephaestus-implement-issues-bulk-implementer.md
+++ b/skills/hephaestus-implement-issues-bulk-implementer.md
@@ -1,12 +1,13 @@
 ---
 name: hephaestus-implement-issues-bulk-implementer
-description: "How to use ProjectHephaestus's canonical bulk issue-implementer (hephaestus-implement-issues) to implement many GitHub issues per repo instead of hand-rolling agent prompts — flags, worker-cap math, and the three failure modes that actually bite (signal-not-main-thread, 429 session-quota, blocking-inside-a-schema'd-Workflow-subagent). Use when: (1) you need to implement N GitHub issues across one or more repos and are tempted to write your own agent loop, (2) you hit 'ValueError: signal only works in main thread', (3) you hit HTTP 429 'session limit' mid-batch, (4) a Workflow subagent wrapping the implementer fails with 'subagent completed without calling StructuredOutput', (5) you need to size --max-workers to a per-CPU-core cap, (6) cleaning up orphaned .worktrees/issue-N after an interrupted run."
+description: "How to use ProjectHephaestus's canonical bulk issue-implementer (hephaestus-implement-issues) to implement many GitHub issues per repo instead of hand-rolling agent prompts — flags, worker-cap math, and the failure modes that actually bite (signal-not-main-thread, 429 session-quota, blocking-inside-a-schema'd-Workflow-subagent, AND the --issues N Depends-on scope-leak that re-implements already-CLOSED dependency issues, bug #1940). Use when: (1) you need to implement N GitHub issues across one or more repos and are tempted to write your own agent loop, (2) you hit 'ValueError: signal only works in main thread', (3) you hit HTTP 429 'session limit' mid-batch, (4) a Workflow subagent wrapping the implementer fails with 'subagent completed without calling StructuredOutput', (5) you need to size --max-workers to a per-CPU-core cap, (6) cleaning up orphaned .worktrees/issue-N after an interrupted run, (7) --issues N logs 'Loaded 3 issues' / re-implements a CLOSED 'Depends on #M' dependency and makes DUPLICATE PRs for merged work, (8) you must drive a serial 'Depends on' cleanup chain safely (sub-agent impl + hephaestus-review-prs, which has no dependency-resolver)."
 category: tooling
-date: 2026-05-29
-version: "1.0.0"
+date: 2026-07-06
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
-tags: [hephaestus, implementer, bulk-issues, max-workers, worktree, claude-session-quota, signal-main-thread, workflow-subagent, automation, pixi]
+verification: verified-ci
+history: hephaestus-implement-issues-bulk-implementer.history
+tags: [hephaestus, implementer, bulk-issues, max-workers, worktree, claude-session-quota, signal-main-thread, workflow-subagent, automation, pixi, depends-on-scope-leak, dependency-resolver, closed-issue-reimplement, duplicate-pr, zombie-issue, review-prs, scoped-chain]
 ---
 
 # hephaestus-implement-issues Bulk Implementer — Usage and Failure Modes
@@ -15,10 +16,11 @@ tags: [hephaestus, implementer, bulk-issues, max-workers, worktree, claude-sessi
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-29 |
-| **Objective** | Use ProjectHephaestus's purpose-built bulk issue-implementer to implement many GitHub issues per repo, rather than hand-rolling agent prompts, worktree isolation, and PR merge logic. |
-| **Outcome** | The console entry `hephaestus-implement-issues` does worktree isolation, signed commits, squash auto-merge, learn/follow-up, and per-issue state persistence out of the box. Three concrete failure modes were observed live and are documented below. |
-| **Verification** | verified-local — the tool was run and observed to fail live; the run mechanics and failure modes were directly observed, not confirmed in CI. |
+| **Date** | 2026-07-06 |
+| **Objective** | Use ProjectHephaestus's purpose-built bulk issue-implementer to implement many GitHub issues per repo, rather than hand-rolling agent prompts, worktree isolation, and PR merge logic — AND safely drive a serial `Depends on` cleanup chain without the tool re-implementing already-CLOSED dependencies. |
+| **Outcome** | The console entry `hephaestus-implement-issues` does worktree isolation, signed commits, squash auto-merge, learn/follow-up, and per-issue state persistence out of the box. Four concrete failure modes were observed live and are documented below — including bug #1940, where `--issues N` expands N through its `Depends on #M` chain and re-implements CLOSED deps, making DUPLICATE PRs. The verified workaround (sub-agent impl + `hephaestus-review-prs`) drove ProjectHephaestus epic #1809's #1819→#1823 cleanup wave to a clean merge. |
+| **Verification** | verified-ci — the sub-agent-per-issue + `hephaestus-review-prs` workaround landed all 5 cleanup-wave PRs (epic #1809, issues #1819–#1823) through CI to merge. Bug #1940 is filed against ProjectHephaestus. |
+| **History** | [changelog](./hephaestus-implement-issues-bulk-implementer.history) |
 
 ## When to Use
 
@@ -28,6 +30,9 @@ tags: [hephaestus, implementer, bulk-issues, max-workers, worktree, claude-sessi
 - A Workflow `agent({schema})` wrapping the implementer fails with `subagent completed without calling StructuredOutput`.
 - You need to size `--max-workers` to a "2 workers per CPU core" cap.
 - You need to clean up orphaned `.worktrees/issue-N` directories after an interrupted run.
+- `--issues N` logs `Loaded 3 issues` (not 1) for a single issue and re-implements a CLOSED `Depends on #M` dependency, creating DUPLICATE PRs for already-merged work (bug #1940).
+- You must drive a serial `Depends on` cleanup chain (each issue depends on the previous, already-merged one) and need the scope to stay at exactly one issue per run.
+- A dependency issue is a ZOMBIE (still OPEN even though its PR merged, never auto-closed), so even the input-level skip-closed filter misses it.
 
 ## Verified Workflow
 
@@ -71,6 +76,49 @@ git worktree prune
 6. **Other flags:** `--resume` (re-read state and continue), `--dry-run`, `--health-check`, `--no-ui`, `-v/--verbose`.
 7. **Size the batch to your Claude session quota** (see Failed Attempts) and `--resume` after a reset.
 
+### DO NOT use `--issues N` for a `Depends on` chain (bug #1940) — drive it per-issue instead
+
+**The bug (ProjectHephaestus #1940):** `hephaestus-implement-issues --issues N` expands `N`
+through its `Depends on #M` chain and **re-implements already-CLOSED dependency issues**, creating
+DUPLICATE PRs for merged work. Root cause: `implementer.py:_load_issues` applies the skip-closed
+filter (~line 401) ONLY to the input `issue_numbers`; the recursive
+`resolver._load_dependencies(issue, cached_states)` (~line 427) adds `Depends on` targets to the
+work graph WITHOUT the `is_done`/`state:skip` filter. Observed: `--issues 1819 --dry-run` logged
+`Loaded 3 issues` and processed CLOSED/merged #1817, #1818 then #1819; a live run made duplicate
+PRs #1938/#1939 on stale `*-auto-impl` branches, hit rebase conflicts, and even ran `/learn` on
+merged #1817.
+
+**Pre-flight for ANY serial chain (do this first):**
+
+1. **Close zombie issues.** An issue OPEN despite its PR merged (never auto-closed) defeats even the
+   input-level filter: `gh issue view N --json state` — if OPEN but the PR is merged, `gh issue close N`.
+2. **Prune stale worktrees/branches.** `build/.worktrees/issue-N` and local `*-auto-impl` branches get
+   REUSED (`Branch X already exists, reusing it` → `git rebase --force-rebase` conflict). Remove them first.
+3. **`--dry-run` and read the `Loaded N issues` line.** For a truly-scoped single-issue run it should be
+   `1`. It currently isn't (that's the bug) — which is your signal to fall back to the workaround below.
+
+**The verified workaround — sub-agent impl + `hephaestus-review-prs`, PER ISSUE:** (drove epic #1809's
+#1819→#1823 cleanup wave to a clean merge). `hephaestus-review-prs` has NO dependency-resolver, so it
+does not leak scope.
+
+```bash
+N=1819   # per issue, in dependency order, prev already merged into main
+# 1. Worktree off CURRENT main (with the previous dep merged):
+git worktree add build/.worktrees/issue-$N -b $N-auto-impl origin/main
+# 2. dev-install INSIDE the worktree — console-script pre-commit hooks
+#    (e.g. hephaestus-check-api-table-docs) resolve, else exit 127:
+cd build/.worktrees/issue-$N && pixi run dev-install
+# 3. FOCUSED general-purpose sub-agent implements THIS issue in the worktree with FULL verification
+#    (ruff / mypy / `pixi run pytest tests/unit -q` / coverage-gate / pre-commit),
+#    signed+DCO commit with `Closes #N`, push — but NO PR.
+# 4. Open the PR yourself.
+# 5. Review with the resolver-free entry (verify log reaches "Analysis complete for PR #N"):
+pixi run --manifest-path "$HEPH/pixi.toml" hephaestus-review-prs --issues $N
+# 6. Resolve threads. 7. Label GO. 8. Arm auto-merge. 9. Watch CI to merge:
+gh pr edit <PR#> --add-label state:implementation-go
+gh pr merge <PR#> --auto --squash
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -79,6 +127,10 @@ git worktree prune
 | Large worker batch against a single Claude account | `--max-workers 16`; each issue spawns its own sub-`claude` invocation | HTTP 429 `You've hit your session limit · resets <time>`; log shows `Claude usage cap hit for issue #N; waiting for reset` — a 16-worker batch drains the account session quota fast | Size batches to the available session quota; after reset, continue with `--resume`. |
 | Wrap implementer in a schema'd Workflow subagent, run FOREGROUND | `agent({schema})` told to run the implementer blocking/foreground | `subagent completed without calling StructuredOutput` — the agent cannot both block on a 10+ minute process and return structured output within its window | Don't run a long blocking implementer inside a schema'd Workflow subagent. Run it from the main session, or poll its `.issue_implementer/` state files. |
 | Background implementer from a subagent, return early | Agent backgrounds the implementer and returns, freeing the workflow | Repos overlap (cap violation since each owns a worker pool); stopping the workflow kills the detached implementer and leaves orphaned `.worktrees/issue-N` | Run repos one at a time in the foreground of the main session. Clean orphans with non-force `git worktree remove` (the `--force` safety net blocks forced removal). |
+| `--issues N` for a `Depends on` chain (bug #1940) | `hephaestus-implement-issues --issues 1819` on an issue whose `Depends on #1817/#1818` were already CLOSED/merged | Logged `Loaded 3 issues`; the recursive `_load_dependencies` (~impl.py:427) adds `Depends on` targets to the work graph WITHOUT the skip-closed filter that `_load_issues` (~impl.py:401) applies only to the INPUT numbers — so it re-implemented CLOSED #1817/#1818 and made DUPLICATE PRs #1938/#1939 on stale `*-auto-impl` branches (rebase conflicts; even ran `/learn` on merged #1817) | Do NOT use `--issues N` for a `Depends on` chain. The skip-closed filter does not reach resolver-expanded deps. |
+| Re-run `--issues N` after closing the deps | Closed the CLOSED dep issues, then re-ran `hephaestus-implement-issues --issues 1819` expecting scope of 1 | STILL `Loaded 3 issues` — the bug is in `_load_dependencies` (resolver expansion), NOT the input filter, so closing/filtering inputs doesn't help | The workaround (sub-agent impl + `hephaestus-review-prs`, which has no dependency-resolver) is the reliable path until #1940 lands. |
+| Trust auto-close for the dep issue | Assumed a dependency issue whose PR merged was CLOSED | It was a ZOMBIE — OPEN despite its PR merged (never auto-closed), so even the input-level skip-closed filter would miss it | Pre-flight `gh issue view N --json state`; if OPEN but PR merged → `gh issue close N` BEFORE any chained run. |
+| Reuse existing worktrees/branches for a chained run | Let a chained run reuse `build/.worktrees/issue-N` and local `*-auto-impl` branches | `Branch X already exists, reusing it` → `git rebase --force-rebase` conflict on stale content | Prune stale worktrees/branches before each chained per-issue run; create the worktree off CURRENT `origin/main` with the previous dep merged. |
 
 ## Results & Parameters
 
@@ -116,10 +168,41 @@ Worker-cap math (2 workers / CPU core):
 Orphan worktree cleanup (after interrupted run):
   git worktree remove .worktrees/issue-N    # NON-force; --force is safety-net blocked
   git worktree prune
+
+--issues N Depends-on scope leak (BUG #1940, ProjectHephaestus):
+  Symptom:   `--issues 1819 --dry-run` -> `Loaded 3 issues`; processes CLOSED #1817/#1818 then #1819.
+             Live run -> DUPLICATE PRs #1938/#1939 on stale *-auto-impl branches; rebase conflicts;
+             even runs /learn on merged #1817.
+  Root cause (hephaestus/automation/implementer.py):
+    _load_issues              (~line 401): skip-closed (is_done/state:skip) filter applied ONLY to
+                                           the INPUT issue_numbers
+    resolver._load_dependencies(~line 427): adds `Depends on #M` targets to the work graph WITHOUT
+                                           that filter -> re-implements CLOSED deps
+  Do NOT `--issues N` a `Depends on` chain until #1940 lands. Use the per-issue workaround below.
+
+Serial `Depends on` chain — verified workaround (drove epic #1809 #1819->#1823 to a clean merge):
+  Pre-flight (once per chain):
+    - close zombies:   gh issue view N --json state ; if OPEN but PR merged -> gh issue close N
+    - prune stale build/.worktrees/issue-N + local *-auto-impl branches (they get REUSED -> conflict)
+    - --dry-run and read `Loaded N issues` (should be 1 for a scoped run; it isn't -> that's the bug)
+  Per issue, in dependency order (prev already merged into main):
+    1. git worktree add build/.worktrees/issue-N -b N-auto-impl origin/main   # off CURRENT main
+    2. (cd worktree) pixi run dev-install   # console-script pre-commit hooks resolve, else exit 127
+    3. FOCUSED general-purpose sub-agent implements THE issue with FULL verification
+       (ruff / mypy / pixi run pytest tests/unit -q / coverage-gate / pre-commit),
+       signed+DCO commit `Closes #N`, push, NO PR
+    4. open the PR yourself
+    5. hephaestus-review-prs --issues N   # NO dependency-resolver -> no scope leak;
+                                          #   verify log reaches "Analysis complete for PR #N"
+    6. resolve threads
+    7. gh pr edit <PR#> --add-label state:implementation-go
+    8. gh pr merge <PR#> --auto --squash
+    9. watch CI to merge
 ```
 
 ## Verified On
 
 | Project | Context | Details |
 | ------- | ------- | ------- |
-| ProjectHephaestus / HomericIntelligence repos | Bulk issue-implementer run observed live (run mechanics + three failure modes) during a multi-repo implementation session | Verified locally — tool ran and failed live; CI validation pending |
+| ProjectHephaestus / HomericIntelligence repos | Bulk issue-implementer run observed live (run mechanics + three original failure modes) during a multi-repo implementation session | Verified locally — tool ran and failed live |
+| ProjectHephaestus epic #1809 | `--issues N` Depends-on scope leak (bug #1940) hit on the #1819→#1823 cleanup wave; drove all 5 issues with the sub-agent-impl + `hephaestus-review-prs` workaround | verified-ci — all 5 cleanup-wave PRs (issues #1819–#1823) landed through CI to merge |


### PR DESCRIPTION
## Summary

Amends the existing `hephaestus-implement-issues-bulk-implementer` skill from v1.0.0 to v1.1.0.

Documents a new, high-severity failure mode of `hephaestus-implement-issues` and the verified per-issue workaround for serial `Depends on` chains.

- New failure mode (ProjectHephaestus bug #1940): `--issues N` expands N through its `Depends on #M` chain and re-implements already-CLOSED dependency issues, creating DUPLICATE PRs for merged work.
- Root cause: `implementer.py:_load_issues` applies the skip-closed filter (~L401) ONLY to the input issue numbers; `resolver._load_dependencies` (~L427) adds `Depends on` targets to the work graph WITHOUT that filter.
- Verified workaround: drive `Depends on` chains per-issue via a focused general-purpose sub-agent (full verification, signed+DCO `Closes #N`, no PR) + `hephaestus-review-prs --issues N` (no dependency-resolver, so no scope leak); pre-flight closes zombie issues and prunes stale worktrees/branches.

## Verification Level

**verified-ci** — the sub-agent-impl + `hephaestus-review-prs` workaround landed all 5 cleanup-wave PRs (epic #1809, issues #1819–#1823) through CI to merge.

## Key Findings

**What Worked**:
- Per-issue driver: sub-agent implementation + `hephaestus-review-prs` (resolver-free) for review.
- Pre-flight: close zombie issues (OPEN despite merged PR), prune stale `*-auto-impl` worktrees/branches, `--dry-run` and read the `Loaded N issues` line.

**What Failed**:
- `--issues 1819` → `Loaded 3 issues`, re-implemented CLOSED #1817/#1818 → duplicate PRs #1938/#1939, rebase conflicts, even ran /learn on merged #1817.
- Re-running `--issues 1819` after closing the deps → STILL `Loaded 3 issues` (bug is in resolver expansion, not the input filter).

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (634/634 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>