### PR TITLE
feat: add Inference360 Warden Slurm ownership skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 634,
+  "total_plugins": 635,
   "categories": {
-    "architecture": 129,
+    "architecture": 130,
     "ci-cd": 122,
     "debugging": 62,
     "documentation": 40,
@@ -18,7 +18,7 @@
     "tooling": 173,
     "training": 7
   },
-  "last_updated": "2026-07-06T21:19:55Z",
+  "last_updated": "2026-07-07T21:29:48Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -1235,7 +1235,7 @@
     {
       "name": "inference360-warden-autoscaling-boundaries",
       "description": "Plan Inference360 Warden autoscaling without creating a second scheduler or lifecycle owner. Use when: (1) adding per-model endpoint scale-out/scale-in policy, (2) deciding Warden, Registry, gateway, and Slurm ownership for autoscaling, (3) writing tests for draining and job-class isolation.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./skills/inference360-warden-autoscaling-boundaries.md",
       "category": "architecture",
       "tags": [
@@ -1247,8 +1247,27 @@
         "registry",
         "gateway",
         "haproxy",
+        "stream-safe-reload",
+        "clock-boundary",
         "job-class-isolation",
         "lifecycle"
+      ]
+    },
+    {
+      "name": "inference360-warden-slurm-job-ownership",
+      "description": "Track Warden-launched user-owned Slurm jobs without classifying arbitrary user jobs as Inference360-owned. Use when: (1) implementing Inference360 Warden orphan or tracking-mismatch detection, (2) comparing Slurm queue state against Warden Registry state, (3) configuring periodic Warden Slurm scans from the runtime manifest.",
+      "version": "1.0.0",
+      "source": "./skills/inference360-warden-slurm-job-ownership.md",
+      "category": "architecture",
+      "tags": [
+        "inference360",
+        "warden",
+        "slurm",
+        "h200",
+        "orphan-detection",
+        "tracking-mismatch",
+        "registry",
+        "manifest-driven"
       ]
     },
     {
@@ -4913,8 +4932,8 @@
     },
     {
       "name": "pr-rebase-conflict-resolution-patterns",
-      "description": "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted \u2014 later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing \u2014 the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes \u2014 confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED \u2014 the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit), (14) multiple rebased PRs \u2014 including ones unrelated to the failing test \u2014 all fail the SAME test after merging onto main; suspect a broken main from a SEMANTIC collision between two independently-merged PRs that never textually conflict (e.g. a return-tuple arity change + a stale test mock), prove it by running the failing test against bare origin/main, and fix main first, (15) two parallel cluster-extraction PRs both create the same new module file and the rebase produces an add/add conflict on BOTH the source module AND its test file \u2014 main's source is authoritative, test files must be semantically merged (keep main's richer base + append your branch's unique test classes), (16) a rebase hits AA (both-added) conflicts on new files \u2014 the conflicted file shows NO <<<<<<< markers and contains only one side's content; you must use git show HEAD:<path> and git show REBASE_HEAD:<path> to read both versions before resolving, (17) a CLUSTER of sibling refactor PRs all edit the SAME shared files and were run in parallel so all but one are CONFLICTING/DIRTY (and possibly hand-braked with state:skip) \u2014 land them as a SEQUENTIAL rebase chain SMALLEST-DIFF-FIRST, rebasing each onto trunk only AFTER the prior merges, resolving every conflict as the UNION of each refactor's extractions (keep both helpers; every duplicated method becomes a thin delegate; merge import lists and drop now-unused imports via lint), then re-sign all commits with `git rebase --exec '...-s -S' origin/main` for DCO+GPG, (18) after rebase, tests fail because test mocks expected the PR branch's refactored signatures but rebase brought in origin/main's different implementation \u2014 the git conflict resolved cleanly (no text-level conflicts), but the test mocks diverge from actual code. Test expects subprocess.check_output but code uses run_subprocess; mock returns 7-tuple but impl expects 9-tuple. After textual conflict resolution succeeds, run tests to surface semantic mismatches, then regenerate test mocks to match CURRENT implementation, not the PR's expected changes (see \u00a7 L), (19) an Inference360 H200 Slurm PR branch has stale/dirty local checkout work before rebase and master renamed control lifecycle to Warden; preserve unrelated staged work first, rebase onto origin/master, keep Warden env names while preserving nested srun --mem=0, and push with an explicit force-with-lease after local + remote head comparison (see \u00a7 O), (20) two branches each APPENDED a DIFFERENT `from <same-module> import <symbols>` line at the same position in the same file (UU both-modified import-line conflict) \u2014 UNION the imported symbols into ONE ruff-ordered import statement, NEVER pick --ours/--theirs (choosing a side silently DROPS the other branch's needed symbol \u2192 NameError at runtime or unused-import on the survivor); also: a PR can be DIRTY/CONFLICTING with a fully GREEN CI rollup \u2014 the conflict is the sole blocker, and `git merge-tree` is a safe non-mutating dry-run to count `<<<<<<<` markers before AND after resolving (see \u00a7 P)",
-      "version": "1.13.0",
+      "description": "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted \u2014 later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing \u2014 the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes \u2014 confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED \u2014 the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit), (14) multiple rebased PRs \u2014 including ones unrelated to the failing test \u2014 all fail the SAME test after merging onto main; suspect a broken main from a SEMANTIC collision between two independently-merged PRs that never textually conflict (e.g. a return-tuple arity change + a stale test mock), prove it by running the failing test against bare origin/main, and fix main first, (15) two parallel cluster-extraction PRs both create the same new module file and the rebase produces an add/add conflict on BOTH the source module AND its test file \u2014 main's source is authoritative, test files must be semantically merged (keep main's richer base + append your branch's unique test classes), (16) a rebase hits AA (both-added) conflicts on new files \u2014 the conflicted file shows NO <<<<<<< markers and contains only one side's content; you must use git show HEAD:<path> and git show REBASE_HEAD:<path> to read both versions before resolving, (17) a CLUSTER of sibling refactor PRs all edit the SAME shared files and were run in parallel so all but one are CONFLICTING/DIRTY (and possibly hand-braked with state:skip) \u2014 land them as a SEQUENTIAL rebase chain SMALLEST-DIFF-FIRST, rebasing each onto trunk only AFTER the prior merges, resolving every conflict as the UNION of each refactor's extractions (keep both helpers; every duplicated method becomes a thin delegate; merge import lists and drop now-unused imports via lint), then re-sign all commits with `git rebase --exec '...-s -S' origin/main` for DCO+GPG, (18) after rebase, tests fail because test mocks expected the PR branch's refactored signatures but rebase brought in origin/main's different implementation \u2014 the git conflict resolved cleanly (no text-level conflicts), but the test mocks diverge from actual code. Test expects subprocess.check_output but code uses run_subprocess; mock returns 7-tuple but impl expects 9-tuple. After textual conflict resolution succeeds, run tests to surface semantic mismatches, then regenerate test mocks to match CURRENT implementation, not the PR's expected changes (see \u00a7 L), (19) an Inference360 H200 Slurm PR branch has stale/dirty local checkout work before rebase and master renamed control lifecycle to Warden; preserve unrelated staged work first, rebase onto origin/master, keep Warden env names while preserving nested srun --mem=0, and push with an explicit force-with-lease after local + remote head comparison (see \u00a7 O), (20) two branches each APPENDED a DIFFERENT `from <same-module> import <symbols>` line at the same position in the same file (UU both-modified import-line conflict) \u2014 UNION the imported symbols into ONE ruff-ordered import statement, NEVER pick --ours/--theirs (choosing a side silently DROPS the other branch's needed symbol \u2192 NameError at runtime or unused-import on the survivor); also: a PR can be DIRTY/CONFLICTING with a fully GREEN CI rollup \u2014 the conflict is the sole blocker, and `git merge-tree` is a safe non-mutating dry-run to count `<<<<<<<` markers before AND after resolving (see \u00a7 P), (21) an Inference360 Warden autoscaling branch rebases across competing HAProxy reload/statistics designs \u2014 keep the active runtime contract (process replacement with `-sf` plus master CLI worker stats), remove obsolete admin-socket `reload` assumptions, update docs/tests to fail closed on missing tracked stats, and verify before force-with-lease (see \u00a7 O2)",
+      "version": "1.14.0",
       "source": "./skills/pr-rebase-conflict-resolution-patterns.md",
       "category": "ci-cd",
       "tags": [
@@ -4998,7 +5017,12 @@
         "dirty-all-green",
         "runtime-import-verify",
         "ruff-import-order",
-        "no-pick-a-side"
+        "no-pick-a-side",
+        "haproxy",
+        "process-replacement",
+        "master-cli-stats",
+        "stats-fail-closed",
+        "autoscaling-rebase"
       ]
     },
     {
@@ -5987,8 +6011,8 @@
     },
     {
       "name": "docker-traefik-network-loss-on-recreation",
-      "description": "Diagnose and fix Traefik 504 Gateway Timeout after container recreation caused by Docker network isolation. Use when: (1) Traefik returns 504 for all backends after being recreated, (2) backends show UP in Traefik dashboard but are unreachable, (3) direct curl to container works but Traefik cannot reach it.",
-      "version": "1.0.0",
+      "description": "Diagnose and fix Traefik 504 Gateway Timeout after container recreation caused by Docker network isolation. Use when: (1) Traefik returns 504 for all backends after being recreated, (2) backends show UP in Traefik dashboard but are unreachable, (3) direct curl to container works but Traefik cannot reach it, (4) planning ANY Traefik container recreate (image bump, major upgrade) and want to check proactively whether it's at risk before touching anything.",
+      "version": "1.1.0",
       "source": "./skills/docker-traefik-network-loss-on-recreation.md",
       "category": "debugging",
       "tags": [

--- a/skills/inference360-warden-autoscaling-boundaries.history
+++ b/skills/inference360-warden-autoscaling-boundaries.history
@@ -1,12 +1,36 @@
+# inference360-warden-autoscaling-boundaries - History
+
+## v1.1.0 (2026-07-07)
+
+**Changed by:** PR #365 strict review and follow-up issue filing session.
+**Verification:** unverified
+
+### What changed
+
+- Added autoscaling review gates for separate monotonic and wall-clock timing.
+- Added gateway publication fail-closed guidance for initial HAProxy start failures.
+- Added stream-safe reload integration coverage as a required validation layer beyond unit command-shape checks.
+- Recorded follow-up GitHub issues #370, #372, and #373 as concrete examples.
+
+### Why
+
+The original v1.0.0 skill captured the high-level Warden autoscaling boundary plan.
+PR #365 implementation review exposed implementation-specific risks that future
+autoscaling work should check before merge: persisted release times cannot reuse
+a monotonic test clock, gateway READY state cannot overwrite an unavailable
+HAProxy startup result, and stream-safe reload claims need real in-flight stream
+coverage.
+
+### Previous version (v1.0.0) snapshot
+
 ---
 name: inference360-warden-autoscaling-boundaries
 description: "Plan Inference360 Warden autoscaling without creating a second scheduler or lifecycle owner. Use when: (1) adding per-model endpoint scale-out/scale-in policy, (2) deciding Warden, Registry, gateway, and Slurm ownership for autoscaling, (3) writing tests for draining and job-class isolation."
 category: architecture
-date: 2026-07-07
-version: "1.1.0"
+date: 2026-07-06
+version: "1.0.0"
 user-invocable: false
 verification: unverified
-history: inference360-warden-autoscaling-boundaries.history
 tags:
   - inference360
   - warden
@@ -16,8 +40,6 @@ tags:
   - registry
   - gateway
   - haproxy
-  - stream-safe-reload
-  - clock-boundary
   - job-class-isolation
   - lifecycle
 ---
@@ -28,11 +50,10 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-07 |
+| **Date** | 2026-07-06 |
 | **Objective** | Preserve Inference360's H200 Slurm lifecycle boundaries while planning Warden autoscaling for model endpoints: scale out when a model's endpoints stay at or above 80% usage for a sustained period, default 30 seconds; scale in when removing one endpoint would keep remaining endpoints below 50% usage. |
-| **Outcome** | Architecture and test-planning guidance only. PR #365 review added concrete implementation guardrails for persisted release clocks, gateway readiness, and stream-safe HAProxy reload coverage. |
+| **Outcome** | Architecture and test-planning guidance only. The autoscaling workflow has not been implemented or tested end-to-end. |
 | **Verification** | unverified |
-| **History** | [changelog](./inference360-warden-autoscaling-boundaries.history) |
 | **Related skills** | `inference360-warden-lifecycle-gpt2-cleanup.md`, `inference360-module-scope-preserve-cli-boundaries.md`, `documentation-architecture-registry-gateway-warden-contracts.md` |
 
 Inference360 is a manifest-driven internal H200 Slurm inference platform. Slurm remains the scheduler of record. Warden remains the lifecycle owner for Slurm-backed endpoints and route publication. Autoscaling should extend those contracts, not introduce Kubernetes, a separate autoscaler authority, or a second control plane.
@@ -44,9 +65,6 @@ Inference360 is a manifest-driven internal H200 Slurm inference platform. Slurm 
 - Ownership between Warden, Registry, HAProxy/gateway, Scheduler/Slurm, manifests, and job classes is unclear.
 - Tests need to prove sustained threshold timing, draining, route publication, and job-class isolation without depending on live Slurm.
 - A review needs to reject designs where HAProxy owns lifecycle, Scheduler mutates routes, or autoscaling state crosses model/job-class boundaries.
-- Autoscale code persists delayed release intent timestamps or exposes test clocks such as `now`.
-- Gateway publication claims READY after HAProxy startup or reload without proving the operation succeeded.
-- A stream-safe reload claim is backed only by HAProxy command-shape unit tests and not by an in-flight streaming validation.
 
 <!-- Validator compatibility: ## Verified Workflow -->
 ## Proposed Workflow
@@ -73,11 +91,6 @@ Ownership:
 - HAProxy/gateway consumes routeable backend state and load-balances ready endpoints.
 - Slurm remains scheduler of record.
 - Scheduler/Slurm must not mutate routes.
-
-Implementation review gates:
-- Keep monotonic threshold timing separate from persisted wall-clock release timestamps.
-- Gateway READY must fail closed if initial HAProxy start or reload fails.
-- Stream-safe reload claims need an integration harness with a live in-flight stream.
 ```
 
 ### Detailed Steps
@@ -113,13 +126,7 @@ Implementation review gates:
    - job-class isolation for observations, endpoints, routes, metrics, and policy state;
    - no cross-module boundary violations, especially HAProxy owning lifecycle or Scheduler mutating routes.
 
-9. Separate timing domains before persisting autoscale release intent. Use a monotonic clock for sustained threshold windows and cooldown math. Use an explicit wall-clock timestamp for `release_after` and persisted audit state. Tests that inject `now=0`, `now=32`, or another monotonic value must either also inject `wall_time` or assert that persisted timestamps are real wall-clock times, not Unix-epoch artifacts.
-
-10. Make gateway route publication fail closed. If `publish_gateway_routes` calls the HAProxy initial-start path and startup marks the gateway unavailable, do not later overwrite it with `status: running` or gateway health `READY`. Cover both no-existing-process and stale-process restart branches; command-shape coverage for `-sf` is not enough.
-
-11. Prove stream-safe reloads at the right layer. Unit tests can check HAProxy master-worker command shape, stats aggregation, and old worker retention, but a claim that existing streams survive reload needs a real HAProxy or documented operator harness that holds an in-flight streaming response, reloads routes, and verifies the existing stream completes while new traffic uses the updated backend set.
-
-12. Keep verification honest. Until implementation and CI exist, describe this as architecture/planning guidance and keep verification `unverified`. If follow-up issues are filed instead of fixed, keep the skill as proposed guidance and cite the issue numbers in results rather than claiming validation.
+9. Keep verification honest. Until implementation and CI exist, describe this as architecture/planning guidance and keep verification `unverified`.
 
 ## Failed Attempts
 
@@ -131,9 +138,6 @@ Implementation review gates:
 | Environment-driven policy | Adding new repository-behavior environment variables for thresholds and timing | Repo guidance requires manifest/config driven lifecycle behavior with explicit inputs | Use manifests, config files, or explicit CLI/config inputs |
 | Immediate scale-in shutdown | Stopping an endpoint as soon as policy says capacity can shrink | Active work could be interrupted and route state could point at a terminating backend | Mark draining/non-routeable first, publish routes, wait for natural drain, then stop |
 | Cross-job-class pooling | Sharing endpoint, route, metric, or policy state across job classes | Inference360 requires strict job-class isolation | Keep decisions and runtime state scoped per model/job class |
-| Reused monotonic test time as wall time | Passed `now` through both autoscale threshold logic and persisted `release_after` wall-clock construction | Tests that used `now=32` could persist timestamps near 1970 while still passing threshold assertions | Split monotonic timing from persisted wall-clock timestamps and assert persisted `release_after` |
-| READY after failed initial HAProxy start | Let route publication call initial HAProxy startup, then unconditionally set gateway status to running and health to READY | A missing HAProxy binary or failed startup could be masked by later state updates | Treat startup/reload success as a precondition for READY and route-count publication |
-| Stream safety proved by command shape only | Verified `haproxy -sf` command construction but did not hold a real in-flight stream through reload | Command shape does not prove client-observed stream continuity | Add live HAProxy/in-flight stream integration coverage or an explicit operator validation harness |
 
 ## Results & Parameters
 
@@ -163,18 +167,14 @@ Implementation review gates:
 - Verification remains unverified until implementation and CI exist.
 ```
 
-### PR #365 Review Follow-ups
-
-| Issue | Review finding | Why it matters |
-|-------|----------------|----------------|
-| LLM360/Inference360#370 | Fix Warden gateway READY state after initial HAProxy start failure | Gateway readiness must fail closed when HAProxy cannot start |
-| LLM360/Inference360#372 | Add integration coverage for stream-safe HAProxy reloads | Stream continuity is a behavioral property, not just a command-line property |
-| LLM360/Inference360#373 | Separate autoscaling monotonic clock from persisted release wall time | Persisted release state must use real wall time and avoid Unix-epoch artifacts from test clocks |
-| LLM360/Inference360#371 | Clean up minor Warden autoscaling audit findings from PR #365 | Keeps runbook, logging, and validation-preview details aligned |
-
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | LLM360/Inference360 | Warden autoscaling planning session on 2026-07-06 | Architecture/planning guidance only; not implemented or tested end-to-end. |
-| LLM360/Inference360 | Strict review of PR #365 on 2026-07-07 | Follow-up issues #370, #371, #372, and #373 were filed. The implementation guardrails remain unverified until those issues land and pass CI. |
+
+---
+
+## v1.0.0 (2026-07-06)
+
+**Initial version.**

--- a/skills/inference360-warden-slurm-job-ownership.md
+++ b/skills/inference360-warden-slurm-job-ownership.md
@@ -1,0 +1,156 @@
+---
+name: inference360-warden-slurm-job-ownership
+description: "Track Warden-launched user-owned Slurm jobs without classifying arbitrary user jobs as Inference360-owned. Use when: (1) implementing Inference360 Warden orphan or tracking-mismatch detection, (2) comparing Slurm queue state against Warden Registry state, (3) configuring periodic Warden Slurm scans from the runtime manifest."
+category: architecture
+date: 2026-07-07
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - inference360
+  - warden
+  - slurm
+  - h200
+  - orphan-detection
+  - tracking-mismatch
+  - registry
+  - manifest-driven
+---
+
+# Inference360 Warden Slurm Job Ownership
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-07 |
+| **Objective** | Implement Inference360 Warden tracking-mismatch detection for active H200 Slurm jobs that Warden launched for the user but that are missing from Warden runtime/Registry state. |
+| **Outcome** | Local implementation pattern and focused tests passed. The key contract is that a Slurm job owned by the Unix user is not automatically Inference360-owned; it must carry Warden/Inference360 scheduler evidence. |
+| **Verification** | verified-local - focused Inference360 tests passed locally; CI validation pending for the uncommitted #343 implementation. |
+
+## When to Use
+
+- Inference360 needs to scan the Slurm queue for orphaned, leaked, or untracked Warden jobs.
+- A user clarifies that "Inference360-owned" means GPU Slurm jobs owned by the user and launched by Warden, not every user-launched Slurm job.
+- You are adding or reviewing Warden `tracking_mismatches`, orphan reports, or Registry reconciliation.
+- You need a repeatable background Warden scan interval controlled by `manifests/services/warden-runtime.yaml`.
+- Tests need to prove manual user jobs are ignored while Warden-launched H200 jobs are reported.
+
+## Verified Workflow
+
+Verified locally only - CI validation pending.
+
+### Quick Reference
+
+```bash
+# Focused local verification used for the captured implementation.
+UV_CACHE_DIR=/tmp/i360-uv-cache uv run pytest tests/test_warden_lifecycle.py \
+  -k 'tracking_mismatch or orphan_detection or warden_serve_runtime_uses_runtime_manifest_server_defaults or warden_server_defaults_are_loaded_from_runtime_manifest' \
+  -q
+```
+
+```yaml
+# Runtime manifest contract.
+server_defaults:
+  orphan_detection:
+    scan_interval_seconds: 60.0
+```
+
+```text
+# Queue scan shape.
+squeue -u <operator-user> --noheader -o '%i|%T|%u|%j|%R'
+scontrol show job <job-id>
+```
+
+### Detailed Steps
+
+1. Treat Slurm as scheduler of record and Warden as lifecycle owner. The reconciliation loop observes Slurm, but it must not cancel or mutate jobs simply because they are untracked.
+
+2. Define ownership from scheduler evidence, not from Unix ownership alone. A job is a Warden/Inference360 job only when its fresh `scontrol show job` record carries an Inference360 scheduler comment such as `inference360:nodepool`, `inference360:warden`, or a model-scoped `inference360:*:*` comment. A manual user job with another comment is ignored.
+
+3. Scan the active user queue first:
+
+   ```text
+   squeue -u <operator-user> --noheader -o '%i|%T|%u|%j|%R'
+   ```
+
+   Only active Slurm states continue to fresh job inspection. Parse failures should fail closed with a manifest/runtime error instead of silently misclassifying jobs.
+
+4. Refresh each candidate with `scontrol show job <job-id>`. Use the fresh `JobState`, `JobName`, `Comment`, `NodeList`, and `BatchHost` instead of trusting stale `squeue` columns.
+
+5. Build the tracked job-id set from Warden runtime state:
+
+   | State source | Include when |
+   |--------------|--------------|
+   | `state["warden"]["slurm_job_id"]` | Warden control job id is present |
+   | `state["nodes"][*]["slurm_job_id"]` | Node is not terminal |
+   | `state["servers"][*]["slurm_job_id"]` | Server is in a current lifecycle state |
+   | `_autoscaling_releases[*]["slurm_job_id"]` | Delayed release intent still owns the allocation |
+
+6. Report only active Inference360-owned Slurm jobs whose ids are absent from the tracked set. Persist them under `tracking_mismatches` with `classification: tracking_mismatch`, `routeable: false`, and `action: inspect_and_reconcile_warden_registry`.
+
+7. Run the scan periodically inside Warden. Source the interval from `server_defaults.orphan_detection.scan_interval_seconds`; the captured default was `60.0` seconds and schema validation rejects non-positive values.
+
+8. On scan failure, redact operational details before storing or logging the error. Endpoint addresses and tokens from scheduler failures should become placeholders such as `<REDACTED_ENDPOINT>` and `<REDACTED_TOKEN>`.
+
+9. Test with fake Slurm runners rather than live Slurm. At minimum cover:
+
+   - Warden-launched active job missing from state is reported as a tracking mismatch.
+   - User-launched or non-Inference360-commented active job is ignored.
+   - Already tracked allocation is ignored.
+   - Scheduler failure increments tracking-mismatch reconcile failures and stores redacted error text.
+   - Manifest validation rejects invalid scan intervals.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Classify by Unix user only | Treated every active Slurm job owned by the operator user as an Inference360 orphan candidate | Users can launch their own Slurm jobs outside Warden; those must not be tracked or flagged by Warden | Require Warden/Inference360 scheduler evidence such as the Slurm `Comment` field before classifying ownership |
+| Trust `squeue` alone | Used queue rows as the full source of ownership truth | `squeue` gives useful ids and state, but not enough ownership evidence to distinguish Warden jobs from manual jobs | Use `squeue` only for enumeration, then refresh each candidate with `scontrol show job` |
+| Cancel or repair automatically | Considered treating untracked Warden jobs as immediately reclaimable or routeable failures | Missing Registry state is an incident that may need operator investigation; automatic cancellation can destroy useful evidence or a live serving allocation | Persist a non-routeable `tracking_mismatch` incident with an inspect/reconcile action |
+| Hard-code scan cadence | Made the repeat interval a code constant or environment variable | Inference360 lifecycle behavior must be manifest-driven and reviewable | Configure `server_defaults.orphan_detection.scan_interval_seconds` in the Warden runtime manifest and schema |
+
+## Results & Parameters
+
+### Observed Local Verification
+
+```text
+Command:
+UV_CACHE_DIR=/tmp/i360-uv-cache uv run pytest tests/test_warden_lifecycle.py -k 'tracking_mismatch or orphan_detection or warden_serve_runtime_uses_runtime_manifest_server_defaults or warden_server_defaults_are_loaded_from_runtime_manifest' -q
+
+Result:
+8 passed, 190 deselected in 0.10s
+```
+
+### Ownership Rules
+
+| Input evidence | Classification |
+|----------------|----------------|
+| Active user job with `Comment=inference360:nodepool` and no tracked Warden state | `tracking_mismatch` |
+| Active user job with model-scoped Inference360 comment and no tracked Warden state | `tracking_mismatch` |
+| Active user job with non-Inference360 comment | Ignored |
+| Active Inference360 job whose id is present in active Warden node/server/control/release state | Ignored as tracked |
+| Inactive Slurm job | Ignored by active-state filter |
+
+### Registry Incident Shape
+
+```json
+{
+  "classification": "tracking_mismatch",
+  "routeable": false,
+  "action": "inspect_and_reconcile_warden_registry",
+  "reason": "Inference360-owned Slurm job is active but missing from Warden runtime state",
+  "slurm_job_id": "101",
+  "slurm_state": "RUNNING",
+  "slurm_user": "operator",
+  "slurm_job_name": "warden-free-h200-a-abc12345",
+  "scheduler_comment": "inference360:nodepool",
+  "ownership_kind": "nodepool"
+}
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue #343 implementation session on 2026-07-07 | Focused local tests passed for tracking mismatch detection and manifest-driven orphan scan interval. Local branch had not yet been committed or CI-validated when this skill was captured. |


### PR DESCRIPTION
## Summary

Adds `inference360-warden-slurm-job-ownership` and amends `inference360-warden-autoscaling-boundaries` from v1.0.0 to v1.1.0.

Documents session learnings from Inference360 Warden work:

- Inference360-owned Slurm jobs are user-owned jobs launched by Warden, not arbitrary user-launched jobs.
- Tracking mismatch scans should use scheduler evidence, persist non-routeable incidents, and run on a manifest-driven cadence.
- Autoscaling review gates should check monotonic-vs-wall-clock separation, HAProxy READY fail-closed behavior, and real stream-safe reload coverage.

## Verification Level

**verified-local** for the new Warden Slurm ownership skill. The autoscaling amendment remains **unverified** follow-up guidance because the PR #365 findings were filed as issues rather than fixed in this session.

## Key Findings

**What Worked**:
- Created a focused Warden Slurm ownership skill instead of overloading generic orphan-config skills.
- Amended the existing autoscaling boundaries skill because the review findings belong to the same search surface.
- Regenerated `.claude-plugin/marketplace.json` after adding a skill so the marketplace count stays in sync.

**What Failed**:
- Plain `python3 scripts/validate_plugins.py` failed because system Python lacked PyYAML.
- `uv run` dependency resolution failed because ProjectMnemosyne declares Python `>=3.9` while `pytest>=9` requires `>=3.10`.
- Initial push failed because marketplace generation was stale (`total_plugins` 634 vs 635); regenerating marketplace fixed it.

## Test Plan

- [x] `UV_CACHE_DIR=/tmp/i360-uv-cache uv run pytest tests/test_warden_lifecycle.py -k "tracking_mismatch or orphan_detection or warden_serve_runtime_uses_runtime_manifest_server_defaults or warden_server_defaults_are_loaded_from_runtime_manifest" -q` in LLM360/Inference360: 8 passed, 190 deselected
- [x] `PYTHONPATH=/tmp/mnemosyne-validator-pydeps python3 scripts/validate_plugins.py`: 635/635 valid
- [x] `PYTHONPATH=/tmp/mnemosyne-validator-pydeps pytest -q tests/test_schema_validation.py::TestMarketplaceSchema::test_total_plugins_matches_skill_files`: 1 passed
- [x] Pre-push hook: `pytest -q`: 260 passed

Co-Authored-By: Codex <noreply@openai.com>